### PR TITLE
CXX-218 Added GridFileBuilder for stream-like GridFile writing in GridFS

### DIFF
--- a/src/mongo/unittest/gridfs_test.cpp
+++ b/src/mongo/unittest/gridfs_test.cpp
@@ -13,6 +13,7 @@
  *    limitations under the License.
  */
 
+#include <algorithm>
 #include <fstream>
 #include <sstream>
 #include <string>
@@ -24,6 +25,7 @@ using boost::scoped_ptr;
 using std::auto_ptr;
 using std::ios;
 using std::ifstream;
+using std::min;
 using std::string;
 using std::stringstream;
 
@@ -223,4 +225,24 @@ namespace {
         );
         ASSERT_EQUALS(files_bad->itcount(), 0);
     }
+
+    TEST_F(GridFSTest, GridFileBuilder) {
+        GridFileBuilder gfb(_gfs.get());
+        for (int i=0; i<DATA_LEN; i+=2)
+            gfb.appendChunk(DATA + i, min(2, DATA_LEN - i));
+        gfb.buildFile(DATA_NAME);
+        GridFile gf = _gfs->findFile(DATA_NAME);
+        ASSERT_EQUALS(gf.getNumChunks(), 1);
+    }
+
+    TEST_F(GridFSTest, GridFileBuilderMultipleChunks) {
+        _gfs->setChunkSize(1);
+        GridFileBuilder gfb(_gfs.get());
+        for (int i=0; i<DATA_LEN; i+=2)
+            gfb.appendChunk(DATA + i, min(2, DATA_LEN - i));
+        gfb.buildFile(DATA_NAME);
+        GridFile gf = _gfs->findFile(DATA_NAME);
+        ASSERT_EQUALS(gf.getNumChunks(), DATA_LEN);
+    }
+
 } // namespace


### PR DESCRIPTION
The basic API of the new class will be:
- GridFileBuilder(GridFS *grid) => the constructor takes the GridFS pointer and annotates the chunkSize which couldn't be changed. The GridFileBuilder will need to access GridFS pointer as a friend, because it needs to access to chunkNS and _client properties.
- void appendChunk(const char *data, size_t length) => appends the given string of data, which would splitted in several chunks or annotated in the auxiliary buffer. Auxiliary buffer data will be stored at GridFS when it arrives to chunkSize length.
- BSONObj buildFile(string name, string contentType) => inserts the new file in GridFS using the method insertFile. If the auxiliary buffer contains data, it will be stored before to call insertFile.

A simple use case is when you need to write a large amount of generated data (not stored in your filesystem disk), and you don't want to store it in temporary disk files.
