### PR TITLE
CXX-89 Make MingW64 work

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -180,6 +180,7 @@ add_option( "mingw", "use the mingw compiler" , 0 , False )
 add_option( "boost-postfix", "postfix to the boost library ex. -mgw48-mt-1_55", 1, False)
 
 add_option( "cxx", "compiler to use" , 1 , True )
+add_option( "ar", "archiver to use" , 1 , True )
 add_option( "cc", "compiler to use for c" , 1 , True )
 add_option( "cc-use-shell-environment", "use $CC from shell for C compiler" , 0 , False )
 add_option( "cxx-use-shell-environment", "use $CXX from shell for C++ compiler" , 0 , False )
@@ -419,6 +420,8 @@ if has_option( "cxx-use-shell-environment" ):
 if has_option( "cc-use-shell-environment" ):
     env["CC"] = os.getenv("CC");
 
+if has_option( "ar" ):
+    env["AR"] = get_option( "ar" )
 if has_option( "cxx" ):
     env["CC"] = get_option( "cxx" )
     env["CXX"] = get_option( "cxx" )

--- a/src/SConscript.client
+++ b/src/SConscript.client
@@ -6,7 +6,7 @@ import os
 import buildscripts.git
 
 Import('env has_option get_option')
-Import('nix linux darwin windows')
+Import('nix linux darwin windows mingw')
 
 buildShared = False
 if has_option("sharedclient"):
@@ -282,7 +282,7 @@ staticLibEnv.AppendUnique(
 sharedLibName = 'mongoclient'
 staticLibName = 'mongoclient'
 
-if windows:
+if windows and not mingw:
     # On Windows, we need to have the static library target and the
     # import library target have different names, so that they aren't
     # ambiguous to scons.  Boost names the static library libxxxx.lib and
@@ -300,6 +300,8 @@ if windows:
         abi_adornment = '-' + abi_adornment
         sharedLibName = sharedLibName + abi_adornment
         staticLibName = staticLibName + abi_adornment
+if mingw:
+    staticLibName = 'libmongoclient'
 
 mongoClientStaticLib = staticLibEnv.StaticLibrary(
     staticLibName, clientSource),
@@ -328,12 +330,14 @@ if buildShared:
 
     # On non-windows systems, we want to match the behavior of DLLs and not export all symbols
     # from the dynamic shared library unless they have been explicitly been marked.
-    if not windows:
+    if not windows or mingw:
         sharedLibEnv.AppendUnique(CCFLAGS="-fvisibility=hidden")
         sharedLibEnv.AppendUnique(SHLINKFLAGS="-fvisibility=hidden")
 
-    mongoClientSharedLib = sharedLibEnv.SharedLibrary(sharedLibName, clientSource)
-
+    if mingw:
+        mongoClientSharedLib = sharedLibEnv.SharedLibrary(sharedLibName, clientSource, SHLIBPREFIX='lib',LIBSUFFIX='.dll.a')
+    else:
+        mongoClientSharedLib = sharedLibEnv.SharedLibrary(sharedLibName, clientSource)
     if darwin:
         # Set up the copy of the client library we will link targets against so that those
         # targets record the relative target directory as the install_name.
@@ -402,8 +406,8 @@ staticClientEnv = clientEnv.Clone()
 
 # On windows, we rely on autolib linking, so need to set a search path to the root of the build
 # dir where the .lib will go. On others, we just add the library to libs.
-if windows:
-    staticClientEnv.PrependUnique(LIBPATH=['$VARIANT_DIR'])
+if windows and not mingw:
+    staticClientEnv.PrependUnique(LIBPATH=['$VARIANT_DIR'])        
 else:
     staticClientEnv.PrependUnique(LIBS=[mongoClientStaticLib])
 
@@ -439,7 +443,7 @@ if buildShared:
 
     # On windows, we rely on autolib linking, so add the variant directory (where the .lib will
     # land) to the search path. Otherwise, just link directly to the binary.
-    if windows:
+    if windows and not mingw:
         sharedClientEnv.PrependUnique(
             LIBPATH=['$VARIANT_DIR']
         )
@@ -463,7 +467,8 @@ if buildShared:
             sharedClientEnv.PrependUnique(
                 LINKFLAGS="-Wl,-z,origin",
                 RPATH=[sharedClientEnv.Literal("\\$$ORIGIN/../../../lib")])
-
+    if mingw:    
+        sharedClientEnv.PrependUnique(RPATH=[sharedClientEnv.Literal("\\$$ORIGIN/../../../lib")])
     sharedClientPrograms = [
         sharedClientEnv.Program(
             "sharedclient/" + target, source) for (target, source) in exampleSourceMap]
@@ -474,7 +479,7 @@ if buildShared:
     # For normal systems with runpaths, install the examples somewhere sane. Otherwise on
     # windows, drop them in the lib directory because there really isn't anywher else they can
     # live where they can find the DLL.
-    sharedClientProgramInstallDir = "$INSTALL_DIR/share/mongo-cxx-driver/examples"
+    sharedClientProgramInstallDir = "$INSTALL_DIR/share/mongo-cxx-driver/examples/shared"
     if windows:
         sharedClientProgramInstallDir = "$INSTALL_DIR/lib"
 

--- a/src/mongo/SConscript
+++ b/src/mongo/SConscript
@@ -1,4 +1,4 @@
-Import('env windows mongoClientStaticLibs libGTestStatic')
+Import('env windows mongoClientStaticLibs libGTestStatic mingw')
 
 staticClientEnv = env.Clone()
 staticClientEnv.PrependUnique(
@@ -63,7 +63,7 @@ gtestEnv = staticClientEnv.Clone()
 gtestEnv.PrependUnique(
     # On windows, we need this odd flag to make the linker
     # search for main in our _test_main libs.
-    LINKFLAGS=(['/SUBSYSTEM:CONSOLE'] if windows else []),
+    LINKFLAGS=(['/SUBSYSTEM:CONSOLE'] if windows and not mingw else []),
     LIBS=[
         libGTestStatic,
     ])

--- a/src/mongo/platform/strtoll.h
+++ b/src/mongo/platform/strtoll.h
@@ -17,7 +17,7 @@
 
 #include <cstdlib>
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__GNUC__)
 static inline long long strtoll(const char* nptr, char** endptr, int base) {
     return _strtoi64(nptr, endptr, base);
 }

--- a/src/mongo/util/concurrency/thread_name.cpp
+++ b/src/mongo/util/concurrency/thread_name.cpp
@@ -27,7 +27,7 @@ namespace mongo {
 namespace {
     boost::thread_specific_ptr<std::string> _threadName;
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(__GNUC__)
 
 #define MS_VC_EXCEPTION 0x406D1388
 #pragma pack(push,8)

--- a/src/mongo/util/time_support.cpp
+++ b/src/mongo/util/time_support.cpp
@@ -81,7 +81,11 @@ namespace mongo {
     std::string time_t_to_String(time_t t) {
         char buf[64];
 #if defined(_WIN32)
+	#if !defined(__GNUC__)
         ctime_s(buf, sizeof(buf), &t);
+	#else
+		strncpy(buf, std::ctime(&t), sizeof(buf));
+	#endif
 #else
         ctime_r(&t, buf);
 #endif
@@ -92,7 +96,11 @@ namespace mongo {
     std::string time_t_to_String_short(time_t t) {
         char buf[64];
 #if defined(_WIN32)
+	#if !defined(__GNUC__)
         ctime_s(buf, sizeof(buf), &t);
+	#else
+		strncpy(buf, std::ctime(&t), sizeof(buf));
+	#endif
 #else
         ctime_r(&t, buf);
 #endif
@@ -150,7 +158,7 @@ namespace {
         if (local) {
             static const int localTzSubstrLen = 5;
             dassert(bufRemaining >= localTzSubstrLen + 1);
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__GNUC__)
             // NOTE(schwerin): The value stored by _get_timezone is the value one adds to local time
             // to get UTC.  This is opposite of the ISO-8601 meaning of the timezone offset.
             // NOTE(schwerin): Microsoft's timezone code always assumes US rules for daylight
@@ -186,7 +194,11 @@ namespace {
         static const size_t millisSubstrLen = 4;
         time_t t = date.toTimeT();
 #if defined(_WIN32)
+#if !defined(__GNUC__)
         ctime_s(result->data, sizeof(result->data), &t);
+	#else
+		strncpy(result->data, std::ctime(&t), sizeof(result->data));
+	#endif        
 #else
         ctime_r(&t, result->data);
 #endif


### PR DESCRIPTION
[CXX_89] Changes to SCons files and minor changes to source files produces a
working mingw64 build of client driver.

msys with mingw64: g++.exe (x86_64-win32-seh, Built by MinGW-W64 project) 4.8.2
boost (1.55) build options: b2 toolset=gcc address-model=64 variant=release link=shared,static threadapi=win32 threading=multi runtime-link=shared -j 4 --prefix=/usr/local/ install
scons build options: scons --cxx=`which g++` --mingw --boost-postfix=-mgw48-mt-1_55 --ssl --sharedclient --prefix=/usr/local/ -j 4 install-mongoclient

Caveats: example builds fail during sharedlibrary build