### PR TITLE
Fix for corruption of data appended to a gridfs  with appendChunk

### DIFF
--- a/src/mongo/client/gridfs.cpp
+++ b/src/mongo/client/gridfs.cpp
@@ -321,7 +321,14 @@ namespace mongo {
             invariant( _pendingDataSize <= _chunkSize );
             if (_pendingDataSize == _chunkSize) {
                 _appendPendingData();
-                _appendChunk( data + size, length - size, false );
+                const char* const end = data + length;
+                data = _appendChunk( data + size, length - size, false );
+                if (data != end) {
+                    invariant(data < end);
+                    size_t nsize = static_cast<size_t>(end - data);
+                    memcpy( _pendingData.get() + _pendingDataSize, data, nsize );
+                    _pendingDataSize += nsize;
+                }
             }
         }
         else {

--- a/src/mongo/integration/standalone/gridfs_test.cpp
+++ b/src/mongo/integration/standalone/gridfs_test.cpp
@@ -226,21 +226,45 @@ namespace {
 
     TEST_F(GridFSTest, GridFileBuilder) {
         GridFileBuilder gfb(_gfs.get());
-        for (int i=0; i<DATA_LEN; i+=2)
-            gfb.appendChunk(DATA + i, min(2, DATA_LEN - i));
+        size_t totalSize = 0;
+        for (int i=0; i<DATA_LEN; i+=2) {
+            size_t chunkSize = min(2, DATA_LEN - i);
+            gfb.appendChunk(DATA + i, chunkSize);
+            totalSize += chunkSize;
+        }
         gfb.buildFile(DATA_NAME);
         GridFile gf = _gfs->findFileByName(DATA_NAME);
         ASSERT_EQUALS(gf.getNumChunks(), 1);
+        ASSERT_EQUALS(gf.getContentLength(), totalSize);
     }
 
     TEST_F(GridFSTest, GridFileBuilderMultipleChunks) {
         _gfs->setChunkSize(1);
         GridFileBuilder gfb(_gfs.get());
-        for (int i=0; i<DATA_LEN; i+=2)
-            gfb.appendChunk(DATA + i, min(2, DATA_LEN - i));
+        size_t total_size = 0;
+        for (int i=0; i<DATA_LEN; i+=2) {
+            size_t chunk_size = min(2, DATA_LEN - i);
+            gfb.appendChunk(DATA + i, chunk_size);
+            total_size += chunk_size;
+        }
         gfb.buildFile(DATA_NAME);
         GridFile gf = _gfs->findFileByName(DATA_NAME);
         ASSERT_EQUALS(gf.getNumChunks(), DATA_LEN);
+        ASSERT_EQUALS(gf.getContentLength(), total_size);
+    }
+
+    TEST_F(GridFSTest, GridFileBuilderAcrossChunkBoundry) {
+        _gfs->setChunkSize(11);
+        GridFileBuilder gfb(_gfs.get());
+        size_t total_size = 0;
+        for (int i=0; i<DATA_LEN; i+=2) {
+            size_t chunk_size = min(2, DATA_LEN - i);
+            gfb.appendChunk(DATA + i, chunk_size);
+            total_size += chunk_size;
+        }
+        gfb.buildFile(DATA_NAME);
+        GridFile gf = _gfs->findFileByName(DATA_NAME);
+        ASSERT_EQUALS(gf.getContentLength(), total_size);
     }
 
 } // namespace


### PR DESCRIPTION
This is a fix for bug CXX-603, which I reported. 

The class mongo::GridFileBuilder, drops parts of appended data blocks from the stream, corrupting it.

Using mongo::GridFileBuilder:appendChunk to append data with arbitrary block sizes can drop part of the data block. The function call _appendChunk( data + size, length - size,false) is used without checking if there is any further data to add to the pending buffer.   The patch checks the returned value and adds it to the append buffer as done in other parts of the code.