### PR TITLE
CXX-125 add missing test to dbclient_rs_test

### DIFF
--- a/src/mongo/client/dbclient_rs_test.cpp
+++ b/src/mongo/client/dbclient_rs_test.cpp
@@ -414,7 +414,10 @@ namespace {
             // Tests for pinning behavior require this.
             ReplicaSetMonitor::useDeterministicHostSelection = true;
 
+            // This shuts down the background RSMWatcher thread and prevents it from running. These
+            // tests depend on controlling when the RSMs are updated.
             ReplicaSetMonitor::cleanup();
+
             _replSet.reset(new MockReplicaSet("test", 5));
             _originalConnectionHook = ConnectionString::getConnectionHook();
             ConnectionString::setConnectionHook(
@@ -525,6 +528,39 @@ namespace {
             BSONObj doc = cursor->next();
             const string newDest = doc[HostField.name()].str();
             ASSERT_EQUALS(dest, newDest);
+        }
+    }
+
+    TEST_F(TaggedFiveMemberRS, ConnShouldNotPinIfHostMarkedAsFailed) {
+        MockReplicaSet* replSet = getReplSet();
+        vector<HostAndPort> seedList;
+        seedList.push_back(HostAndPort(replSet->getPrimary()));
+
+        DBClientReplicaSet replConn(replSet->getSetName(), seedList);
+
+        string dest;
+        {
+            Query query;
+            query.readPref(mongo::ReadPreference_PrimaryPreferred, BSONArray());
+
+            // Note: IdentityNS contains the name of the server.
+            auto_ptr<DBClientCursor> cursor = replConn.query(IdentityNS, query);
+            BSONObj doc = cursor->next();
+            dest = doc[HostField.name()].str();
+        }
+
+        // This is the only difference from ConnShouldPinIfSameSettings which tests that we *do* pin
+        // in if the host is still marked as up. Note that this only notifies the RSM, and does not
+        // directly effect the DBClientRS.
+        ReplicaSetMonitor::get(replSet->getSetName())->failedHost(dest);
+
+        {
+            Query query;
+            query.readPref(mongo::ReadPreference_PrimaryPreferred, BSONArray());
+            auto_ptr<DBClientCursor> cursor = replConn.query(IdentityNS, query);
+            BSONObj doc = cursor->next();
+            const string newDest = doc[HostField.name()].str();
+            ASSERT_NOT_EQUALS(dest, newDest);
         }
     }
 


### PR DESCRIPTION
It seems like this file was not updated to the current state when we forked so this is adding the missing test and other updates that had occurred before fork time.

Let me know if we don't want to take the other changes and I'll update the pull request accordingly.
