### PR TITLE
CXX-479 Backport server r2.6.7..r2.6.9 changes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -96,7 +96,7 @@ def add_option( name, help, nargs, contributesToVariantDir,
     if type == 'choice' and not metavar:
         metavar = '[' + '|'.join(choices) + ']'
 
-    AddOption( "--" + name , 
+    AddOption( "--" + name ,
                dest=dest,
                type=type,
                nargs=nargs,
@@ -133,7 +133,7 @@ def use_system_version_of_library(name):
 
 def get_variant_dir():
     if has_option('variant-dir'):
-        return "#build/" + get_option('variant-dir') 
+        return "#build/" + get_option('variant-dir')
 
     substitute = lambda x: re.sub( "[:,\\\\/]" , "_" , x )
 
@@ -346,7 +346,7 @@ boostLibs = [ "thread" , "filesystem" , "program_options", "system" ]
 onlyServer = len( COMMAND_LINE_TARGETS ) == 0 or ( len( COMMAND_LINE_TARGETS ) == 1 and str( COMMAND_LINE_TARGETS[0] ) in [ "mongod" , "mongos" , "test" ] )
 
 linux64  = False
-force32 = has_option( "force32" ) 
+force32 = has_option( "force32" )
 force64 = has_option( "force64" )
 if not force64 and not force32 and os.getcwd().endswith( "mongo-64" ):
     force64 = True
@@ -436,9 +436,9 @@ else:
 
 static = has_option( "static" )
 
-noshell = has_option( "noshell" ) 
+noshell = has_option( "noshell" )
 
-usev8 = has_option( "usev8" ) 
+usev8 = has_option( "usev8" )
 
 asio = has_option( "asio" )
 
@@ -582,7 +582,7 @@ if has_option( "libpath" ):
 if has_option( "cpppath" ):
     env["CPPPATH"] = [get_option( "cpppath" )]
 
-env.Prepend( CPPDEFINES=[ "_SCONS" , 
+env.Prepend( CPPDEFINES=[ "_SCONS" ,
                           "MONGO_EXPOSE_MACROS" ,
                           "SUPPORT_UTF8" ],  # for pcre
 
@@ -688,8 +688,6 @@ elif linux:
 
     if static:
         env.Append( LINKFLAGS=" -static " )
-    if has_option( "static-libstdc++" ):
-        env.Append( LINKFLAGS=["-static-libstdc++", "-static-libgcc"] )
 
 elif solaris:
      env.Append( CPPDEFINES=[ "__sunos__" ] )
@@ -739,7 +737,7 @@ elif windows:
     #    The this pointer is valid only within nonstatic member functions. It cannot be used in the initializer list for a base class.
     # c4800
     # 'type' : forcing value to bool 'true' or 'false' (performance warning)
-    #    This warning is generated when a value that is not bool is assigned or coerced into type bool. 
+    #    This warning is generated when a value that is not bool is assigned or coerced into type bool.
     # c4267
     # 'var' : conversion from 'size_t' to 'type', possible loss of data
     # When compiling with /Wp64, or when compiling on a 64-bit operating system, type is 32 bits but size_t is 64 bits when compiling for 64-bit targets. To fix this warning, use size_t instead of a type.
@@ -761,12 +759,12 @@ elif windows:
 
     env.Append( CPPDEFINES=["_CONSOLE","_CRT_SECURE_NO_WARNINGS"] )
 
-    # this would be for pre-compiled headers, could play with it later  
+    # this would be for pre-compiled headers, could play with it later
     #env.Append( CCFLAGS=['/Yu"pch.h"'] )
 
     # docs say don't use /FD from command line (minimal rebuild)
     # /Gy function level linking (implicit when using /Z7)
-    # /Z7 debug info goes into each individual .obj file -- no .pdb created 
+    # /Z7 debug info goes into each individual .obj file -- no .pdb created
     env.Append( CCFLAGS= ["/Z7", "/errorReport:none"] )
 
     # /DEBUG will tell the linker to create a .pdb file
@@ -821,6 +819,9 @@ elif windows:
     env.Append( EXTRALIBPATH=["#/../winpcap/Lib"] )
 
 if nix:
+
+    if has_option( "static-libstdc++" ):
+        env.Append( LINKFLAGS=["-static-libstdc++", "-static-libgcc"] )
 
     if has_option( "distcc" ):
         env["CXX"] = "distcc " + env["CXX"]
@@ -1378,7 +1379,7 @@ def doConfigure(myenv):
 
         conf.env.Append(CPPDEFINES=[("BOOST_THREAD_VERSION", "2")])
 
-        # Note that on Windows with using-system-boost builds, the following 
+        # Note that on Windows with using-system-boost builds, the following
         # FindSysLibDep calls do nothing useful (but nothing problematic either)
         for b in boostLibs:
             boostlib = "boost_" + b
@@ -1415,10 +1416,10 @@ def doConfigure(myenv):
         env.Append( CPPDEFINES=["MONGO_SASL"] )
 
     if conf.env['MONGO_BUILD_SASL_CLIENT'] and not conf.CheckLibWithHeader(
-            "sasl2", 
-            ["stddef.h","sasl/sasl.h"], 
-            "C", 
-            "sasl_version_info(0, 0, 0, 0, 0, 0);", 
+            "sasl2",
+            ["stddef.h","sasl/sasl.h"],
+            "C",
+            "sasl_version_info(0, 0, 0, 0, 0, 0);",
             autoadd=False ):
         Exit(1)
 
@@ -1482,7 +1483,7 @@ def doStyling( env , target , source ):
         print( "astyle 2.x needed, found:" + res )
         Exit(-1)
 
-    files = utils.getAllSourceFiles() 
+    files = utils.getAllSourceFiles()
     files = filter( lambda x: not x.endswith( ".c" ) , files )
 
     cmd = "astyle --options=mongo_astyle " + " ".join( files )

--- a/src/mongo/bson/bson-inl.h
+++ b/src/mongo/bson/bson-inl.h
@@ -1003,6 +1003,13 @@ dodouble:
         return true;
     }
 
+    template<> inline bool BSONElement::coerce<long long>( long long* out ) const {
+        if ( !isNumber() )
+            return false;
+        *out = numberLong();
+        return true;
+    }
+
     template<> inline bool BSONElement::coerce<double>( double* out ) const {
         if ( !isNumber() )
             return false;

--- a/src/mongo/bson/bson_validate.cpp
+++ b/src/mongo/bson/bson_validate.cpp
@@ -17,6 +17,7 @@
 
 #include <cstring>
 #include <deque>
+#include <limits>
 
 #include "mongo/bson/bson_validate.h"
 #include "mongo/bson/oid.h"
@@ -77,6 +78,11 @@ namespace mongo {
                 int sz;
                 if ( !readNumber<int>( &sz ) )
                     return makeError("invalid bson", _idElem);
+
+                if ( sz <= 0 ) {
+                    // must have NULL at the very least
+                    return makeError("invalid bson", _idElem);
+                }
 
                 if ( out ) {
                     *out = StringData( _buffer + _position, sz );
@@ -237,6 +243,8 @@ namespace mongo {
                 int sz;
                 if ( !buffer->readNumber<int>( &sz ) )
                     return makeError("invalid bson", idElem);
+                if ( sz < 0 || sz == std::numeric_limits<int>::max() )
+                    return makeError("invalid size in bson", idElem);
                 if ( !buffer->skip( 1 + sz ) )
                     return makeError("invalid bson", idElem);
                 return Status::OK();

--- a/src/mongo/bson/bson_validate_test.cpp
+++ b/src/mongo/bson/bson_validate_test.cpp
@@ -273,4 +273,20 @@ namespace {
         ASSERT_NOT_OK(status);
         ASSERT_EQUALS(status.reason(), "not null terminated string in object with unknown _id");
     }
+
+    TEST(BSONValidateFast, StringHasSomething) {
+        BufBuilder bb;
+        BSONObjBuilder ob(bb);
+        bb.appendChar(String);
+        bb.appendStr("x", /*withNUL*/true);
+        bb.appendNum(0);
+        const BSONObj x = ob.done();
+        ASSERT_EQUALS(5 // overhead
+                      + 1 // type
+                      + 2 // name
+                      + 4 // size
+                      , x.objsize());
+        ASSERT_NOT_OK(validateBSON(x.objdata(), x.objsize()));
+    }
+
 }

--- a/src/mongo/bson/util/builder.h
+++ b/src/mongo/bson/util/builder.h
@@ -110,6 +110,7 @@ namespace mongo {
                 data = 0;
             }
             l = 0;
+            reservedBytes = 0;
         }
         ~_BufBuilder() { kill(); }
 
@@ -122,9 +123,11 @@ namespace mongo {
 
         void reset() {
             l = 0;
+            reservedBytes = 0;
         }
         void reset( int maxSize ) {
             l = 0;
+            reservedBytes = 0;
             if ( maxSize && size > maxSize ) {
                 al.Free(data);
                 data = (char*)al.Malloc(maxSize);
@@ -201,19 +204,43 @@ namespace mongo {
         inline char* grow(int by) {
             int oldlen = l;
             int newLen = l + by;
-            if ( newLen > size ) {
-                grow_reallocate(newLen);
+            int minSize = newLen + reservedBytes;
+            if ( minSize > size ) {
+                grow_reallocate(minSize);
             }
             l = newLen;
             return data + oldlen;
         }
 
+        /**
+         * Reserve room for some number of bytes to be claimed at a later time.
+         */
+        void reserveBytes(int bytes) {
+            int minSize = l + reservedBytes + bytes;
+            if (minSize > size)
+                grow_reallocate(minSize);
+
+            // This must happen *after* any attempt to grow.
+            reservedBytes += bytes;
+        }
+
+        /**
+         * Claim an earlier reservation of some number of bytes. These bytes must already have been
+         * reserved. Appends of up to this many bytes immediately following a claim are
+         * guaranteed to succeed without a need to reallocate.
+         */
+        void claimReservedBytes(int bytes) {
+            invariant(reservedBytes >= bytes);
+            reservedBytes -= bytes;
+        }
+
     private:
         /* "slow" portion of 'grow()'  */
-        void NOINLINE_DECL grow_reallocate(int newLen) {
+        void NOINLINE_DECL grow_reallocate(int minSize) {
             int a = 64;
-            while( a < newLen ) 
+            while (a < minSize)
                 a = a * 2;
+
             if ( a > BufferMaxSize ) {
                 std::stringstream ss;
                 ss << "BufBuilder attempted to grow() to " << a << " bytes, past the 64MB limit.";
@@ -228,6 +255,7 @@ namespace mongo {
         char *data;
         int l;
         int size;
+        int reservedBytes; // eagerly grow_reallocate to keep this many bytes of spare room.
 
         friend class StringBuilderImpl<Allocator>;
     };

--- a/src/mongo/client/dbclient.cpp
+++ b/src/mongo/client/dbclient.cpp
@@ -850,28 +850,97 @@ namespace mongo {
 
         return names;
     }
-
     list<string> DBClientWithCommands::getCollectionNames( const string& db ) {
+        list<BSONObj> infos = getCollectionInfos( db );
         list<string> names;
-
-        string ns = db + ".system.namespaces";
-        auto_ptr<DBClientCursor> c = query( ns.c_str() , BSONObj() );
-        while ( c->more() ) {
-            string name = c->nextSafe()["name"].valuestr();
-            if ( name.find( "$" ) != string::npos )
-                continue;
-            names.push_back( name );
+        for ( list<BSONObj>::iterator it = infos.begin(); it != infos.end(); ++it ) {
+            names.push_back( db + "." + (*it)["name"].valuestr() );
         }
         return names;
     }
 
-    bool DBClientWithCommands::exists( const string& ns ) {
+    list<BSONObj> DBClientWithCommands::getCollectionInfos( const string& db,
+                                                            const BSONObj& filter ) {
+        list<BSONObj> infos;
 
-        string db = nsGetDB( ns ) + ".system.namespaces";
-        BSONObj q = BSON( "name" << ns );
-        return count( db.c_str() , q, QueryOption_SlaveOk ) != 0;
+        // first we're going to try the command
+        // it was only added in 3.0, so if we're talking to an older server
+        // we'll fail back to querying system.namespaces
+        // TODO(spencer): remove fallback behavior after 3.0 
+
+        {
+            BSONObj res;
+            if (runCommand(db,
+                           BSON("listCollections" << 1 << "filter" << filter
+                                                       << "cursor" << BSONObj()),
+                           res,
+                           QueryOption_SlaveOk)) {
+                BSONObj cursorObj = res["cursor"].Obj();
+                BSONObj collections = cursorObj["firstBatch"].Obj();
+                BSONObjIterator it( collections );
+                while ( it.more() ) {
+                    BSONElement e = it.next();
+                    infos.push_back( e.Obj().getOwned() );
+                }
+
+                const long long id = cursorObj["id"].Long();
+
+                if ( id != 0 ) {
+                    const std::string ns = cursorObj["ns"].String();
+                    auto_ptr<DBClientCursor> cursor = getMore(ns, id, 0, 0);
+                    while ( cursor->more() ) {
+                        infos.push_back(cursor->nextSafe().getOwned());
+                    }
+                }
+
+                return infos;
+            }
+
+            // command failed
+
+            int code = res["code"].numberInt();
+            string errmsg = res["errmsg"].valuestrsafe();
+            if ( code == ErrorCodes::CommandNotFound ||
+                 errmsg.find( "no such cmd" ) != string::npos ) {
+                // old version of server, ok, fall through to old code
+            }
+            else {
+                uasserted( 18630, str::stream() << "listCollections failed: " << res );
+            }
+
+        }
+
+        // SERVER-14951 filter for old version fallback needs to db qualify the 'name' element
+        BSONObjBuilder fallbackFilter;
+        if ( filter.hasField( "name" ) && filter["name"].type() == String ) {
+            fallbackFilter.append( "name", db + "." + filter["name"].str() );
+        }
+        fallbackFilter.appendElementsUnique( filter );
+
+        string ns = db + ".system.namespaces";
+        auto_ptr<DBClientCursor> c = query(
+                ns.c_str(), fallbackFilter.obj(), 0, 0, 0, QueryOption_SlaveOk);
+        uassert(28611, str::stream() << "listCollections failed querying " << ns, c.get());
+
+        while ( c->more() ) {
+            BSONObj obj = c->nextSafe();
+            string ns = obj["name"].valuestr();
+            if ( ns.find( "$" ) != string::npos )
+                continue;
+            BSONObjBuilder b;
+            b.append( "name", ns.substr( db.size() + 1 ) );
+            b.appendElementsUnique( obj );
+            infos.push_back( b.obj() );
+        }
+
+        return infos;
     }
 
+    bool DBClientWithCommands::exists( const string& ns ) {
+        BSONObj filter = BSON( "name" << nsToCollectionSubstring( ns ) );
+        list<BSONObj> results = getCollectionInfos( nsToDatabase( ns ), filter );
+        return !results.empty();
+    }
     /* --- dbclientconnection --- */
 
     void DBClientConnection::_auth(const BSONObj& params) {

--- a/src/mongo/client/dbclient_rs.cpp
+++ b/src/mongo/client/dbclient_rs.cpp
@@ -339,6 +339,16 @@ namespace {
             return false;
         }
 
+        // If _lastSlaveOkConn is pointing to a connection to primary, make sure that it is
+        // the same as _master, as this is the connection that has the version set.
+        if (_lastSlaveOkHost == _masterHost) {
+            if (_master.get() == NULL) {
+                // _master conn has been invalidated, need to reset connections.
+                return false;
+            }
+            _lastSlaveOkConn = _master;
+        }
+
         // Make sure we don't think the host is down.
         if (_lastSlaveOkConn->isFailed() || !_getMonitor()->isHostUp(_lastSlaveOkHost)) {
             invalidateLastSlaveOkCache();
@@ -627,7 +637,9 @@ namespace {
         if ( monitor ) {
             monitor->failedHost( _masterHost );
         }
-        _master.reset(); 
+
+        _masterHost = HostAndPort();
+        _master.reset();
     }
 
     auto_ptr<DBClientCursor> DBClientReplicaSet::checkSlaveQueryResult( auto_ptr<DBClientCursor> result ){

--- a/src/mongo/client/dbclientinterface.h
+++ b/src/mongo/client/dbclientinterface.h
@@ -930,6 +930,14 @@ namespace mongo {
          */
         list<string> getCollectionNames( const string& db );
 
+        /**
+         * { name : "<short collection name>",
+         *   options : { }
+         * }
+         */
+        std::list<BSONObj> getCollectionInfos( const std::string& db,
+                                               const BSONObj& filter = BSONObj() );
+
         bool exists( const string& ns );
 
         /** Create an index if it does not already exist.

--- a/src/mongo/util/net/ssl_manager.cpp
+++ b/src/mongo/util/net/ssl_manager.cpp
@@ -134,6 +134,7 @@ namespace mongo {
                    const std::string& clusterpwd,
                    const std::string& cafile = "",
                    const std::string& crlfile = "",
+                   const std::string& cipherConfig = "",
                    bool weakCertificateValidation = false,
                    bool allowInvalidCertificates = false,
                    bool allowInvalidHostnames = false,
@@ -144,6 +145,7 @@ namespace mongo {
                 clusterpwd(clusterpwd),
                 cafile(cafile),
                 crlfile(crlfile),
+                cipherConfig(cipherConfig),
                 weakCertificateValidation(weakCertificateValidation),
                 allowInvalidCertificates(allowInvalidCertificates),
                 allowInvalidHostnames(allowInvalidHostnames),
@@ -155,6 +157,7 @@ namespace mongo {
             std::string clusterpwd;
             std::string cafile;
             std::string crlfile;
+            std::string cipherConfig;
             bool weakCertificateValidation;
             bool allowInvalidCertificates;
             bool allowInvalidHostnames;
@@ -293,6 +296,7 @@ namespace mongo {
                 sslGlobalParams.sslClusterPassword,
                 sslGlobalParams.sslCAFile,
                 sslGlobalParams.sslCRLFile,
+                sslGlobalParams.sslCipherConfig,
                 sslGlobalParams.sslWeakCertificateValidation,
                 sslGlobalParams.sslAllowInvalidCertificates,
                 sslGlobalParams.sslAllowInvalidHostnames,
@@ -540,15 +544,29 @@ namespace mongo {
         // !EXPORT - Disable export ciphers (40/56 bit) 
         // !aNULL - Disable anonymous auth ciphers
         // @STRENGTH - Sort ciphers based on strength 
-        SSL_CTX_set_cipher_list(*context, "HIGH:!EXPORT:!aNULL@STRENGTH");
+        std::string cipherConfig = "HIGH:!EXPORT:!aNULL@STRENGTH";
+
+        // Allow the cipher configuration string to be overriden by --sslCipherConfig
+        if (!params.cipherConfig.empty()) {
+            cipherConfig = params.cipherConfig;
+        }
+
+        massert(28615, mongoutils::str::stream() << "can't set supported cipher suites: " <<
+                getSSLErrorMessage(ERR_get_error()),
+                SSL_CTX_set_cipher_list(*context, cipherConfig.c_str()));
 
         // If renegotiation is needed, don't return from recv() or send() until it's successful.
         // Note: this is for blocking sockets only.
         SSL_CTX_set_mode(*context, SSL_MODE_AUTO_RETRY);
 
-        // Disable session caching (see SERVER-10261)
-        SSL_CTX_set_session_cache_mode(*context, SSL_SESS_CACHE_OFF);
- 
+        massert(28607,
+                mongoutils::str::stream() << "can't store ssl session id context: " <<
+                    getSSLErrorMessage(ERR_get_error()),
+                SSL_CTX_set_session_id_context(
+                    *context,
+                    static_cast<unsigned char*>(static_cast<void*>(context)),
+                    sizeof(*context)));
+
         // Use the clusterfile for internal outgoing SSL connections if specified 
         if (context == &_clientContext && !params.clusterfile.empty()) {
             EVP_set_pw_prompt("Enter cluster certificate passphrase");

--- a/src/mongo/util/net/ssl_options.h
+++ b/src/mongo/util/net/ssl_options.h
@@ -37,6 +37,7 @@ namespace mongo {
         std::string sslClusterPassword;   // --sslInternalKeyPassword
         std::string sslCAFile;      // --sslCAFile
         std::string sslCRLFile;     // --sslCRLFile
+        std::string sslCipherConfig; // --sslCipherConfig
         bool sslWeakCertificateValidation; // --sslWeakCertificateValidation
         bool sslFIPSMode; // --sslFIPSMode
         bool sslAllowInvalidCertificates; // --sslAllowInvalidCertificates

--- a/src/mongo/util/version.cpp
+++ b/src/mongo/util/version.cpp
@@ -31,7 +31,7 @@ namespace mongo {
      *      1.2.3-rc4-pre-
      * If you really need to do something else you'll need to fix _versionArray()
      */
-    const char versionString[] = "2.6.7";
+    const char versionString[] = "2.6.9";
 
     // See unit test for example outputs
     BSONArray toVersionArray(const char* version){


### PR DESCRIPTION
Note that this is the backport of both 2.6.8 and 2.6.9. Server 2.6.8 had a client affecting bug, so we aren't going to be issuing a 26compat 2.6.8 release; opting instead to move on to 2.6.9 which contains the fix for the regression.

Please give it a look. There is more here than I expected. I'm particularly interested in someone evaluating the listCollections changes.