### PR TITLE
CXX-709: Fix reinterpret_cast for VS 2015

### DIFF
--- a/src/mongo/bson/util/builder_test.cpp
+++ b/src/mongo/bson/util/builder_test.cpp
@@ -34,7 +34,7 @@ TEST(Builder, String1) {
 
 TEST(Builder, StringBuilderAddress) {
     const void* longPtr = reinterpret_cast<const void*>(-1);
-    const void* shortPtr = reinterpret_cast<const void*>(0xDEADBEEF);
+    const void* shortPtr = reinterpret_cast<const void*>(0xDEADBEEFULL);
     const void* nullPtr = NULL;
 
     StringBuilder sb;


### PR DESCRIPTION
I have verified this on all support platforms & compilers in Evergreen including the 32-bit builders.