### PR TITLE
CXX-553 include inline keyword in inline macros

### DIFF
--- a/src/bsoncxx/array/value.hpp
+++ b/src/bsoncxx/array/value.hpp
@@ -81,8 +81,8 @@ class BSONCXX_API value {
     ///
     /// Get a view over the document owned by this value.
     ///
-    inline BSONCXX_INLINE array::view view() const noexcept;
-    inline BSONCXX_INLINE operator array::view() const noexcept;
+    BSONCXX_INLINE array::view view() const noexcept;
+    BSONCXX_INLINE operator array::view() const noexcept;
 
     ///
     /// Transfer ownership of the underlying buffer to the caller.
@@ -100,11 +100,11 @@ class BSONCXX_API value {
     std::size_t _length;
 };
 
-inline BSONCXX_INLINE array::view value::view() const noexcept {
+BSONCXX_INLINE array::view value::view() const noexcept {
     return array::view{static_cast<uint8_t*>(_data.get()), _length};
 }
 
-inline BSONCXX_INLINE value::operator array::view() const noexcept {
+BSONCXX_INLINE value::operator array::view() const noexcept {
     return view();
 }
 

--- a/src/bsoncxx/b64_ntop.h
+++ b/src/bsoncxx/b64_ntop.h
@@ -123,7 +123,7 @@ const char Pad64 = '=';
  *    characters followed by one "=" padding character.
  */
 
-inline BSONCXX_INLINE int
+BSONCXX_INLINE int
 ntop (std::uint8_t const *src,
       std::size_t         srclength,
       char          *target,

--- a/src/bsoncxx/config/prelude.hpp
+++ b/src/bsoncxx/config/prelude.hpp
@@ -15,4 +15,4 @@
 #include <bsoncxx/config/config.hpp>
 #include <bsoncxx/export.hpp>
 
-#define BSONCXX_INLINE __attribute__ ((__visibility__("hidden"), __always_inline__))
+#define BSONCXX_INLINE inline __attribute__ ((__visibility__("hidden"), __always_inline__))

--- a/src/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/document/value.hpp
@@ -80,9 +80,9 @@ class BSONCXX_API value {
     ///
     /// Get a view over the document owned by this value.
     ///
-    inline BSONCXX_INLINE document::view view() const noexcept;
+    BSONCXX_INLINE document::view view() const noexcept;
 
-    inline BSONCXX_INLINE operator document::view() const noexcept;
+    BSONCXX_INLINE operator document::view() const noexcept;
 
     ///
     /// Transfer ownership of the underlying buffer to the caller.
@@ -101,11 +101,11 @@ class BSONCXX_API value {
 
 };
 
-inline BSONCXX_INLINE document::view value::view() const noexcept {
+BSONCXX_INLINE document::view value::view() const noexcept {
     return document::view{static_cast<uint8_t*>(_data.get()), _length};
 }
 
-inline BSONCXX_INLINE value::operator document::view() const noexcept {
+BSONCXX_INLINE value::operator document::view() const noexcept {
     return view();
 }
 

--- a/src/bsoncxx/types.hpp
+++ b/src/bsoncxx/types.hpp
@@ -83,7 +83,7 @@ struct BSONCXX_API b_double {
     BSONCXX_INLINE operator double() { return value; }
 };
 
-inline BSONCXX_INLINE bool operator==(const b_double& lhs, const b_double& rhs) {
+BSONCXX_INLINE bool operator==(const b_double& lhs, const b_double& rhs) {
     return lhs.value == rhs.value;
 }
 
@@ -103,7 +103,7 @@ struct BSONCXX_API b_utf8 {
     BSONCXX_INLINE operator stdx::string_view() { return value; }
 };
 
-inline BSONCXX_INLINE bool operator==(const b_utf8& lhs, const b_utf8& rhs) {
+BSONCXX_INLINE bool operator==(const b_utf8& lhs, const b_utf8& rhs) {
     return lhs.value == rhs.value;
 }
 
@@ -118,7 +118,7 @@ struct BSONCXX_API b_document {
     BSONCXX_INLINE operator document::view() { return value; }
 };
 
-inline BSONCXX_INLINE bool operator==(const b_document& lhs, const b_document& rhs) {
+BSONCXX_INLINE bool operator==(const b_document& lhs, const b_document& rhs) {
     return lhs.value == rhs.value;
 }
 
@@ -133,7 +133,7 @@ struct BSONCXX_API b_array {
     BSONCXX_INLINE operator array::view() { return value; }
 };
 
-inline BSONCXX_INLINE bool operator==(const b_array& lhs, const b_array& rhs) {
+BSONCXX_INLINE bool operator==(const b_array& lhs, const b_array& rhs) {
     return lhs.value == rhs.value;
 }
 
@@ -148,7 +148,7 @@ struct BSONCXX_API b_binary {
     const uint8_t* bytes;
 };
 
-inline BSONCXX_INLINE bool operator==(const b_binary& lhs, const b_binary& rhs) {
+BSONCXX_INLINE bool operator==(const b_binary& lhs, const b_binary& rhs) {
     return lhs.sub_type == rhs.sub_type && lhs.size == rhs.size && (std::memcmp(lhs.bytes, rhs.bytes, lhs.size) == 0);
 }
 
@@ -163,7 +163,7 @@ struct BSONCXX_API b_undefined {
     static constexpr auto type_id = type::k_undefined;
 };
 
-inline BSONCXX_INLINE bool operator==(const b_undefined&, const b_undefined&) {
+BSONCXX_INLINE bool operator==(const b_undefined&, const b_undefined&) {
     return true;
 }
 
@@ -176,7 +176,7 @@ struct BSONCXX_API b_oid {
     oid value;
 };
 
-inline BSONCXX_INLINE bool operator==(const b_oid& lhs, const b_oid& rhs) {
+BSONCXX_INLINE bool operator==(const b_oid& lhs, const b_oid& rhs) {
     return lhs.value == rhs.value;
 }
 
@@ -191,7 +191,7 @@ struct BSONCXX_API b_bool {
     BSONCXX_INLINE operator bool() { return value; }
 };
 
-inline BSONCXX_INLINE bool operator==(const b_bool& lhs, const b_bool& rhs) {
+BSONCXX_INLINE bool operator==(const b_bool& lhs, const b_bool& rhs) {
     return lhs.value == rhs.value;
 }
 
@@ -206,7 +206,7 @@ struct BSONCXX_API b_date {
     BSONCXX_INLINE operator int64_t() { return value; }
 };
 
-inline BSONCXX_INLINE bool operator==(const b_date& lhs, const b_date& rhs) {
+BSONCXX_INLINE bool operator==(const b_date& lhs, const b_date& rhs) {
     return lhs.value == rhs.value;
 }
 
@@ -221,7 +221,7 @@ struct BSONCXX_API b_null {
     static constexpr auto type_id = type::k_null;
 };
 
-inline BSONCXX_INLINE bool operator==(const b_null&, const b_null&) {
+BSONCXX_INLINE bool operator==(const b_null&, const b_null&) {
     return true;
 }
 
@@ -244,7 +244,7 @@ struct BSONCXX_API b_regex {
     stdx::string_view options;
 };
 
-inline BSONCXX_INLINE bool operator==(const b_regex& lhs, const b_regex& rhs) {
+BSONCXX_INLINE bool operator==(const b_regex& lhs, const b_regex& rhs) {
     return lhs.regex == rhs.regex && lhs.options == rhs.options;
 }
 
@@ -261,7 +261,7 @@ struct BSONCXX_API b_dbpointer {
     oid value;
 };
 
-inline BSONCXX_INLINE bool operator==(const b_dbpointer& lhs, const b_dbpointer& rhs) {
+BSONCXX_INLINE bool operator==(const b_dbpointer& lhs, const b_dbpointer& rhs) {
     return lhs.collection == rhs.collection && lhs.value == rhs.value;
 }
 
@@ -285,7 +285,7 @@ struct BSONCXX_API b_code {
     BSONCXX_INLINE operator stdx::string_view() { return code; }
 };
 
-inline BSONCXX_INLINE bool operator==(const b_code& lhs, const b_code& rhs) {
+BSONCXX_INLINE bool operator==(const b_code& lhs, const b_code& rhs) {
     return lhs.code == rhs.code;
 }
 
@@ -309,7 +309,7 @@ struct BSONCXX_API b_symbol {
     BSONCXX_INLINE operator stdx::string_view() { return symbol; }
 };
 
-inline BSONCXX_INLINE bool operator==(const b_symbol& lhs, const b_symbol& rhs) {
+BSONCXX_INLINE bool operator==(const b_symbol& lhs, const b_symbol& rhs) {
     return lhs.symbol == rhs.symbol;
 }
 
@@ -332,7 +332,7 @@ struct BSONCXX_API b_codewscope {
     document::view scope;
 };
 
-inline BSONCXX_INLINE bool operator==(const b_codewscope& lhs, const b_codewscope& rhs) {
+BSONCXX_INLINE bool operator==(const b_codewscope& lhs, const b_codewscope& rhs) {
     return lhs.code == rhs.code && lhs.scope == rhs.scope;
 }
 
@@ -347,7 +347,7 @@ struct BSONCXX_API b_int32 {
     BSONCXX_INLINE operator int32_t() { return value; }
 };
 
-inline BSONCXX_INLINE bool operator==(const b_int32& lhs, const b_int32& rhs) {
+BSONCXX_INLINE bool operator==(const b_int32& lhs, const b_int32& rhs) {
     return lhs.value == rhs.value;
 }
 
@@ -365,7 +365,7 @@ struct BSONCXX_API b_timestamp {
     uint32_t timestamp;
 };
 
-inline BSONCXX_INLINE bool operator==(const b_timestamp& lhs, const b_timestamp& rhs) {
+BSONCXX_INLINE bool operator==(const b_timestamp& lhs, const b_timestamp& rhs) {
     return lhs.increment == rhs.increment && lhs.timestamp == rhs.timestamp;
 }
 
@@ -380,7 +380,7 @@ struct BSONCXX_API b_int64 {
     BSONCXX_INLINE operator int64_t() { return value; }
 };
 
-inline BSONCXX_INLINE bool operator==(const b_int64& lhs, const b_int64& rhs) {
+BSONCXX_INLINE bool operator==(const b_int64& lhs, const b_int64& rhs) {
     return lhs.value == rhs.value;
 }
 
@@ -395,7 +395,7 @@ struct BSONCXX_API b_minkey {
     static constexpr auto type_id = type::k_minkey;
 };
 
-inline BSONCXX_INLINE bool operator==(const b_minkey&, const b_minkey&) {
+BSONCXX_INLINE bool operator==(const b_minkey&, const b_minkey&) {
     return true;
 }
 
@@ -410,12 +410,12 @@ struct BSONCXX_API b_maxkey {
     static constexpr auto type_id = type::k_maxkey;
 };
 
-inline BSONCXX_INLINE bool operator==(const b_maxkey&, const b_maxkey&) {
+BSONCXX_INLINE bool operator==(const b_maxkey&, const b_maxkey&) {
     return true;
 }
 
 #define BSONCXX_ENUM(name, val) \
-inline BSONCXX_INLINE bool operator!=(const b_##name& lhs, const b_##name& rhs) { \
+BSONCXX_INLINE bool operator!=(const b_##name& lhs, const b_##name& rhs) { \
     return !(lhs == rhs); \
 }
 #include <bsoncxx/enums/type.hpp>

--- a/src/mongocxx/client.hpp
+++ b/src/mongocxx/client.hpp
@@ -164,8 +164,8 @@ class MONGOCXX_API client {
     ///
     /// @return Client side representation of a server side database
     ///
-    inline MONGOCXX_INLINE class database operator[](bsoncxx::stdx::string_view name) const &;
-    inline MONGOCXX_INLINE class database operator[](bsoncxx::stdx::string_view name) const && = delete;
+    MONGOCXX_INLINE class database operator[](bsoncxx::stdx::string_view name) const &;
+    MONGOCXX_INLINE class database operator[](bsoncxx::stdx::string_view name) const && = delete;
 
    private:
     friend class database;
@@ -176,7 +176,7 @@ class MONGOCXX_API client {
 
 };
 
-inline MONGOCXX_INLINE database client::operator[](bsoncxx::stdx::string_view name) const & {
+MONGOCXX_INLINE database client::operator[](bsoncxx::stdx::string_view name) const & {
     return database(name);
 }
 

--- a/src/mongocxx/collection.hpp
+++ b/src/mongocxx/collection.hpp
@@ -129,7 +129,7 @@ class MONGOCXX_API collection {
     /// @see http://docs.mongodb.org/manual/core/bulk-write-operations/
     ///
     template<typename container_type>
-    inline MONGOCXX_INLINE bsoncxx::stdx::optional<result::bulk_write> bulk_write(
+    MONGOCXX_INLINE bsoncxx::stdx::optional<result::bulk_write> bulk_write(
         const container_type& writes,
         const options::bulk_write& options = options::bulk_write()
     );
@@ -156,7 +156,7 @@ class MONGOCXX_API collection {
     /// @see http://docs.mongodb.org/manual/core/bulk-write-operations/
     ///
     template<typename write_model_iterator_type>
-    inline MONGOCXX_INLINE bsoncxx::stdx::optional<result::bulk_write> bulk_write(
+    MONGOCXX_INLINE bsoncxx::stdx::optional<result::bulk_write> bulk_write(
         write_model_iterator_type begin,
         write_model_iterator_type end,
         const options::bulk_write& options = options::bulk_write()
@@ -426,7 +426,7 @@ class MONGOCXX_API collection {
     /// @throws exception::write when the operation fails.
     ///
     template<typename container_type>
-    inline MONGOCXX_INLINE bsoncxx::stdx::optional<result::insert_many> insert_many(
+    MONGOCXX_INLINE bsoncxx::stdx::optional<result::insert_many> insert_many(
         const container_type& container,
         const options::insert& options = options::insert()
     );
@@ -455,7 +455,7 @@ class MONGOCXX_API collection {
     ///
     /// TODO: document DocumentViewIterator concept or static assert
     template<typename document_view_iterator_type>
-    inline MONGOCXX_INLINE bsoncxx::stdx::optional<result::insert_many> insert_many(
+    MONGOCXX_INLINE bsoncxx::stdx::optional<result::insert_many> insert_many(
         document_view_iterator_type begin,
         document_view_iterator_type end,
         const options::insert& options = options::insert()
@@ -588,7 +588,7 @@ class MONGOCXX_API collection {
 };
 
 template<typename container_type>
-inline MONGOCXX_INLINE bsoncxx::stdx::optional<result::bulk_write> collection::bulk_write(
+MONGOCXX_INLINE bsoncxx::stdx::optional<result::bulk_write> collection::bulk_write(
     const container_type& requests,
     const options::bulk_write& options
 ) {
@@ -596,7 +596,7 @@ inline MONGOCXX_INLINE bsoncxx::stdx::optional<result::bulk_write> collection::b
 }
 
 template<typename write_model_iterator_type>
-inline MONGOCXX_INLINE bsoncxx::stdx::optional<result::bulk_write> collection::bulk_write(
+MONGOCXX_INLINE bsoncxx::stdx::optional<result::bulk_write> collection::bulk_write(
     write_model_iterator_type begin,
     write_model_iterator_type end,
     const options::bulk_write& options
@@ -611,7 +611,7 @@ inline MONGOCXX_INLINE bsoncxx::stdx::optional<result::bulk_write> collection::b
 }
 
 template<typename container_type>
-inline MONGOCXX_INLINE bsoncxx::stdx::optional<result::insert_many> collection::insert_many(
+MONGOCXX_INLINE bsoncxx::stdx::optional<result::insert_many> collection::insert_many(
     const container_type& container,
     const options::insert& options
 ) {
@@ -619,7 +619,7 @@ inline MONGOCXX_INLINE bsoncxx::stdx::optional<result::insert_many> collection::
 }
 
 template<typename document_view_iterator_type>
-inline MONGOCXX_INLINE bsoncxx::stdx::optional<result::insert_many> collection::insert_many(
+MONGOCXX_INLINE bsoncxx::stdx::optional<result::insert_many> collection::insert_many(
     document_view_iterator_type begin,
     document_view_iterator_type end,
     const options::insert& options

--- a/src/mongocxx/config/prelude.hpp
+++ b/src/mongocxx/config/prelude.hpp
@@ -15,4 +15,4 @@
 #include <mongocxx/config/config.hpp>
 #include <mongocxx/export.hpp>
 
-#define MONGOCXX_INLINE __attribute__ ((__visibility__("hidden"), __always_inline__))
+#define MONGOCXX_INLINE inline __attribute__ ((__visibility__("hidden"), __always_inline__))

--- a/src/mongocxx/database.hpp
+++ b/src/mongocxx/database.hpp
@@ -198,7 +198,7 @@ class MONGOCXX_API database {
     ///
     /// @return the collection.
     ///
-    inline MONGOCXX_INLINE class collection operator[](bsoncxx::stdx::string_view name) const;
+    MONGOCXX_INLINE class collection operator[](bsoncxx::stdx::string_view name) const;
 
    private:
     friend class client;
@@ -211,7 +211,7 @@ class MONGOCXX_API database {
 
 };
 
-inline MONGOCXX_INLINE collection database::operator[](bsoncxx::stdx::string_view name) const {
+MONGOCXX_INLINE collection database::operator[](bsoncxx::stdx::string_view name) const {
     return collection(name);
 }
 


### PR DESCRIPTION
fixes warnings on GCC.