### PR TITLE
CXX-270 Clarify Scons Targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,13 +72,13 @@ before_script:
     - scons $SCONS_FLAGS $SCONS_CONCURRENCY_FLAG all
 
     # Install the driver
-    - scons $SCONS_FLAGS $SCONS_CONCURRENCY_FLAG install-mongoclient
+    - scons $SCONS_FLAGS $SCONS_CONCURRENCY_FLAG install
 
     # Check the installation
-    - scons $SCONS_FLAGS check-install-mongoclient
+    - scons $SCONS_FLAGS check-install
 
 script:
     # Test the driver
-    - scons $SCONS_FLAGS test
+    - scons $SCONS_FLAGS unit
     - scons $SCONS_FLAGS integration
-    - scons $SCONS_FLAGS smokeClient
+    - scons $SCONS_FLAGS examples

--- a/SConstruct
+++ b/SConstruct
@@ -1650,4 +1650,7 @@ if has_option("gcov"):
     env.AlwaysBuild(coverageCmd)
     env.Alias('coverage', coverageCmd)
 
-env.Alias('all', ['unittests', 'integration_tests', 'clientTests'])
+env.Alias('all', ['mongoclient', 'build-unit', 'build-integration', 'build-examples'])
+env.Alias('test', ['unit', 'integration'])
+
+Default('mongoclient')

--- a/site_scons/site_tools/integration_test.py
+++ b/site_scons/site_tools/integration_test.py
@@ -7,7 +7,7 @@ def exists(env):
 def build_integration_test(env, target, source, **kwargs):
     result = env.Program(target, source, **kwargs)
     buildAlias = env.Alias('build-' + target, result)
-    env.Alias('integration_tests', buildAlias)
+    env.Alias('build-integration', buildAlias)
     env['ENV']['GTEST_FILTER'] = env.get("gtest_filter", "*")
     runAlias = env.Alias('run-' + target, [result],
         "%s --port 27999" % result[0].abspath)

--- a/site_scons/site_tools/unittest.py
+++ b/site_scons/site_tools/unittest.py
@@ -7,13 +7,13 @@ def exists(env):
 def build_cpp_unit_test(env, target, source, **kwargs):
     result = env.Program(target, source, **kwargs)
     buildAlias = env.Alias('build-' + target, result)
-    env.Alias('unittests', buildAlias)
+    env.Alias('build-unit', buildAlias)
     env['ENV']['GTEST_FILTER'] = env.get("gtest_filter", "*")
     runAlias = env.Alias('run-' + target, [result], result[0].abspath)
     env.AlwaysBuild(runAlias)
-    testAliases = ['test', 'smokeCppUnittests', 'smoke']
-    env.Alias(testAliases, runAlias)
-    env.AlwaysBuild(testAliases)
+    testAlias = 'unit'
+    env.Alias(testAlias, runAlias)
+    env.AlwaysBuild(testAlias)
 
     return result
 

--- a/src/SConscript.client
+++ b/src/SConscript.client
@@ -348,6 +348,8 @@ if windows:
 mongoClientStaticLib = staticLibEnv.StaticLibrary(
     staticLibName, clientSource),
 
+buildMongoClientAlias = libEnv.Alias('mongoclient', mongoClientStaticLib)
+
 mongoClientPrefixInstalls.append(libEnv.Install("$INSTALL_DIR/lib", mongoClientStaticLib))
 
 # Other things like tests need to link against the static library (and the deps of that static
@@ -404,7 +406,7 @@ libEnv.AddPostAction(inst, Chmod('$TARGET', 0644))
 mongoClientPrefixInstalls.append(inst);
 
 
-installAlias = libEnv.Alias('install-mongoclient', mongoClientPrefixInstalls)
+installAlias = libEnv.Alias('install', mongoClientPrefixInstalls)
 
 # Build some simple mainlines that include the dbclient.h and bson.h headers
 # with things set up to include from the installation directory.
@@ -437,7 +439,7 @@ include_bsonh_test = installationTestEnv.Object(
 libEnv.AlwaysBuild(include_bsonh_test)
 libEnv.NoCache(include_bsonh_test)
 
-libEnv.Alias('check-install-mongoclient', [
+libEnv.Alias('check-install', [
     include_dbclienth_test,
     include_bsonh_test,
 ])
@@ -529,7 +531,7 @@ if buildShared:
     sharedClientEnv.Depends(sharedClientProgramInstalls, mongoClientSharedLibPrefixInstall)
 
 clientTestPrograms = staticClientPrograms + sharedClientPrograms
-clientEnv.Alias('clientTests', clientTestPrograms)
+clientEnv.Alias('build-examples', clientTestPrograms)
 
 # NOTE: There must be a mongod listening on 127.0.0.1:27999 (the traditional mongodb smoke test
 # port) for the smokeClient target to run. In the server repo that is no problem, the smoke.py
@@ -550,7 +552,7 @@ for clientTest in clientTestProgramInstalls:
         continue
 
     clientEnv.AlwaysBuild(clientEnv.Alias(
-        'smokeClient',
+        'examples',
         [clientTest],
         "%s --port 27999" % clientTest.abspath))
 


### PR DESCRIPTION
New Scons targets:

scons mongoclient (build libmongoclient.a)
scons install (install mongoclient, static or shared depends on existence of --sharedclient flag)

scons unit (run unit tests)
scons build-unit (build unit tests)

scons integration (run integration tests)
scons build-integration (build integration tests)

scons examples (run examples)
scons build-examples (build examples)

scons all = mongoclient + build-unit + build-integration + build-examples
scons test = unit + integration (should examples be in here as well?)

default target = mongoclient

also renamed check-install-mongoclient to check-install (this seems to only be used in the travis build)
also updated .travis.yml accordingly
