### PR TITLE
CXX-537: Add support for $maxTimeMS

### DIFF
--- a/src/mongo/client/dbclient.cpp
+++ b/src/mongo/client/dbclient.cpp
@@ -239,6 +239,7 @@ namespace mongo {
     const BSONField<BSONObj> Query::ReadPrefField("$readPreference");
     const BSONField<string> Query::ReadPrefModeField("mode");
     const BSONField<BSONArray> Query::ReadPrefTagsField("tags");
+    static const char* maxTimeMsField = "$maxTimeMS";
 
     Query::Query( const string &json ) : obj( fromjson( json ) ) {}
 
@@ -271,6 +272,11 @@ namespace mongo {
 
     Query& Query::hint(BSONObj keyPattern) {
         appendComplex( "$hint", keyPattern );
+        return *this;
+    }
+
+    Query& Query::maxTimeMs(int millis) {
+        appendComplex( maxTimeMsField, millis );
         return *this;
     }
 
@@ -356,6 +362,10 @@ namespace mongo {
                 hasReadPrefOption;
     }
 
+    bool Query::hasMaxTimeMs() const {
+        return obj.hasField( maxTimeMsField );
+    }
+
     BSONObj Query::getFilter() const {
         bool hasDollar;
         if ( ! isComplex( &hasDollar ) )
@@ -376,6 +386,11 @@ namespace mongo {
             return BSONObj();
         return obj.getObjectField( "$hint" );
     }
+
+    int Query::getMaxTimeMs() const {
+        return obj.getIntField(maxTimeMsField);
+    }
+
     bool Query::isExplain() const {
         return isComplex() && obj.getBoolField( "$explain" );
     }

--- a/src/mongo/client/dbclientinterface.h
+++ b/src/mongo/client/dbclientinterface.h
@@ -389,6 +389,12 @@ namespace mongo {
         Query& hint(BSONObj keyPattern);
         Query& hint(const string &jsonKeyPatt);
 
+        /**
+         * Specifies a cumulative time limit in milliseconds for processing an operation.
+         * MongoDB will interrupt the operation at the earliest following interrupt point.
+         */
+        Query& maxTimeMs(int millis);
+
         /** Provide min and/or max index limits for the query.
             min <= x < max
          */
@@ -450,11 +456,13 @@ namespace mongo {
         BSONObj getSort() const;
         BSONObj getHint() const;
         bool isExplain() const;
+        int getMaxTimeMs() const;
 
         /**
          * @return true if the query object contains a read preference specification object.
          */
         static bool hasReadPreference(const BSONObj& queryObj);
+        bool hasMaxTimeMs() const;
 
         string toString() const;
         operator string() const { return toString(); }


### PR DESCRIPTION
Followup of https://groups.google.com/forum/#!topic/mongodb-dev/oKnOaF56gto for the maxTimeMS and 26compat branch part:
- merged the $maxTimeMS implementation from the legacy branch