### PR TITLE
CXX-589 Add a view() method on pipeline

### DIFF
--- a/src/mongocxx/pipeline.cpp
+++ b/src/mongocxx/pipeline.cpp
@@ -15,7 +15,6 @@
 #include <mongocxx/pipeline.hpp>
 
 #include <bsoncxx/stdx/make_unique.hpp>
-#include <bsoncxx/json.hpp>
 #include <mongocxx/private/pipeline.hpp>
 
 namespace mongocxx {
@@ -76,8 +75,8 @@ pipeline& pipeline::unwind(std::string field_name) {
     return *this;
 }
 
-std::string pipeline::to_string() {
-    return bsoncxx::to_json(_impl->view());
+bsoncxx::document::view pipeline::view() const {
+    return _impl->view();
 }
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/pipeline.cpp
+++ b/src/mongocxx/pipeline.cpp
@@ -15,6 +15,7 @@
 #include <mongocxx/pipeline.hpp>
 
 #include <bsoncxx/stdx/make_unique.hpp>
+#include <bsoncxx/json.hpp>
 #include <mongocxx/private/pipeline.hpp>
 
 namespace mongocxx {
@@ -73,6 +74,10 @@ pipeline& pipeline::sort(bsoncxx::document::view sort) {
 pipeline& pipeline::unwind(std::string field_name) {
     _impl->sink() << open_document << "$unwind" << field_name << close_document;
     return *this;
+}
+
+std::string pipeline::to_string() {
+    return bsoncxx::to_json(_impl->view());
 }
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/pipeline.hpp
+++ b/src/mongocxx/pipeline.hpp
@@ -151,9 +151,9 @@ class MONGOCXX_API pipeline {
     pipeline& unwind(std::string field_name);
 
     ///
-    /// Return a string representation of the pipeline.
+    /// @return A view of the BSON pipeline.
     ///
-    std::string to_string();
+    bsoncxx::document::view view() const;
 
    private:
     friend class collection;

--- a/src/mongocxx/pipeline.hpp
+++ b/src/mongocxx/pipeline.hpp
@@ -150,6 +150,11 @@ class MONGOCXX_API pipeline {
     ///
     pipeline& unwind(std::string field_name);
 
+    ///
+    /// Return a string representation of the pipeline.
+    ///
+    std::string to_string();
+
    private:
     friend class collection;
 

--- a/src/mongocxx/pipeline.hpp
+++ b/src/mongocxx/pipeline.hpp
@@ -151,7 +151,7 @@ class MONGOCXX_API pipeline {
     pipeline& unwind(std::string field_name);
 
     ///
-    /// @return A view of the BSON pipeline.
+    /// @return A view of the underlying BSON document this pipeline represents.
     ///
     bsoncxx::document::view view() const;
 


### PR DESCRIPTION
Added a to_string function in mongocxx::pipeline.

Not sure if we want to check there whether the pipeline is empty, or to leave that to the caller?