### PR TITLE
CXX-588 Cannot use kvp() with a std::string param

### DIFF
--- a/src/bsoncxx/test/bson_builder.cpp
+++ b/src/bsoncxx/test/bson_builder.cpp
@@ -682,6 +682,29 @@ TEST_CASE("basic document builder works", "[bsoncxx::builder::basic]") {
         viewable_eq_viewable(stream, basic);
     }
 
+    SECTION("kvp works with std::string key/value") {
+        {
+            using namespace builder::basic;
+
+            std::string a("hello");
+            std::string b("world");
+            basic.append(kvp(a, b));
+        }
+
+        viewable_eq_viewable(stream, basic);
+    }
+
+    SECTION("kvp works with stdx::string_view key/value") {
+        {
+            using namespace builder::basic;
+
+            stdx::string_view a("hello");
+            stdx::string_view b("world");
+            basic.append(kvp(a, b));
+        }
+
+        viewable_eq_viewable(stream, basic);
+    }
     SECTION("variadic works") {
         {
             using namespace builder::stream;


### PR DESCRIPTION
sub_document.append() specializations for std::string and
stdx::string_view keyed tuples fail to forward for the various cv and
ref qualified variants.  To keep up the perfect forwarding, these
functions need to take the key type as a template type parameter and
SFINAE themselves to disambiguate.