### PR TITLE
CXX-536: Query::getMaxTimeMs() does not use the correct field name

### DIFF
--- a/src/mongo/client/dbclient.cpp
+++ b/src/mongo/client/dbclient.cpp
@@ -498,6 +498,7 @@ namespace mongo {
     const BSONField<BSONObj> Query::ReadPrefField("$readPreference");
     const BSONField<string> Query::ReadPrefModeField("mode");
     const BSONField<BSONArray> Query::ReadPrefTagsField("tags");
+    static const char* maxTimeMsField = "$maxTimeMS";
 
     Query::Query( const string &json ) : obj( fromjson( json ) ) {}
 
@@ -537,7 +538,7 @@ namespace mongo {
     }
 
     Query& Query::maxTimeMs(int millis) {
-        appendComplex( "$maxTimeMS", millis );
+        appendComplex( maxTimeMsField, millis );
         return *this;
     }
 
@@ -647,7 +648,7 @@ namespace mongo {
     }
 
     bool Query::hasMaxTimeMs() const {
-        return obj.hasField( "$maxTimeMS" );
+        return obj.hasField( maxTimeMsField );
     }
 
     BSONObj Query::getFilter() const {
@@ -676,7 +677,7 @@ namespace mongo {
     }
 
     int Query::getMaxTimeMs() const {
-        return obj.getIntField("maxTimeMs");
+        return obj.getIntField(maxTimeMsField);
     }
 
     bool Query::isExplain() const {

--- a/src/mongo/integration/standalone/dbclient_test.cpp
+++ b/src/mongo/integration/standalone/dbclient_test.cpp
@@ -1100,6 +1100,12 @@ namespace {
         c.insert(TEST_NS, BSON("a" << true));
         BSONObj result;
 
+        // Use a dummy query in order to check if maxTimeMs() is correctly applied
+        Query dummyQuery("{}");
+        ASSERT_EQUALS(&dummyQuery.maxTimeMs(10), &dummyQuery);
+        ASSERT_TRUE(dummyQuery.hasMaxTimeMs());
+        ASSERT_EQUALS(dummyQuery.getMaxTimeMs(), 10);
+
         if (serverGTE(&c, 2, 6)) {
             c.runCommand("admin", BSON(
                 "configureFailPoint" << "maxTimeAlwaysTimeOut" <<


### PR DESCRIPTION
Follow up of https://groups.google.com/forum/#!topic/mongodb-dev/oKnOaF56gto for the getMaxTimeMs() part:
- added static variable to hold the string "$maxTimeMS" in order to avoid mistakes
- adapted the tests in order to check if the *{m|M}axTimeMs() functions behave correctly