### PR TITLE
CXX-188 Add parallel scan helper

### DIFF
--- a/src/mongo/client/dbclientinterface.h
+++ b/src/mongo/client/dbclientinterface.h
@@ -1220,6 +1220,32 @@ namespace mongo {
         virtual std::auto_ptr<DBClientCursor> query(const std::string &ns, Query query, int nToReturn = 0, int nToSkip = 0,
                                                     const BSONObj *fieldsToReturn = 0, int queryOptions = 0 , int batchSize = 0 );
 
+        /**
+         * Returns a list of up to 'numCursors' cursors that can be iterated concurrently.
+         *
+         * As long as the collection is not modified during scanning, each document appears once
+         * in one of the cursors' result sets.
+         *
+         * @note Warning: One must delete the cursors after use.
+         * @note Warning: One must delete any new connections created by the connection factory
+         *  after use.
+         *
+         * @see example usage in dbclient_test.cpp -> DBClientTest/ParallelCollectionScan
+         *
+         * @param ns The namespace to scan
+         * @param numCursors Number of cursors to return. You may get back less than you asked for.
+         * @param cursors Output vector to hold cursors created for this scan.
+         * @param connectionFactory Function that returns a pointer to a DBClientBase for use by
+         *  newly created cursors. The function takes zero parameters but additional parameters
+         *  may be bound (if required) using std::bind. See the example listed above for more info.
+         */
+        virtual void parallelScan(
+            const StringData& ns,
+            int numCursors,
+            std::vector<DBClientCursor*>* cursors,
+            stdx::function<DBClientBase* ()> connectionFactory
+        );
+
         virtual std::auto_ptr<DBClientCursor> aggregate(const std::string& ns,
                                                         const BSONObj& pipeline,
                                                         const BSONObj* aggregateOptions = NULL,


### PR DESCRIPTION
I have some comments in the code but essentially the implementation works as follows:
- The connection used to call the parallel scan method is used to initiate the scan by sending the `parallelCollectionScan` command to the server.
- The method then checks out/creates new connections for each cursorId returned and constructs a cursor using those connections for use by the caller.
- The additional connections are retrieved from the connection pool using the same hostname and socketTimeout as the connection that was used to invoke the method.
- The caller is responsible for cleaning up the Cursors after consuming their results.
- In a Cursor's destructor it checks the connection it used back into the pool for future use.
