### PR TITLE
CXX-55 Enforce symbol visibility when building shared objects

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -824,7 +824,6 @@ elif windows:
     env.Append( EXTRACPPPATH=["#/../winpcap/Include"] )
     env.Append( EXTRALIBPATH=["#/../winpcap/Lib"] )
 
-env['STATIC_AND_SHARED_OBJECTS_ARE_THE_SAME'] = 1
 if nix:
 
     if has_option( "distcc" ):

--- a/src/SConscript.client
+++ b/src/SConscript.client
@@ -14,9 +14,15 @@ if has_option("sharedclient"):
 
 clientEnv = env.Clone()
 libEnv = env.Clone()
+
+# We want to build the same objects in two different ways, once for a static (LIBDEPSy library)
+# and once for a DLL, with different defines in play. That works fine on platforms where by
+# default SHOBJSUFFIX and OBJSUFFIX differ, but by default on windows they don't. Repair that.
+if windows:
+    libEnv['SHOBJSUFFIX'] = libEnv['OBJSUFFIX'] + 's'
+
 del env
 clientEnv['CPPDEFINES'].remove('MONGO_EXPOSE_MACROS')
-libEnv.Append(CPPDEFINES='LIBMONGOCLIENT_BUILDING')
 
 libEnv.Command(['mongo/base/error_codes.h', 'mongo/base/error_codes.cpp',],
                ['mongo/base/generate_error_codes.py', 'mongo/base/error_codes.err'],
@@ -229,10 +235,6 @@ clientHeaders = [
     'mongo/util/version.h',
 ]
 
-# This relies on static and shared objects being the same, since we will link these object
-# files twice: once into a .a, and another time into a .so
-clientObjects = [libEnv.Object(source) for source in clientSource]
-
 mongoClientLibs = []
 mongoClientLibDeps = ['$BUILD_DIR/third_party/shim_boost']
 mongoClientSysLibDeps = []
@@ -260,7 +262,7 @@ else:
     staticLibName = 'mongoclient'
 
 mongoClientStaticLib = staticLibEnv.StaticLibrary(
-    staticLibName, clientObjects),
+    staticLibName, clientSource),
 mongoClientInstalls.append(staticLibEnv.Install('#/', mongoClientStaticLib))
 
 if installSetup.libraries:
@@ -276,6 +278,10 @@ if buildShared:
     # InstallVersionedLibrary support is only stable in SCons > 2.3.0, so if you add support
     # here, be sure to add an EnsuredSconsVersion here as well.
     sharedLibEnv = libEnv.Clone()
+
+    # This causes export macros to be applied, which we want only for shared librray or DLL builds.
+    sharedLibEnv.Append(CPPDEFINES='LIBMONGOCLIENT_BUILDING')
+
     sharedLibEnv.AppendUnique(LIBS=mongoClientSysLibDeps)
 
     # On windows, we always want to attach the shim, since independently of whether we are
@@ -298,7 +304,7 @@ if buildShared:
         sharedLibEnv.AppendUnique(CCFLAGS="-fvisibility=hidden")
         sharedLibEnv.AppendUnique(SHLINKFLAGS="-fvisibility=hidden")
 
-    mongoClientSharedLib = sharedLibEnv.SharedLibrary('mongoclient', clientObjects)
+    mongoClientSharedLib = sharedLibEnv.SharedLibrary('mongoclient', clientSource)
 
     mongoClientSharedLibInstall = sharedLibEnv.Install(
         '#/sharedclient', mongoClientSharedLib)

--- a/src/mongo/util/hex.h
+++ b/src/mongo/util/hex.h
@@ -57,7 +57,7 @@ namespace mongo {
         return out.str();
     }
 
-    template <typename T> std::string integerToHex(T val);
+    template <typename T> std::string MONGO_CLIENT_API integerToHex(T val);
 
     inline std::string toHexLower(const void* inRaw, int len) {
         static const char hexchars[] = "0123456789abcdef";

--- a/src/mongo/util/net/sock.h
+++ b/src/mongo/util/net/sock.h
@@ -184,7 +184,7 @@ namespace mongo {
      * thin wrapped around file descriptor and system calls
      * todo: ssl
      */
-    class Socket {
+    class MONGO_CLIENT_API Socket {
         MONGO_DISALLOW_COPYING(Socket);
     public:
 


### PR DESCRIPTION
This sets things up so that the static library is not built with visibility attributes applied, but the shared library is. Since the objects are now built with different flags, we need to patch up the windows build to build the second set of objects with a different suffix.

It also fixes up two missing visibility attributes.

@andy10gen would appreciate your thoughts on this one.
