### PR TITLE
CXX-689 Assert bypassDocumentValidation is not used with unacknowledged writes

### DIFF
--- a/src/mongo/client/dbclient.cpp
+++ b/src/mongo/client/dbclient.cpp
@@ -2040,8 +2040,7 @@ void DBClientBase::_write(const string& ns,
                           WriteResult* writeResult) {
     const WriteConcern* operationWriteConcern = writeConcern ? writeConcern : &getWriteConcern();
 
-    if (getMaxWireVersion() >= 2 &&
-        (operationWriteConcern->requiresConfirmation() || bypassDocumentValidation))
+    if (getMaxWireVersion() >= 2 && operationWriteConcern->requiresConfirmation())
         _commandWriter->write(
             ns, writes, ordered, bypassDocumentValidation, operationWriteConcern, writeResult);
     else

--- a/src/mongo/client/wire_protocol_writer.cpp
+++ b/src/mongo/client/wire_protocol_writer.cpp
@@ -31,7 +31,17 @@ void WireProtocolWriter::write(const StringData& ns,
                                bool bypassDocumentValidation,
                                const WriteConcern* writeConcern,
                                WriteResult* writeResult) {
-    invariant(bypassDocumentValidation == false);
+    if (_client->getMaxWireVersion() >= 4) {
+        // Per DRIVERS-250:
+        // If your driver sends unacknowledged writes using op codes (OP_INSERT, OP_UPDATE,
+        // OP_DELETE), you MUST raise an error when bypassDocumentValidation is explicitly set by a
+        // user on >= 3.2 servers.
+        //
+        uassert(0,
+                "bypassDocumentValidation is not supported for unacknowledged writes with MongoDB "
+                "3.2 and later.",
+                !bypassDocumentValidation);
+    }
 
     // Effectively a map of batch relative indexes to WriteOperations
     std::vector<WriteOperation*> batchOps;

--- a/src/mongo/integration/standalone/dbclient_test.cpp
+++ b/src/mongo/integration/standalone/dbclient_test.cpp
@@ -125,6 +125,13 @@ TEST_F(DBClientTest, ByPassDocumentValidation) {
 
         ASSERT_EQUALS(c->count(TEST_NS), 1U);
 
+        // Validate we fail with ByPassDocumentValidation, and unacknowledged writes against 3.2
+        ASSERT_THROWS(c->insert(TEST_NS,
+                                BSON("fieldName" << 1000),
+                                InsertOption_BypassDocumentValidation,
+                                &WriteConcern::unacknowledged),
+                      std::exception);
+
         c->update(TEST_NS,
                   BSON("fieldName" << 1000),
                   BSON("fieldName" << 1001),


### PR DESCRIPTION
Per DRIVERS-250, when the a driver uses the legacy write operations to support unacknowledged writes, and the user sets bypassDocumentValidation, the driver should error.

Note: We cannot differentiate between a user setting bypassDocumentValidation to false, or if bypassDocumentValidation was simply initialized to false via default parameter at the moment. This could addressed, but I do not think it is worth the cost to differentiate these two scenarios.