### PR TITLE
CXX-230 Windows MCI integration fixups

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -187,6 +187,10 @@ add_option( "libpath", "Library path if you have libraries in a nonstandard dire
 add_option( "extrapath", "comma separated list of add'l paths  (--extrapath /opt/foo/,/foo) static linking" , 1 , False )
 add_option( "extralib", "comma separated list of libraries  (--extralib js_static,readline" , 1 , False )
 
+if windows:
+    add_option( "dllpath", "semicolon separated list of dirs to append to PATH to find DLLs at runtime",
+                1, False)
+
 add_option( "ssl" , "Enable SSL" , 0 , True )
 
 # library choices
@@ -349,6 +353,11 @@ if "sunos5" == os.sys.platform:
 
 if has_option("propagate-shell-environment"):
     env['ENV'] = dict(os.environ);
+
+if windows and has_option("dllpath"):
+    new_components = env.Dir(get_option("dllpath").split(";"))
+    for nc in new_components:
+        env.AppendENVPath('PATH', nc, delete_existing=0)
 
 if has_option('build-fast-and-loose'):
     # See http://www.scons.org/wiki/GoFastButton for details

--- a/src/SConscript.client
+++ b/src/SConscript.client
@@ -302,9 +302,9 @@ mongoClientStaticLib = staticLibEnv.StaticLibrary(
 
 mongoClientPrefixInstalls.append(libEnv.Install("$INSTALL_DIR/lib", mongoClientStaticLib))
 
-# Other things like tests need to link against this library,
-# so export it so it can be named.
-Export({'libMongoclientStatic' : mongoClientStaticLib})
+# Other things like tests need to link against the static library (and the deps of that static
+# lib) so export it so it can be easily referenced.
+Export({'mongoClientStaticLibs' : [mongoClientStaticLib] + mongoClientLibs})
 
 mongoClientSharedLib = None
 
@@ -370,7 +370,7 @@ limit_cpppath=[p for p in libEnv['CPPPATH']
 installationTestEnv = libEnv.Clone(
     CPPPATH=["$INSTALL_DIR/include"] + limit_cpppath,
     LIBPATH=["$INSTALL_DIR/lib"],
-    CPPDEFINES=[],
+    CPPDEFINES=['STATIC_LIBMONGOCLIENT'],
 )
 
 include_dbclienth_test_file = 'mongo/client/include_dbclienth_test.cpp'
@@ -402,6 +402,9 @@ if windows:
     staticClientEnv.PrependUnique(LIBPATH=['$VARIANT_DIR'])
 else:
     staticClientEnv.PrependUnique(LIBS=[mongoClientStaticLib])
+
+# Pull in the libs that the static client depends on.
+staticClientEnv.AppendUnique(LIBS=mongoClientLibs)
 
 staticClientEnv.AppendUnique(CPPDEFINES=['STATIC_LIBMONGOCLIENT'])
 

--- a/src/mongo/SConscript
+++ b/src/mongo/SConscript
@@ -1,13 +1,12 @@
-Import('env windows libMongoclientStatic libGTestStatic')
+Import('env windows mongoClientStaticLibs libGTestStatic')
 
 staticClientEnv = env.Clone()
 staticClientEnv.PrependUnique(
     CPPDEFINES=[
         'STATIC_LIBMONGOCLIENT'
     ],
-    LIBS=[
-        libMongoclientStatic
-    ])
+    LIBS=mongoClientStaticLibs,
+)
 
 libMock = staticClientEnv.StaticLibrary(
     target='mocklib',

--- a/src/mongo/util/net/ssl_manager.cpp
+++ b/src/mongo/util/net/ssl_manager.cpp
@@ -26,6 +26,7 @@
 #include "mongo/platform/atomic_word.h"
 #include "mongo/client/options.h"
 #include "mongo/util/concurrency/mutex.h"
+#include "mongo/util/debug_util.h"
 #include "mongo/util/log.h"
 #include "mongo/util/mongoutils/str.h"
 #include "mongo/util/net/sock.h"


### PR DESCRIPTION
- Add ability to specify dll search path on windows (amends PATH inside scons)
- Export all libs required to link static mongo library
- Include check-install headers with static mode defined so as not to trip #error
- Add missing debug_util.h header to ssl_manager, needed for strcasecmp on windows
