### PR TITLE
CXX-692: findAndModify take a write concern

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -428,7 +428,7 @@ if releaseBuild and (debugBuild or not optBuild):
     print("Error: A --release build may not have debugging, and must have optimization")
     Exit(1)
 
-mongoclientVersion = "1.0.6"
+mongoclientVersion = "1.1.0-rc0-pre"
 # We don't keep the -pre in the user testable version identifiers, because
 # nobody should be conditioning on the pre-release status.
 mongoclientVersionComponents = re.split(r'\.|-rc', mongoclientVersion.partition('-pre')[0])

--- a/etc/doxygen/config
+++ b/etc/doxygen/config
@@ -3,7 +3,7 @@
 #---------------------------------------------------------------------------
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "MongoDB C++ Driver"
-PROJECT_NUMBER         = legacy-1.0.6
+PROJECT_NUMBER         = legacy-1.1.0-rc0-pre
 OUTPUT_DIRECTORY       = docs/doxygen
 CREATE_SUBDIRS         = NO
 OUTPUT_LANGUAGE        = English

--- a/src/mongo/client/dbclient.cpp
+++ b/src/mongo/client/dbclient.cpp
@@ -1336,14 +1336,15 @@ BSONObj DBClientWithCommands::distinct(const StringData& ns,
     return result.getField("values").Obj().getOwned();
 }
 
-void DBClientWithCommands::_findAndModify(const StringData& ns,
-                                          const BSONObj& query,
-                                          const BSONObj& update,
-                                          const BSONObj& sort,
-                                          bool returnNew,
-                                          bool upsert,
-                                          const BSONObj& fields,
-                                          BSONObjBuilder* out) {
+void DBClientBase::_findAndModify(const StringData& ns,
+                                  const BSONObj& query,
+                                  const BSONObj& update,
+                                  const BSONObj& sort,
+                                  bool returnNew,
+                                  bool upsert,
+                                  const BSONObj& fields,
+                                  const WriteConcern* writeConcern,
+                                  BSONObjBuilder* out) {
     BSONObjBuilder commandBuilder;
 
     commandBuilder.append("findAndModify", nsGetCollection(ns.toString()));
@@ -1365,6 +1366,17 @@ void DBClientWithCommands::_findAndModify(const StringData& ns,
     commandBuilder.append("new", returnNew);
     commandBuilder.append("upsert", upsert);
 
+    if (getMaxWireVersion() >= 4) {
+        const WriteConcern* operationWriteConcern =
+            writeConcern ? writeConcern : &getWriteConcern();
+
+        commandBuilder.append("writeConcern", operationWriteConcern->obj());
+    } else {
+        uassert(0,
+                "WriteConcern is not supported for findAndModify with this server version.",
+                writeConcern == NULL);
+    }
+
     BSONObj result;
     bool ok = runCommand(nsGetDB(ns.toString()), commandBuilder.obj(), result);
 
@@ -1374,24 +1386,26 @@ void DBClientWithCommands::_findAndModify(const StringData& ns,
     out->appendElements(result.getObjectField("value"));
 }
 
-BSONObj DBClientWithCommands::findAndModify(const StringData& ns,
-                                            const BSONObj& query,
-                                            const BSONObj& update,
-                                            bool upsert,
-                                            bool returnNew,
-                                            const BSONObj& sort,
-                                            const BSONObj& fields) {
+BSONObj DBClientBase::findAndModify(const StringData& ns,
+                                    const BSONObj& query,
+                                    const BSONObj& update,
+                                    bool upsert,
+                                    bool returnNew,
+                                    const BSONObj& sort,
+                                    const BSONObj& fields,
+                                    const WriteConcern* wc) {
     BSONObjBuilder result;
-    _findAndModify(ns, query, update, sort, returnNew, upsert, fields, &result);
+    _findAndModify(ns, query, update, sort, returnNew, upsert, fields, wc, &result);
     return result.obj();
 }
 
-BSONObj DBClientWithCommands::findAndRemove(const StringData& ns,
-                                            const BSONObj& query,
-                                            const BSONObj& sort,
-                                            const BSONObj& fields) {
+BSONObj DBClientBase::findAndRemove(const StringData& ns,
+                                    const BSONObj& query,
+                                    const BSONObj& sort,
+                                    const BSONObj& fields,
+                                    const WriteConcern* wc) {
     BSONObjBuilder result;
-    _findAndModify(ns, query, BSONObj(), sort, false, false, fields, &result);
+    _findAndModify(ns, query, BSONObj(), sort, false, false, fields, wc, &result);
     return result.obj();
 }
 

--- a/src/mongo/client/dbclientinterface.h
+++ b/src/mongo/client/dbclientinterface.h
@@ -1134,42 +1134,6 @@ public:
      */
     BSONObj distinct(const StringData& ns, const StringData& field, const Query& query = Query());
 
-    /**
-     * Modifies and returns a single document.
-     *
-     * @note By default, the returned document does not include modifications made on update.
-     *
-     * @param ns Namespace on which to perform this findAndModify.
-     * @param update Update document to be applied.
-     * @param query Filter for the update.
-     * @param upsert Insert if object does not exist.
-     * @param sort Sort for the filter.
-     * @param new Return the updated rather than original object.
-     * @param fields Fields to return. Specifies inclusion with 1, "{<field1>: 1, ...}"
-     */
-    BSONObj findAndModify(const StringData& ns,
-                          const BSONObj& query,
-                          const BSONObj& update,
-                          bool upsert = false,
-                          bool returnNew = false,
-                          const BSONObj& sort = BSONObj(),
-                          const BSONObj& fields = BSONObj());
-
-    /**
-     * Removes and returns a single document.
-     *
-     * @note By default, the returned document does not include modifications made on update.
-     *
-     * @param ns Namespace on which to perform this findAndModify.
-     * @param query Filter for the update.
-     * @param sort Sort for the filter.
-     * @param fields Fields to return. Specifies inclusion with 1, "{<field1>: 1, ...}"
-     */
-    BSONObj findAndRemove(const StringData& ns,
-                          const BSONObj& query,
-                          const BSONObj& sort = BSONObj(),
-                          const BSONObj& fields = BSONObj());
-
     /** Run javascript code on the database server.
        dbname    database SavedContext in which the code runs. The javascript variable 'db' will be
                  assigned to this database when the function is invoked.
@@ -1444,15 +1408,6 @@ private:
                    const Query& query,
                    std::vector<BSONObj>* output);
 
-    void _findAndModify(const StringData& ns,
-                        const BSONObj& query,
-                        const BSONObj& update,
-                        const BSONObj& sort,
-                        bool returnNew,
-                        bool upsert,
-                        const BSONObj& fields,
-                        BSONObjBuilder* out);
-
     std::auto_ptr<DBClientCursor> _legacyCollectionInfo(const std::string& db,
                                                         const BSONObj& filter,
                                                         int batchSize);
@@ -1637,6 +1592,46 @@ public:
         const std::string& ns, Query query, BSONObj obj, int flags, const WriteConcern* wc = NULL);
 
     /**
+     * Modifies and returns a single document.
+     *
+     * @note By default, the returned document does not include modifications made on update.
+     *
+     * @param ns Namespace on which to perform this findAndModify.
+     * @param update Update document to be applied.
+     * @param query Filter for the update.
+     * @param upsert Insert if object does not exist.
+     * @param sort Sort for the filter.
+     * @param new Return the updated rather than original object.
+     * @param fields Fields to return. Specifies inclusion with 1, "{<field1>: 1, ...}"
+     * @param wc The write concern for this operation.
+     */
+    BSONObj findAndModify(const StringData& ns,
+                          const BSONObj& query,
+                          const BSONObj& update,
+                          bool upsert = false,
+                          bool returnNew = false,
+                          const BSONObj& sort = BSONObj(),
+                          const BSONObj& fields = BSONObj(),
+                          const WriteConcern* wc = NULL);
+
+    /**
+     * Removes and returns a single document.
+     *
+     * @note By default, the returned document does not include modifications made on update.
+     *
+     * @param ns Namespace on which to perform this findAndModify.
+     * @param query Filter for the update.
+     * @param sort Sort for the filter.
+     * @param fields Fields to return. Specifies inclusion with 1, "{<field1>: 1, ...}"
+     * @param wc The write concern for this operation.
+     */
+    BSONObj findAndRemove(const StringData& ns,
+                          const BSONObj& query,
+                          const BSONObj& sort = BSONObj(),
+                          const BSONObj& fields = BSONObj(),
+                          const WriteConcern* wc = NULL);
+
+    /**
      * Initializes an ordered bulk operation by returning an object that can be
      * used to enqueue multiple operations for batch execution.
      *
@@ -1690,6 +1685,17 @@ public:
     }
 
     virtual void reset() {}
+
+private:
+    void _findAndModify(const StringData& ns,
+                        const BSONObj& query,
+                        const BSONObj& update,
+                        const BSONObj& sort,
+                        bool returnNew,
+                        bool upsert,
+                        const BSONObj& fields,
+                        const WriteConcern* wc,
+                        BSONObjBuilder* out);
 
 };  // DBClientBase
 

--- a/src/mongo/integration/standalone/dbclient_test.cpp
+++ b/src/mongo/integration/standalone/dbclient_test.cpp
@@ -240,6 +240,25 @@ TEST_F(DBClientTest, FindAndModifyDuplicateKeyError) {
         OperationException);
 }
 
+TEST_F(DBClientTest, FindAndModifyWriteConcern) {
+    if (serverGTE(c.get(), 3, 1)) {
+        c->insert(TEST_NS, BSON("_id" << 1 << "i" << 1));
+
+        BSONObj result = c->findAndModify(TEST_NS,
+                                          BSON("i" << 1),
+                                          BSON("$inc" << BSON("i" << 1)),
+                                          false,
+                                          false,
+                                          BSONObj(),
+                                          BSONObj(),
+                                          &WriteConcern::journaled);
+
+        ASSERT_EQUALS(result.getIntField("_id"), 1);
+        ASSERT_EQUALS(result.getIntField("i"), 1);
+        ASSERT_EQUALS(c->count(TEST_NS), 1U);
+    }
+}
+
 TEST_F(DBClientTest, FindAndRemove) {
     c->insert(TEST_NS, BSON("_id" << 1 << "i" << 1));
 
@@ -279,6 +298,19 @@ TEST_F(DBClientTest, FindAndRemoveProjection) {
     ASSERT_FALSE(result.hasField("_id"));
     ASSERT_TRUE(result.hasField("i"));
     ASSERT_EQUALS(c->count(TEST_NS), 0U);
+}
+
+TEST_F(DBClientTest, FindAndRemoveWriteConcern) {
+    if (serverGTE(c.get(), 3, 1)) {
+        c->insert(TEST_NS, BSON("_id" << 1 << "i" << 1));
+
+        BSONObj result = c->findAndRemove(
+            TEST_NS, BSON("i" << 1), BSONObj(), BSONObj(), &WriteConcern::journaled);
+
+        ASSERT_EQUALS(result.getIntField("_id"), 1);
+        ASSERT_EQUALS(result.getIntField("i"), 1);
+        ASSERT_EQUALS(c->count(TEST_NS), 0U);
+    }
 }
 
 TEST_F(DBClientTest, ManualGetMore) {


### PR DESCRIPTION
Add a `writeConcern` argument to `findAndModify`.

I needed to move `findAndModify` to `DBClientBase` since this is the class that had `writeConcern` has the connection-level default `writeConcern`.