### PR TITLE
minor: add support for testing on MonogDB 2.0

### DIFF
--- a/src/mongo/client/examples/aggregation.cpp
+++ b/src/mongo/client/examples/aggregation.cpp
@@ -49,6 +49,13 @@ int main(int argc, char* argv[]) {
     conn.connect(std::string("localhost:").append(port));
     conn.dropCollection("test.test");
 
+    // Don't run on MongoDB < 2.2
+    BSONObj cmdResult;
+    conn.runCommand("admin", BSON("buildinfo" << true), cmdResult);
+    std::vector<BSONElement> versionArray = cmdResult["versionArray"].Array();
+    if (versionArray[0].Int() < 2 || versionArray[1].Int() < 2)
+        return EXIT_SUCCESS;
+
     conn.insert("test.test", BSON("x" << 0));
     conn.insert("test.test", BSON("x" << 1));
     conn.insert("test.test", BSON("x" << 1));

--- a/src/mongo/unittest/dbclient_test.cpp
+++ b/src/mongo/unittest/dbclient_test.cpp
@@ -814,25 +814,27 @@ namespace {
     }
 
     TEST_F(DBClientTest, Aggregate) {
-        BSONObj doc = BSON("hello" << "world");
+        if (serverGTE(&c, 2, 2)) {
+            BSONObj doc = BSON("hello" << "world");
 
-        BSONObj pipeline = BSON("0" << BSON("$match" << doc));
+            BSONObj pipeline = BSON("0" << BSON("$match" << doc));
 
-        c.insert(TEST_NS, doc);
-        c.insert(TEST_NS, doc);
+            c.insert(TEST_NS, doc);
+            c.insert(TEST_NS, doc);
 
-        std::auto_ptr<DBClientCursor> cursor = c.aggregate(TEST_NS, pipeline);
-        ASSERT_TRUE(cursor.get());
+            std::auto_ptr<DBClientCursor> cursor = c.aggregate(TEST_NS, pipeline);
+            ASSERT_TRUE(cursor.get());
 
-        for (int i = 0; i < 2; i++) {
-            ASSERT_TRUE(cursor->more());
+            for (int i = 0; i < 2; i++) {
+                ASSERT_TRUE(cursor->more());
 
-            BSONObj result = cursor->next();
-            ASSERT_TRUE(result.valid());
-            ASSERT_EQUALS(result["hello"].String(), "world");
+                BSONObj result = cursor->next();
+                ASSERT_TRUE(result.valid());
+                ASSERT_EQUALS(result["hello"].String(), "world");
+            }
+
+            ASSERT_FALSE(cursor->more());
         }
-
-        ASSERT_FALSE(cursor->more());
     }
 
     TEST_F(DBClientTest, CreateCollection) {
@@ -846,7 +848,9 @@ namespace {
 
         bool server26plus = serverGTE(&c, 2, 6);
 
-        ASSERT_EQUALS(info.getIntField("userFlags"), server26plus ? 1 : 0);
+        if (serverGTE(&c, 2, 2)) {
+            ASSERT_EQUALS(info.getIntField("userFlags"), server26plus ? 1 : 0);
+        }
         ASSERT_EQUALS(info.getIntField("nindexes"), 1);
     }
 
@@ -859,7 +863,9 @@ namespace {
         BSONObj info;
         ASSERT_TRUE(c.runCommand(TEST_DB, BSON("collstats" << TEST_COLL), info));
 
-        ASSERT_EQUALS(info.getIntField("userFlags"), 0);
+        if (serverGTE(&c, 2, 2)) {
+            ASSERT_EQUALS(info.getIntField("userFlags"), 0);
+        }
         ASSERT_EQUALS(info.getIntField("nindexes"), 0);
     }
 


### PR DESCRIPTION
Does what it says on the box... we can add another supported version to the matrix.
