### PR TITLE
Prepare for 1.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,33 +3,27 @@ Welcome to the MongoDB C++ Driver!
 
 Please see our [wiki page](https://github.com/mongodb/mongo-cxx-driver/wiki/Download%20and%20Compile) for information about building, testing, and using the driver.
 
-  Version [1.0.0-rc4](https://github.com/mongodb/mongo-cxx-driver/releases/tag/legacy-1.0.0-rc4)
-  of the C++ legacy driver has been released. Help us test it out!
-  Please report any bugs or issues in the C++
-  [JIRA project](http://jira.mongodb.org/browse/CXX).
-
-> **NOTE:** The legacy branch is currently in testing. If you are looking for a production-ready release of the C++ driver you should use the 26compat branch until our RC testing is complete.
+  Version [1.0.0](https://github.com/mongodb/mongo-cxx-driver/releases/tag/legacy-1.0.0)
+  of the C++ legacy driver has been released. Please report any bugs or issues in the C++ [JIRA project](http://jira.mongodb.org/browse/CXX).
 
 Use the legacy branch if:
 
- - You want to help test the upcoming 1.0 release of the legacy C++ driver.
- - You are using MongoDB's C++ driver for the first time and do not mind the driver being actively worked on.
- - You had been using 26compat (or the driver inside of the server source) and want to benefit from incremental improvements while having the same overall API.
+ - You are using MongoDB's C++ driver for the first time.
+ - You had been using 26compat (or the driver inside of the server source), can tolerate source level changes, and want to benefit from incremental improvements while having the same overall API.
 
-Switch to the 26compat branch if:
+Use the 26compat branch only if:
 
- - You need a production ready release of the C++ driver that is not under active development.
- - You have existing code that used the driver from the server source and want it to continue working without modification.
+ - You have existing code that used the driver from the 2.6 or earlier server source and want it to continue working without modification.
 
-> **Note:** As of MongoDB 2.6.0-rc1, it is no longer possible to build the driver from the server sources: this repository is the only approved source for driver builds.
+> **Note:** As of MongoDB 2.6.0-rc1, it is no longer possible to build the driver from the server sources: this repository is the only approved source for C++ driver builds.
 
 ## Repository Overview
 
-| Branch   | Stability   | Development       | Purpose                                               |
-| -------- | ------------| ----------------- | ----------------------------------------------------- |
-| master   | Unstable    | Planning          | New C++ driver (work in progress)                     |
-| legacy   | Pre-release | RC Testing        | Existing C++ driver with non-compatible improvements  |
-| 26compat | Stable      | Maintenance Only  | Drop in replacement for users of existing C++ driver  |
+| Branch   | Stability   | Development       | Purpose                                                      |
+| -------- | ------------| ----------------- | -----------------------------------------------------        |
+| master   | Unstable    | Planning          | New C++11 driver (work in progress)                          |
+| legacy   | Stable      | Stable Evolution  | Primary stable C++ driver release                            |
+| 26compat | Stable      | Maintenance Only  | Drop in replacement for users of existing 2.6 era C++ driver |
 
 > **WARNING:** The master branch will contain future development work on a new driver with a completely new API and implementation. It is a work in progress and currently should not be used.
 

--- a/SConstruct
+++ b/SConstruct
@@ -421,7 +421,7 @@ if releaseBuild and (debugBuild or not optBuild):
     print("Error: A --release build may not have debugging, and must have optimization")
     Exit(1)
 
-mongoclientVersion = "1.0.0-rc5-pre"
+mongoclientVersion = "1.0.0"
 # We don't keep the -pre in the user testable version identifiers, because
 # nobody should be conditioning on the pre-release status.
 mongoclientVersionComponents = re.split(r'\.|-rc', mongoclientVersion.partition('-pre')[0])

--- a/SConstruct
+++ b/SConstruct
@@ -421,7 +421,7 @@ if releaseBuild and (debugBuild or not optBuild):
     print("Error: A --release build may not have debugging, and must have optimization")
     Exit(1)
 
-mongoclientVersion = "1.0.0"
+mongoclientVersion = "1.0.1-rc0-pre"
 # We don't keep the -pre in the user testable version identifiers, because
 # nobody should be conditioning on the pre-release status.
 mongoclientVersionComponents = re.split(r'\.|-rc', mongoclientVersion.partition('-pre')[0])

--- a/etc/doxygen/config
+++ b/etc/doxygen/config
@@ -3,7 +3,7 @@
 #---------------------------------------------------------------------------
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "MongoDB C++ Driver"
-PROJECT_NUMBER         = legacy-1.0.0-rc5-pre
+PROJECT_NUMBER         = legacy-1.0.0
 OUTPUT_DIRECTORY       = docs/doxygen
 CREATE_SUBDIRS         = NO
 OUTPUT_LANGUAGE        = English

--- a/etc/doxygen/config
+++ b/etc/doxygen/config
@@ -3,7 +3,7 @@
 #---------------------------------------------------------------------------
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "MongoDB C++ Driver"
-PROJECT_NUMBER         = legacy-1.0.0
+PROJECT_NUMBER         = legacy-1.0.1-rc0-pre
 OUTPUT_DIRECTORY       = docs/doxygen
 CREATE_SUBDIRS         = NO
 OUTPUT_LANGUAGE        = English


### PR DESCRIPTION
There are two separate commits here, the BUMP and the post, along with more stubstantial than usual updates to the README. I figured, since we got this wrong for rc4 we should codereview.

The two commits need to be reviewed independently, not as cumulative edits.