### PR TITLE
CXX-396 Add MCI host curl path for windows builds

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -91,7 +91,7 @@ cxx_driver_variables:
     ## Extras
     extra:
       basic_extras: &extrapath
-        extrapath: --extrapath="c:\openssl,c:\sasl"
+        extrapath: --extrapath="c:\openssl,c:\sasl,c:\curl"
     ## Library paths
     lib:
       lib_msvc2010: &libpath_msvc2010

--- a/src/mongo/integration/replica_set/read_preference.cpp
+++ b/src/mongo/integration/replica_set/read_preference.cpp
@@ -181,7 +181,7 @@ namespace {
                 WriteConcern wcAll = WriteConcern().nodes(2);
                 replset_conn->insert(TEST_NS, BSON("x" << 2), 0, &wcAll);
                 break;
-            } catch (DBException& ex) {
+            } catch (const DBException&) {
                 mongo::sleepsecs(1);
             }
         }


### PR DESCRIPTION
Also a drive by fix for a windows unused variable warning that cropped up between when the windows build was red and this fix.
