### PR TITLE
CXX-302 work on MCI config file

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -20,7 +20,7 @@ cxx_driver_variables:
     windows64-bit: &mongo_url_windows64
       mongo_url: "http://downloads.10gen.com/win32/mongodb-win32-x86_64-enterprise-windows-64-2.6.2.zip"
     rhel55: &mongo_url_rhel55
-      mongo_url: "TODO"
+      mongo_url: "downloads.mongodb.org/linux/mongodb-linux-x86_64-rhel55-latest.tgz"
 
 ## Common mongodb arguments
   mongodb_arguments:


### PR DESCRIPTION
Some stylistic changes:
  -rename our builds so it's clear what we're testing (ie "Linux" -> "Ubuntu 14040")
  -refactor code to store common attributes in referenced hashes
And some changes to our buildvariants:
  -drop the static buildvariants
  -add a non-debug Ubuntu 1404 build
  -add a non-debug, non-dynamic Windows build
  -add a Windows build that uses msvc2013
