### PR TITLE
CXX-408 Update README to reflect active development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,29 @@
 # MongoDB C++ Driver [![Build Status](https://travis-ci.org/mongodb/mongo-cxx-driver.svg?branch=master)](https://travis-ci.org/mongodb/mongo-cxx-driver)
 Welcome to the MongoDB C++ Driver!
 
-> **WARNING:** This is not the branch you want, there is nothing here yet.
+This branch contains active development on a new driver written in C++11.
 
-Switch to the legacy branch if:
+> **WARNING:** This branch is being actively developed. For a stable driver, switch to the ['legacy'](https://github.com/mongodb/mongo-cxx-driver/tree/legacy) or ['26compat'](https://github.com/mongodb/mongo-cxx-driver/tree/26compat) branch.
 
- - You are using MongoDB's C++ driver for the first time and do not mind the driver being actively worked on.
- - You had been using 26compat (or the driver inside of the server source) and want to benefit from incremental improvements while having the same overall API.
-
-Switch to the 26compat branch if:
-
- - You need a production ready release of the C++ driver that is not under active development.
- - You have existing code that used the driver from the server source and want it to continue working without modification.
-
-> **Note:** As of MongoDB 2.6.0-rc1, it is no longer possible to build the driver from the server sources: this repository is the only approved source for driver builds.
-
-This branch will contain future development work on a new driver with a completely new API and implementation. It is a work in progress and currently should not be used.
+#### Why a rewrite?
+The new driver will contain a completely new API and implementation. A complete rewrite allows us to take full advantage of the features offered in C++11, and gives us the chance to re-architect the driver based on past driver design decisions and their effectiveness. We aim for this new driver to be more modern, more lightweight, and friendlier to contributors than its predecessors.
 
 ## Repository Overview
 
-| Branch   | Stability | Development       | Purpose                                               |
-| -------- | ----------| ----------------- | ----------------------------------------------------- |
-| master   | Unstable  | Planning          | New C++ driver (work in progress)                     |
-| legacy   | Unstable  | Active            | Existing C++ driver with non-compatible improvements  |
-| 26compat | Stable    | Maintenance Only  | Drop in replacement for users of existing C++ driver  |
+| Branch   | Stability    | Development       | Purpose                                               |
+| -------- | ------------ | ----------------- | ----------------------------------------------------- |
+| master   | Unstable     | Active            | New C++ driver (work in progress)                     |
+| legacy   | Pre-release  | RC Testing        | Existing C++ driver with non-compatible improvements  |
+| 26compat | Stable       | Maintenance Only  | Drop in replacement for users of existing C++ driver  |
 
+## Bugs and Issues
+
+See our [JIRA project](http://jira.mongodb.org/browse/CXX).
+
+## Mailing Lists and IRC
+
+Outlined on the [MongoDB Community site](http://dochub.mongodb.org/core/community).
+
+## License
+
+The source files in this repository are made available under the terms of the Apache License, version 2.0.


### PR DESCRIPTION
Added some things about development on the new driver.  Also took out the specifics about the other branches: we have the "repository overview" chart, and each branch says what it is for when you go to it, so this felt unnecessary.  Can always add that back in if desired.
