### PR TITLE
CXX-348 no journal preallocation in tests

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -32,7 +32,7 @@ cxx_driver_variables:
 ## Common mongodb arguments
   mongodb_arguments:
     standard: &mongodb_args
-      mongodb_args: "--dbpath /data/db --port 27999 --httpinterface --setParameter=enableTestCommands=1 &"
+      mongodb_args: "--dbpath /data/db --port 27999 --httpinterface --nopreallocj --setParameter=enableTestCommands=1 &"
 
 ## Common sets of scons flags
   scons_flags:


### PR DESCRIPTION
Journal preallocation can take over 90 seconds on Ubuntu 1404 :O

Adding the `--smallfiles` flag to our mongod speeds this up to consistently under 20 seconds.  We'll still need to wait a bit for journal allocation to finish before connecting to the mongod.

Also, I am not sure why this is only showing up in our integration tests.  My guess is that the other tasks take more time to do additional setup before attempting to connect to the mongod, or that those tasks have been running on faster or less-fragmented machines.
