### PR TITLE
Update SConscript.client

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -456,7 +456,7 @@ tools = decide_platform_tools() + ["unittest", "integration_test", "textfile"]
 envDict = dict(BUILD_DIR=buildDir,
                VARIANT_DIR=get_variant_dir(),
                EXTRAPATH=get_option("extrapath"),
-               PYTHON=buildscripts.utils.find_python(),
+               PYTHON=File(buildscripts.utils.find_python()),
                tools=tools,
                PYSYSPLATFORM=os.sys.platform,
                CONFIGUREDIR=sconsDataDir.Dir('sconf_temp'),

--- a/src/SConscript.client
+++ b/src/SConscript.client
@@ -34,7 +34,7 @@ del env
 
 libEnv.Command(['mongo/base/error_codes.h', 'mongo/base/error_codes.cpp',],
                ['mongo/base/generate_error_codes.py', 'mongo/base/error_codes.err'],
-               '$PYTHON $SOURCES $TARGETS')
+               '"$PYTHON" $SOURCES $TARGETS')
 
 def makeConfigHDefine(env, subst_key, env_var):
     replacement = "// #undef %s"

--- a/src/SConscript.client
+++ b/src/SConscript.client
@@ -34,7 +34,7 @@ del env
 
 libEnv.Command(['mongo/base/error_codes.h', 'mongo/base/error_codes.cpp',],
                ['mongo/base/generate_error_codes.py', 'mongo/base/error_codes.err'],
-               '"$PYTHON" $SOURCES $TARGETS')
+               '$PYTHON $SOURCES $TARGETS')
 
 def makeConfigHDefine(env, subst_key, env_var):
     replacement = "// #undef %s"


### PR DESCRIPTION
If python is installed in a directory containing spaces (i.e. C:\Program Files(x86)\Python27) the scons script didn't worked (output was something like "the command C:\Program could not be found").

Adding the double quotes there solves the issue.