### PR TITLE
CXX-83 Handle Windows pernicious NOMINMAX more gracefully

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -524,6 +524,7 @@ elif windows:
 
     env.Append( CPPDEFINES=[ "_UNICODE" ] )
     env.Append( CPPDEFINES=[ "UNICODE" ] )
+    env.Append( CPPDEFINES=[ "NOMINMAX" ] )
 
     # /EHsc exception handling style for visual studio
     # /W3 warning level

--- a/src/mongo/bson/bson-inl.h
+++ b/src/mongo/bson/bson-inl.h
@@ -23,12 +23,6 @@
 #include <map>
 #include <limits>
 
-
-#if defined(_WIN32)
-#undef max
-#undef min
-#endif
-
 namespace mongo {
 
     /* must be same type when called, unless both sides are #s 

--- a/src/mongo/client/redef_macros.h
+++ b/src/mongo/client/redef_macros.h
@@ -22,6 +22,17 @@
 
 #define MONGO_MACROS_PUSHED 1
 
+#if defined(_WIN32)
+#pragma push_macro("min")
+#undef min
+#pragma push_macro("max")
+#undef max
+#pragma push_macro("NOMINMAX")
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#endif
+
 // util/assert_util.h
 #pragma push_macro("verify")
 #undef verify

--- a/src/mongo/client/undef_macros.h
+++ b/src/mongo/client/undef_macros.h
@@ -21,6 +21,12 @@
 
 #ifdef MONGO_MACROS_PUSHED
 
+#if defined(_WIN32)
+#pragma pop_macro("min")
+#pragma pop_macro("max")
+#pragma pop_macro("NOMINMAX")
+#endif
+
 // util/assert_util.h
 #undef dassert
 #pragma pop_macro("dassert")

--- a/src/mongo/platform/windows_basic.h
+++ b/src/mongo/platform/windows_basic.h
@@ -53,9 +53,6 @@
 
 // for rand_s() usage:
 # define _CRT_RAND_S
-# ifndef NOMINMAX
-#  define NOMINMAX
-# endif
 
 // Do not complain that about standard library functions that Windows believes should have
 // underscores in front of them, such as unlink().


### PR DESCRIPTION
The goals here are:
- All of our translation units are compiled with NOMINMAX defined
- When included by way of bson.h or dbclient.h, our headers do not see the 'min' or 'max' macros as defined, even if they were.
- If the 'min' or 'max' macros were defined before the inclusion of our header, their state is restored after our headers have been processed
- The state of NOMINMAX is not observably altered by including our headers.

I think this accomplishes all of the above.
