### PR TITLE
CXX-556 prevent converting rvalue document::values to document::views

### DIFF
--- a/examples/mongocxx/query.cpp
+++ b/examples/mongocxx/query.cpp
@@ -33,8 +33,8 @@ int main(int, char**) {
     // Query for equality on a top level field.
     {
         // @begin: cpp-query-top-level-field
-        auto cursor = db["restaurants"]
-            .find(document{} << "borough" << "Manhattan" << finalize);
+        auto query = document{} << "borough" << "Manhattan" << finalize;
+        auto cursor = db["restaurants"].find(query.view());
 
         for (auto&& doc : cursor) {
             std::cout << bsoncxx::to_json(doc) << std::endl;

--- a/src/bsoncxx/array/value.hpp
+++ b/src/bsoncxx/array/value.hpp
@@ -81,8 +81,11 @@ class BSONCXX_API value {
     ///
     /// Get a view over the document owned by this value.
     ///
-    inline BSONCXX_INLINE array::view view() const noexcept;
-    inline BSONCXX_INLINE operator array::view() const noexcept;
+    inline BSONCXX_INLINE array::view view() const & noexcept;
+    inline BSONCXX_INLINE array::view view() const && = delete;
+
+    inline BSONCXX_INLINE operator array::view() const & noexcept;
+    inline BSONCXX_INLINE operator array::view() const && = delete;
 
     ///
     /// Transfer ownership of the underlying buffer to the caller.
@@ -100,11 +103,11 @@ class BSONCXX_API value {
     std::size_t _length;
 };
 
-inline BSONCXX_INLINE array::view value::view() const noexcept {
+inline BSONCXX_INLINE array::view value::view() const & noexcept {
     return array::view{static_cast<uint8_t*>(_data.get()), _length};
 }
 
-inline BSONCXX_INLINE value::operator array::view() const noexcept {
+inline BSONCXX_INLINE value::operator array::view() const & noexcept {
     return view();
 }
 

--- a/src/bsoncxx/array/value.hpp
+++ b/src/bsoncxx/array/value.hpp
@@ -82,10 +82,10 @@ class BSONCXX_API value {
     /// Get a view over the document owned by this value.
     ///
     inline BSONCXX_INLINE array::view view() const & noexcept;
-    inline BSONCXX_INLINE array::view view() const && = delete;
+    array::view view() const && = delete;
 
     inline BSONCXX_INLINE operator array::view() const & noexcept;
-    inline BSONCXX_INLINE operator array::view() const && = delete;
+    operator array::view() const && = delete;
 
     ///
     /// Transfer ownership of the underlying buffer to the caller.

--- a/src/bsoncxx/array/view.hpp
+++ b/src/bsoncxx/array/view.hpp
@@ -30,7 +30,7 @@ BSONCXX_INLINE_NAMESPACE_BEGIN
 namespace array {
 
 ///
-/// A read-only, non-owning view of a BSON document.
+/// A read-only, non-owning view of a BSON array.
 ///
 class BSONCXX_API view {
 

--- a/src/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/document/value.hpp
@@ -81,10 +81,10 @@ class BSONCXX_API value {
     /// Get a view over the document owned by this value.
     ///
     inline BSONCXX_INLINE document::view view() const & noexcept;
-    inline BSONCXX_INLINE document::view view() const && = delete;
+    document::view view() const && = delete;
 
     inline BSONCXX_INLINE operator document::view() const & noexcept;
-    inline BSONCXX_INLINE operator document::view() const && = delete;
+    operator document::view() const && = delete;
 
     ///
     /// Transfer ownership of the underlying buffer to the caller.

--- a/src/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/document/value.hpp
@@ -80,9 +80,11 @@ class BSONCXX_API value {
     ///
     /// Get a view over the document owned by this value.
     ///
-    inline BSONCXX_INLINE document::view view() const noexcept;
+    inline BSONCXX_INLINE document::view view() const & noexcept;
+    inline BSONCXX_INLINE document::view view() const && = delete;
 
-    inline BSONCXX_INLINE operator document::view() const noexcept;
+    inline BSONCXX_INLINE operator document::view() const & noexcept;
+    inline BSONCXX_INLINE operator document::view() const && = delete;
 
     ///
     /// Transfer ownership of the underlying buffer to the caller.
@@ -101,11 +103,11 @@ class BSONCXX_API value {
 
 };
 
-inline BSONCXX_INLINE document::view value::view() const noexcept {
+inline BSONCXX_INLINE document::view value::view() const & noexcept {
     return document::view{static_cast<uint8_t*>(_data.get()), _length};
 }
 
-inline BSONCXX_INLINE value::operator document::view() const noexcept {
+inline BSONCXX_INLINE value::operator document::view() const & noexcept {
     return view();
 }
 

--- a/src/mongocxx/test/collection_mocked.cpp
+++ b/src/mongocxx/test/collection_mocked.cpp
@@ -108,8 +108,10 @@ TEST_CASE("Collection", "[collection]") {
             return NULL;
         });
 
-        pipe.match(builder::stream::document{} << "foo" << "bar" << builder::stream::finalize);
-        pipe.sort(builder::stream::document{} << "foo" << 1 << builder::stream::finalize);
+        auto match_stage = builder::stream::document{} << "foo" << "bar" << builder::stream::finalize;
+        pipe.match(match_stage);
+        auto sort_stage = builder::stream::document{} << "foo" << 1 << builder::stream::finalize;
+        pipe.sort(sort_stage);
 
         SECTION("With default options") {}
 


### PR DESCRIPTION
During skunkworks I found that this was a source of bugs. It is currently very easy to create a dangling document::view by passing a temporary value to an options struct. This change should make it a bit harder to do so.