### PR TITLE
CXX-346 add getIndexNames helper

### DIFF
--- a/src/mongo/client/dbclient.cpp
+++ b/src/mongo/client/dbclient.cpp
@@ -1867,6 +1867,15 @@ namespace mongo {
         return specs;
     }
 
+    list<std::string> DBClientWithCommands::getIndexNames( const std::string &ns ) {
+        list<std::string> indexNames;
+        list<BSONObj> specs( getIndexSpecs(ns) );
+
+        for (list<BSONObj>::const_iterator it = specs.begin(); it != specs.end(); ++it) {
+            indexNames.push_back((*it)["name"].valuestr());
+        }
+        return indexNames;
+    }
 
     void DBClientWithCommands::dropIndex( const string& ns , BSONObj keys ) {
         dropIndex( ns , genIndexName( keys ) );

--- a/src/mongo/client/dbclientinterface.h
+++ b/src/mongo/client/dbclientinterface.h
@@ -1145,6 +1145,11 @@ namespace mongo {
 
         virtual std::list<BSONObj> getIndexSpecs( const std::string &ns, int options = 0 );
 
+        /**
+         * Enumerates all indexes on ns (a db-qualified collection name). Returns a list of the index names.
+         */
+        virtual std::list<std::string> getIndexNames( const std::string& ns );
+
         virtual void dropIndex( const std::string& ns , BSONObj keys );
         virtual void dropIndex( const std::string& ns , const std::string& indexName );
 

--- a/src/mongo/client/examples/clientTest.cpp
+++ b/src/mongo/client/examples/clientTest.cpp
@@ -30,6 +30,7 @@
 #include "mongo/client/dbclient.h"
 
 #include <iostream>
+#include <set>
 
 #ifndef verify
 #  define verify(x) MONGO_verify(x)
@@ -258,6 +259,22 @@ int main( int argc, const char **argv ) {
         for ( list<string>::iterator i = l.begin(); i != l.end(); i++ ) {
             cout << "coll name : " << *i << endl;
         }
+    }
+
+    {
+        const string ns = "test.listMyIndexes";
+        conn.dropCollection(ns);
+        conn.insert(ns, BSON( "a" << 1 ));
+        conn.createIndex(ns, BSON ( "a" << 1 ));
+        conn.createIndex(ns, BSON ( "b" << 1 ));
+        conn.createIndex(ns, BSON ( "c" << 1 ));
+        list<string> indexNames(conn.getIndexNames(ns));
+        std::multiset<string> names(indexNames.begin(), indexNames.end());
+        verify(indexNames.size() == 4);
+        verify(names.count(string("_id_")) == 1);
+        verify(names.count(string("a_1")) == 1);
+        verify(names.count(string("b_1")) == 1);
+        verify(names.count(string("c_1")) == 1);
     }
 
     {


### PR DESCRIPTION
This isn't required by the listIndexes spec, but since we have getCollectionNames, I figured we might as well be consistent.
