### PR TITLE
SERVER-5436 improve ipv6 parsing in HostAndPort

### DIFF
--- a/src/mongo/client/connection_string_test.cpp
+++ b/src/mongo/client/connection_string_test.cpp
@@ -62,9 +62,6 @@ namespace {
 
         { "mongodb://127.0.0.1:1234,127.0.0.1:1234/dbName?foo=a&c=b&replicaSet=replName", "", "", kSet, "replName", 2, 3, "dbName" },
 
-#if 0
-        // TODO: Re-enable these tests when HostAndPort can properly parse IPv6
-
         { "mongodb://user:pwd@[::1]", "user", "pwd", kMaster, "", 1, 0, "" },
 
         { "mongodb://user@[::1]", "user", "", kMaster, "", 1, 0, "" },
@@ -112,7 +109,6 @@ namespace {
         { "mongodb://user@[::1]:1234,127.0.0.2:1234/?replicaSet=replName", "user", "", kSet, "replName", 2, 1, "" },
 
         { "mongodb://[::1]:1234,[::1]:1234/dbName?foo=a&c=b&replicaSet=replName", "", "", kSet, "replName", 2, 3, "dbName"},
-#endif
     };
 
 

--- a/src/mongo/util/net/hostandport.cpp
+++ b/src/mongo/util/net/hostandport.cpp
@@ -77,8 +77,15 @@ namespace mongo {
         return ss.str();
     }
 
-    void HostAndPort::append( StringBuilder& ss ) const {
-        ss << host() << ':' << port();
+    void HostAndPort::append(StringBuilder& ss) const {
+        // wrap ipv6 addresses in []s for roundtrip-ability
+        if (host().find(':') != std::string::npos) {
+            ss << '[' << host() << ']';
+        }
+        else {
+            ss << host();
+        }
+        ss << ':' << port();
     }
 
     bool HostAndPort::empty() const {
@@ -86,8 +93,40 @@ namespace mongo {
     }
 
     Status HostAndPort::initialize(const StringData& s) {
-        const size_t colonPos = s.rfind(':');
-        const StringData hostPart = s.substr(0, colonPos);
+        size_t colonPos = s.rfind(':');
+        StringData hostPart = s.substr(0, colonPos);
+
+        // handle ipv6 hostPart (which we require to be wrapped in []s)
+        const size_t openBracketPos = s.find('[');
+        const size_t closeBracketPos = s.find(']');
+        if (openBracketPos != std::string::npos) {
+            if (openBracketPos != 0) {
+                return Status(ErrorCodes::FailedToParse,
+                              str::stream() << "'[' present, but not first character in "
+                                            << s.toString());
+            }
+            if (closeBracketPos == std::string::npos) {
+                return Status(ErrorCodes::FailedToParse,
+                              str::stream() << "ipv6 address is missing closing ']' in hostname in "
+                                            << s.toString());
+            }
+
+            hostPart = s.substr(openBracketPos+1, closeBracketPos-openBracketPos-1);
+            // prevent accidental assignment of port to the value of the final portion of hostPart
+            if (colonPos < closeBracketPos) {
+                colonPos = std::string::npos;
+            }
+            else if (colonPos != closeBracketPos+1) {
+                return Status(ErrorCodes::FailedToParse,
+                              str::stream() << "Extraneous characters between ']' and pre-port ':'"
+                                            << " in " << s.toString());
+            }
+        }
+        else if (closeBracketPos != std::string::npos) {
+            return Status(ErrorCodes::FailedToParse,
+                          str::stream() << "']' present without '[' in " << s.toString());
+        }
+
         if (hostPart.empty()) {
             return Status(ErrorCodes::FailedToParse, str::stream() <<
                           "Empty host component parsing HostAndPort from \"" <<

--- a/src/mongo/util/net/hostandport_test.cpp
+++ b/src/mongo/util/net/hostandport_test.cpp
@@ -58,9 +58,15 @@ namespace {
         ASSERT_THROWS(HostAndPort("a:"), AssertionException);
         ASSERT_THROWS(HostAndPort("a:0xa"), AssertionException);
         ASSERT_THROWS(HostAndPort(":123"), AssertionException);
+        ASSERT_THROWS(HostAndPort("[124d:"), AssertionException);
+        ASSERT_THROWS(HostAndPort("[124d:]asdf:34"), AssertionException);
+        ASSERT_THROWS(HostAndPort("frim[124d:]:34"), AssertionException);
+        ASSERT_THROWS(HostAndPort("[124d:]12:34"), AssertionException);
 
         ASSERT_EQUALS(HostAndPort("abc"), HostAndPort("abc", -1));
         ASSERT_EQUALS(HostAndPort("abc.def:3421"), HostAndPort("abc.def", 3421));
+        ASSERT_EQUALS(HostAndPort("[124d:]:34"), HostAndPort("124d:", 34));
+        ASSERT_EQUALS(HostAndPort("[124d:]"), HostAndPort("124d:", -1));
     }
 
     TEST(HostAndPort, StaticParseFunction) {
@@ -69,10 +75,20 @@ namespace {
         ASSERT_EQUALS(ErrorCodes::FailedToParse, HostAndPort::parse("a:0").getStatus());
         ASSERT_EQUALS(ErrorCodes::FailedToParse, HostAndPort::parse("a:0xa").getStatus());
         ASSERT_EQUALS(ErrorCodes::FailedToParse, HostAndPort::parse(":123").getStatus());
+        ASSERT_EQUALS(ErrorCodes::FailedToParse, HostAndPort::parse("[124d:").getStatus());
+        ASSERT_EQUALS(ErrorCodes::FailedToParse, HostAndPort::parse("[124d:]asdf:34").getStatus());
 
         ASSERT_EQUALS(unittest::assertGet(HostAndPort::parse("abc")), HostAndPort("abc", -1));
         ASSERT_EQUALS(unittest::assertGet(HostAndPort::parse("abc.def:3421")),
                       HostAndPort("abc.def", 3421));
+    }
+
+    TEST(HostAndPort, RoundTripAbility) {
+        ASSERT_EQUALS(HostAndPort("abc"), HostAndPort(HostAndPort("abc").toString()));
+        ASSERT_EQUALS(HostAndPort("abc.def:3421"),
+                      HostAndPort(HostAndPort("abc.def:3421").toString()));
+        ASSERT_EQUALS(HostAndPort("[124d:]:34"), HostAndPort(HostAndPort("[124d:]:34").toString()));
+        ASSERT_EQUALS(HostAndPort("[124d:]"), HostAndPort(HostAndPort("[124d:]").toString()));
     }
 
 }  // namespace


### PR DESCRIPTION
adds support for ipv6
expects []s surrounding host portion
confirms : for port occurs immediately after ]
