### PR TITLE
CXX-599 Backport server r3.0.2..r3.0.3 changes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -335,6 +335,10 @@ env_vars.Add('LINKFLAGS',
     help='Sets flags for the linker',
     converter=variable_shlex_converter)
 
+env_vars.Add('RPATH',
+    help='Set the RPATH for dynamic libraries and executables',
+    converter=variable_shlex_converter)
+
 env_vars.Add('SHCCFLAGS',
     help='Sets flags for the C and C++ compiler when building shared libraries',
     converter=variable_shlex_converter)

--- a/SConstruct
+++ b/SConstruct
@@ -283,9 +283,19 @@ add_option('cache-dir',
            "Specify the directory to use for caching objects if --cache is in use",
            1, False, default="$BUILD_DIR/scons/cache")
 
+variable_parse_mode_choices=['auto', 'posix', 'other']
+add_option('variable-parse-mode',
+           "Select which parsing mode is used to interpret command line variables",
+           1, False,
+           type='choice', default=variable_parse_mode_choices[0],
+           choices=variable_parse_mode_choices)
+
 # Setup the command-line variables
 def variable_shlex_converter(val):
-    return shlex.split(val)
+    parse_mode = get_option('variable-parse-mode')
+    if parse_mode == 'auto':
+        parse_mode = 'other' if windows else 'posix'
+    return shlex.split(val, posix=(parse_mode == 'posix'))
 
 env_vars = Variables()
 

--- a/src/mongo/client/options.cpp
+++ b/src/mongo/client/options.cpp
@@ -99,6 +99,15 @@ namespace client {
         return _useFIPSMode;
     }
 
+    Options& Options::setSSLDisabledTLSProtocols(const std::vector<TLSProtocol>& protocols) {
+        _sslDisabledTLSProtocols = protocols;
+        return *this;
+    }
+
+    const std::vector<Options::TLSProtocol>& Options::SSLDisabledTLSProtocols() const {
+        return _sslDisabledTLSProtocols;
+    }
+
     Options& Options::setSSLCAFile(const std::string& fileName) {
         _sslCAFile = fileName;
         return *this;

--- a/src/mongo/client/options.cpp
+++ b/src/mongo/client/options.cpp
@@ -153,6 +153,15 @@ namespace client {
         return _sslAllowInvalidHostnames;
     }
 
+    Options& Options::setSSLCipherConfig(const std::string& config) {
+        _sslCipherConfig = config;
+        return *this;
+    }
+
+    const std::string& Options::SSLCipherConfig() const {
+        return _sslCipherConfig;
+    }
+
     Options& Options::setLogAppenderFactory(const Options::LogAppenderFactory& factory) {
         _appenderFactory = factory;
         return *this;

--- a/src/mongo/client/options.h
+++ b/src/mongo/client/options.h
@@ -76,6 +76,12 @@ namespace client {
             kSSLRequired
         };
 
+        /** The TLS protocols */
+        enum TLSProtocol {
+            kTLS1_0,
+            kTLS1_1,
+            kTLS1_2
+        };
 
         //
         // Startup and shutdown
@@ -146,6 +152,14 @@ namespace client {
          */
         Options& setFIPSMode(bool value = true);
         const bool FIPSMode() const;
+
+        /** Allow disabling particular TLS protocols
+         *
+         * Default: OpenSSL default
+         */
+
+        Options& setSSLDisabledTLSProtocols(const std::vector<TLSProtocol>& protocols);
+        const std::vector<TLSProtocol>& SSLDisabledTLSProtocols() const;
 
         /** Configure the SSL CA file to use. Has no effect if 'useSSL' is false.
          *
@@ -231,6 +245,7 @@ namespace client {
         unsigned int _autoShutdownGracePeriodMillis;
         SSLModes _sslMode;
         bool _useFIPSMode;
+        std::vector<TLSProtocol> _sslDisabledTLSProtocols;
         std::string _sslCAFile;
         std::string _sslPEMKeyFile;
         std::string _sslPEMKeyPassword;

--- a/src/mongo/client/options.h
+++ b/src/mongo/client/options.h
@@ -189,6 +189,13 @@ namespace client {
         Options& setSSLAllowInvalidHostnames(bool value = true);
         const bool SSLAllowInvalidHostnames() const;
 
+        /** Override the default OpenSSL cipher configuration
+         *
+         *  Default: OpenSSL default
+         */
+        Options& setSSLCipherConfig(const std::string& config);
+        const std::string& SSLCipherConfig() const;
+
         //
         // Logging
         //
@@ -230,6 +237,7 @@ namespace client {
         std::string _sslCRLFile;
         bool _sslAllowInvalidCertificates;
         bool _sslAllowInvalidHostnames;
+        std::string _sslCipherConfig;
         int _defaultLocalThresholdMillis;
         LogAppenderFactory _appenderFactory;
         logger::LogSeverity _minLoggedSeverity;

--- a/src/mongo/crypto/crypto_openssl.cpp
+++ b/src/mongo/crypto/crypto_openssl.cpp
@@ -22,6 +22,8 @@
 
 #include "mongo/platform/basic.h"
 
+#include "mongo/util/scopeguard.h"
+
 #include <openssl/sha.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
@@ -34,7 +36,19 @@ namespace crypto {
     bool sha1(const unsigned char* input,
               const size_t inputLen,
               unsigned char* output) {
-        return SHA1(input, inputLen, output);
+
+        EVP_MD_CTX digestCtx;
+        EVP_MD_CTX_init(&digestCtx);
+
+        if (1 != EVP_DigestInit_ex(&digestCtx, EVP_sha1(), NULL)) {
+            return false;
+        }
+
+        if (1 != EVP_DigestUpdate(&digestCtx, input, inputLen)) {
+            return false;
+        }
+
+        return (1 == EVP_DigestFinal_ex(&digestCtx, output, NULL));
     }
 
     /*

--- a/src/mongo/crypto/crypto_openssl.cpp
+++ b/src/mongo/crypto/crypto_openssl.cpp
@@ -39,6 +39,7 @@ namespace crypto {
 
         EVP_MD_CTX digestCtx;
         EVP_MD_CTX_init(&digestCtx);
+        ON_BLOCK_EXIT(EVP_MD_CTX_cleanup, &digestCtx);
 
         if (1 != EVP_DigestInit_ex(&digestCtx, EVP_sha1(), NULL)) {
             return false;

--- a/src/mongo/util/net/ssl_manager.cpp
+++ b/src/mongo/util/net/ssl_manager.cpp
@@ -50,6 +50,18 @@ namespace mongo {
         return "";
     }
 #else
+
+// Old copies of OpenSSL will not have constants to disable protocols they don't support.
+// Define them to values we can OR together safely to generically disable these protocols across
+// all versions of OpenSSL.
+#ifndef SSL_OP_NO_TLSv1_1
+#define SSL_OP_NO_TLSv1_1 0
+#endif
+#ifndef SSL_OP_NO_TLSv1_2
+#define SSL_OP_NO_TLSv1_2 0
+#endif
+
+
     const std::string getSSLVersion(const std::string &prefix, const std::string &suffix) {
         return prefix + SSLeay_version(SSLEAY_VERSION) + suffix;
     }
@@ -139,6 +151,7 @@ namespace mongo {
                    const std::string& pempwd,
                    const std::string& clusterfile,
                    const std::string& clusterpwd,
+                   const std::vector<client::Options::TLSProtocol>& disabledProtocols,
                    const std::string& cafile = "",
                    const std::string& crlfile = "",
                    const std::string& cipherConfig = "",
@@ -153,6 +166,7 @@ namespace mongo {
                 cafile(cafile),
                 crlfile(crlfile),
                 cipherConfig(cipherConfig),
+                disabledProtocols(disabledProtocols),
                 weakCertificateValidation(weakCertificateValidation),
                 allowInvalidCertificates(allowInvalidCertificates),
                 allowInvalidHostnames(allowInvalidHostnames),
@@ -165,6 +179,7 @@ namespace mongo {
             std::string cafile;
             std::string crlfile;
             std::string cipherConfig;
+            std::vector<client::Options::TLSProtocol> disabledProtocols;
             bool weakCertificateValidation;
             bool allowInvalidCertificates;
             bool allowInvalidHostnames;
@@ -304,6 +319,7 @@ namespace mongo {
                 options.SSLPEMKeyPassword(),
                 std::string(), // server only parameter
                 std::string(), // server only parameter
+                options.SSLDisabledTLSProtocols(),
                 options.SSLCAFile(),
                 options.SSLCRLFile(),
                 options.SSLCipherConfig(),
@@ -548,7 +564,22 @@ namespace mongo {
         // SSL_OP_ALL - Activate all bug workaround options, to support buggy client SSL's.
         // SSL_OP_NO_SSLv2 - Disable SSL v2 support
         // SSL_OP_NO_SSLv3 - Disable SSL v3 support
-        SSL_CTX_set_options(*context, SSL_OP_ALL|SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3);
+        long supportedProtocols = SSL_OP_ALL|SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3;
+
+        // Set the supported TLS protocols. Allow --disabledProtocols to disable selected ciphers.
+        if (!params.disabledProtocols.empty()) {
+            for (std::vector<client::Options::TLSProtocol>::const_iterator it =
+                    params.disabledProtocols.begin(); it != params.disabledProtocols.end(); ++it) {
+                if (*it == client::Options::kTLS1_0) {
+                    supportedProtocols |= SSL_OP_NO_TLSv1;
+                } else if (*it == client::Options::kTLS1_1) {
+                    supportedProtocols |= SSL_OP_NO_TLSv1_1;
+                } else if (*it == client::Options::kTLS1_2) {
+                    supportedProtocols |= SSL_OP_NO_TLSv1_2;
+                }
+            }
+        }
+        SSL_CTX_set_options(*context, supportedProtocols);
 
         // HIGH - Enable strong ciphers
         // !EXPORT - Disable export ciphers (40/56 bit) 

--- a/src/mongo/util/net/ssl_manager.cpp
+++ b/src/mongo/util/net/ssl_manager.cpp
@@ -766,39 +766,31 @@ namespace mongo {
     }
 
     SSLConnection* SSLManager::connect(Socket* socket) {
-        SSLConnection* sslConn = new SSLConnection(_clientContext, socket, NULL, 0);
-        ScopeGuard sslGuard = MakeGuard(::SSL_free, sslConn->ssl);
-        ScopeGuard bioGuard = MakeGuard(::BIO_free, sslConn->networkBIO);
+        std::auto_ptr<SSLConnection> sslConn(new SSLConnection(_clientContext, socket, NULL, 0));
  
         int ret;
         do {
             ret = ::SSL_connect(sslConn->ssl);
-        } while(!_doneWithSSLOp(sslConn, ret));
+        } while(!_doneWithSSLOp(sslConn.get(), ret));
  
         if (ret != 1)
-            _handleSSLError(SSL_get_error(sslConn, ret), ret);
+            _handleSSLError(SSL_get_error(sslConn.get(), ret), ret);
  
-        sslGuard.Dismiss();
-        bioGuard.Dismiss();
-        return sslConn;
+        return sslConn.release();
     }
 
     SSLConnection* SSLManager::accept(Socket* socket, const char* initialBytes, int len) {
-        SSLConnection* sslConn = new SSLConnection(_serverContext, socket, initialBytes, len);
-        ScopeGuard sslGuard = MakeGuard(::SSL_free, sslConn->ssl);
-        ScopeGuard bioGuard = MakeGuard(::BIO_free, sslConn->networkBIO);
+        std::auto_ptr<SSLConnection> sslConn(new SSLConnection(_serverContext, socket, initialBytes, len));
  
         int ret;
         do {
             ret = ::SSL_accept(sslConn->ssl);
-        } while(!_doneWithSSLOp(sslConn, ret));
+        } while(!_doneWithSSLOp(sslConn.get(), ret));
  
         if (ret != 1)
-            _handleSSLError(SSL_get_error(sslConn, ret), ret);
+            _handleSSLError(SSL_get_error(sslConn.get(), ret), ret);
  
-        sslGuard.Dismiss();
-        bioGuard.Dismiss();
-        return sslConn;
+        return sslConn.release();
     }
 
     // TODO SERVER-11601 Use NFC Unicode canonicalization

--- a/src/mongo/util/net/ssl_manager.cpp
+++ b/src/mongo/util/net/ssl_manager.cpp
@@ -141,6 +141,7 @@ namespace mongo {
                    const std::string& clusterpwd,
                    const std::string& cafile = "",
                    const std::string& crlfile = "",
+                   const std::string& cipherConfig = "",
                    bool weakCertificateValidation = false,
                    bool allowInvalidCertificates = false,
                    bool allowInvalidHostnames = false,
@@ -151,6 +152,7 @@ namespace mongo {
                 clusterpwd(clusterpwd),
                 cafile(cafile),
                 crlfile(crlfile),
+                cipherConfig(cipherConfig),
                 weakCertificateValidation(weakCertificateValidation),
                 allowInvalidCertificates(allowInvalidCertificates),
                 allowInvalidHostnames(allowInvalidHostnames),
@@ -162,6 +164,7 @@ namespace mongo {
             std::string clusterpwd;
             std::string cafile;
             std::string crlfile;
+            std::string cipherConfig;
             bool weakCertificateValidation;
             bool allowInvalidCertificates;
             bool allowInvalidHostnames;
@@ -303,6 +306,7 @@ namespace mongo {
                 std::string(), // server only parameter
                 options.SSLCAFile(),
                 options.SSLCRLFile(),
+                options.SSLCipherConfig(),
                 false, // server only parameter
                 options.SSLAllowInvalidCertificates(),
                 options.SSLAllowInvalidHostnames(),
@@ -550,7 +554,16 @@ namespace mongo {
         // !EXPORT - Disable export ciphers (40/56 bit) 
         // !aNULL - Disable anonymous auth ciphers
         // @STRENGTH - Sort ciphers based on strength 
-        SSL_CTX_set_cipher_list(*context, "HIGH:!EXPORT:!aNULL@STRENGTH");
+        std::string cipherConfig = "HIGH:!EXPORT:!aNULL@STRENGTH";
+
+        // Allow the cipher configuration string to be overriden by --sslCipherConfig
+        if (!params.cipherConfig.empty()) {
+            cipherConfig = params.cipherConfig;
+        }
+
+        massert(28615, mongoutils::str::stream() << "can't set supported cipher suites: " <<
+                getSSLErrorMessage(ERR_get_error()),
+                SSL_CTX_set_cipher_list(*context, cipherConfig.c_str()));
 
         // If renegotiation is needed, don't return from recv() or send() until it's successful.
         // Note: this is for blocking sockets only.


### PR DESCRIPTION
This is a little ahead of the game because we haven't even released legacy-1.0.2, but these are the server backports that would flow into a 1.0.3. There is some actual work in here, since I had to refactor how the SSL changes worked in some places, since we don't have SSLGlobalParams like the server does.

FYI @spencerjackson would appreciate you giving this a look as much of this is backports of your work.