### PR TITLE
CXX-283 Clarify documentation for startRunningPeriodicTasks

### DIFF
--- a/src/mongo/util/background.h
+++ b/src/mongo/util/background.h
@@ -138,10 +138,10 @@ namespace mongo {
         virtual std::string taskName() const = 0;
 
         /**
-         *  Starts the BackgroundJob that runs PeriodicTasks. You may call this multiple times,
-         *  from multiple threads, and the BackgroundJob will be started only once. Please note
-         *  that since this method starts threads, it is not appropriate to call it from within
-         *  a mongo initializer. Calling this method after calling 'stopRunningPeriodicTasks'
+         *  Starts the BackgroundJob that runs PeriodicTasks. This method is intended to
+         *  be called internally from initialize() only. You may not call this method twice.
+         *  As this method starts threads, it is not appropriate to call it from within a
+         *  mongo initializer. Calling this method after calling 'stopRunningPeriodicTasks'
          *  does not re-start the background job.
          */
         static void startRunningPeriodicTasks();


### PR DESCRIPTION
The old documentation stated that startRunningPeriodicTasks() could be called multiple times.  This isn't true, doing so will lead to [an assertion](https://github.com/mongodb/mongo-cxx-driver/blob/legacy/src/mongo/util/background.cpp#L185-L187).

Now that initialize() has been clarified users should not be able to cause startRunningPeriodicTasks() to be called twice, but I think it's worth fixing the documentation.
