### PR TITLE
CXX-295 Allow count to work with query hints

### DIFF
--- a/src/mongo/client/dbclientinterface.h
+++ b/src/mongo/client/dbclientinterface.h
@@ -398,7 +398,7 @@ namespace mongo {
               hint("{ts:1}")
         */
         Query& hint(BSONObj keyPattern);
-        Query& hint(const std::string &jsonKeyPatt);
+        Query& hint(const std::string& indexName);
 
         /**
          * Specifies a cumulative time limit in milliseconds for processing an operation.
@@ -466,7 +466,7 @@ namespace mongo {
 
         BSONObj getFilter() const;
         BSONObj getSort() const;
-        BSONObj getHint() const;
+        BSONElement getHint() const;
         BSONObj getReadPref() const;
         int getMaxTimeMs() const;
         bool isExplain() const;
@@ -476,6 +476,7 @@ namespace mongo {
          */
         static bool MONGO_CLIENT_FUNC hasReadPreference(const BSONObj& queryObj);
         bool hasReadPreference() const;
+        bool hasHint() const;
         bool hasMaxTimeMs() const;
 
         std::string toString() const;
@@ -522,7 +523,7 @@ namespace mongo {
         bool isExplain() const { return _queryObj.isExplain(); }
         BSONObj filter() const { return _queryObj.getFilter(); }
 
-        BSONObj hint() const { return _queryObj.getHint(); }
+        BSONElement hint() const { return _queryObj.getHint(); }
         BSONObj sort() const { return _queryObj.getSort(); }
         BSONObj query() const { return _query; }
         BSONObj fields() const { return _fields; }

--- a/src/mongo/client/examples/clientTest.cpp
+++ b/src/mongo/client/examples/clientTest.cpp
@@ -230,7 +230,7 @@ int main( int argc, const char **argv ) {
         // nonexistent index test
         bool asserted = false;
         try {
-            conn.findOne(ns, Query("{name:\"eliot\"}").hint("{foo:1}"));
+            conn.findOne(ns, Query("{name:\"eliot\"}").hint("foo_1}"));
         }
         catch ( ... ) {
             asserted = true;
@@ -238,7 +238,7 @@ int main( int argc, const char **argv ) {
         verify( asserted );
 
         //existing index
-        verify( conn.findOne(ns, Query("{name:'eliot'}").hint("{name:1}")).hasElement("name") );
+        verify( conn.findOne(ns, Query("{name:'eliot'}").hint("name_1")).hasElement("name") );
 
         // run validate
         verify( conn.validate( ns ) );


### PR DESCRIPTION
@acmorrow, it seems we can take advantage of the fact that Query::hint() had a useless overload that took a string. What I did was repurpose that method to take an index name as opposed to a json string representation of the index spec. This way we can use Query to hold a hint that can either be either an index spec (BSONObj) or index name (std::string). 

This is good because:
- When the query gets unpacked in the _countCmd method we can use either to support current and future server versions.
- The api isn't terrible because we avoid adding another parameter to the count method.
- It fits well with our current design.
