### PR TITLE
fix strict aliasing warnings CXX-49

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -610,7 +610,6 @@ if nix:
 
     # -Winvalid-pch Warn if a precompiled header (see Precompiled Headers) is found in the search path but can't be used.
     env.Append( CCFLAGS=["-fPIC",
-                         "-fno-strict-aliasing",
                          "-ggdb",
                          "-pthread",
                          "-Wall",

--- a/src/mongo/SConscript
+++ b/src/mongo/SConscript
@@ -36,6 +36,8 @@ unittests = [
     'bson/bson_obj_test',
     'bson/bson_validate_test',
     'bson/bsonobjbuilder_test',
+    'bson/oid_test',
+    'bson/optime_test',
     'bson/util/bson_extract_test',
     'client/dbclient_rs_test',
     'client/scoped_db_conn_test',
@@ -52,6 +54,7 @@ unittests = [
     'platform/process_id_test',
     'platform/random_test',
     'util/net/sock_test',
+    'util/net/message_test',
     'util/stringutils_test',
     'util/time_support_test',
 ]

--- a/src/mongo/bson/oid.h
+++ b/src/mongo/bson/oid.h
@@ -109,12 +109,17 @@ namespace mongo {
         static unsigned getMachineId(); // features command uses
         static void regenMachineId(); // used by unit tests
 
-    private:
         struct MachineAndPid {
             unsigned char _machineNumber[3];
             unsigned short _pid;
+            bool operator==(const OID::MachineAndPid& rhs) const;
             bool operator!=(const OID::MachineAndPid& rhs) const;
+            
+            void foldInPid(unsigned pid);
+            unsigned getMachineNumber();
         };
+
+    private:
         static MachineAndPid ourMachine;
         static MachineAndPid ourMachineAndPid;
         union {

--- a/src/mongo/bson/oid_test.cpp
+++ b/src/mongo/bson/oid_test.cpp
@@ -1,0 +1,74 @@
+/*    Copyright 2013 10gen Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "mongo/db/jsobj.h"
+#include "mongo/db/json.h"
+
+#include "mongo/unittest/unittest.h"
+
+namespace mongo {
+
+  TEST(foldInPid, smallPid) {
+        OID::MachineAndPid machineAndPid = {{0x44, 0x66, 0x99}, 0xAACC};
+
+        machineAndPid.foldInPid(0x01);
+
+        OID::MachineAndPid expected = {{0x44, 0x66, 0x99}, 0xAACD};
+        ASSERT_EQUALS(expected, machineAndPid);
+    }
+
+    TEST(foldInPid, bigPid) {
+        OID::MachineAndPid machineAndPid = {{0x44, 0x66, 0x99}, 0xAACC};
+
+        machineAndPid.foldInPid(0x12345678);
+
+        OID::MachineAndPid expected = {{0x44, 0x52, 0x8B}, 0xFCB4};
+        ASSERT_EQUALS(expected, machineAndPid);
+    }
+    
+    TEST(OID, initMin) {
+      OID oid;
+      oid.init(0x471C71C4C0, false);
+      ASSERT_EQUALS("123456780000000000000000", oid.str());
+    }
+
+    TEST(OID, initMax) {
+      OID oid;
+      oid.init(0x471C71C4C0, true);
+      ASSERT_EQUALS("12345678ffffffffffffffff", oid.str());
+    }
+    
+    TEST(OID, getMachineId) {
+      OID::MachineAndPid machineAndPid = {{0x44, 0x66, 0x99}};
+      ASSERT_EQUALS(0x00996644U, machineAndPid.getMachineNumber());
+    }
+
+    using mongo::OID;
+    TEST(MachineAndPid, Equal) {
+      OID::MachineAndPid a = { { 0x33, 0x66, 0x99 }, 0xccff };
+      OID::MachineAndPid b(a);
+      
+      ASSERT_EQ(a, b);
+    }
+
+    TEST(MachineAndPid, NotEqual) {
+      OID::MachineAndPid a = { { 0x33, 0x66, 0x99 }, 0xccff };
+      OID::MachineAndPid b = { { 0x33, 0x00, 0x99 }, 0xccff };
+      
+      ASSERT_NE(a, b);
+    }
+    
+
+} // unnamed namespace

--- a/src/mongo/bson/optime.h
+++ b/src/mongo/bson/optime.h
@@ -105,10 +105,13 @@ namespace mongo {
          bytes of overhead.
          */
         unsigned long long asDate() const {
-            return reinterpret_cast<const unsigned long long*>(&i)[0];
+            unsigned long long date = secs;
+            date <<= 32;
+            date |= i;
+            return date;
         }
         long long asLL() const {
-            return reinterpret_cast<const long long*>(&i)[0];
+            return asDate();
         }
 
         bool isNull() const { return secs == 0; }

--- a/src/mongo/bson/optime_test.cpp
+++ b/src/mongo/bson/optime_test.cpp
@@ -1,0 +1,34 @@
+/*    Copyright 2013 10gen Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "mongo/bson/optime.h"
+
+#include "mongo/unittest/unittest.h"
+
+namespace {
+  
+    using mongo::OpTime;
+
+    TEST(asDate, Simple) {
+        OpTime o(0xc2345678ULL);
+        ASSERT_EQUALS(o.asDate(), 0xc2345678ULL);
+    }
+
+    TEST(asLL, Simple) {
+        OpTime o(0xc2345678L);
+        ASSERT_EQUALS(o.asLL(), 0xc2345678LL);
+    }
+
+} // unnamed namespace

--- a/src/mongo/db/dbmessage.cpp
+++ b/src/mongo/db/dbmessage.cpp
@@ -65,7 +65,7 @@ namespace mongo {
         b.skip(sizeof(QueryResult));
         b.appendBuf(data, size);
         QueryResult *qr = (QueryResult *) b.buf();
-        qr->_resultFlags() = queryResultFlags;
+        qr->setResultFlags(queryResultFlags);
         qr->len = b.len();
         qr->setOperation(opReply);
         qr->cursorId = cursorId;
@@ -100,7 +100,7 @@ namespace mongo {
         QueryResult* queryResult = reinterpret_cast< QueryResult* >( bufBuilder.buf() );
         bufBuilder.decouple();
 
-        queryResult->_resultFlags() = queryResultFlags;
+        queryResult->setResultFlags( queryResultFlags );
         queryResult->len = bufBuilder.len();
         queryResult->setOperation( opReply );
         queryResult->cursorId = 0;

--- a/src/mongo/db/dbmessage.h
+++ b/src/mongo/db/dbmessage.h
@@ -89,14 +89,14 @@ namespace mongo {
         int resultFlags() {
             return dataAsInt();
         }
-        int& _resultFlags() {
-            return dataAsInt();
+        void setResultFlags(int flags) {
+            setData(flags);
         }
         void setResultFlagsToOk() {
-            _resultFlags() = ResultFlag_AwaitCapable;
+            setResultFlags(ResultFlag_AwaitCapable);
         }
         void initializeResultFlags() {
-            _resultFlags() = 0;   
+            setResultFlags(0);
         }
     };
 

--- a/src/mongo/util/net/message.h
+++ b/src/mongo/util/net/message.h
@@ -123,8 +123,18 @@ namespace mongo {
         }
         char _data[4];
 
-        int& dataAsInt() {
-            return *((int *) _data);
+        int dataAsInt() {
+            return this->_data[0] |
+            		(this->_data[1] << 8) |
+            		(this->_data[2] << 16) |
+            		(this->_data[3] << 24);
+        }
+
+        void setData(int data) {
+        	this->_data[3] = (data >> 24) & 0xff;
+        	this->_data[2] = (data >> 16) & 0xff;
+        	this->_data[1] = (data >> 8) & 0xff;
+        	this->_data[0] = data & 0xff;
         }
 
         bool valid() {

--- a/src/mongo/util/net/message_port.cpp
+++ b/src/mongo/util/net/message_port.cpp
@@ -221,7 +221,7 @@ again:
             memcpy(md, &header, headerLen);
             int left = len - headerLen;
 
-            psock->recv( (char *)&md->_data, left );
+            psock->recv( md->_data, left );
 
             guard.Dismiss();
             m.setData(md, true);

--- a/src/mongo/util/net/message_test.cpp
+++ b/src/mongo/util/net/message_test.cpp
@@ -1,0 +1,43 @@
+/*    Copyright 2013 10gen Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "mongo/util/net/message.h"
+
+#include "mongo/unittest/unittest.h"
+
+namespace {
+  
+    using mongo::MsgData;
+
+    TEST(dataAsInt, get) {
+        MsgData msg_data;
+        msg_data._data[0] = 0x01;
+        msg_data._data[1] = 0x02;
+        msg_data._data[2] = 0x03;
+        msg_data._data[3] = 0x04;
+        ASSERT_EQUALS(msg_data.dataAsInt(), 0x04030201);
+    }
+
+    TEST(dataAsInt, set) {
+        MsgData msg_data;
+        msg_data.setData(0x04030201);
+        ASSERT_EQUALS(msg_data._data[0], 0x01);
+        ASSERT_EQUALS(msg_data._data[1], 0x02);
+        ASSERT_EQUALS(msg_data._data[2], 0x03);
+        ASSERT_EQUALS(msg_data._data[3], 0x04);
+    }
+
+} // unnamed namespace
+


### PR DESCRIPTION
Fixed strict aliasing warnings and added tests for modified functions. I needed to do some refactorings to make the functions testable without friend-declarations.
Also fixed a bug in OID::MachineAndPid not-equal-operator, which compared pointers instead of memory content.
