### PR TITLE
CXX-329 don't include timegm on windows

### DIFF
--- a/src/SConscript.client
+++ b/src/SConscript.client
@@ -153,7 +153,7 @@ clientSourceBasic = [
     'third_party/murmurhash3/MurmurHash3.cpp',
     ]
 
-clientSourceTz = [] if clientEnv['MONGO_HAVE_TIMEGM'] else ['third_party/tz/timegm.c']
+clientSourceTz = [] if (clientEnv['MONGO_HAVE_TIMEGM'] or windows) else ['third_party/tz/timegm.c']
 
 clientSourceSasl = [
     'mongo/client/sasl_client_authenticate_impl.cpp',

--- a/src/mongo/util/time_support.cpp
+++ b/src/mongo/util/time_support.cpp
@@ -40,7 +40,7 @@
 #define snprintf _snprintf
 #endif
 
-#if !defined(MONGO_HAVE_TIMEGM)
+#if !defined(_WIN32) && !defined(MONGO_HAVE_TIMEGM)
 // Not all systems have timegm defined (it isn't part of POSIX), so fall back to our vendored
 // implementation if our configure checks did not detect it as available on the current
 // system. See SERVER-13446, SERVER-14019, and CXX-204.


### PR DESCRIPTION
On windows we should not include the vendored timegm implementation since we use Windows specific APIs in time_support.cpp. 

Also, we should not define the timegm symbol on windows.
