### PR TITLE
CXX-164 Become agnostic about boost thread version

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1336,7 +1336,11 @@ def doConfigure(myenv):
                 print( "can't find boost")
                 Exit(1)
 
-    conf.env.Append(CPPDEFINES=[("BOOST_THREAD_VERSION", "2")])
+    # We need xtime internally no matter what the local boost thread version may be since we
+    # cannot require the existence of chrono. It is important that no uses of xtime become part
+    # of the public interface of the library so that we do not impose this burden on our
+    # consumers.
+    conf.env.Append(CPPDEFINES=[("BOOST_THREAD_USES_DATETIME")])
 
     if conf.CheckHeader('unistd.h'):
         conf.env['MONGO_HAVE_HEADER_UNISTD_H'] = True

--- a/src/SConscript.client
+++ b/src/SConscript.client
@@ -246,7 +246,6 @@ clientHeaders = [
     'mongo/util/assert_util.h',
     'mongo/util/background.h',
     'mongo/util/bufreader.h',
-    'mongo/util/concurrency/mutex.h',
     'mongo/util/concurrency/thread_name.h',
     'mongo/util/debug_util.h',
     'mongo/util/goodies.h',

--- a/src/mongo/bson/optime.h
+++ b/src/mongo/bson/optime.h
@@ -16,11 +16,12 @@
 #pragma once
 
 #include <boost/thread/condition.hpp>
+#include <boost/thread/mutex.hpp>
+
 #include <iostream>
 #include <sstream>
 
 #include "mongo/util/assert_util.h"
-#include "mongo/util/concurrency/mutex.h"
 #include "mongo/util/time_support.h"
 
 namespace mongo {

--- a/src/mongo/client/dbclient.cpp
+++ b/src/mongo/client/dbclient.cpp
@@ -144,7 +144,7 @@ namespace mongo {
         case CUSTOM: {
 
             // Lock in case other things are modifying this at the same time
-            boost::mutex::scoped_lock lk( _connectHookMutex );
+            boost::lock_guard<boost::mutex> lk( _connectHookMutex );
 
             // Allow the replacement of connections with other connections - useful for testing.
 
@@ -1552,7 +1552,7 @@ namespace mongo {
     static SSLManagerInterface* s_sslMgr(NULL);
 
     SSLManagerInterface* DBClientConnection::sslManager() {
-        boost::mutex::scoped_lock lk(s_mtx);
+        boost::lock_guard<boost::mutex> lk(s_mtx);
         if (s_sslMgr) 
             return s_sslMgr;
         s_sslMgr = getSSLManager();

--- a/src/mongo/client/dbclientinterface.h
+++ b/src/mongo/client/dbclientinterface.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <boost/thread/locks.hpp>
+
 #include "mongo/config.h"
 
 #include "mongo/base/string_data.h"
@@ -257,12 +259,12 @@ namespace mongo {
         };
 
         static void setConnectionHook( ConnectionHook* hook ){
-            boost::mutex::scoped_lock lk( _connectHookMutex );
+            boost::lock_guard<boost::mutex> lk( _connectHookMutex );
             _connectHook = hook;
         }
 
         static ConnectionHook* getConnectionHook() {
-            boost::mutex::scoped_lock lk( _connectHookMutex );
+            boost::lock_guard<boost::mutex> lk( _connectHookMutex );
             return _connectHook;
         }
 

--- a/src/mongo/client/replica_set_monitor_internal.h
+++ b/src/mongo/client/replica_set_monitor_internal.h
@@ -21,10 +21,11 @@
 
 #pragma once
 
+#include <boost/thread/condition_variable.hpp>
 #include <deque>
+#include <set>
 #include <string>
 #include <vector>
-#include <set>
 
 #include "mongo/base/disallow_copying.h"
 #include "mongo/client/dbclient_rs.h" // for TagSet and ReadPreferenceSettings

--- a/src/mongo/client/sasl_client_session.cpp
+++ b/src/mongo/client/sasl_client_session.cpp
@@ -15,9 +15,10 @@
 
 #include "mongo/client/sasl_client_session.h"
 
+#include <boost/thread/mutex.hpp>
+
 #include "mongo/base/init.h"
 #include "mongo/util/assert_util.h"
-#include "mongo/util/concurrency/mutex.h"
 #include "mongo/util/mongoutils/str.h"
 
 namespace mongo {

--- a/src/mongo/client/scoped_db_conn_test.cpp
+++ b/src/mongo/client/scoped_db_conn_test.cpp
@@ -267,7 +267,7 @@ namespace mongo {
             }
 
             bool is_running() {
-                boost::mutex::scoped_lock lock(_mutex);
+                boost::lock_guard<boost::mutex> lock(_mutex);
                 return _running;
             }
 
@@ -300,7 +300,7 @@ namespace mongo {
             }
 
             void stop() {
-                boost::mutex::scoped_lock lock(_mutex);
+                boost::lock_guard<boost::mutex> lock(_mutex);
                 _running = false;
             }
 

--- a/src/mongo/dbtests/mock/mock_conn_registry.cpp
+++ b/src/mongo/dbtests/mock/mock_conn_registry.cpp
@@ -47,7 +47,7 @@ namespace mongo {
     }
 
     void MockConnRegistry::addServer(MockRemoteDBServer* server) {
-        boost::mutex::scoped_lock sl(_registryMutex);
+        boost::lock_guard<boost::mutex> sl(_registryMutex);
 
         const std::string hostName(server->getServerAddress());
         fassert(16533, _registry.count(hostName) == 0);
@@ -56,17 +56,17 @@ namespace mongo {
     }
 
     bool MockConnRegistry::removeServer(const std::string& hostName) {
-        boost::mutex::scoped_lock sl(_registryMutex);
+        boost::lock_guard<boost::mutex> sl(_registryMutex);
         return _registry.erase(hostName) == 1;
     }
 
     void MockConnRegistry::clear() {
-        boost::mutex::scoped_lock sl(_registryMutex);
+        boost::lock_guard<boost::mutex> sl(_registryMutex);
         _registry.clear();
     }
 
     MockDBClientConnection* MockConnRegistry::connect(const std::string& connStr) {
-        boost::mutex::scoped_lock sl(_registryMutex);
+        boost::lock_guard<boost::mutex> sl(_registryMutex);
         fassert(16534, _registry.count(connStr) == 1);
         return new MockDBClientConnection(_registry[connStr], true);
     }

--- a/src/mongo/dbtests/mock/mock_conn_registry.h
+++ b/src/mongo/dbtests/mock/mock_conn_registry.h
@@ -15,12 +15,13 @@
 
 #pragma once
 
+#include <boost/thread/mutex.hpp>
+
 #include "mongo/base/status.h"
 #include "mongo/client/dbclientinterface.h"
 #include "mongo/dbtests/mock/mock_dbclient_connection.h"
 #include "mongo/dbtests/mock/mock_remote_db_server.h"
 #include "mongo/platform/unordered_map.h"
-#include "mongo/util/concurrency/mutex.h"
 
 namespace mongo {
     /**

--- a/src/mongo/dbtests/mock/mock_remote_db_server.cpp
+++ b/src/mongo/dbtests/mock/mock_remote_db_server.cpp
@@ -63,28 +63,28 @@ namespace mongo {
     }
 
     void MockRemoteDBServer::setDelay(long long milliSec) {
-        boost::mutex::scoped_lock sLock(_lock);
+        boost::lock_guard<boost::mutex> sLock(_lock);
         _delayMilliSec = milliSec;
     }
 
     void MockRemoteDBServer::shutdown() {
-        boost::mutex::scoped_lock sLock(_lock);
+        boost::lock_guard<boost::mutex> sLock(_lock);
         _isRunning = false;
     }
 
     void MockRemoteDBServer::reboot() {
-        boost::mutex::scoped_lock sLock(_lock);
+        boost::lock_guard<boost::mutex> sLock(_lock);
         _isRunning = true;
         _instanceID++;
     }
 
     MockRemoteDBServer::InstanceID MockRemoteDBServer::getInstanceID() const {
-        boost::mutex::scoped_lock sLock(_lock);
+        boost::lock_guard<boost::mutex> sLock(_lock);
         return _instanceID;
     }
 
     bool MockRemoteDBServer::isRunning() const {
-        boost::mutex::scoped_lock sLock(_lock);
+        boost::lock_guard<boost::mutex> sLock(_lock);
         return _isRunning;
     }
 
@@ -97,19 +97,19 @@ namespace mongo {
 
     void MockRemoteDBServer::setCommandReply(const string& cmdName,
             const vector<BSONObj>& replySequence) {
-        boost::mutex::scoped_lock sLock(_lock);
+        boost::lock_guard<boost::mutex> sLock(_lock);
         _cmdMap[cmdName].reset(new CircularBSONIterator(replySequence));
     }
 
     void MockRemoteDBServer::insert(const string &ns, BSONObj obj, int flags) {
-        boost::mutex::scoped_lock sLock(_lock);
+        boost::lock_guard<boost::mutex> sLock(_lock);
 
         vector<BSONObj>& mockCollection = _dataMgr[ns];
         mockCollection.push_back(obj.copy());
     }
 
     void MockRemoteDBServer::remove(const string& ns, Query query, int flags) {
-        boost::mutex::scoped_lock sLock(_lock);
+        boost::lock_guard<boost::mutex> sLock(_lock);
         if (_dataMgr.count(ns) == 0) {
             return;
         }
@@ -143,7 +143,7 @@ namespace mongo {
                 _cmdMap.count(cmdName) == 1);
 
         {
-            boost::mutex::scoped_lock sLock(_lock);
+            boost::lock_guard<boost::mutex> sLock(_lock);
             info = _cmdMap[cmdName]->next();
         }
 
@@ -153,7 +153,7 @@ namespace mongo {
 
         checkIfUp(id);
 
-        boost::mutex::scoped_lock sLock(_lock);
+        boost::lock_guard<boost::mutex> sLock(_lock);
         _cmdCount++;
         return info["ok"].trueValue();
     }
@@ -177,7 +177,7 @@ namespace mongo {
 
         checkIfUp(id);
 
-        boost::mutex::scoped_lock sLock(_lock);
+        boost::lock_guard<boost::mutex> sLock(_lock);
         _queryCount++;
 
         const vector<BSONObj>& coll = _dataMgr[ns];
@@ -201,17 +201,17 @@ namespace mongo {
     }
 
     size_t MockRemoteDBServer::getCmdCount() const {
-        boost::mutex::scoped_lock sLock(_lock);
+        boost::lock_guard<boost::mutex> sLock(_lock);
         return _cmdCount;
     }
 
     size_t MockRemoteDBServer::getQueryCount() const {
-        boost::mutex::scoped_lock sLock(_lock);
+        boost::lock_guard<boost::mutex> sLock(_lock);
         return _queryCount;
     }
 
     void MockRemoteDBServer::clearCounters() {
-        boost::mutex::scoped_lock sLock(_lock);
+        boost::lock_guard<boost::mutex> sLock(_lock);
         _cmdCount = 0;
         _queryCount = 0;
     }
@@ -225,7 +225,7 @@ namespace mongo {
     }
 
     void MockRemoteDBServer::checkIfUp(InstanceID id) const {
-        boost::mutex::scoped_lock sLock(_lock);
+        boost::lock_guard<boost::mutex> sLock(_lock);
 
         if (!_isRunning || id < _instanceID) {
             throw mongo::SocketException(mongo::SocketException::CLOSED, _hostAndPort);

--- a/src/mongo/dbtests/mock/mock_remote_db_server.h
+++ b/src/mongo/dbtests/mock/mock_remote_db_server.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <boost/shared_ptr.hpp>
+#include <boost/thread/mutex.hpp>
 #include <string>
 #include <vector>
 
@@ -23,7 +24,6 @@
 #include "mongo/bson/bsonobjbuilder.h"
 #include "mongo/client/dbclientinterface.h"
 #include "mongo/platform/unordered_map.h"
-#include "mongo/util/concurrency/mutex.h"
 
 namespace mongo {
 

--- a/src/mongo/util/concurrency/mutex.h
+++ b/src/mongo/util/concurrency/mutex.h
@@ -17,8 +17,7 @@
 
 #pragma once
 
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/xtime.hpp>
+#include <boost/noncopyable.hpp>
 
 #include "mongo/util/time_support.h"
 

--- a/src/mongo/util/concurrency/synchronization.h
+++ b/src/mongo/util/concurrency/synchronization.h
@@ -17,8 +17,9 @@
 
 #pragma once
 
-#include <boost/thread/condition.hpp>
-#include "mutex.h"
+#include <boost/noncopyable.hpp>
+#include <boost/thread/condition_variable.hpp>
+#include <boost/thread/mutex.hpp>
 
 namespace mongo {
 
@@ -46,7 +47,7 @@ namespace mongo {
         boost::mutex _mutex;          // protects state below
         unsigned long long lookFor;
         unsigned long long cur;
-        boost::condition _condition;  // cond over _notified being true
+        boost::condition_variable _condition;  // cond over _notified being true
     };
 
     /** establishes a synchronization point between threads. N threads are waits and one is notifier.
@@ -76,7 +77,7 @@ namespace mongo {
 
     private:
         boost::mutex _mutex;
-        boost::condition _condition;
+        boost::condition_variable _condition;
         When _lastDone;
         When _lastReturned;
         unsigned _nWaiting;

--- a/src/mongo/util/fail_point.cpp
+++ b/src/mongo/util/fail_point.cpp
@@ -15,6 +15,8 @@
 
 #include "mongo/util/fail_point.h"
 
+#include <boost/thread/locks.hpp>
+
 #include "mongo/util/mongoutils/str.h"
 #include "mongo/util/time_support.h"
 
@@ -44,7 +46,7 @@ namespace mongo {
          * 3. Sets the new mode.
          */
 
-        boost::mutex::scoped_lock scoped(_modMutex);
+        boost::lock_guard<boost::mutex> scoped(_modMutex);
 
         // Step 1
         disableFailPoint();
@@ -134,7 +136,7 @@ namespace mongo {
     BSONObj FailPoint::toBSON() const {
         BSONObjBuilder builder;
 
-        boost::mutex::scoped_lock scoped(_modMutex);
+        boost::lock_guard<boost::mutex> scoped(_modMutex);
         builder.append("mode", _mode);
         builder.append("data", _data);
 

--- a/src/mongo/util/fail_point.h
+++ b/src/mongo/util/fail_point.h
@@ -15,10 +15,11 @@
 
 #pragma once
 
+#include <boost/thread/mutex.hpp>
+
 #include "mongo/base/disallow_copying.h"
 #include "mongo/db/jsobj.h"
 #include "mongo/platform/atomic_word.h"
-#include "mongo/util/concurrency/mutex.h"
 
 namespace mongo {
     /**

--- a/src/mongo/util/net/message_port.cpp
+++ b/src/mongo/util/net/message_port.cpp
@@ -19,6 +19,7 @@
 
 #include "mongo/util/net/message_port.h"
 
+#include <boost/thread/locks.hpp>
 #include <boost/thread/mutex.hpp>
 #include <fcntl.h>
 #include <set>
@@ -106,7 +107,7 @@ namespace mongo {
     public:
         Ports() : ports(), m() {}
         void closeAll(unsigned skip_mask) {
-            boost::mutex::scoped_lock bl(m);
+            boost::lock_guard<boost::mutex> bl(m);
             for ( set<MessagingPort*>::iterator i = ports.begin(); i != ports.end(); i++ ) {
                 if( (*i)->tag & skip_mask )
                     continue;
@@ -114,11 +115,11 @@ namespace mongo {
             }
         }
         void insert(MessagingPort* p) {
-            boost::mutex::scoped_lock bl(m);
+            boost::lock_guard<boost::mutex> bl(m);
             ports.insert(p);
         }
         void erase(MessagingPort* p) {
-            boost::mutex::scoped_lock bl(m);
+            boost::lock_guard<boost::mutex> bl(m);
             ports.erase(p);
         }
     };

--- a/src/mongo/util/net/sock_test.cpp
+++ b/src/mongo/util/net/sock_test.cpp
@@ -142,16 +142,19 @@ namespace {
             stdx::bind(&detail::awaitConnect, &connectSock, *connectRes, boost::ref(connected)));
 
         connected.waitToBeNotified();
+        connected.join();
         if (connectSock == INVALID_SOCKET) {
             closesocket(listenSock);
             ::freeaddrinfo(res);
             ::freeaddrinfo(connectRes);
             closesocket(acceptSock);
             closesocket(connectSock);
+            accepted.join();
             return SocketPair();
         }
 
         accepted.waitToBeNotified();
+        accepted.join();
         if (acceptSock == INVALID_SOCKET) {
             closesocket(listenSock);
             ::freeaddrinfo(res);

--- a/src/mongo/util/net/ssl_manager.cpp
+++ b/src/mongo/util/net/ssl_manager.cpp
@@ -17,6 +17,8 @@
 
 #include "mongo/util/net/ssl_manager.h"
 
+#include <boost/thread/locks.hpp>
+#include <boost/thread/mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>
 #include <boost/thread/tss.hpp>
 #include <string>
@@ -25,7 +27,6 @@
 #include "mongo/base/init.h"
 #include "mongo/platform/atomic_word.h"
 #include "mongo/client/options.h"
-#include "mongo/util/concurrency/mutex.h"
 #include "mongo/util/debug_util.h"
 #include "mongo/util/log.h"
 #include "mongo/util/mongoutils/str.h"
@@ -286,7 +287,7 @@ namespace mongo {
 
         const client::Options& options = client::Options::current();
 
-        boost::mutex::scoped_lock lck(sslManagerMtx);
+        boost::lock_guard<boost::mutex> lck(sslManagerMtx);
         if (options.SSLEnabled()) {
             const Params params(
                 options.SSLPEMKeyFile(),
@@ -304,7 +305,7 @@ namespace mongo {
     }
 
     SSLManagerInterface* getSSLManager() {
-        boost::mutex::scoped_lock lck(sslManagerMtx);
+        boost::lock_guard<boost::mutex> lck(sslManagerMtx);
         if (theSSLManager)
             return theSSLManager;
         return NULL;

--- a/src/mongo/util/time_support.cpp
+++ b/src/mongo/util/time_support.cpp
@@ -31,7 +31,7 @@
 
 #ifdef _WIN32
 #include <boost/date_time/filetime_functions.hpp>
-#include "mongo/util/concurrency/mutex.h"
+#include <boost/thread/mutex.hpp>
 #include "mongo/util/timer.h"
 
 // NOTE(schwerin): MSVC's _snprintf is not a drop-in replacement for C99's snprintf().  In
@@ -892,7 +892,7 @@ namespace {
     static boost::mutex _curTimeMicros64ResyncMutex;
 
     static unsigned long long resyncTime() {
-        boost::mutex::scoped_lock lkResync(_curTimeMicros64ResyncMutex);
+        boost::lock_guard<boost::mutex> lkResync(_curTimeMicros64ResyncMutex);
         unsigned long long ftOld;
         unsigned long long ftNew;
         ftOld = ftNew = getFiletime();
@@ -904,7 +904,7 @@ namespace {
 
         // Make sure that we use consistent values for baseFiletime and basePerfCounter.
         //
-        boost::mutex::scoped_lock lkRead(_curTimeMicros64ReadMutex);
+        boost::lock_guard<boost::mutex> lkRead(_curTimeMicros64ReadMutex);
         baseFiletime = ftNew;
         basePerfCounter = newPerfCounter;
         resyncInterval = 60 * Timer::_countsPerSecond;
@@ -928,7 +928,7 @@ namespace {
 
         // Make sure that we use consistent values for baseFiletime and basePerfCounter.
         //
-        boost::mutex::scoped_lock lkRead(_curTimeMicros64ReadMutex);
+        boost::lock_guard<boost::mutex> lkRead(_curTimeMicros64ReadMutex);
 
         // Compute the current time in FILETIME format by adding our base FILETIME and an offset
         // from that time based on QueryPerformanceCounter.  The math is (logically) to compute the

--- a/src/mongo/util/time_support.h
+++ b/src/mongo/util/time_support.h
@@ -20,6 +20,8 @@
 #include <iosfwd>
 #include <ctime>
 #include <string>
+#include <boost/date_time/gregorian/gregorian.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/thread/xtime.hpp>
 #include <boost/version.hpp>
 


### PR DESCRIPTION
This lets our users have whatever BOOST_THREAD_VERSION they like when consuming the library, and also lets us work with the newer semantics (so, in principle we can bump along to BOOST_THREAD_VERSION 3 when building, if we felt the need). This change does three things:
- Switches to using forward compatible names for things (condition to condition_variable, uses lock_guard and unique_lock instead of mutex::scoped_lock, etc.)
- Adds calls to detach/join where needed.
- Removes xtime from the public API (I think)
- Removes mutex.h from the set of public headers.

Please have a look at the behavior changes, not just the renamings.
