### PR TITLE
CXX-191 add optional extra parameter support to createCollection

### DIFF
--- a/src/mongo/client/dbclient.cpp
+++ b/src/mongo/client/dbclient.cpp
@@ -723,7 +723,24 @@ namespace mongo {
         return ok;
     }
 
-    bool DBClientWithCommands::createCollection(const string &ns, long long size, bool capped, int max, BSONObj *info) {
+    bool DBClientWithCommands::createCollection(
+        const string &ns,
+        long long size,
+        bool capped,
+        int max,
+        BSONObj *info
+    ) {
+        return createCollectionWithOptions(ns, size, capped, max, BSONObj(), info);
+    }
+
+    bool DBClientWithCommands::createCollectionWithOptions(
+        const string &ns,
+        long long size,
+        bool capped,
+        int max,
+        const BSONObj& extra,
+        BSONObj *info
+    ) {
         verify(!capped||size);
         BSONObj o;
         if ( info == 0 )    info = &o;
@@ -733,6 +750,7 @@ namespace mongo {
         if ( size ) b.append("size", size);
         if ( capped ) b.append("capped", true);
         if ( max ) b.append("max", max);
+        if ( !extra.isEmpty() ) b.appendElements(extra);
         return runCommand(db.c_str(), b.done(), *info);
     }
 

--- a/src/mongo/client/dbclientinterface.h
+++ b/src/mongo/client/dbclientinterface.h
@@ -682,9 +682,40 @@ namespace mongo {
            @param capped if true, this is a fixed size collection (where old data rolls out).
            @param max    maximum number of objects if capped (optional).
 
-           returns true if successful.
+           @return true if successful.
         */
-        bool createCollection(const std::string &ns, long long size = 0, bool capped = false, int max = 0, BSONObj *info = 0);
+        bool createCollection(
+            const std::string &ns,
+            long long size = 0,
+            bool capped = false,
+            int max = 0,
+            BSONObj *info = 0
+        );
+
+        /**
+         * Creates a new collection in the database. Allows for a user to provide a BSONObj that
+         * contains extra options.
+         *
+         * @param extraOptions Add extra parameters to the create collection command for features
+         *  that are version specific or for which default values have flipped between server
+         *  releases. Some examples are "usePowerOf2Sizes" and "autoIndexId".
+         *
+         * @warning Options set in extraOptions which shadow those passed in as parameters will
+         *  have indeterminate behavior.
+         *
+         * @see the form of createCollection with less parameters above.
+         *
+         * @see http://docs.mongodb.org/manual/reference/command/create/#dbcmd.create for available
+         * options.
+         */
+        bool createCollectionWithOptions(
+            const std::string &ns,
+            long long size = 0,
+            bool capped = false,
+            int max = 0,
+            const BSONObj& extraOptions = BSONObj(),
+            BSONObj *info = 0
+        );
 
         /** Get error result from the last write operation (insert/update/delete) on this connection.
             db doesn't change the command's behavior - it is just for auth checks.

--- a/src/mongo/unittest/dbclient_test.cpp
+++ b/src/mongo/unittest/dbclient_test.cpp
@@ -898,6 +898,27 @@ namespace {
         ASSERT_TRUE(c.createCollection(TEST_NS));
         ASSERT_FALSE(c.createCollection(TEST_NS));
         ASSERT_TRUE(c.exists(TEST_NS));
+
+        BSONObj info;
+        ASSERT_TRUE(c.runCommand(TEST_DB, BSON("collstats" << TEST_COLL), info));
+
+        bool server26plus = serverGTE(&c, 2, 6);
+
+        ASSERT_EQUALS(info.getIntField("userFlags"), server26plus ? 1 : 0);
+        ASSERT_EQUALS(info.getIntField("nindexes"), 1);
+    }
+
+    TEST_F(DBClientTest, CreateCollectionAdvanced) {
+        BSONObjBuilder opts;
+        opts.append("usePowerOf2Sizes", 0);
+        opts.append("autoIndexId", false);
+        c.createCollectionWithOptions(TEST_NS, 1, true, 1, opts.obj());
+
+        BSONObj info;
+        ASSERT_TRUE(c.runCommand(TEST_DB, BSON("collstats" << TEST_COLL), info));
+
+        ASSERT_EQUALS(info.getIntField("userFlags"), 0);
+        ASSERT_EQUALS(info.getIntField("nindexes"), 0);
     }
 
     TEST_F(DBClientTest, CopyDatabase) {


### PR DESCRIPTION
Note that I changed the API here by putting the `extra` option argument before `info` (the output parameter). I wouldn't be hung up on changing it back so that the options come after the output to keep things the same. Let me know what you think.
