### PR TITLE
fix mongocxx installation

### DIFF
--- a/src/mongo/driver/CMakeLists.txt
+++ b/src/mongo/driver/CMakeLists.txt
@@ -69,8 +69,8 @@ install(TARGETS
     ARCHIVE DESTINATION lib
 )
 
-install (DIRECTORY
-    DESTINATION "include/mongo/driver"
+install (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    DESTINATION "include/mongo"
     FILES_MATCHING
         PATTERN "*.hpp"
         PATTERN "*private*" EXCLUDE
@@ -79,6 +79,10 @@ install (DIRECTORY
 configure_file (
     ${PROJECT_SOURCE_DIR}/version.hpp.in
     ${PROJECT_BINARY_DIR}/version.hpp
+)
+
+install (FILES "${CMAKE_CURRENT_BINARY_DIR}/version.hpp"
+  DESTINATION "include/mongo/driver"
 )
 
 # TODO: MONGOCXX_SHARED_NO_EXPORT -> LIBMONGOCXX_PRIVATE


### PR DESCRIPTION
- fixes install target to actually install headers (currently nothing is installed)
- fixes install target to copy generated version.hpp from the build directory (without polluting the source tree)