### PR TITLE
CXX-81 Tag all exported free functions with calling convention macro

### DIFF
--- a/src/mongo/base/generate_error_codes.py
+++ b/src/mongo/base/generate_error_codes.py
@@ -179,21 +179,21 @@ namespace mongo {
             MaxError
         };
 
-        static std::string errorString(Error err);
+        static std::string MONGO_CLIENT_FUNC errorString(Error err);
 
         /**
          * Parses an Error from its "name".  Returns UnknownError if "name" is unrecognized.
          *
          * NOTE: Also returns UnknownError for the string "UnknownError".
          */
-        static Error fromString(const StringData& name);
+        static Error MONGO_CLIENT_FUNC fromString(const StringData& name);
 
         /**
          * Casts an integer "code" to an Error.  Unrecognized codes are preserved, meaning
          * that the result of a call to fromInt() may not be one of the values in the
          * Error enumeration.
          */
-        static Error fromInt(int code);
+        static Error MONGO_CLIENT_FUNC fromInt(int code);
 
         %(error_code_class_predicate_declarations)s;
     };

--- a/src/mongo/base/initializer.h
+++ b/src/mongo/base/initializer.h
@@ -68,17 +68,18 @@ namespace mongo {
      * This means that the few initializers that might want to terminate the program by failing
      * should probably arrange to terminate the process themselves.
      */
-    MONGO_CLIENT_API Status runGlobalInitializers(const InitializerContext::ArgumentVector& args,
-                                                  const InitializerContext::EnvironmentMap& env);
+    MONGO_CLIENT_API Status MONGO_CLIENT_FUNC runGlobalInitializers(
+        const InitializerContext::ArgumentVector& args,
+        const InitializerContext::EnvironmentMap& env);
 
-    MONGO_CLIENT_API Status runGlobalInitializers(
+    MONGO_CLIENT_API Status MONGO_CLIENT_FUNC runGlobalInitializers(
             int argc, const char* const* argv, const char* const* envp);
 
     /**
      * Same as runGlobalInitializers(), except prints a brief message to std::cerr
      * and terminates the process on failure.
      */
-    MONGO_CLIENT_API void runGlobalInitializersOrDie(
+    MONGO_CLIENT_API void MONGO_CLIENT_FUNC runGlobalInitializersOrDie(
             int argc, const char* const* argv, const char* const* envp);
 
 }  // namespace mongo

--- a/src/mongo/base/parse_number.h
+++ b/src/mongo/base/parse_number.h
@@ -43,7 +43,7 @@ namespace mongo {
      * See parse_number.cpp for the available instantiations, and add any new instantiations there.
      */
     template <typename NumberType>
-    MONGO_CLIENT_API Status parseNumberFromStringWithBase(const StringData& stringValue, int base, NumberType* result);
+    MONGO_CLIENT_API Status MONGO_CLIENT_FUNC parseNumberFromStringWithBase(const StringData& stringValue, int base, NumberType* result);
 
     template <typename NumberType>
     static Status parseNumberFromString(const StringData& stringValue, NumberType* result) {

--- a/src/mongo/base/status-inl.h
+++ b/src/mongo/base/status-inl.h
@@ -75,11 +75,11 @@ namespace mongo {
             delete error;
     }
 
-    inline bool operator==(const ErrorCodes::Error lhs, const Status& rhs) {
+    inline bool MONGO_CLIENT_FUNC operator==(const ErrorCodes::Error lhs, const Status& rhs) {
         return rhs == lhs;
     }
 
-    inline bool operator!=(const ErrorCodes::Error lhs, const Status& rhs) {
+    inline bool MONGO_CLIENT_FUNC operator!=(const ErrorCodes::Error lhs, const Status& rhs) {
         return rhs != lhs;
     }
 

--- a/src/mongo/base/status.h
+++ b/src/mongo/base/status.h
@@ -50,7 +50,7 @@ namespace mongo {
     class MONGO_CLIENT_API Status {
     public:
         // Short-hand for returning an OK status.
-        static inline Status OK();
+        static inline Status MONGO_CLIENT_FUNC OK();
 
         /**
          * Builds an error status given the error code, a textual description of what
@@ -125,20 +125,20 @@ namespace mongo {
          *
          * @param error  ErrorInfo to be incremented
          */
-        static inline void ref(ErrorInfo* error);
-        static inline void unref(ErrorInfo* error);
+        static inline void MONGO_CLIENT_FUNC ref(ErrorInfo* error);
+        static inline void MONGO_CLIENT_FUNC unref(ErrorInfo* error);
     };
 
-    MONGO_CLIENT_API inline bool operator==(const ErrorCodes::Error lhs, const Status& rhs);
+    MONGO_CLIENT_API inline bool MONGO_CLIENT_FUNC operator==(const ErrorCodes::Error lhs, const Status& rhs);
 
-    MONGO_CLIENT_API inline bool operator!=(const ErrorCodes::Error lhs, const Status& rhs);
+    MONGO_CLIENT_API inline bool MONGO_CLIENT_FUNC operator!=(const ErrorCodes::Error lhs, const Status& rhs);
 
     //
     // Convenience method for unittest code. Please use accessors otherwise.
     //
 
-    MONGO_CLIENT_API std::ostream& operator<<(std::ostream& os, const Status& status);
-    MONGO_CLIENT_API std::ostream& operator<<(std::ostream& os, ErrorCodes::Error);
+    MONGO_CLIENT_API std::ostream& MONGO_CLIENT_FUNC operator<<(std::ostream& os, const Status& status);
+    MONGO_CLIENT_API std::ostream& MONGO_CLIENT_FUNC operator<<(std::ostream& os, ErrorCodes::Error);
 
 }  // namespace mongo
 

--- a/src/mongo/bson/bsonobj.h
+++ b/src/mongo/bson/bsonobj.h
@@ -96,7 +96,7 @@ namespace mongo {
         /** Construct an empty BSONObj -- that is, {}. */
         BSONObj();
 
-        static BSONObj make( const Record* r );
+        static BSONObj MONGO_CLIENT_FUNC make( const Record* r );
 
         ~BSONObj() {
             _objdata = 0; // defensive
@@ -542,7 +542,7 @@ namespace mongo {
     /// members for Sorter
     struct SorterDeserializeSettings {}; // unused
     void serializeForSorter(BufBuilder& buf) const { buf.appendBuf(objdata(), objsize()); }
-    static BSONObj deserializeForSorter(BufReader& buf, const SorterDeserializeSettings&) {
+    static BSONObj MONGO_CLIENT_FUNC deserializeForSorter(BufReader& buf, const SorterDeserializeSettings&) {
         const int size = buf.peek<int>();
         const void* ptr = buf.skip(size);
         return BSONObj(static_cast<const char*>(ptr));

--- a/src/mongo/bson/bsonobjbuilder.h
+++ b/src/mongo/bson/bsonobjbuilder.h
@@ -620,7 +620,7 @@ namespace mongo {
 
         void appendKeys( const BSONObj& keyPattern , const BSONObj& values );
 
-        static std::string numStr( int i ) {
+        static std::string MONGO_CLIENT_FUNC numStr( int i ) {
             if (i>=0 && i<100 && numStrsReady)
                 return numStrs[i];
             StringBuilder o;

--- a/src/mongo/bson/oid.h
+++ b/src/mongo/bson/oid.h
@@ -74,7 +74,7 @@ namespace mongo {
         /** @return the random/sequential part of the object ID as 6 hex digits */
         std::string toIncString() const { return toHexLower(_inc, kIncSize); }
 
-        static OID gen() { OID o; o.init(); return o; }
+        static OID MONGO_CLIENT_FUNC gen() { OID o; o.init(); return o; }
 
         /** sets the contents to a new oid / randomized value */
         void init();
@@ -104,10 +104,10 @@ namespace mongo {
         void hash_combine(size_t &seed) const;
 
         /** call this after a fork to update the process id */
-        static void justForked();
+        static void MONGO_CLIENT_FUNC justForked();
 
-        static unsigned getMachineId(); // features command uses
-        static void regenMachineId(); // used by unit tests
+        static unsigned MONGO_CLIENT_FUNC getMachineId(); // features command uses
+        static void MONGO_CLIENT_FUNC regenMachineId(); // used by unit tests
 
     private:
         struct MachineAndPid {
@@ -139,13 +139,13 @@ namespace mongo {
             unsigned char data[kOIDSize];
         };
 
-        static void foldInPid(MachineAndPid& x);
-        static MachineAndPid genMachineAndPid();
+        static void MONGO_CLIENT_FUNC foldInPid(MachineAndPid& x);
+        static MachineAndPid MONGO_CLIENT_FUNC genMachineAndPid();
     };
 #pragma pack()
 
-    MONGO_CLIENT_API std::ostream& operator<<( std::ostream &s, const OID &o );
-    inline StringBuilder& operator<< (StringBuilder& s, const OID& o) { return (s << o.str()); }
+    MONGO_CLIENT_API std::ostream& MONGO_CLIENT_FUNC operator<<( std::ostream &s, const OID &o );
+    inline StringBuilder& MONGO_CLIENT_FUNC operator<< (StringBuilder& s, const OID& o) { return (s << o.str()); }
 
     /** Formatting mode for generating JSON from BSON.
         See <http://dochub.mongodb.org/core/mongodbextendedjson>

--- a/src/mongo/client/connpool.h
+++ b/src/mongo/client/connpool.h
@@ -271,7 +271,7 @@ namespace mongo {
         /**
          * @return total number of current instances of AScopedConnection
          */
-        static int getNumConnections() { return _numConnections; }
+        static int MONGO_CLIENT_FUNC getNumConnections() { return _numConnections; }
 
     private:
         static AtomicUInt _numConnections;
@@ -301,7 +301,7 @@ namespace mongo {
             _setSocketTimeout();
         }
 
-        static void clearPool();
+        static void MONGO_CLIENT_FUNC clearPool();
 
         ~ScopedDbConnection();
 

--- a/src/mongo/client/dbclient_rs.h
+++ b/src/mongo/client/dbclient_rs.h
@@ -150,9 +150,9 @@ namespace mongo {
          *
          * @return true if the query/cmd could potentially be sent to a secondary, false otherwise
          */
-        static bool isSecondaryQuery( const std::string& ns,
-                                      const BSONObj& queryObj,
-                                      int queryOptions );
+        static bool MONGO_CLIENT_FUNC isSecondaryQuery( const std::string& ns,
+                                                        const BSONObj& queryObj,
+                                                        int queryOptions );
 
         virtual void setRunCommandHook(DBClientWithCommands::RunCommandHookFunc func);
         virtual void setPostRunCommandHook(DBClientWithCommands::PostRunCommandHookFunc func);

--- a/src/mongo/client/dbclientinterface.h
+++ b/src/mongo/client/dbclientinterface.h
@@ -261,9 +261,9 @@ namespace mongo {
          */
         bool sameLogicalEndpoint( const ConnectionString& other ) const;
 
-        static ConnectionString parse( const std::string& url , std::string& errmsg );
+        static ConnectionString MONGO_CLIENT_FUNC parse( const std::string& url , std::string& errmsg );
 
-        static std::string typeToString( ConnectionType type );
+        static std::string MONGO_CLIENT_FUNC typeToString( ConnectionType type );
 
         //
         // Allow overriding the default connection behavior
@@ -429,7 +429,7 @@ namespace mongo {
          * @return true if this query has an orderby, hint, or some other field
          */
         bool isComplex( bool * hasDollar = 0 ) const;
-        static bool isComplex(const BSONObj& obj, bool* hasDollar = 0);
+        static bool MONGO_CLIENT_FUNC isComplex(const BSONObj& obj, bool* hasDollar = 0);
 
         BSONObj getFilter() const;
         BSONObj getSort() const;
@@ -439,7 +439,7 @@ namespace mongo {
         /**
          * @return true if the query object contains a read preference specification object.
          */
-        static bool hasReadPreference(const BSONObj& queryObj);
+        static bool MONGO_CLIENT_FUNC hasReadPreference(const BSONObj& queryObj);
 
         std::string toString() const;
         operator std::string() const { return toString(); }
@@ -517,10 +517,10 @@ namespace mongo {
 
     // Useful utilities for namespaces
     /** @return the database name portion of an ns string */
-    MONGO_CLIENT_API std::string nsGetDB( const std::string &ns );
+    MONGO_CLIENT_API std::string MONGO_CLIENT_FUNC nsGetDB( const std::string &ns );
 
     /** @return the collection name portion of an ns string */
-    MONGO_CLIENT_API std::string nsGetCollection( const std::string &ns );
+    MONGO_CLIENT_API std::string MONGO_CLIENT_FUNC nsGetCollection( const std::string &ns );
 
     /**
        interface that handles communication with the db
@@ -671,7 +671,7 @@ namespace mongo {
         */
         virtual unsigned long long count(const std::string &ns, const BSONObj& query = BSONObj(), int options=0, int limit=0, int skip=0 );
 
-        static std::string createPasswordDigest(const std::string &username, const std::string &clearTextPassword);
+        static std::string MONGO_CLIENT_FUNC createPasswordDigest(const std::string &username, const std::string &clearTextPassword);
 
         /** returns true in isMaster parm if this db is the current master
            of a replica pair.
@@ -735,7 +735,7 @@ namespace mongo {
         /** Can be called with the returned value from getLastErrorDetailed to extract an error string.
             If all you need is the string, just call getLastError() instead.
         */
-        static std::string getLastErrorString( const BSONObj& res );
+        static std::string MONGO_CLIENT_FUNC getLastErrorString( const BSONObj& res );
 
         /** Return the last error which has occurred, even if not the very last operation.
 
@@ -1300,7 +1300,7 @@ namespace mongo {
 
         virtual bool lazySupported() const { return true; }
 
-        static int getNumConnections() {
+        static int MONGO_CLIENT_FUNC getNumConnections() {
             return _numConnections;
         }
 
@@ -1316,8 +1316,8 @@ namespace mongo {
          */
         void setReplSetClientCallback(DBClientReplicaSet* rsClient);
 
-        static void setLazyKillCursor( bool lazy ) { _lazyKillCursor = lazy; }
-        static bool getLazyKillCursor() { return _lazyKillCursor; }
+        static void MONGO_CLIENT_FUNC setLazyKillCursor( bool lazy ) { _lazyKillCursor = lazy; }
+        static bool MONGO_CLIENT_FUNC getLazyKillCursor() { return _lazyKillCursor; }
 
         uint64_t getSockCreationMicroSec() const;
 
@@ -1353,12 +1353,12 @@ namespace mongo {
 
     /** pings server to check if it's up
      */
-    MONGO_CLIENT_API bool serverAlive( const std::string &uri );
+    MONGO_CLIENT_API bool MONGO_CLIENT_FUNC serverAlive( const std::string &uri );
 
-    MONGO_CLIENT_API BSONElement getErrField( const BSONObj& result );
-    MONGO_CLIENT_API bool hasErrField( const BSONObj& result );
+    MONGO_CLIENT_API BSONElement MONGO_CLIENT_FUNC getErrField( const BSONObj& result );
+    MONGO_CLIENT_API bool MONGO_CLIENT_FUNC hasErrField( const BSONObj& result );
 
-    MONGO_CLIENT_API inline std::ostream& operator<<( std::ostream &s, const Query &q ) {
+    MONGO_CLIENT_API inline std::ostream& MONGO_CLIENT_FUNC operator<<( std::ostream &s, const Query &q ) {
         return s << q.toString();
     }
 

--- a/src/mongo/client/export_macros.h
+++ b/src/mongo/client/export_macros.h
@@ -17,6 +17,19 @@
 
 #include "mongo/platform/compiler.h"
 
+#if defined(_WIN32) && (defined(__i386) || defined(_M_IX86))
+// For 32-bit windows, we need to define API calls as __cdecl. For 64 bit windows
+// the calling convention is always __fastcall. For non-windows, we don't care.
+#if defined _MSC_VER
+#define MONGO_CLIENT_FUNC __cdecl
+#else
+#error "Don't know how to declare cdecl on this system"
+#endif
+#else
+// On anything other than windows 32-bit , we don't need to bother specifying.
+#define MONGO_CLIENT_FUNC
+#endif
+
 /**
  * Definition of macros used to label the mongo client api.
  *
@@ -50,3 +63,5 @@
 #else
 #error "Must not define both LIBMONGOCLIENT_BUILDING and LIBMONGOCLIENT_CONSUMER"
 #endif
+
+

--- a/src/mongo/client/init.h
+++ b/src/mongo/client/init.h
@@ -50,7 +50,7 @@ namespace client {
      *  'runGlobalInitializers' if calling 'initialize'. If a non-OK status is returned by this
      *  function, the error should be reported and the client driver API must not be used.
      */
-    MONGO_CLIENT_API Status initialize(bool callShutdownAtExit = true);
+    MONGO_CLIENT_API Status MONGO_CLIENT_FUNC initialize(bool callShutdownAtExit = true);
 
     /**
      *  Terminates the client driver. If the driver does not terminate within the provided
@@ -60,7 +60,7 @@ namespace client {
      *  failure to terminate the driver should be reported, and it may be unsafe to exit the
      *  process by any mechanism which causes normal destruction of static objects.
      */
-    MONGO_CLIENT_API Status shutdown(int gracePeriodMillis = kDefaultShutdownGracePeriodMillis);
+    MONGO_CLIENT_API Status MONGO_CLIENT_FUNC shutdown(int gracePeriodMillis = kDefaultShutdownGracePeriodMillis);
 
 } // namespace client
 } // namespace mongo

--- a/src/mongo/client/replica_set_monitor.h
+++ b/src/mongo/client/replica_set_monitor.h
@@ -125,26 +125,26 @@ namespace mongo {
         /**
          * Creates a new ReplicaSetMonitor, if it doesn't already exist.
          */
-        static void createIfNeeded(const std::string& name , const std::set<HostAndPort>& servers);
+        static void MONGO_CLIENT_FUNC createIfNeeded(const std::string& name , const std::set<HostAndPort>& servers);
 
         /**
          * gets a cached Monitor per name. If the monitor is not found and createFromSeed is false,
          * it will return none. If createFromSeed is true, it will try to look up the last known
          * servers list for this set and will create a new monitor using that as the seed list.
          */
-        static ReplicaSetMonitorPtr get(const std::string& name, bool createFromSeed = false);
+        static ReplicaSetMonitorPtr MONGO_CLIENT_FUNC get(const std::string& name, bool createFromSeed = false);
 
         /**
          * Returns all the currently tracked replica set names.
          */
-        static std::set<std::string> getAllTrackedSets();
+        static std::set<std::string> MONGO_CLIENT_FUNC getAllTrackedSets();
 
         /**
          * Removes the ReplicaSetMonitor for the given set name from _sets, which will delete it.
          * If clearSeedCache is true, then the cached seed string for this Replica Set will be
          * removed from _seedServers.
          */
-        static void remove(const std::string& name, bool clearSeedCache = false);
+        static void MONGO_CLIENT_FUNC remove(const std::string& name, bool clearSeedCache = false);
 
         /**
          * Sets the hook to be called whenever the config of any replica set changes.
@@ -155,14 +155,14 @@ namespace mongo {
          *
          * The hook must not be changed while the program has multiple threads.
          */
-        static void setConfigChangeHook(ConfigChangeHook hook);
+        static void MONGO_CLIENT_FUNC setConfigChangeHook(ConfigChangeHook hook);
 
         /**
          * Permanently stops all monitoring on replica sets and clears all cached information
          * as well. As a consequence, NEVER call this if you have other threads that have a
          * DBClientReplicaSet instance.
          */
-        static void cleanup();
+        static void MONGO_CLIENT_FUNC cleanup();
 
         /**
          * If a ReplicaSetMonitor has been refreshed more than this many times in a row without
@@ -289,7 +289,7 @@ namespace mongo {
         /**
          * Starts a new scan over the hosts in set.
          */
-        static ScanStatePtr startNewScan(const SetState* set);
+        static ScanStatePtr MONGO_CLIENT_FUNC startNewScan(const SetState* set);
 
     private:
         /**

--- a/src/mongo/client/sasl_client_authenticate.h
+++ b/src/mongo/client/sasl_client_authenticate.h
@@ -55,8 +55,9 @@ namespace mongo {
      * rejected.  Other failures, all of which are tantamount to authentication failure, may also be
      * returned.
      */
-    extern MONGO_CLIENT_API Status (*saslClientAuthenticate)(DBClientWithCommands* client,
-                                            const BSONObj& saslParameters);
+    extern MONGO_CLIENT_API Status (MONGO_CLIENT_FUNC *saslClientAuthenticate)(
+        DBClientWithCommands* client,
+        const BSONObj& saslParameters);
 
     /**
      * Extracts the payload field from "cmdObj", and store it into "*payload".
@@ -67,7 +68,7 @@ namespace mongo {
      * stores into "*payload".  If the type is BinData, the contents are stored directly
      * into "*payload".  In all other cases, returns
      */
-    Status MONGO_CLIENT_API saslExtractPayload(const BSONObj& cmdObj, std::string* payload, BSONType* type);
+    MONGO_CLIENT_API Status MONGO_CLIENT_FUNC saslExtractPayload(const BSONObj& cmdObj, std::string* payload, BSONType* type);
 
     // Constants
 

--- a/src/mongo/db/json.h
+++ b/src/mongo/db/json.h
@@ -36,10 +36,10 @@ namespace mongo {
      * @throws MsgAssertionException if parsing fails.  The message included with
      * this assertion includes the character offset where parsing failed.
      */
-    MONGO_CLIENT_API BSONObj fromjson(const std::string& str);
+    MONGO_CLIENT_API BSONObj MONGO_CLIENT_FUNC fromjson(const std::string& str);
 
     /** @param len will be size of JSON object in text chars. */
-    MONGO_CLIENT_API BSONObj fromjson(const char* str, int* len=NULL);
+    MONGO_CLIENT_API BSONObj MONGO_CLIENT_FUNC fromjson(const char* str, int* len=NULL);
 
     /**
      * Parser class.  A BSONObj is constructed incrementally by passing a

--- a/src/mongo/logger/logger.h
+++ b/src/mongo/logger/logger.h
@@ -31,7 +31,7 @@ namespace logger {
     /**
      * Gets a global singleton instance of LogManager.
      */
-    MONGO_CLIENT_API LogManager* globalLogManager();
+    MONGO_CLIENT_API LogManager* MONGO_CLIENT_FUNC globalLogManager();
 
     /**
      * Gets the global MessageLogDomain associated for the global log manager.

--- a/src/mongo/logger/logstream_builder.h
+++ b/src/mongo/logger/logstream_builder.h
@@ -35,9 +35,9 @@ namespace logger {
      */
     class MONGO_CLIENT_API LogstreamBuilder {
     public:
-        static LogSeverity severityCast(int ll) { return LogSeverity::cast(ll); }
-        static LogSeverity severityCast(LogSeverity ls) { return ls; }
-        static LabeledLevel severityCast(const LabeledLevel &labeled) { return labeled; }
+        static LogSeverity MONGO_CLIENT_FUNC severityCast(int ll) { return LogSeverity::cast(ll); }
+        static LogSeverity MONGO_CLIENT_FUNC severityCast(LogSeverity ls) { return ls; }
+        static LabeledLevel MONGO_CLIENT_FUNC severityCast(const LabeledLevel &labeled) { return labeled; }
 
         /**
          * Construct a LogstreamBuilder that writes to "domain" on destruction.
@@ -105,11 +105,11 @@ namespace logger {
             return *this;
         }
 
-        LogstreamBuilder& operator<< (std::ostream& ( *manip )(std::ostream&)) {
+        LogstreamBuilder& operator<< (std::ostream& ( MONGO_CLIENT_FUNC *manip )(std::ostream&)) {
             stream() << manip;
             return *this;
         }
-        LogstreamBuilder& operator<< (std::ios_base& (*manip)(std::ios_base&)) {
+        LogstreamBuilder& operator<< (std::ios_base& ( MONGO_CLIENT_FUNC *manip)(std::ios_base&)) {
             stream() << manip;
             return *this;
         }

--- a/src/mongo/util/assert_util.h
+++ b/src/mongo/util/assert_util.h
@@ -74,8 +74,8 @@ namespace mongo {
     };
 
     class DBException;
-    MONGO_CLIENT_API std::string causedBy( const DBException& e );
-    MONGO_CLIENT_API std::string causedBy( const std::string& e );
+    MONGO_CLIENT_API std::string MONGO_CLIENT_FUNC causedBy( const DBException& e );
+    MONGO_CLIENT_API std::string MONGO_CLIENT_FUNC causedBy( const std::string& e );
 
     /** Most mongo exceptions inherit from this; this is commonly caught in most threads */
     class MONGO_CLIENT_API DBException : public std::exception {
@@ -93,7 +93,7 @@ namespace mongo {
         }
 
         // Utilities for the migration to Status objects
-        static ErrorCodes::Error convertExceptionCode(int exCode);
+        static ErrorCodes::Error MONGO_CLIENT_FUNC convertExceptionCode(int exCode);
 
         Status toStatus(const std::string& context) const {
             return Status(convertExceptionCode(getCode()), context + causedBy(*this));
@@ -143,40 +143,40 @@ namespace mongo {
         virtual void appendPrefix( std::stringstream& ss ) const;
     };
 
-    MONGO_CLIENT_API MONGO_COMPILER_NORETURN void verifyFailed(const char *msg, const char *file, unsigned line);
-    MONGO_CLIENT_API MONGO_COMPILER_NORETURN void invariantFailed(const char *msg, const char *file, unsigned line);
-    MONGO_CLIENT_API void wasserted(const char *msg, const char *file, unsigned line);
-    MONGO_CLIENT_API MONGO_COMPILER_NORETURN void fassertFailed( int msgid );
-    MONGO_CLIENT_API MONGO_COMPILER_NORETURN void fassertFailedWithStatus(
+    MONGO_CLIENT_API MONGO_COMPILER_NORETURN void MONGO_CLIENT_FUNC verifyFailed(const char *msg, const char *file, unsigned line);
+    MONGO_CLIENT_API MONGO_COMPILER_NORETURN void MONGO_CLIENT_FUNC invariantFailed(const char *msg, const char *file, unsigned line);
+    MONGO_CLIENT_API void MONGO_CLIENT_FUNC wasserted(const char *msg, const char *file, unsigned line);
+    MONGO_CLIENT_API MONGO_COMPILER_NORETURN void MONGO_CLIENT_FUNC fassertFailed( int msgid );
+    MONGO_CLIENT_API MONGO_COMPILER_NORETURN void MONGO_CLIENT_FUNC fassertFailedWithStatus(
             int msgid, const Status& status);
 
     /** a "user assertion".  throws UserAssertion.  logs.  typically used for errors that a user
         could cause, such as duplicate key, disk full, etc.
     */
-    MONGO_CLIENT_API MONGO_COMPILER_NORETURN void uasserted(int msgid, const char *msg);
-    MONGO_CLIENT_API MONGO_COMPILER_NORETURN void uasserted(int msgid , const std::string &msg);
+    MONGO_CLIENT_API MONGO_COMPILER_NORETURN void MONGO_CLIENT_FUNC uasserted(int msgid, const char *msg);
+    MONGO_CLIENT_API MONGO_COMPILER_NORETURN void MONGO_CLIENT_FUNC uasserted(int msgid , const std::string &msg);
 
     /** msgassert and massert are for errors that are internal but have a well defined error text
         std::string.  a stack trace is logged.
     */
-    MONGO_CLIENT_API MONGO_COMPILER_NORETURN void msgassertedNoTrace(int msgid, const char *msg);
-    MONGO_CLIENT_API MONGO_COMPILER_NORETURN void msgasserted(int msgid, const char *msg);
-    MONGO_CLIENT_API MONGO_COMPILER_NORETURN void msgasserted(int msgid, const std::string &msg);
+    MONGO_CLIENT_API MONGO_COMPILER_NORETURN void MONGO_CLIENT_FUNC msgassertedNoTrace(int msgid, const char *msg);
+    MONGO_CLIENT_API MONGO_COMPILER_NORETURN void MONGO_CLIENT_FUNC msgasserted(int msgid, const char *msg);
+    MONGO_CLIENT_API MONGO_COMPILER_NORETURN void MONGO_CLIENT_FUNC msgasserted(int msgid, const std::string &msg);
 
     /* convert various types of exceptions to strings */
-    MONGO_CLIENT_API std::string causedBy( const char* e );
-    MONGO_CLIENT_API std::string causedBy( const DBException& e );
-    MONGO_CLIENT_API std::string causedBy( const std::exception& e );
-    MONGO_CLIENT_API std::string causedBy( const std::string& e );
-    MONGO_CLIENT_API std::string causedBy( const std::string* e );
-    MONGO_CLIENT_API std::string causedBy( const Status& e );
+    MONGO_CLIENT_API std::string MONGO_CLIENT_FUNC causedBy( const char* e );
+    MONGO_CLIENT_API std::string MONGO_CLIENT_FUNC causedBy( const DBException& e );
+    MONGO_CLIENT_API std::string MONGO_CLIENT_FUNC causedBy( const std::exception& e );
+    MONGO_CLIENT_API std::string MONGO_CLIENT_FUNC causedBy( const std::string& e );
+    MONGO_CLIENT_API std::string MONGO_CLIENT_FUNC causedBy( const std::string* e );
+    MONGO_CLIENT_API std::string MONGO_CLIENT_FUNC causedBy( const Status& e );
 
     /** aborts on condition failure */
-    MONGO_CLIENT_API inline void fassert(int msgid, bool testOK) {
+    MONGO_CLIENT_API inline void MONGO_CLIENT_FUNC fassert(int msgid, bool testOK) {
         if (MONGO_unlikely(!testOK)) fassertFailed(msgid);
     }
 
-    MONGO_CLIENT_API inline void fassert(int msgid, const Status& status) {
+    MONGO_CLIENT_API inline void MONGO_CLIENT_FUNC fassert(int msgid, const Status& status) {
         if (MONGO_unlikely(!status.isOK())) {
             fassertFailedWithStatus(msgid, status);
         }
@@ -186,7 +186,7 @@ namespace mongo {
     /* "user assert".  if asserts, user did something wrong, not our code */
 #define MONGO_uassert(msgid, msg, expr) (void)( MONGO_likely(!!(expr)) || (::mongo::uasserted(msgid, msg), 0) )
 
-    MONGO_CLIENT_API inline void uassertStatusOK(const Status& status) {
+    MONGO_CLIENT_API inline void MONGO_CLIENT_FUNC uassertStatusOK(const Status& status) {
         if (MONGO_unlikely(!status.isOK())) {
             uasserted((status.location() != 0 ? status.location() : status.code()),
                       status.reason());

--- a/src/mongo/util/concurrency/thread_name.h
+++ b/src/mongo/util/concurrency/thread_name.h
@@ -31,6 +31,6 @@ namespace mongo {
      * Retrieves the name of the current thread, as previously set, or "" if no name was previously
      * set.
      */
-    MONGO_CLIENT_API const std::string& getThreadName();
+    MONGO_CLIENT_API const std::string& MONGO_CLIENT_FUNC getThreadName();
 
 }  // namespace mongo

--- a/src/mongo/util/hex.h
+++ b/src/mongo/util/hex.h
@@ -57,7 +57,7 @@ namespace mongo {
         return out.str();
     }
 
-    template <typename T> std::string MONGO_CLIENT_API integerToHex(T val);
+    template <typename T> MONGO_CLIENT_API std::string MONGO_CLIENT_FUNC integerToHex(T val);
 
     inline std::string toHexLower(const void* inRaw, int len) {
         static const char hexchars[] = "0123456789abcdef";

--- a/src/mongo/util/time_support.h
+++ b/src/mongo/util/time_support.h
@@ -48,7 +48,7 @@ namespace mongo {
 
     // uses ISO 8601 dates without trailing Z
     // colonsOk should be false when creating filenames
-    MONGO_CLIENT_API std::string terseCurrentTime(bool colonsOk=true);
+    MONGO_CLIENT_API std::string MONGO_CLIENT_FUNC terseCurrentTime(bool colonsOk=true);
 
     /**
      * Formats "time" according to the ISO 8601 extended form standard, including date,
@@ -56,7 +56,7 @@ namespace mongo {
      *
      * Sample format: "2013-07-23T18:42:14Z"
      */
-    MONGO_CLIENT_API std::string timeToISOString(time_t time);
+    MONGO_CLIENT_API std::string MONGO_CLIENT_FUNC timeToISOString(time_t time);
 
     /**
      * Formats "date" according to the ISO 8601 extended form standard, including date,
@@ -64,7 +64,7 @@ namespace mongo {
      *
      * Sample format: "2013-07-23T18:42:14.072Z"
      */
-    MONGO_CLIENT_API std::string dateToISOStringUTC(Date_t date);
+    MONGO_CLIENT_API std::string MONGO_CLIENT_FUNC dateToISOStringUTC(Date_t date);
 
     /**
      * Formats "date" according to the ISO 8601 extended form standard, including date,
@@ -72,14 +72,14 @@ namespace mongo {
      *
      * Sample format: "2013-07-23T18:42:14.072-05:00"
      */
-    MONGO_CLIENT_API std::string dateToISOStringLocal(Date_t date);
+    MONGO_CLIENT_API std::string MONGO_CLIENT_FUNC dateToISOStringLocal(Date_t date);
 
     /**
      * Formats "date" in fixed width in the local time zone.
      *
      * Sample format: "Wed Oct 31 13:34:47.996"
      */
-    MONGO_CLIENT_API std::string dateToCtimeString(Date_t date);
+    MONGO_CLIENT_API std::string MONGO_CLIENT_FUNC dateToCtimeString(Date_t date);
 
     /**
      * Parses a Date_t from an ISO 8601 string representation.
@@ -89,16 +89,16 @@ namespace mongo {
      *
      * Local times are currently not supported.
      */
-    MONGO_CLIENT_API StatusWith<Date_t> dateFromISOString(const StringData& dateString);
+    MONGO_CLIENT_API StatusWith<Date_t> MONGO_CLIENT_FUNC dateFromISOString(const StringData& dateString);
 
     boost::gregorian::date currentDate();
 
     // parses time of day in "hh:mm" format assuming 'hh' is 00-23
     bool toPointInTime( const std::string& str , boost::posix_time::ptime* timeOfDay );
 
-    MONGO_CLIENT_API void sleepsecs(int s);
-    MONGO_CLIENT_API void sleepmillis(long long ms);
-    MONGO_CLIENT_API void sleepmicros(long long micros);
+    MONGO_CLIENT_API void MONGO_CLIENT_FUNC sleepsecs(int s);
+    MONGO_CLIENT_API void MONGO_CLIENT_FUNC sleepmillis(long long ms);
+    MONGO_CLIENT_API void MONGO_CLIENT_FUNC sleepmicros(long long micros);
 
     class Backoff {
     public:
@@ -136,7 +136,7 @@ namespace mongo {
     long long getJSTimeVirtualThreadSkew();
 
     /** Date_t is milliseconds since epoch */
-    MONGO_CLIENT_API Date_t jsTime();
+    MONGO_CLIENT_API Date_t MONGO_CLIENT_FUNC jsTime();
 
     /** warning this will wrap */
     unsigned curTimeMicros();


### PR DESCRIPTION
OK, this tags all exported free functions and static members of exported classes as being explicitly __cdecl. This should protect against consumers changing the default with http://msdn.microsoft.com/en-us/library/46t77ak2.aspx, since it explicitly does not affect member functions.

I was only sort of able to test this without building my own boost with an alternate calling convention from source, but I was able to get it so that if I built the shared library client examples with /Gr, switching the default to __fastcall, that there were no unresolved symbols from the mongo environment, as there would be if we had not tagged the functions correctly.

Obviously this only verifies the functions that were actually consumed by the client tests, but it is a start.
