### PR TITLE
remove some unneccessary reinterpret casts

### DIFF
--- a/src/mongo/client/sasl_scramsha1_client_conversation.cpp
+++ b/src/mongo/client/sasl_scramsha1_client_conversation.cpp
@@ -100,7 +100,7 @@ namespace mongo {
         std::string user =
             _saslClientSession->getParameter(SaslClientSession::parameterUser).toString();
         encodeSCRAMUsername(user);
-        std::string clientNonce = base64::encode(reinterpret_cast<char*>(binaryNonce),
+        std::string clientNonce = base64::encode(&binaryNonce,
                                                  sizeof(binaryNonce));
 
         // Append client-first-message-bare to authMessage
@@ -176,7 +176,7 @@ namespace mongo {
 
         scram::generateSaltedPassword(
                             _saslClientSession->getParameter(SaslClientSession::parameterPassword),
-                            reinterpret_cast<const unsigned char*>(decodedSalt.c_str()),
+                            decodedSalt.c_str(),
                             decodedSalt.size(),
                             iterationCount,
                             _saltedPassword);

--- a/src/mongo/crypto/mechanism_scram.cpp
+++ b/src/mongo/crypto/mechanism_scram.cpp
@@ -89,7 +89,7 @@ namespace scram {
                                 const int iterationCount,
                                 unsigned char saltedPassword[hashSize]) {
         // saltedPassword = Hi(password, salt)
-        HMACIteration(reinterpret_cast<const unsigned char*>(password.rawData()),
+        HMACIteration(password.rawData(),
                       password.size(),
                       salt,
                       saltLen,
@@ -120,7 +120,7 @@ namespace scram {
         fassert(17498, HMAC(EVP_sha1(),
                             saltedPassword,
                             hashSize,
-                            reinterpret_cast<const unsigned char*>(clientKeyConst.data()),
+                            clientKeyConst.data(),
                             clientKeyConst.size(),
                             clientKey,
                             &hashLen));
@@ -132,7 +132,7 @@ namespace scram {
         fassert(17500, HMAC(EVP_sha1(),
                             saltedPassword,
                             hashSize,
-                            reinterpret_cast<const unsigned char*>(serverKeyConst.data()),
+                            serverKeyConst.data(),
                             serverKeyConst.size(),
                             serverKey,
                             &hashLen));
@@ -156,23 +156,23 @@ namespace scram {
         userSalt[0] = sr->nextInt64();
         userSalt[1] = sr->nextInt64();
         std::string encodedUserSalt =
-            base64::encode(reinterpret_cast<char*>(userSalt), sizeof(userSalt));
+            base64::encode(&userSalt, sizeof(userSalt));
 
         // Compute SCRAM secrets serverKey and storedKey
         unsigned char storedKey[hashSize];
         unsigned char serverKey[hashSize];
 
         computeProperties(hashedPassword,
-                          reinterpret_cast<unsigned char*>(userSalt),
+                          &userSalt,
                           saltLenQWords*sizeof(uint64_t),
                           iterationCount,
                           storedKey,
                           serverKey);
 
         std::string encodedStoredKey =
-            base64::encode(reinterpret_cast<char*>(storedKey), hashSize);
+            base64::encode(&storedKey, hashSize);
         std::string encodedServerKey =
-            base64::encode(reinterpret_cast<char*>(serverKey), hashSize);
+            base64::encode(&serverKey, hashSize);
 
         return BSON("iterationCount" << iterationCount <<
                     "salt" << encodedUserSalt <<
@@ -193,7 +193,7 @@ namespace scram {
         fassert(18689, HMAC(EVP_sha1(),
                             saltedPassword,
                             hashSize,
-                            reinterpret_cast<const unsigned char*>(clientKeyConst.data()),
+                            clientKeyConst.data(),
                             clientKeyConst.size(),
                             clientKey,
                             &hashLen));
@@ -207,7 +207,7 @@ namespace scram {
         fassert(18702, HMAC(EVP_sha1(),
                             storedKey,
                             hashSize,
-                            reinterpret_cast<const unsigned char*>(authMessage.c_str()),
+                            authMessage.c_str(),
                             authMessage.size(),
                             clientSignature,
                             &hashLen));
@@ -218,7 +218,7 @@ namespace scram {
             clientProof[i] = clientKey[i] ^ clientSignature[i];
         }
 
-        return base64::encode(reinterpret_cast<char*>(clientProof), hashSize);
+        return base64::encode(&clientProof, hashSize);
 
 #endif // MONGO_SSL
     }
@@ -235,7 +235,7 @@ namespace scram {
         fassert(18703, HMAC(EVP_sha1(),
                             saltedPassword,
                             hashSize,
-                            reinterpret_cast<const unsigned char*>(serverKeyConst.data()),
+                            serverKeyConst.data(),
                             serverKeyConst.size(),
                             serverKey,
                             &hashLen));
@@ -245,13 +245,13 @@ namespace scram {
         fassert(18704, HMAC(EVP_sha1(),
                             serverKey,
                             hashSize,
-                            reinterpret_cast<const unsigned char*>(authMessage.c_str()),
+                            authMessage.c_str(),
                             authMessage.size(),
                             serverSignature,
                             &hashLen));
 
         std::string encodedServerSignature =
-            base64::encode(reinterpret_cast<char*>(serverSignature), sizeof(serverSignature));
+            base64::encode(&serverSignature, sizeof(serverSignature));
         return (receivedServerSignature == encodedServerSignature);
 #endif
     }

--- a/src/mongo/db/dbmessage.cpp
+++ b/src/mongo/db/dbmessage.cpp
@@ -200,8 +200,7 @@ namespace mongo {
     void replyToQuery( int queryResultFlags, Message& response, const BSONObj& resultObj ) {
         BufBuilder bufBuilder;
         bufBuilder.skip( sizeof( QueryResult::Value ));
-        bufBuilder.appendBuf( reinterpret_cast< void *>(
-                const_cast< char* >( resultObj.objdata() )), resultObj.objsize() );
+        bufBuilder.appendBuf( const_cast< char* >( resultObj.objdata() ), resultObj.objsize() );
 
         QueryResult::View queryResult = bufBuilder.buf();
         bufBuilder.decouple();

--- a/src/mongo/db/json.cpp
+++ b/src/mongo/db/json.cpp
@@ -1025,7 +1025,7 @@ namespace mongo {
             // and therefore 'corrupted' unless we force them to be unsigned ... 0x80 becomes
             // 0xffffff80 as seen by isspace when sign-extended ... we want it to be 0x00000080
             while (_input < _input_end &&
-                   isspace(*reinterpret_cast<const unsigned char*>(_input))) {
+                   isspace(static_cast<unsigned char>(*_input))) {
                 ++_input;
             }
             if (_input >= _input_end) {
@@ -1180,7 +1180,7 @@ namespace mongo {
         // 'isspace()' takes an 'int' (signed), so (default signed) 'char's get sign-extended
         // and therefore 'corrupted' unless we force them to be unsigned ... 0x80 becomes
         // 0xffffff80 as seen by isspace when sign-extended ... we want it to be 0x00000080
-        while (check < _input_end && isspace(*reinterpret_cast<const unsigned char*>(check))) {
+        while (check < _input_end && isspace(static_cast<const unsigned char>(*check))) {
             ++check;
         }
         while (*token != '\0') {

--- a/src/mongo/util/hex.h
+++ b/src/mongo/util/hex.h
@@ -41,11 +41,10 @@ namespace mongo {
         return (char)(( fromHex( c[ 0 ] ) << 4 ) | fromHex( c[ 1 ] ));
     }
 
-    inline std::string toHex(const void* inRaw, int len) {
+    inline std::string toHex(const char* in, int len) {
         static const char hexchars[] = "0123456789ABCDEF";
 
         StringBuilder out;
-        const char* in = reinterpret_cast<const char*>(inRaw);
         for (int i=0; i<len; ++i) {
             char c = in[i];
             char hi = hexchars[(c & 0xF0) >> 4];


### PR DESCRIPTION
found these while reviewing the scram code in the c driver (looked at cpp code for comparison).

I did a bit of an audit of how we use reinterpret_cast, and removed the ones that were unnecessary and/or trivial to remove.
