### PR TITLE
CXX-179 Support read preference for commands

### DIFF
--- a/src/mongo/client/dbclientinterface.h
+++ b/src/mongo/client/dbclientinterface.h
@@ -407,12 +407,14 @@ namespace mongo {
         BSONObj getFilter() const;
         BSONObj getSort() const;
         BSONObj getHint() const;
+        BSONObj getReadPref() const;
         bool isExplain() const;
 
         /**
          * @return true if the query object contains a read preference specification object.
          */
         static bool MONGO_CLIENT_FUNC hasReadPreference(const BSONObj& queryObj);
+        bool hasReadPreference() const;
 
         std::string toString() const;
         operator std::string() const { return toString(); }
@@ -654,7 +656,7 @@ namespace mongo {
         /** count number of objects in collection ns that match the query criteria specified
             throws UserAssertion if database returns an error
         */
-        virtual unsigned long long count(const std::string &ns, const BSONObj& query = BSONObj(), int options=0, int limit=0, int skip=0 );
+        virtual unsigned long long count(const std::string &ns, const Query& query = Query(), int options=0, int limit=0, int skip=0 );
 
         static std::string MONGO_CLIENT_FUNC createPasswordDigest(const std::string &username, const std::string &clearTextPassword);
 
@@ -862,7 +864,13 @@ namespace mongo {
                result.getField("ok").trueValue()
              on the result to check if ok.
         */
-        BSONObj mapreduce(const std::string &ns, const std::string &jsmapf, const std::string &jsreducef, BSONObj query = BSONObj(), MROutput output = MRInline);
+        BSONObj mapreduce(
+            const std::string &ns,
+            const std::string &jsmapf,
+            const std::string &jsreducef,
+            Query query = Query(),
+            MROutput output = MRInline
+        );
 
         /**
          * Groups documents in a collection by the specified key and performs simple aggregation
@@ -880,7 +888,7 @@ namespace mongo {
          * aggregation result for that group.
          * @param output The output vector.
          * @param initial Initial aggregation result document.
-         * @param cond Optional selection criteria to determine which documents to process.
+         * @param query Optional selection criteria to determine which documents to process.
          * @param finalize Optional function that runs for each item in the result set before
          * returning the final values in the output vector.
          */
@@ -889,7 +897,7 @@ namespace mongo {
             const StringData& jsreduce,
             std::vector<BSONObj>* output,
             const BSONObj& initial = BSONObj(),
-            const BSONObj& cond = BSONObj(),
+            const Query& query = Query(),
             const BSONObj& key = BSONObj(),
             const StringData& finalize = ""
         );
@@ -906,7 +914,7 @@ namespace mongo {
             const StringData& jsreduce,
             std::vector<BSONObj>* output,
             const BSONObj& initial = BSONObj(),
-            const BSONObj& cond = BSONObj(),
+            const Query& query = Query(),
             const StringData& jskey = "",
             const StringData& finalize = ""
         );
@@ -924,7 +932,7 @@ namespace mongo {
         BSONObj distinct(
             const StringData& ns,
             const StringData& field,
-            const BSONObj& query=BSONObj()
+            const Query& query = Query()
         );
 
         /**
@@ -1111,7 +1119,7 @@ namespace mongo {
         /** if the element contains a not master error */
         bool isNotMasterErrorString( const BSONElement& e );
 
-        BSONObj _countCmd(const std::string &ns, const BSONObj& query, int options, int limit, int skip );
+        BSONObj _countCmd(const std::string &ns, const Query& query, int options, int limit, int skip );
 
         /**
          * Look up the options available on this client.  Caches the answer from
@@ -1158,12 +1166,17 @@ namespace mongo {
             const StringData& ns,
             const StringData& jsreduce,
             const BSONObj& initial,
-            const BSONObj& cond,
+            const Query& query,
             const StringData& finalize,
             BSONObjBuilder* groupObj
         );
 
-        void _runGroup(const StringData& ns, const BSONObj& group, std::vector<BSONObj>* output);
+        void _runGroup(
+            const StringData& ns,
+            const BSONObj& group,
+            const Query& query,
+            std::vector<BSONObj>* output
+        );
 
         void _findAndModify(
             const StringData& ns,

--- a/src/mongo/unittest/bulk_operation_test.cpp
+++ b/src/mongo/unittest/bulk_operation_test.cpp
@@ -90,7 +90,7 @@ namespace {
         ASSERT_TRUE(result.upserted().empty());
         ASSERT_FALSE(result.hasErrors());
 
-        BSONObj doc = this->c->findOne(TEST_NS, Query("{}").obj);
+        BSONObj doc = this->c->findOne(TEST_NS, Query("{}"));
         ASSERT_EQUALS(doc["a"].numberInt(), 1);
     }
 
@@ -113,7 +113,7 @@ namespace {
         ASSERT_TRUE(result.upserted().empty());
         ASSERT_FALSE(result.hasErrors());
 
-        BSONObj doc = this->c->findOne(TEST_NS, Query("{}").obj);
+        BSONObj doc = this->c->findOne(TEST_NS, Query("{}"));
         ASSERT_EQUALS(doc["a"].numberInt(), 1);
     }
 
@@ -128,7 +128,7 @@ namespace {
             bulk.execute(&WriteConcern::acknowledged, &result),
             OperationException
         );
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}").obj), 0U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}")), 0U);
     }
 
     TYPED_TEST(BulkOperationTest, InsertBadKeyUnordered) {
@@ -142,7 +142,7 @@ namespace {
             bulk.execute(&WriteConcern::acknowledged, &result),
             OperationException
         );
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}").obj), 0U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}")), 0U);
     }
 
     TYPED_TEST(BulkOperationTest, UpdateOneMatchingSelector) {
@@ -166,7 +166,7 @@ namespace {
         ASSERT_TRUE(result.upserted().empty());
         ASSERT_FALSE(result.hasErrors());
 
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{x: 1}").obj), 1U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{x: 1}")), 1U);
     }
 
     TYPED_TEST(BulkOperationTest, UpdateMultiMatchingSelector) {
@@ -191,7 +191,7 @@ namespace {
         ASSERT_TRUE(result.upserted().empty());
         ASSERT_FALSE(result.hasErrors());
 
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{a: 1, x: 1}").obj), 2U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{a: 1, x: 1}")), 2U);
     }
 
     TYPED_TEST(BulkOperationTest, UpdateAllDocuments) {
@@ -217,7 +217,7 @@ namespace {
         ASSERT_FALSE(result.hasErrors());
 
 
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{x: 1}").obj), 3U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{x: 1}")), 3U);
     }
 
     TYPED_TEST(BulkOperationTest, ReplaceEntireDocument) {
@@ -242,8 +242,8 @@ namespace {
         ASSERT_FALSE(result.hasErrors());
 
 
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{x: 1}").obj), 1U);
-        ASSERT_FALSE(this->c->findOne(TEST_NS, Query("{x: 1}").obj).hasField("a"));
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{x: 1}")), 1U);
+        ASSERT_FALSE(this->c->findOne(TEST_NS, Query("{x: 1}")).hasField("a"));
     }
 
     TYPED_TEST(BulkOperationTest, UpsertOneMatchingSelector) {
@@ -268,8 +268,8 @@ namespace {
         ASSERT_TRUE(result.upserted().empty());
         ASSERT_FALSE(result.hasErrors());
 
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{x: 1}").obj), 1U);
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}").obj), 3U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{x: 1}")), 1U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}")), 3U);
     }
 
     TYPED_TEST(BulkOperationTest, UpsertOneNotMatchingSelector) {
@@ -293,9 +293,9 @@ namespace {
         ASSERT_EQUALS(result.upserted().size(), 1U);
         ASSERT_FALSE(result.hasErrors());
 
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{x: 1}").obj), 1U);
-        ASSERT_TRUE(this->c->findOne(TEST_NS, Query("{x: 1}").obj).hasField("a"));
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}").obj), 3U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{x: 1}")), 1U);
+        ASSERT_TRUE(this->c->findOne(TEST_NS, Query("{x: 1}")).hasField("a"));
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}")), 3U);
     }
 
     TYPED_TEST(BulkOperationTest, UpsertMultiMatchingSelector) {
@@ -320,8 +320,8 @@ namespace {
         ASSERT_TRUE(result.upserted().empty());
         ASSERT_FALSE(result.hasErrors());
 
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{x: 1}").obj), 2U);
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}").obj), 3U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{x: 1}")), 2U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}")), 3U);
     }
 
     TYPED_TEST(BulkOperationTest, UpsertMultiNotMatchingSelector) {
@@ -345,9 +345,9 @@ namespace {
         ASSERT_EQUALS(result.upserted().size(), 1U);
         ASSERT_FALSE(result.hasErrors());
 
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{x: 1}").obj), 1U);
-        ASSERT_TRUE(this->c->findOne(TEST_NS, Query("{x: 1}").obj).hasField("a"));
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}").obj), 3U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{x: 1}")), 1U);
+        ASSERT_TRUE(this->c->findOne(TEST_NS, Query("{x: 1}")).hasField("a"));
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}")), 3U);
     }
 
     TYPED_TEST(BulkOperationTest, MultipleUpsertsMixedBatchHaveCorrectSequence) {
@@ -391,9 +391,9 @@ namespace {
         ASSERT_TRUE(result.upserted().empty());
         ASSERT_FALSE(result.hasErrors());
 
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{x: 1}").obj), 1U);
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{a: 1}").obj), 1U);
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}").obj), 3U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{x: 1}")), 1U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{a: 1}")), 1U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}")), 3U);
     }
 
     TYPED_TEST(BulkOperationTest, UpsertReplaceNotMatchingSelector) {
@@ -418,9 +418,9 @@ namespace {
         ASSERT_FALSE(result.hasErrors());
 
         ASSERT_EQUALS(result.nUpserted(), 1);
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{x: 1}").obj), 1U);
-        ASSERT_FALSE(this->c->findOne(TEST_NS, Query("{x: 1}").obj).hasField("a"));
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}").obj), 3U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{x: 1}")), 1U);
+        ASSERT_FALSE(this->c->findOne(TEST_NS, Query("{x: 1}")).hasField("a"));
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}")), 3U);
     }
 
     TYPED_TEST(BulkOperationTest, RemoveOneMatchingSelector) {
@@ -445,8 +445,8 @@ namespace {
         ASSERT_TRUE(result.upserted().empty());
         ASSERT_FALSE(result.hasErrors());
 
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}").obj), 2U);
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{a: 1}").obj), 1U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}")), 2U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{a: 1}")), 1U);
     }
 
     TYPED_TEST(BulkOperationTest, RemoveAllMatchingSelector) {
@@ -471,8 +471,8 @@ namespace {
         ASSERT_TRUE(result.upserted().empty());
         ASSERT_FALSE(result.hasErrors());
 
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}").obj), 1U);
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{a: 1}").obj), 0U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}")), 1U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{a: 1}")), 0U);
     }
 
     TYPED_TEST(BulkOperationTest, RemoveAll) {
@@ -498,7 +498,7 @@ namespace {
         ASSERT_TRUE(result.upserted().empty());
         ASSERT_FALSE(result.hasErrors());
 
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}").obj), 0U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query("{}")), 0U);
     }
 
     TYPED_TEST(BulkOperationTest, MultipleOrderedOperations) {
@@ -838,7 +838,7 @@ namespace {
         ASSERT_EQUALS(writeError.getIntField("index"), 6);
         ASSERT_TRUE(writeError.hasField("errmsg"));
 
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query().obj), 6U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query()), 6U);
     }
 
     TYPED_TEST(BulkOperationTest, UnorderedBatchSplitting) {
@@ -879,7 +879,7 @@ namespace {
         ASSERT_EQUALS(writeError.getIntField("index"), 6);
         ASSERT_TRUE(writeError.hasField("errmsg"));
 
-        ASSERT_EQUALS(this->c->count(TEST_NS, Query().obj), 7U);
+        ASSERT_EQUALS(this->c->count(TEST_NS, Query()), 7U);
     }
 
     TYPED_TEST(BulkOperationTest, EmptyBatch) {

--- a/src/mongo/unittest/dbclient_writer_test.cpp
+++ b/src/mongo/unittest/dbclient_writer_test.cpp
@@ -87,8 +87,8 @@ namespace {
         inserts.push_back(&insert2);
         WriteResult result;
         this->writer->write(TEST_NS, inserts, true, &WriteConcern::acknowledged, &result);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}").obj), 1U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}").obj), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}")), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}")), 1U);
         ASSERT_FALSE(result.hasErrors());
     }
 
@@ -101,8 +101,8 @@ namespace {
         inserts.push_back(&insert2);
         WriteResult result;
         this->writer->write(TEST_NS, inserts, false, &WriteConcern::acknowledged, &result);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}").obj), 1U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}").obj), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}")), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}")), 1U);
         ASSERT_FALSE(result.hasErrors());
     }
 
@@ -119,8 +119,8 @@ namespace {
             this->writer->write(TEST_NS, inserts, true, &WriteConcern::acknowledged, &result),
             OperationException
         );
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{_id: 1}").obj), 1U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{_id: 2}").obj), 0U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{_id: 1}")), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{_id: 2}")), 0U);
     }
 
     TYPED_TEST(DBClientWriterTest, MultipleUnorderedInsertsWithError) {
@@ -136,8 +136,8 @@ namespace {
             this->writer->write(TEST_NS, inserts, false, &WriteConcern::acknowledged, &result),
             OperationException
         );
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{_id: 1}").obj), 1U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{_id: 2}").obj), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{_id: 1}")), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{_id: 2}")), 1U);
     }
 
     TYPED_TEST(DBClientWriterTest, MultipleOrderedInsertsWithErrorNoConcern) {
@@ -150,8 +150,8 @@ namespace {
         inserts.push_back(&insert2);
         WriteResult result;
         this->writer->write(TEST_NS, inserts, true, &WriteConcern::unacknowledged, &result);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{_id: 1}").obj), 1U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{_id: 2}").obj), 0U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{_id: 1}")), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{_id: 2}")), 0U);
     }
 
     TYPED_TEST(DBClientWriterTest, MultipleUnorderedInsertsWithErrorNoConcern) {
@@ -164,8 +164,8 @@ namespace {
         inserts.push_back(&insert2);
         WriteResult result;
         this->writer->write(TEST_NS, inserts, false, &WriteConcern::unacknowledged, &result);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{_id: 1}").obj), 1U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{_id: 2}").obj), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{_id: 1}")), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{_id: 2}")), 1U);
     }
 
     TYPED_TEST(DBClientWriterTest, SingleUpdate) {
@@ -178,8 +178,8 @@ namespace {
         updates.push_back(&update);
         WriteResult result;
         this->writer->write(TEST_NS, updates, true, &WriteConcern::acknowledged, &result);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}").obj), 1U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}").obj), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}")), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}")), 1U);
     }
 
     TYPED_TEST(DBClientWriterTest, SingleMultiUpdate) {
@@ -192,8 +192,8 @@ namespace {
         updates.push_back(&update);
         WriteResult result;
         this->writer->write(TEST_NS, updates, true, &WriteConcern::acknowledged, &result);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}").obj), 0U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}").obj), 2U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}")), 0U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}")), 2U);
     }
 
     TYPED_TEST(DBClientWriterTest, SingleUpsertDoesUpdate) {
@@ -206,8 +206,8 @@ namespace {
         updates.push_back(&update);
         WriteResult result;
         this->writer->write(TEST_NS, updates, true, &WriteConcern::acknowledged, &result);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}").obj), 0U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}").obj), 2U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}")), 0U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}")), 2U);
     }
 
     TYPED_TEST(DBClientWriterTest, SingleUpsertDoesUpsert) {
@@ -220,8 +220,8 @@ namespace {
         updates.push_back(&update);
         WriteResult result;
         this->writer->write(TEST_NS, updates, true, &WriteConcern::acknowledged, &result);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}").obj), 1U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}").obj), 2U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}")), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}")), 2U);
     }
 
     TYPED_TEST(DBClientWriterTest, MultipleOrderedUpdates) {
@@ -236,8 +236,8 @@ namespace {
         updates.push_back(&updateB);
         WriteResult result;
         this->writer->write(TEST_NS, updates, true, &WriteConcern::acknowledged, &result);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}").obj), 1U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{b: 2}").obj), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}")), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{b: 2}")), 1U);
     }
 
     TYPED_TEST(DBClientWriterTest, MultipleUnorderedUpdates) {
@@ -252,8 +252,8 @@ namespace {
         updates.push_back(&updateB);
         WriteResult result;
         this->writer->write(TEST_NS, updates, false, &WriteConcern::acknowledged, &result);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}").obj), 1U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{b: 2}").obj), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}")), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{b: 2}")), 1U);
     }
 
     TYPED_TEST(DBClientWriterTest, MultipleOrderedUpdatesWithError) {
@@ -272,8 +272,8 @@ namespace {
             this->writer->write(TEST_NS, updates, true, &WriteConcern::acknowledged, &result),
             OperationException
         );
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}").obj), 1U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{b: 1}").obj), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}")), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{b: 1}")), 1U);
     }
 
     TYPED_TEST(DBClientWriterTest, MultipleUnorderedUpdatesWithError) {
@@ -292,8 +292,8 @@ namespace {
             this->writer->write(TEST_NS, updates, false, &WriteConcern::acknowledged, &result),
             OperationException
         );
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}").obj), 1U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{b: 1}").obj), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}")), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{b: 1}")), 1U);
     }
 
     TYPED_TEST(DBClientWriterTest, MultipleOrderedUpdatesWithErrorNoConcern) {
@@ -309,8 +309,8 @@ namespace {
         updates.push_back(&updateB);
         WriteResult result;
         this->writer->write(TEST_NS, updates, true, &WriteConcern::unacknowledged, &result);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}").obj), 1U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{b: 1}").obj), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}")), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{b: 1}")), 1U);
     }
 
     TYPED_TEST(DBClientWriterTest, MultipleUnorderedUpdatesWithErrorNoConcern) {
@@ -326,8 +326,8 @@ namespace {
         updates.push_back(&updateB);
         WriteResult result;
         this->writer->write(TEST_NS, updates, false, &WriteConcern::unacknowledged, &result);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}").obj), 1U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{b: 1}").obj), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}")), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{b: 1}")), 1U);
     }
 
     TYPED_TEST(DBClientWriterTest, SingleDelete) {
@@ -341,9 +341,9 @@ namespace {
         deletes.push_back(&delete_op);
         WriteResult result;
         this->writer->write(TEST_NS, deletes, true, &WriteConcern::acknowledged, &result);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 0}").obj), 1U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}").obj), 0U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}").obj), 0U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 0}")), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}")), 0U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}")), 0U);
     }
 
     TYPED_TEST(DBClientWriterTest, SingleDeleteJustOne) {
@@ -357,9 +357,9 @@ namespace {
         deletes.push_back(&delete_op);
         WriteResult result;
         this->writer->write(TEST_NS, deletes, true, &WriteConcern::acknowledged, &result);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 0}").obj), 1U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}").obj), 0U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}").obj), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 0}")), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}")), 0U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 2}")), 1U);
     }
 
     TYPED_TEST(DBClientWriterTest, MultipleOrderedDeletes) {
@@ -373,11 +373,11 @@ namespace {
         deletes.push_back(&deleteA);
         deletes.push_back(&deleteB);
         WriteResult result;
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}").obj), 1U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{b: 1}").obj), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}")), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{b: 1}")), 1U);
         this->writer->write(TEST_NS, deletes, true, &WriteConcern::acknowledged, &result);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}").obj), 0U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{b: 1}").obj), 0U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}")), 0U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{b: 1}")), 0U);
     }
 
     TYPED_TEST(DBClientWriterTest, MultipleUnorderedDeletes) {
@@ -391,11 +391,11 @@ namespace {
         deletes.push_back(&deleteA);
         deletes.push_back(&deleteB);
         WriteResult result;
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}").obj), 1U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{b: 1}").obj), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}")), 1U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{b: 1}")), 1U);
         this->writer->write(TEST_NS, deletes, false, &WriteConcern::acknowledged, &result);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}").obj), 0U);
-        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{b: 1}").obj), 0U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{a: 1}")), 0U);
+        ASSERT_EQUALS(this->c.count(TEST_NS, Query("{b: 1}")), 0U);
     }
 
 }


### PR DESCRIPTION
The idea here is to make minimal changes to the way the existing driver works in order to support passing a read preference to commands by having them take a Query object (upon which read preferences can be piggybacked) instead of a BSONObj.
