### PR TITLE
Tests now pass on Evergreen

### DIFF
--- a/src/mongocxx/test/pool.cpp
+++ b/src/mongocxx/test/pool.cpp
@@ -127,7 +127,7 @@ TEST_CASE(
     "[pool]") {
     MOCK_POOL
 
-    std::max_align_t dummy_address;
+    ::max_align_t dummy_address;
     bool try_pop_called = false;
 
     mongoc_client_t* fake = reinterpret_cast<mongoc_client_t*>(&dummy_address);


### PR DESCRIPTION
switch max_align_t to global scope