### PR TITLE
CXX-679 basic::builder should support concatenate

### DIFF
--- a/src/bsoncxx/builder/basic/helpers.hpp
+++ b/src/bsoncxx/builder/basic/helpers.hpp
@@ -1,0 +1,41 @@
+// Copyright 2015 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/config/prelude.hpp>
+
+#include <bsoncxx/document/view.hpp>
+
+namespace bsoncxx {
+BSONCXX_INLINE_NAMESPACE_BEGIN
+namespace builder {
+namespace basic {
+
+///
+/// Container to concatenate a document. Use it by constructing an instance with the
+/// document to be concatenated, and pass it to append.
+///
+struct BSONCXX_API concatenate {
+    document::view view;
+
+    BSONCXX_INLINE operator document::view() const { return view; }
+};
+
+}  // namespace basic
+}  // namespace builder
+BSONCXX_INLINE_NAMESPACE_END
+}  // namespace bsoncxx
+
+#include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/builder/basic/sub_array.hpp
+++ b/src/bsoncxx/builder/basic/sub_array.hpp
@@ -16,6 +16,7 @@
 
 #include <bsoncxx/config/prelude.hpp>
 
+#include <bsoncxx/builder/basic/helpers.hpp>
 #include <bsoncxx/builder/core.hpp>
 
 namespace bsoncxx {
@@ -45,20 +46,31 @@ class BSONCXX_API sub_array {
     template <typename Arg, typename... Args>
     BSONCXX_INLINE
     void append(Arg&& a, Args&&... args) {
-        append(std::forward<Arg>(a));
+        append_(std::forward<Arg>(a));
         append(std::forward<Args>(args)...);
     }
 
+    BSONCXX_INLINE
+    void append() {}
+
+   private:
     ///
     /// Appends a BSON value.
     ///
     template <typename T>
     BSONCXX_INLINE
-    void append(T&& t) {
+    void append_(T&& t) {
         impl::value_append(_core, std::forward<T>(t));
     }
 
-   private:
+    ///
+    /// Concatenates another bson document directly.
+    ///
+    BSONCXX_INLINE
+    void append_(concatenate concatenate) {
+        _core->concatenate(concatenate);
+    }
+
     core* _core;
 };
 

--- a/src/bsoncxx/test/bson_builder.cpp
+++ b/src/bsoncxx/test/bson_builder.cpp
@@ -747,6 +747,56 @@ TEST_CASE("basic array builder works", "[bsoncxx::builder::basic]") {
     }
 }
 
+TEST_CASE("basic document builder works with concat", "[bsoncxx::builder::basic]") {
+    using namespace builder::basic;
+
+    auto subdoc = builder::stream::document{} << "hello" << "world" << builder::stream::finalize;
+
+    builder::stream::document stream;
+    builder::basic::document basic;
+
+    stream << builder::stream::concatenate{subdoc};
+
+    SECTION("single insert works") {
+        basic.append(builder::basic::concatenate{subdoc});
+
+        viewable_eq_viewable(stream, basic);
+    }
+
+    SECTION("variadic works") {
+        stream << builder::stream::concatenate{subdoc};
+
+        basic.append(builder::basic::concatenate{subdoc}, builder::basic::concatenate{subdoc});
+
+        viewable_eq_viewable(stream, basic);
+    }
+}
+
+TEST_CASE("basic array builder works with concat", "[bsoncxx::builder::basic]") {
+    using namespace builder::basic;
+
+    auto subdoc = builder::stream::array{} << 1 << 2 << builder::stream::finalize;
+
+    builder::stream::array stream;
+    builder::basic::array basic;
+
+    stream << builder::stream::concatenate{subdoc.view()};
+
+    SECTION("single insert works") {
+        basic.append(builder::basic::concatenate{subdoc.view()});
+
+        viewable_eq_viewable(stream, basic);
+    }
+
+    SECTION("variadic works") {
+        stream << builder::stream::concatenate{subdoc.view()};
+
+        basic.append(builder::basic::concatenate{subdoc.view()}, builder::basic::concatenate{subdoc.view()});
+
+        viewable_eq_viewable(stream, basic);
+    }
+}
+
 TEST_CASE("element throws on bad get_", "[bsoncxx::builder::basic]") {
     using namespace builder::basic;
 


### PR DESCRIPTION
This adds support for concatenate in the basic builder api in a way that mirrors the stream api (with a tagged type)