### PR TITLE
CXX-533 safely expose implementation to users

### DIFF
--- a/src/mongocxx/bulk_write.cpp
+++ b/src/mongocxx/bulk_write.cpp
@@ -84,6 +84,10 @@ void bulk_write::append(const model::write& operation) {
     }
 }
 
+void* bulk_write::implementation() const {
+    return _impl->operation_t;
+}
+
 void bulk_write::write_concern(class write_concern wc) {
     libmongoc::bulk_operation_set_write_concern(_impl->operation_t, wc._impl->write_concern_t);
 }

--- a/src/mongocxx/bulk_write.hpp
+++ b/src/mongocxx/bulk_write.hpp
@@ -89,6 +89,15 @@ class MONGOCXX_API bulk_write {
     void append(const model::write& operation);
 
     ///
+    /// Gets a handle to the underlying implementation.
+    ///
+    /// Returned pointer is only valid for the lifetime of this object.
+    ///
+    /// @return Pointer to implementation of this object, or nullptr if not available.
+    ///
+    MONGOCXX_DEPRECATED void* implementation() const;
+
+    ///
     /// Sets the write_concern for this operation.
     ///
     /// @param wc

--- a/src/mongocxx/client.cpp
+++ b/src/mongocxx/client.cpp
@@ -32,6 +32,10 @@ client& client::operator=(client&&) noexcept = default;
 
 client::~client() = default;
 
+void* client::implementation() const {
+    return _impl->client_t;
+}
+
 void client::read_preference(class read_preference rp) {
     libmongoc::client_set_read_prefs(_impl->client_t, rp._impl->read_preference_t);
 }

--- a/src/mongocxx/client.hpp
+++ b/src/mongocxx/client.hpp
@@ -79,6 +79,15 @@ class MONGOCXX_API client {
     ~client();
 
     ///
+    /// Gets a handle to the underlying implementation.
+    ///
+    /// Returned pointer is only valid for the lifetime of this object.
+    ///
+    /// @return Pointer to implementation of this object, or nullptr if not available.
+    ///
+    MONGOCXX_DEPRECATED void* implementation() const;
+
+    ///
     /// Sets the read preference for this client.
     ///
     /// Modifications at this level do not effect existing databases instances that have have been

--- a/src/mongocxx/collection.cpp
+++ b/src/mongocxx/collection.cpp
@@ -166,6 +166,10 @@ cursor collection::aggregate(const pipeline& pipeline, const options::aggregate&
                                                   stages.bson(), options_bson.bson(), rp_ptr));
 }
 
+void* collection::implementation() const {
+    return _impl->collection_t;
+}
+
 bsoncxx::stdx::optional<result::insert_one> collection::insert_one(bsoncxx::document::view document,
                                                     const options::insert& options) {
     class bulk_write bulk_op(false);

--- a/src/mongocxx/collection.hpp
+++ b/src/mongocxx/collection.hpp
@@ -369,6 +369,15 @@ class MONGOCXX_API collection {
     );
 
     ///
+    /// Gets a handle to the underlying implementation.
+    ///
+    /// Returned pointer is only valid for the lifetime of this object.
+    ///
+    /// @return Pointer to implementation of this object, or nullptr if not available.
+    ///
+    MONGOCXX_DEPRECATED void* implementation() const;
+
+    ///
     /// Inserts a single document into the collection. If the document is missing an identifier
     /// (@c _id field) one will be generated for it.
     ///

--- a/src/mongocxx/cursor.cpp
+++ b/src/mongocxx/cursor.cpp
@@ -62,6 +62,10 @@ cursor::iterator cursor::end() {
     return iterator(nullptr);
 }
 
+void* cursor::implementation() const {
+    return _impl->cursor_t;
+}
+
 cursor::iterator::iterator(cursor* cursor) : _cursor(cursor) {
     if (cursor) operator++();
 }

--- a/src/mongocxx/cursor.hpp
+++ b/src/mongocxx/cursor.hpp
@@ -63,6 +63,15 @@ class MONGOCXX_API cursor {
     /// @return the cursor::iterator
     iterator end();
 
+    ///
+    /// Gets a handle to the underlying implementation.
+    ///
+    /// Returned pointer is only valid for the lifetime of this object.
+    ///
+    /// @return Pointer to implementation of this object, or nullptr if not available.
+    ///
+    MONGOCXX_DEPRECATED void* implementation() const;
+
    private:
     friend class collection;
 

--- a/src/mongocxx/database.cpp
+++ b/src/mongocxx/database.cpp
@@ -36,6 +36,10 @@ database::database(const class client& client, const std::string& name)
           name.c_str())) {
 }
 
+void* database::implementation() const {
+    return _impl->database_t;
+}
+
 const std::string& database::name() const {
     return _impl->name;
 }

--- a/src/mongocxx/database.hpp
+++ b/src/mongocxx/database.hpp
@@ -94,6 +94,15 @@ class MONGOCXX_API database {
     bool has_collection(const std::string& name);
 
     ///
+    /// Gets a handle to the underlying implementation.
+    ///
+    /// Returned pointer is only valid for the lifetime of this object.
+    ///
+    /// @return Pointer to implementation of this object, or nullptr if not available.
+    ///
+    MONGOCXX_DEPRECATED void* implementation() const;
+
+    ///
     /// Enumerates the collections in this database.
     ///
     /// @return mongocxx::cursor containing the collection information.

--- a/src/mongocxx/read_preference.cpp
+++ b/src/mongocxx/read_preference.cpp
@@ -51,6 +51,10 @@ read_preference::read_preference(read_mode mode, bsoncxx::document::view tags)
 
 read_preference::~read_preference() = default;
 
+void* read_preference::implementation() const {
+    return _impl->read_preference_t;
+}
+
 void read_preference::mode(read_mode mode) {
     libmongoc::read_prefs_set_mode(_impl->read_preference_t, static_cast<mongoc_read_mode_t>(mode));
 }

--- a/src/mongocxx/read_preference.hpp
+++ b/src/mongocxx/read_preference.hpp
@@ -137,6 +137,15 @@ class MONGOCXX_API read_preference {
     ~read_preference();
 
     ///
+    /// Gets a handle to the underlying implementation.
+    ///
+    /// Returned pointer is only valid for the lifetime of this object.
+    ///
+    /// @return Pointer to implementation of this object, or nullptr if not available.
+    ///
+    MONGOCXX_DEPRECATED void* implementation() const;
+
+    ///
     /// Sets a new mode for this read_preference.
     ///
     /// @param mode

--- a/src/mongocxx/uri.cpp
+++ b/src/mongocxx/uri.cpp
@@ -60,6 +60,10 @@ std::vector<uri::host> uri::hosts() const {
     return result;
 }
 
+void* uri::implementation() const {
+    return _impl->uri_t;
+}
+
 std::string uri::password() const {
     return mongoc_uri_get_password(_impl->uri_t);
 }

--- a/src/mongocxx/uri.hpp
+++ b/src/mongocxx/uri.hpp
@@ -102,6 +102,15 @@ class MONGOCXX_API uri {
     std::string database() const;
 
     ///
+    /// Gets a handle to the underlying implementation.
+    ///
+    /// Returned pointer is only valid for the lifetime of this object.
+    ///
+    /// @return Pointer to implementation of this object, or nullptr if not available.
+    ///
+    MONGOCXX_DEPRECATED void* implementation() const;
+
+    ///
     /// Returns other uri options.
     ///
     /// @return A document view containing other options.

--- a/src/mongocxx/write_concern.cpp
+++ b/src/mongocxx/write_concern.cpp
@@ -48,6 +48,10 @@ void write_concern::fsync(bool fsync) {
     libmongoc::write_concern_set_fsync(_impl->write_concern_t, fsync);
 }
 
+void* write_concern::implementation() const {
+    return _impl->write_concern_t;
+}
+
 void write_concern::journal(bool journal) {
     libmongoc::write_concern_set_journal(_impl->write_concern_t, journal);
 }

--- a/src/mongocxx/write_concern.hpp
+++ b/src/mongocxx/write_concern.hpp
@@ -95,6 +95,15 @@ class MONGOCXX_API write_concern {
     void fsync(bool fsync);
 
     ///
+    /// Gets a handle to the underlying implementation.
+    ///
+    /// Returned pointer is only valid for the lifetime of this object.
+    ///
+    /// @return Pointer to implementation of this object, or nullptr if not available.
+    ///
+    MONGOCXX_DEPRECATED void* implementation() const;
+
+    ///
     /// Sets the journal parameter for this write concern.
     ///
     /// @param journal


### PR DESCRIPTION
I think it is OK to expose the interface as suggested by @acmorrow using stdx::optional so that we reserve the right to optionally return a pointer but actually always do so in the implementation. Questions, comments, and tips are all welcome.