### PR TITLE
CXX-546 test should pass 'flags' option key instead of 'usePowerOf2Sizes'

### DIFF
--- a/src/mongo/integration/standalone/dbclient_test.cpp
+++ b/src/mongo/integration/standalone/dbclient_test.cpp
@@ -904,7 +904,7 @@ namespace {
 
     TEST_F(DBClientTest, CreateCollectionAdvanced) {
         BSONObjBuilder opts;
-        opts.append("usePowerOf2Sizes", 0);
+        opts.append("flags", 0);
         opts.append("autoIndexId", false);
         c.createCollectionWithOptions(TEST_NS, 1, true, 1, opts.obj());
 


### PR DESCRIPTION
see: http://docs.mongodb.org/manual/reference/command/create/#dbcmd.create

still unsure why it was passing in the first place.
