### PR TITLE
CXX-204 actually include vendored timegm on solaris

### DIFF
--- a/src/SConscript.client
+++ b/src/SConscript.client
@@ -161,11 +161,9 @@ clientSourceSasl = [
     'mongo/client/sasl_sspi.cpp',
 ]
 
-clientSourceAll = clientSourceBasic + clientSourceTz + clientSourceSasl
-
 usingSasl = libEnv['MONGO_SASL']
 
-clientSource = list(clientSourceBasic)
+clientSource = clientSourceBasic + clientSourceTz
 if usingSasl:
     clientSource += clientSourceSasl
 


### PR DESCRIPTION
This fixes a bug in SConscript.client where the vendored `timegm` wasn't getting compiled in since `clientSourceAll` isn't actually used.
