### PR TITLE
CXX-703: Add clang-format to scons lint, and add scons lint to Evergreen

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -30,6 +30,7 @@ cxx_driver_variables:
 
   version_test_list: &version_tests
     - name: "compile"
+    - name: "lint"
     - name: "unit test"
     - name: "integration test 2.2"
     - name: "integration test 2.4"

--- a/SConstruct
+++ b/SConstruct
@@ -18,6 +18,7 @@ import urllib2
 import buildscripts.utils
 import buildscripts.docs
 import buildscripts.lint
+import buildscripts.clang_format
 
 EnsureSConsVersion( 1, 1, 0 )
 
@@ -1854,6 +1855,10 @@ env.AlwaysBuild("docs")
 # --- lint ----
 
 def doLint( env , target , source ):
+    import buildscripts.clang_format
+    if not buildscripts.clang_format.lint(None, []):
+        raise Exception("clang-format lint errors")
+
     if not buildscripts.lint.run_lint( [ "src/mongo/" ] ):
         raise Exception( "lint errors" )
 

--- a/site_scons/buildscripts/clang_format.py
+++ b/site_scons/buildscripts/clang_format.py
@@ -259,7 +259,10 @@ class ClangFormat(object):
     def _validate_version(self, warn=False):
         """Validate clang-format is the expected version
         """
-        cf_version = callo([self.path, "--version"])
+        try:
+            cf_version = callo([self.path, "--version"])
+        except CalledProcessError:
+            cf_version = "clang-format call failed."
 
         if CLANG_FORMAT_VERSION in cf_version:
             return True


### PR DESCRIPTION
1. Add call to clang-format.py in scons lint
2. Add lint task to RHEL 5.5 builder

Verified on Mac OS X 10.9
