### PR TITLE
Exported logging-related symbols

### DIFF
--- a/src/mongo/logger/log_domain.h
+++ b/src/mongo/logger/log_domain.h
@@ -47,7 +47,7 @@ namespace logger {
      * messages.
      */
     template <typename E>
-    class LogDomain {
+    class MONGO_CLIENT_API LogDomain {
         MONGO_DISALLOW_COPYING(LogDomain);
     public:
         typedef E Event;

--- a/src/mongo/logger/log_severity.h
+++ b/src/mongo/logger/log_severity.h
@@ -18,6 +18,7 @@
 #include <iosfwd>
 #include <string>
 
+#include "mongo/client/export_macros.h"
 #include "mongo/base/string_data.h"
 
 namespace mongo {
@@ -29,7 +30,7 @@ namespace logger {
      * Severities are totally ordered, from most severe to least severe as follows:
      * Severe, Error, Warning, Info, Log, Debug(1), Debug(2), ...
      */
-    class LogSeverity {
+    class MONGO_CLIENT_API LogSeverity {
     public:
         //
         // Static factory methods for getting LogSeverity objects of the various severity levels.

--- a/src/mongo/logger/message_event.h
+++ b/src/mongo/logger/message_event.h
@@ -29,7 +29,7 @@ namespace logger {
      *
      * Used and owned by one thread.  This is the message type used by MessageLogDomain.
      */
-    class MessageEventEphemeral {
+    class MONGO_CLIENT_API MessageEventEphemeral {
     public:
         MessageEventEphemeral(
                 Date_t date,


### PR DESCRIPTION
The change is meant to allow apps to hook user-defined log-callbacks in order for the driver's logs to be intercepted.
(see https://groups.google.com/forum/#!topic/mongodb-dev/dfc89gSvr7E)