### PR TITLE
CXX-681: fix bulk_write results to return int_32t values

### DIFF
--- a/src/mongocxx/result/bulk_write.cpp
+++ b/src/mongocxx/result/bulk_write.cpp
@@ -21,24 +21,24 @@ namespace result {
 bulk_write::bulk_write(bsoncxx::document::value raw_response) : _response(std::move(raw_response)) {
 }
 
-std::int64_t bulk_write::inserted_count() const {
-    return view()["nInserted"].get_int64();
+std::int32_t bulk_write::inserted_count() const {
+    return view()["nInserted"].get_int32();
 }
 
-std::int64_t bulk_write::matched_count() const {
-    return view()["nMatched"].get_int64();
+std::int32_t bulk_write::matched_count() const {
+    return view()["nMatched"].get_int32();
 }
 
-std::int64_t bulk_write::modified_count() const {
-    return view()["nModified"].get_int64();
+std::int32_t bulk_write::modified_count() const {
+    return view()["nModified"].get_int32();
 };
 
-std::int64_t bulk_write::deleted_count() const {
-    return view()["nRemoved"].get_int64();
+std::int32_t bulk_write::deleted_count() const {
+    return view()["nRemoved"].get_int32();
 }
 
-std::int64_t bulk_write::upserted_count() const {
-    return view()["nUpserted"].get_int64();
+std::int32_t bulk_write::upserted_count() const {
+    return view()["nUpserted"].get_int32();
 }
 
 bsoncxx::document::element bulk_write::inserted_ids() const {

--- a/src/mongocxx/result/bulk_write.hpp
+++ b/src/mongocxx/result/bulk_write.hpp
@@ -40,35 +40,35 @@ class MONGOCXX_API bulk_write {
     ///
     /// @return The number of documents that were inserted.
     ///
-    std::int64_t inserted_count() const;
+    std::int32_t inserted_count() const;
 
     ///
     /// Gets the number of documents that were matched during this operation.
     ///
     /// @return The number of documents that were matched.
     ///
-    std::int64_t matched_count() const;
+    std::int32_t matched_count() const;
 
     ///
     /// Gets the number of documents that were modified during this operation.
     ///
     /// @return The number of documents that were modified.
     ///
-    std::int64_t modified_count() const;
+    std::int32_t modified_count() const;
 
     ///
     /// Gets the number of documents that were deleted during this operation.
     ///
     /// @return The number of documents that were deleted.
     ///
-    std::int64_t deleted_count() const;
+    std::int32_t deleted_count() const;
 
     ///
     /// Gets the number of documents that were upserted during this operation.
     ///
     /// @return The number of documents that were upserted.
     ///
-    std::int64_t upserted_count() const;
+    std::int32_t upserted_count() const;
 
     ///
     /// Gets the ids of the inserted documents.

--- a/src/mongocxx/result/delete.cpp
+++ b/src/mongocxx/result/delete.cpp
@@ -25,7 +25,7 @@ const result::bulk_write& delete_result::result() const {
     return _result;
 }
 
-std::int64_t delete_result::deleted_count() const {
+std::int32_t delete_result::deleted_count() const {
     return _result.deleted_count();
 }
 

--- a/src/mongocxx/result/delete.hpp
+++ b/src/mongocxx/result/delete.hpp
@@ -45,7 +45,7 @@ class MONGOCXX_API delete_result {
     ///
     /// @return The number of documents that were deleted.
     ///
-    std::int64_t deleted_count() const;
+    std::int32_t deleted_count() const;
 
    private:
     result::bulk_write _result;

--- a/src/mongocxx/result/insert_many.cpp
+++ b/src/mongocxx/result/insert_many.cpp
@@ -26,7 +26,7 @@ insert_many::id_map insert_many::inserted_ids() {
     return _generated_ids;
 }
 
-std::int64_t insert_many::inserted_count() const {
+std::int32_t insert_many::inserted_count() const {
     return _result.inserted_count();
 }
 

--- a/src/mongocxx/result/insert_many.hpp
+++ b/src/mongocxx/result/insert_many.hpp
@@ -50,7 +50,7 @@ class MONGOCXX_API insert_many {
     ///
     /// @return The number of documents that were inserted.
     ///
-    std::int64_t inserted_count() const;
+    std::int32_t inserted_count() const;
 
     ///
     /// Gets the _ids of the inserted documents.

--- a/src/mongocxx/result/replace_one.cpp
+++ b/src/mongocxx/result/replace_one.cpp
@@ -25,11 +25,11 @@ const result::bulk_write& replace_one::result() const {
     return _result;
 }
 
-std::int64_t replace_one::matched_count() const {
+std::int32_t replace_one::matched_count() const {
     return _result.matched_count();
 }
 
-std::int64_t replace_one::modified_count() const {
+std::int32_t replace_one::modified_count() const {
     return _result.modified_count();
 }
 

--- a/src/mongocxx/result/replace_one.hpp
+++ b/src/mongocxx/result/replace_one.hpp
@@ -45,14 +45,14 @@ class MONGOCXX_API replace_one {
     ///
     /// @return The number of documents that were matched.
     ///
-    std::int64_t matched_count() const;
+    std::int32_t matched_count() const;
 
     ///
     /// Gets the number of documents that were modified during this operation.
     ///
     /// @return The number of documents that were modified.
     ///
-    std::int64_t modified_count() const;
+    std::int32_t modified_count() const;
 
     ///
     /// Gets the id of the upserted document.

--- a/src/mongocxx/result/update.cpp
+++ b/src/mongocxx/result/update.cpp
@@ -24,11 +24,11 @@ update::update(result::bulk_write result) : _result(std::move(result)) {
 const result::bulk_write& update::result() const {
     return _result;
 }
-std::int64_t update::matched_count() const {
+std::int32_t update::matched_count() const {
     return _result.matched_count();
 }
 
-std::int64_t update::modified_count() const {
+std::int32_t update::modified_count() const {
     return _result.modified_count();
 }
 

--- a/src/mongocxx/result/update.hpp
+++ b/src/mongocxx/result/update.hpp
@@ -45,14 +45,13 @@ class MONGOCXX_API update {
     ///
     /// @return The number of documents that were matched.
     ///
-    std::int64_t matched_count() const;
+    std::int32_t matched_count() const;
 
     ///
     /// Gets the number of documents that were modified during this operation.
     ///
     /// @return The number of documents that were modified.
-    ///    std::int64_t matched_count() const;
-    std::int64_t modified_count() const;
+    std::int32_t modified_count() const;
 
     ///
     /// If a document was upserted during this operation, gets the _id of the upserted document.

--- a/src/mongocxx/test/result/delete.cpp
+++ b/src/mongocxx/test/result/delete.cpp
@@ -22,7 +22,7 @@
 TEST_CASE("delete", "[delete][result]") {
     bsoncxx::builder::stream::document build;
     build << "_id" << bsoncxx::oid{bsoncxx::oid::init_tag} << "nRemoved"
-          << bsoncxx::types::b_int64{1};
+          << bsoncxx::types::b_int32{1};
 
     mongocxx::result::bulk_write b(bsoncxx::document::value(build.view()));
 

--- a/src/mongocxx/test/result/replace_one.cpp
+++ b/src/mongocxx/test/result/replace_one.cpp
@@ -21,7 +21,7 @@
 TEST_CASE("replace_one", "[replace_one][result]") {
     bsoncxx::builder::stream::document build;
     build << "_id" << bsoncxx::oid{bsoncxx::oid::init_tag} << "nMatched"
-          << bsoncxx::types::b_int64{2} << "nModified" << bsoncxx::types::b_int64{1};
+          << bsoncxx::types::b_int32{2} << "nModified" << bsoncxx::types::b_int32{1};
 
     mongocxx::result::bulk_write b(bsoncxx::document::value(build.view()));
 

--- a/src/mongocxx/test/result/update.cpp
+++ b/src/mongocxx/test/result/update.cpp
@@ -21,7 +21,7 @@
 TEST_CASE("update", "[update][result]") {
     bsoncxx::builder::stream::document build;
     build << "_id" << bsoncxx::oid{bsoncxx::oid::init_tag} << "nMatched"
-          << bsoncxx::types::b_int64{2} << "nModified" << bsoncxx::types::b_int64{1};
+          << bsoncxx::types::b_int32{2} << "nModified" << bsoncxx::types::b_int32{1};
 
     mongocxx::result::bulk_write b(bsoncxx::document::value(build.view()));
 


### PR DESCRIPTION
The server and C driver both return int_32's for these commands, the bsoncxx `get_int64()` was causing and error.