### PR TITLE
CXX-717: implement C++ version verification

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1696,11 +1696,28 @@ def doConfigure(myenv):
         context.Result(ret)
         return ret
 
+    def GetCXXVersion(context):
+        test_body = """
+        #include <cstdio>
+
+        int
+        main(int argc, char **argv)
+        {
+          printf("%lu", __cplusplus);
+          return 0;
+        }
+        """
+        context.Message('Checking for C++ version... ')
+        ret = context.TryRun(textwrap.dedent(test_body), '.cpp')
+        context.Result(ret[1])
+        return ret[1]
+
     conf = Configure(myenv, help=False, custom_tests = {
         'CheckCXX11Atomics': CheckCXX11Atomics,
         'CheckGCCAtomicBuiltins': CheckGCCAtomicBuiltins,
         'CheckGCCSyncBuiltins': CheckGCCSyncBuiltins,
         'CheckCXX11IsTriviallyCopyable': CheckCXX11IsTriviallyCopyable,
+	'GetCXXVersion': GetCXXVersion
     })
 
     # Figure out what atomics mode to use by way of the tests defined above.
@@ -1733,6 +1750,8 @@ def doConfigure(myenv):
 
     if (cxx11_mode == "on") and conf.CheckCXX11IsTriviallyCopyable():
         conf.env['MONGO_HAVE_STD_IS_TRIVIALLY_COPYABLE'] = True
+
+    conf.env["CXX_VERSION"] = conf.GetCXXVersion()
 
     myenv = conf.Finish()
 

--- a/src/SConscript.client
+++ b/src/SConscript.client
@@ -50,6 +50,12 @@ def makeConfigHDefineWithValue(env, subst_key, env_var):
     return (subst_key, replacement % (env_var, value))
 libEnv.AddMethod(makeConfigHDefineWithValue)
 
+def makeConfigHDefineWithNameAndValue(env, subst_key, name, env_var):
+    value = env.get(env_var)
+    replacement = "#define %s %s"
+    return (subst_key, replacement % (name, value))
+libEnv.AddMethod(makeConfigHDefineWithNameAndValue)
+
 configSubstitutions = [
     libEnv.makeConfigHDefine('@mongoclient_ssl@', 'MONGO_SSL'),
     libEnv.makeConfigHDefine('@mongoclient_sasl@', 'MONGO_SASL'),
@@ -60,6 +66,7 @@ configSubstitutions = [
     libEnv.makeConfigHDefine('@mongoclient_have_std_is_trivially_copyable@', 'MONGO_HAVE_STD_IS_TRIVIALLY_COPYABLE'),
     libEnv.makeConfigHDefine('@mongoclient_have_strnlen@', 'MONGO_HAVE_STRNLEN'),
     libEnv.makeConfigHDefineWithValue('@mongoclient_byte_order@', 'MONGO_BYTE_ORDER'),
+    libEnv.makeConfigHDefineWithNameAndValue('@mongoclient_lib_cxx_version@', 'MONGOCLIENT_LIB_CXX_VERSION', 'CXX_VERSION'),
 ]
 libEnv.Substfile('mongo/config.h.in', SUBST_DICT=configSubstitutions)
 

--- a/src/mongo/config.h.in
+++ b/src/mongo/config.h.in
@@ -42,3 +42,11 @@
 // Define to 1 if this platform provides the strnlen(3) function
 @mongoclient_have_strnlen@
 
+// Defines the C++ version the library was compiled with
+@mongoclient_lib_cxx_version@
+
+// Verifies that the currently used C++ version is compatible
+#if __cplusplus != MONGOCLIENT_LIB_CXX_VERSION
+#  error Incompatible C++ versions used (different C++ standard for lib than current module)
+#endif
+


### PR DESCRIPTION
mongo-cxx-driver crashes if used in an application built with a
different C++ version than the library itself. Add a little compile time
generator that adds the library C++ version and a snippet in config.h
that throws an error if compiling a file against mongo-cxx-driver
headers with a different C++ version.