### PR TITLE
CXX-72 Add compatibility targets for old smoke targets

### DIFF
--- a/site_scons/site_tools/unittest.py
+++ b/site_scons/site_tools/unittest.py
@@ -13,8 +13,9 @@ def build_cpp_unit_test(env, target, source, **kwargs):
     result = env.Program(target, source, **kwargs)
     runAlias = env.Alias('run-' + target, [result], result[0].abspath)
     env.AlwaysBuild(runAlias)
-    env.Alias('test', runAlias)
-    env.AlwaysBuild('test')
+    testAliases = ['test', 'smokeCppUnittests', 'smoke']
+    env.Alias(testAliases, runAlias)
+    env.AlwaysBuild(testAliases)
 
     return result
 

--- a/src/SConscript.client
+++ b/src/SConscript.client
@@ -408,6 +408,21 @@ if buildShared:
     libEnv.Depends(sharedClientPrograms, mongoClientInstalls)
 
     sharedClientProgramInstalls = sharedClientEnv.Install("#/sharedclient", sharedClientPrograms)
-    clientTests.append(sharedClientProgramInstalls)
+    clientTests.extend(sharedClientProgramInstalls)
 
 clientEnv.Alias('clientTests', clientTests, [])
+
+# NOTE: There must be a mongod listening on 127.0.0.1:27999 (the traditional mongodb smoke test
+# port) for the smokeClient target to run. In the server repo that is no problem, the smoke.py
+# subsystem can start a mongod as needed. We don't have the same ability in this repo, since we
+# have no way of reaching a mongod executable or knowing if it is safe to start one.
+for clientTest in clientTests:
+    # the rsExample test needs a replica set to talk to. The old smokeClient never tested it
+    # The old smoke subsystem did test authTest, not sure why it isn't working now.
+    if 'rsExample' in clientTest.abspath:# or 'authTest' in clientTest.abspath:
+        continue
+
+    clientEnv.AlwaysBuild(clientEnv.Alias(
+        'smokeClient',
+        [clientTest],
+        "%s --port 27999" % clientTest.abspath))

--- a/src/mongo/client/examples/tutorial.cpp
+++ b/src/mongo/client/examples/tutorial.cpp
@@ -37,7 +37,7 @@ int printIfAge(DBClientConnection& c, int age) {
     return EXIT_SUCCESS;
 }
 
-int run() {
+int run(int argc, char* argv[]) {
 
     Status status = client::initialize();
     if ( !status.isOK() ) {
@@ -45,8 +45,17 @@ int run() {
         return EXIT_FAILURE;
     }
 
+    const char *port = "27017";
+    if ( argc != 1 ) {
+        if ( argc != 3 ) {
+            std::cout << "need to pass port as second param" << endl;
+            return EXIT_FAILURE;
+        }
+        port = argv[ 2 ];
+    }
+
     DBClientConnection c;
-    c.connect("localhost"); //"192.168.58.1");
+    c.connect(string("localhost:") + port); //"192.168.58.1");
     cout << "connected ok" << endl;
     BSONObj p = BSON( "name" << "Joe" << "age" << 33 );
     c.insert("tutorial.persons", p);
@@ -77,10 +86,10 @@ int run() {
     return printIfAge(c, 33);
 }
 
-int main() {
+int main(int argc, char* argv[]) {
     int ret = EXIT_SUCCESS;
     try {
-        ret = run();
+        ret = run(argc, argv);
     }
     catch( DBException &e ) {
         cout << "caught " << e.what() << endl;


### PR DESCRIPTION
Make the 'smokeClient', 'smokeCppUnittest', and 'smoke' targets have behavior similar to what they did in the server repo:
- 'smokeCppUnittest' and 'smoke' mean to run the ported tests (since we no longer distinguish between C++ tests and dbtests)
- 'smokeClient' runs the same tests that the old smokeClient runs (basically the targets in client/examples). We can't actually run those unless there is a mongod started on 27999, but that isn't this repo's problem because it doesn't have a way to start/stop such a beast.
