### PR TITLE
CXX-74 enable clang support for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: cpp
 
 compiler:
     - gcc
+    - clang
 
 env:
   global:
@@ -9,18 +10,22 @@ env:
 
 # Setup required repositories before installation
 before_install:
-    - sudo add-apt-repository -y ppa:boost-latest/ppa
+    - sudo add-apt-repository -y ppa:jkeiren/ppa
     - sudo apt-get update -qq
 
-# Install the latest boost version
+# Install Boost 1.49 dependencies via PPA
 install:
-    - sudo apt-get install -qq libboost1.55-all-dev
+    - sudo apt-get install -qq
+      libboost1.49-dev
+      libboost-program-options1.49-dev
+      libboost-filesystem1.49-dev
+      libboost-thread1.49-dev
 
 script:
-    - $CXX --version
     - scons
        -j2
        --mute
+       --quiet
        --prefix=$PREFIX
        --use-system-boost
        --full


### PR DESCRIPTION
This pull request successfully enables clang support for our build using Boost 1.49.

Also, currently testing output is cluttered with compile output so --quiet has been added to the compile flags. Check out how much nicer it is to look at the test results now.

Ideally we should have a two phase script that first builds all the necessary components of the project and a second which runs the tests so they are cleanly separated (and subsequently collapsed) so the test output is front and center.
