### PR TITLE
CXX-661 - Added missing memcpy in oid constructor.

### DIFF
--- a/src/bsoncxx/oid.cpp
+++ b/src/bsoncxx/oid.cpp
@@ -35,6 +35,7 @@ oid::oid(stdx::string_view str) : _is_valid(bson_oid_is_valid(str.data(), str.le
     if (_is_valid) {
         bson_oid_t oid;
         bson_oid_init_from_string(&oid, str.data());
+        memcpy(_bytes, oid.bytes, sizeof(_bytes));
     }
 }
 


### PR DESCRIPTION
Had some issues regarding oids. Found a missing memcpy. The memcpy could be avoided by storing the result of a hex conversion directly in _bytes but the rest of the code seems to use the bson_oid_* functions so I just added the memcpy. 