### PR TITLE
CXX-716: use stdx names in the mongocxx via mongocxx/stdx.hpp

### DIFF
--- a/src/mongocxx/bulk_write.cpp
+++ b/src/mongocxx/bulk_write.cpp
@@ -31,7 +31,7 @@ bulk_write& bulk_write::operator=(bulk_write&&) noexcept = default;
 bulk_write::~bulk_write() = default;
 
 bulk_write::bulk_write(bool ordered)
-    : _impl(bsoncxx::stdx::make_unique<impl>(libmongoc::bulk_operation_new(ordered))) {
+    : _impl(stdx::make_unique<impl>(libmongoc::bulk_operation_new(ordered))) {
 }
 
 void bulk_write::append(const model::write& operation) {
@@ -93,9 +93,8 @@ void bulk_write::write_concern(class write_concern wc) {
 }
 
 class write_concern bulk_write::write_concern() const {
-    class write_concern wc(
-        bsoncxx::stdx::make_unique<write_concern::impl>(libmongoc::write_concern_copy(
-            libmongoc::bulk_operation_get_write_concern(_impl->operation_t))));
+    class write_concern wc(stdx::make_unique<write_concern::impl>(libmongoc::write_concern_copy(
+        libmongoc::bulk_operation_get_write_concern(_impl->operation_t))));
     return wc;
 }
 

--- a/src/mongocxx/client.hpp
+++ b/src/mongocxx/client.hpp
@@ -164,8 +164,8 @@ class MONGOCXX_API client {
     ///
     /// @return The database
     ///
-    class database database(stdx::string_view name) const &;
-    class database database(stdx::string_view name) const && = delete;
+    class database database(stdx::string_view name) const&;
+    class database database(stdx::string_view name) const&& = delete;
 
     ///
     /// Allows the syntax @c client["db_name"] as a convenient shorthand for the client::database()
@@ -178,8 +178,8 @@ class MONGOCXX_API client {
     ///
     /// @return Client side representation of a server side database
     ///
-    MONGOCXX_INLINE class database operator[](stdx::string_view name) const &;
-    MONGOCXX_INLINE class database operator[](stdx::string_view name) const && = delete;
+    MONGOCXX_INLINE class database operator[](stdx::string_view name) const&;
+    MONGOCXX_INLINE class database operator[](stdx::string_view name) const&& = delete;
 
     ///
     /// Enumerates the databases in the client.

--- a/src/mongocxx/collection.cpp
+++ b/src/mongocxx/collection.cpp
@@ -73,18 +73,17 @@ collection::operator bool() const noexcept {
     return static_cast<bool>(_impl);
 }
 
-bsoncxx::stdx::string_view collection::name() const noexcept {
+stdx::string_view collection::name() const noexcept {
     return _impl->name;
 }
 
-collection::collection(const database& database, bsoncxx::stdx::string_view collection_name)
-    : _impl(bsoncxx::stdx::make_unique<impl>(
+collection::collection(const database& database, stdx::string_view collection_name)
+    : _impl(stdx::make_unique<impl>(
           libmongoc::database_get_collection(database._impl->database_t, collection_name.data()),
           database.name(), database._impl->client_impl, collection_name.data())) {
 }
 
-bsoncxx::stdx::optional<result::bulk_write> collection::bulk_write(
-    const class bulk_write& bulk_write) {
+stdx::optional<result::bulk_write> collection::bulk_write(const class bulk_write& bulk_write) {
     mongoc_bulk_operation_t* b = bulk_write._impl->operation_t;
     libmongoc::bulk_operation_set_client(b, _impl->client_impl->client_t);
     libmongoc::bulk_operation_set_database(b, _impl->database_name.c_str());
@@ -101,7 +100,7 @@ bsoncxx::stdx::optional<result::bulk_write> collection::bulk_write(
 
     result::bulk_write result(reply.steal());
 
-    return bsoncxx::stdx::optional<result::bulk_write>(std::move(result));
+    return stdx::optional<result::bulk_write>(std::move(result));
 }
 
 cursor collection::find(bsoncxx::document::view filter, const options::find& options) {
@@ -133,16 +132,16 @@ cursor collection::find(bsoncxx::document::view filter, const options::find& opt
         projection.bson(), rp_ptr));
 }
 
-bsoncxx::stdx::optional<bsoncxx::document::value> collection::find_one(
-    bsoncxx::document::view filter, const options::find& options) {
+stdx::optional<bsoncxx::document::value> collection::find_one(bsoncxx::document::view filter,
+                                                              const options::find& options) {
     options::find copy(options);
     copy.limit(1);
     cursor cursor = find(filter, copy);
     cursor::iterator it = cursor.begin();
     if (it == cursor.end()) {
-        return bsoncxx::stdx::nullopt;
+        return stdx::nullopt;
     }
-    return bsoncxx::stdx::optional<bsoncxx::document::value>(bsoncxx::document::value{*it});
+    return stdx::optional<bsoncxx::document::value>(bsoncxx::document::value{*it});
 }
 
 cursor collection::aggregate(const pipeline& pipeline, const options::aggregate& options) {
@@ -187,8 +186,8 @@ void* collection::implementation() const {
     return _impl->collection_t;
 }
 
-bsoncxx::stdx::optional<result::insert_one> collection::insert_one(bsoncxx::document::view document,
-                                                                   const options::insert& options) {
+stdx::optional<result::insert_one> collection::insert_one(bsoncxx::document::view document,
+                                                          const options::insert& options) {
     class bulk_write bulk_op(false);
     bsoncxx::document::element oid{};
 
@@ -209,16 +208,16 @@ bsoncxx::stdx::optional<result::insert_one> collection::insert_one(bsoncxx::docu
 
     auto result = bulk_write(bulk_op);
     if (!result) {
-        return bsoncxx::stdx::optional<result::insert_one>();
+        return stdx::optional<result::insert_one>();
     }
 
-    return bsoncxx::stdx::optional<result::insert_one>(
+    return stdx::optional<result::insert_one>(
         result::insert_one(std::move(result.value()), std::move(oid.get_value())));
 }
 
-bsoncxx::stdx::optional<result::replace_one> collection::replace_one(
-    bsoncxx::document::view filter, bsoncxx::document::view replacement,
-    const options::update& options) {
+stdx::optional<result::replace_one> collection::replace_one(bsoncxx::document::view filter,
+                                                            bsoncxx::document::view replacement,
+                                                            const options::update& options) {
     class bulk_write bulk_op(false);
     model::replace_one replace_op(filter, replacement);
 
@@ -230,16 +229,15 @@ bsoncxx::stdx::optional<result::replace_one> collection::replace_one(
 
     auto result = bulk_write(bulk_op);
     if (!result) {
-        return bsoncxx::stdx::optional<result::replace_one>();
+        return stdx::optional<result::replace_one>();
     }
 
-    return bsoncxx::stdx::optional<result::replace_one>(
-        result::replace_one(std::move(result.value())));
+    return stdx::optional<result::replace_one>(result::replace_one(std::move(result.value())));
 };
 
-bsoncxx::stdx::optional<result::update> collection::update_many(bsoncxx::document::view filter,
-                                                                bsoncxx::document::view update,
-                                                                const options::update& options) {
+stdx::optional<result::update> collection::update_many(bsoncxx::document::view filter,
+                                                       bsoncxx::document::view update,
+                                                       const options::update& options) {
     class bulk_write bulk_op(false);
     model::update_many update_op(filter, update);
 
@@ -251,13 +249,13 @@ bsoncxx::stdx::optional<result::update> collection::update_many(bsoncxx::documen
 
     auto result = bulk_write(bulk_op);
     if (!result) {
-        return bsoncxx::stdx::optional<result::update>();
+        return stdx::optional<result::update>();
     }
 
-    return bsoncxx::stdx::optional<result::update>(result::update(std::move(result.value())));
+    return stdx::optional<result::update>(result::update(std::move(result.value())));
 }
 
-bsoncxx::stdx::optional<result::delete_result> collection::delete_many(
+stdx::optional<result::delete_result> collection::delete_many(
     bsoncxx::document::view filter, const options::delete_options& options) {
     class bulk_write bulk_op(false);
     model::delete_many delete_op(filter);
@@ -267,16 +265,15 @@ bsoncxx::stdx::optional<result::delete_result> collection::delete_many(
 
     auto result = bulk_write(bulk_op);
     if (!result) {
-        return bsoncxx::stdx::optional<result::delete_result>();
+        return stdx::optional<result::delete_result>();
     }
 
-    return bsoncxx::stdx::optional<result::delete_result>(
-        result::delete_result(std::move(result.value())));
+    return stdx::optional<result::delete_result>(result::delete_result(std::move(result.value())));
 }
 
-bsoncxx::stdx::optional<result::update> collection::update_one(bsoncxx::document::view filter,
-                                                               bsoncxx::document::view update,
-                                                               const options::update& options) {
+stdx::optional<result::update> collection::update_one(bsoncxx::document::view filter,
+                                                      bsoncxx::document::view update,
+                                                      const options::update& options) {
     class bulk_write bulk_op(false);
     model::update_one update_op(filter, update);
 
@@ -288,13 +285,13 @@ bsoncxx::stdx::optional<result::update> collection::update_one(bsoncxx::document
 
     auto result = bulk_write(bulk_op);
     if (!result) {
-        return bsoncxx::stdx::optional<result::update>();
+        return stdx::optional<result::update>();
     }
 
-    return bsoncxx::stdx::optional<result::update>(result::update(std::move(result.value())));
+    return stdx::optional<result::update>(result::update(std::move(result.value())));
 }
 
-bsoncxx::stdx::optional<result::delete_result> collection::delete_one(
+stdx::optional<result::delete_result> collection::delete_one(
     bsoncxx::document::view filter, const options::delete_options& options) {
     class bulk_write bulk_op(false);
     model::delete_one delete_op(filter);
@@ -304,13 +301,12 @@ bsoncxx::stdx::optional<result::delete_result> collection::delete_one(
 
     auto result = bulk_write(bulk_op);
     if (!result) {
-        return bsoncxx::stdx::optional<result::delete_result>();
+        return stdx::optional<result::delete_result>();
     }
-    return bsoncxx::stdx::optional<result::delete_result>(
-        result::delete_result(std::move(result.value())));
+    return stdx::optional<result::delete_result>(result::delete_result(std::move(result.value())));
 }
 
-bsoncxx::stdx::optional<bsoncxx::document::value> collection::find_one_and_replace(
+stdx::optional<bsoncxx::document::value> collection::find_one_and_replace(
     bsoncxx::document::view filter, bsoncxx::document::view replacement,
     const options::find_one_and_replace& options) {
     scoped_bson_t bson_filter{filter};
@@ -338,14 +334,14 @@ bsoncxx::stdx::optional<bsoncxx::document::value> collection::find_one_and_repla
     bsoncxx::document::view result = reply.view();
 
     if (result["value"].type() == bsoncxx::type::k_null)
-        return bsoncxx::stdx::optional<bsoncxx::document::value>{};
+        return stdx::optional<bsoncxx::document::value>{};
 
     bsoncxx::builder::stream::document b;
     b << bsoncxx::builder::stream::concatenate{result["value"].get_document()};
     return b.extract();
 }
 
-bsoncxx::stdx::optional<bsoncxx::document::value> collection::find_one_and_update(
+stdx::optional<bsoncxx::document::value> collection::find_one_and_update(
     bsoncxx::document::view filter, bsoncxx::document::view update,
     const options::find_one_and_update& options) {
     scoped_bson_t bson_filter{filter};
@@ -373,14 +369,14 @@ bsoncxx::stdx::optional<bsoncxx::document::value> collection::find_one_and_updat
     bsoncxx::document::view result = reply.view();
 
     if (result["value"].type() == bsoncxx::type::k_null)
-        return bsoncxx::stdx::optional<bsoncxx::document::value>{};
+        return stdx::optional<bsoncxx::document::value>{};
 
     bsoncxx::builder::stream::document b;
     b << bsoncxx::builder::stream::concatenate{result["value"].get_document()};
     return b.extract();
 }
 
-bsoncxx::stdx::optional<bsoncxx::document::value> collection::find_one_and_delete(
+stdx::optional<bsoncxx::document::value> collection::find_one_and_delete(
     bsoncxx::document::view filter, const options::find_one_and_delete& options) {
     scoped_bson_t bson_filter{filter};
     scoped_bson_t bson_sort{options.sort()};
@@ -402,7 +398,7 @@ bsoncxx::stdx::optional<bsoncxx::document::value> collection::find_one_and_delet
     bsoncxx::document::view result = reply.view();
 
     if (result["value"].type() == bsoncxx::type::k_null)
-        return bsoncxx::stdx::optional<bsoncxx::document::value>{};
+        return stdx::optional<bsoncxx::document::value>{};
 
     bsoncxx::builder::stream::document b;
     b << bsoncxx::builder::stream::concatenate{result["value"].get_document()};
@@ -447,7 +443,7 @@ bsoncxx::document::value collection::create_index(bsoncxx::document::view keys,
     return bsoncxx::document::value{bsoncxx::document::view{}};
 }
 
-cursor collection::distinct(bsoncxx::stdx::string_view field_name, bsoncxx::document::view query,
+cursor collection::distinct(stdx::string_view field_name, bsoncxx::document::view query,
                             const options::distinct& options) {
     auto command = bsoncxx::builder::stream::document{}
                    << "distinct" << name() << "key" << field_name << "query"
@@ -489,7 +485,7 @@ void collection::read_preference(class read_preference rp) {
 }
 
 class read_preference collection::read_preference() const {
-    class read_preference rp(bsoncxx::stdx::make_unique<read_preference::impl>(
+    class read_preference rp(stdx::make_unique<read_preference::impl>(
         libmongoc::read_prefs_copy(libmongoc::collection_get_read_prefs(_impl->collection_t))));
     return rp;
 }
@@ -499,9 +495,8 @@ void collection::write_concern(class write_concern wc) {
 }
 
 class write_concern collection::write_concern() const {
-    class write_concern wc(
-        bsoncxx::stdx::make_unique<write_concern::impl>(libmongoc::write_concern_copy(
-            libmongoc::collection_get_write_concern(_impl->collection_t))));
+    class write_concern wc(stdx::make_unique<write_concern::impl>(libmongoc::write_concern_copy(
+        libmongoc::collection_get_write_concern(_impl->collection_t))));
     return wc;
 }
 

--- a/src/mongocxx/collection.hpp
+++ b/src/mongocxx/collection.hpp
@@ -142,11 +142,9 @@ class MONGOCXX_API collection {
     /// @see mongocxx::bulk_write
     /// @see http://docs.mongodb.org/manual/core/bulk-write-operations/
     ///
-    template<typename container_type>
-    MONGOCXX_INLINE bsoncxx::stdx::optional<result::bulk_write> bulk_write(
-        const container_type& writes,
-        const options::bulk_write& options = options::bulk_write()
-    );
+    template <typename container_type>
+    MONGOCXX_INLINE stdx::optional<result::bulk_write> bulk_write(
+        const container_type& writes, const options::bulk_write& options = options::bulk_write());
 
     ///
     /// Sends writes starting at @c begin and ending at @c end to the server as a bulk write
@@ -169,12 +167,10 @@ class MONGOCXX_API collection {
     /// @see mongocxx::bulk_write
     /// @see http://docs.mongodb.org/manual/core/bulk-write-operations/
     ///
-    template<typename write_model_iterator_type>
-    MONGOCXX_INLINE bsoncxx::stdx::optional<result::bulk_write> bulk_write(
-        write_model_iterator_type begin,
-        write_model_iterator_type end,
-        const options::bulk_write& options = options::bulk_write()
-    );
+    template <typename write_model_iterator_type>
+    MONGOCXX_INLINE stdx::optional<result::bulk_write> bulk_write(
+        write_model_iterator_type begin, write_model_iterator_type end,
+        const options::bulk_write& options = options::bulk_write());
 
     ///
     /// Sends a batch of writes represented by the bulk_write to the server.
@@ -187,9 +183,7 @@ class MONGOCXX_API collection {
     ///
     /// @see http://docs.mongodb.org/manual/core/bulk-write-operations/
     ///
-    bsoncxx::stdx::optional<result::bulk_write> bulk_write(
-        const class bulk_write& bulk_write
-    );
+    stdx::optional<result::bulk_write> bulk_write(const class bulk_write& bulk_write);
 
     ///
     /// Counts the number of documents matching the provided filter.
@@ -240,10 +234,9 @@ class MONGOCXX_API collection {
     ///
     /// @see http://docs.mongodb.org/manual/reference/command/delete/
     ///
-    bsoncxx::stdx::optional<result::delete_result> delete_many(
+    stdx::optional<result::delete_result> delete_many(
         bsoncxx::document::view filter,
-        const options::delete_options& options = options::delete_options()
-    );
+        const options::delete_options& options = options::delete_options());
 
     ///
     /// Deletes a single matching document from the collection.
@@ -258,10 +251,9 @@ class MONGOCXX_API collection {
     ///
     /// @see http://docs.mongodb.org/manual/reference/command/delete/
     ///
-    bsoncxx::stdx::optional<result::delete_result> delete_one(
+    stdx::optional<result::delete_result> delete_one(
         bsoncxx::document::view filter,
-        const options::delete_options& options = options::delete_options()
-    );
+        const options::delete_options& options = options::delete_options());
 
     ///
     /// Finds the distinct values for a specified field accross the collection.
@@ -280,11 +272,8 @@ class MONGOCXX_API collection {
     ///
     /// @see http://docs.mongodb.org/manual/reference/command/distinct/
     ///
-    cursor distinct(
-        bsoncxx::stdx::string_view name,
-        bsoncxx::document::view filter,
-        const options::distinct& options = options::distinct()
-    );
+    cursor distinct(stdx::string_view name, bsoncxx::document::view filter,
+                    const options::distinct& options = options::distinct());
 
     ///
     /// Drops this collection and all its contained documents from the database.
@@ -329,10 +318,8 @@ class MONGOCXX_API collection {
     ///
     /// @see http://docs.mongodb.org/manual/core/read-operations-introduction/
     ///
-    bsoncxx::stdx::optional<bsoncxx::document::value> find_one(
-        bsoncxx::document::view filter,
-        const options::find& options = options::find()
-    );
+    stdx::optional<bsoncxx::document::value> find_one(
+        bsoncxx::document::view filter, const options::find& options = options::find());
 
     ///
     /// Finds a single document matching the filter, deletes it, and returns the original.
@@ -345,10 +332,9 @@ class MONGOCXX_API collection {
     /// @return The document that was deleted.
     /// @throws exception::write if the operation fails.
     ///
-    bsoncxx::stdx::optional<bsoncxx::document::value> find_one_and_delete(
+    stdx::optional<bsoncxx::document::value> find_one_and_delete(
         bsoncxx::document::view filter,
-        const options::find_one_and_delete& options = options::find_one_and_delete()
-    );
+        const options::find_one_and_delete& options = options::find_one_and_delete());
 
     ///
     /// Finds a single document matching the filter, replaces it, and returns either the original
@@ -368,11 +354,9 @@ class MONGOCXX_API collection {
     ///   In order to pass a write concern to this, you must use the collection
     ///   level set write concern - collection::write_concern(wc).
     ///
-    bsoncxx::stdx::optional<bsoncxx::document::value> find_one_and_replace(
-        bsoncxx::document::view filter,
-        bsoncxx::document::view replacement,
-        const options::find_one_and_replace& options = options::find_one_and_replace()
-    );
+    stdx::optional<bsoncxx::document::value> find_one_and_replace(
+        bsoncxx::document::view filter, bsoncxx::document::view replacement,
+        const options::find_one_and_replace& options = options::find_one_and_replace());
 
     ///
     /// Finds a single document matching the filter, updates it, and returns either the original
@@ -392,11 +376,9 @@ class MONGOCXX_API collection {
     ///   In order to pass a write concern to this, you must use the collection
     ///   level set write concern - collection::write_concern(wc).
     ///
-    bsoncxx::stdx::optional<bsoncxx::document::value> find_one_and_update(
-        bsoncxx::document::view filter,
-        bsoncxx::document::view update,
-        const options::find_one_and_update& options = options::find_one_and_update()
-    );
+    stdx::optional<bsoncxx::document::value> find_one_and_update(
+        bsoncxx::document::view filter, bsoncxx::document::view update,
+        const options::find_one_and_update& options = options::find_one_and_update());
 
     ///
     /// Gets a handle to the underlying implementation.
@@ -422,10 +404,8 @@ class MONGOCXX_API collection {
     /// @return The result of attempting to perform the insert.
     /// @throws exception::write if the operation fails.
     ///
-    bsoncxx::stdx::optional<result::insert_one> insert_one(
-        bsoncxx::document::view document,
-        const options::insert& options = options::insert()
-    );
+    stdx::optional<result::insert_one> insert_one(
+        bsoncxx::document::view document, const options::insert& options = options::insert());
 
     ///
     /// Inserts multiple documents into the collection. If any of the documents are missing
@@ -447,11 +427,9 @@ class MONGOCXX_API collection {
     /// @return The result of attempting to performing the insert.
     /// @throws exception::write when the operation fails.
     ///
-    template<typename container_type>
-    MONGOCXX_INLINE bsoncxx::stdx::optional<result::insert_many> insert_many(
-        const container_type& container,
-        const options::insert& options = options::insert()
-    );
+    template <typename container_type>
+    MONGOCXX_INLINE stdx::optional<result::insert_many> insert_many(
+        const container_type& container, const options::insert& options = options::insert());
 
     ///
     /// Inserts multiple documents into the collection. If any of the documents are missing
@@ -476,12 +454,10 @@ class MONGOCXX_API collection {
     /// @throws exception::write if the operation fails.
     ///
     /// TODO: document DocumentViewIterator concept or static assert
-    template<typename document_view_iterator_type>
-    MONGOCXX_INLINE bsoncxx::stdx::optional<result::insert_many> insert_many(
-        document_view_iterator_type begin,
-        document_view_iterator_type end,
-        const options::insert& options = options::insert()
-    );
+    template <typename document_view_iterator_type>
+    MONGOCXX_INLINE stdx::optional<result::insert_many> insert_many(
+        document_view_iterator_type begin, document_view_iterator_type end,
+        const options::insert& options = options::insert());
 
     ///
     /// Returns a list of the indexes currently on this collection.
@@ -498,7 +474,7 @@ class MONGOCXX_API collection {
     ///
     /// @return The name of the collection.
     ///
-    bsoncxx::stdx::string_view name() const noexcept;
+    stdx::string_view name() const noexcept;
 
     ///
     /// Sets the read_preference for this collection. Changes will not have any effect on existing
@@ -535,11 +511,9 @@ class MONGOCXX_API collection {
     ///
     /// @see http://docs.mongodb.org/manual/reference/command/update/
     ///
-    bsoncxx::stdx::optional<result::replace_one> replace_one(
-        bsoncxx::document::view filter,
-        bsoncxx::document::view replacement,
-        const options::update& options = options::update()
-    );
+    stdx::optional<result::replace_one> replace_one(
+        bsoncxx::document::view filter, bsoncxx::document::view replacement,
+        const options::update& options = options::update());
 
     ///
     /// Updates multiple documents matching the provided filter in this collection.
@@ -556,11 +530,9 @@ class MONGOCXX_API collection {
     ///
     /// @see http://docs.mongodb.org/manual/reference/command/update/
     ///
-    bsoncxx::stdx::optional<result::update> update_many(
-        bsoncxx::document::view filter,
-        bsoncxx::document::view update,
-        const options::update& options = options::update()
-    );
+    stdx::optional<result::update> update_many(bsoncxx::document::view filter,
+                                               bsoncxx::document::view update,
+                                               const options::update& options = options::update());
 
     ///
     /// Updates a single document matching the provided filter in this collection.
@@ -577,11 +549,9 @@ class MONGOCXX_API collection {
     ///
     /// @see http://docs.mongodb.org/manual/reference/command/update/
     ///
-    bsoncxx::stdx::optional<result::update> update_one(
-        bsoncxx::document::view filter,
-        bsoncxx::document::view update,
-        const options::update& options = options::update()
-    );
+    stdx::optional<result::update> update_one(bsoncxx::document::view filter,
+                                              bsoncxx::document::view update,
+                                              const options::update& options = options::update());
 
     ///
     /// Sets the write_concern for this collection. Changes will not have any effect on existing
@@ -602,27 +572,23 @@ class MONGOCXX_API collection {
    private:
     friend class database;
 
-    MONGOCXX_PRIVATE collection(const database& database, bsoncxx::stdx::string_view collection_name);
+    MONGOCXX_PRIVATE collection(const database& database, stdx::string_view collection_name);
 
     class MONGOCXX_PRIVATE impl;
     std::unique_ptr<impl> _impl;
 
 };
 
-template<typename container_type>
-MONGOCXX_INLINE bsoncxx::stdx::optional<result::bulk_write> collection::bulk_write(
-    const container_type& requests,
-    const options::bulk_write& options
-) {
+template <typename container_type>
+MONGOCXX_INLINE stdx::optional<result::bulk_write> collection::bulk_write(
+    const container_type& requests, const options::bulk_write& options) {
     return bulk_write(requests.begin(), requests.end(), options);
 }
 
-template<typename write_model_iterator_type>
-MONGOCXX_INLINE bsoncxx::stdx::optional<result::bulk_write> collection::bulk_write(
-    write_model_iterator_type begin,
-    write_model_iterator_type end,
-    const options::bulk_write& options
-) {
+template <typename write_model_iterator_type>
+MONGOCXX_INLINE stdx::optional<result::bulk_write> collection::bulk_write(
+    write_model_iterator_type begin, write_model_iterator_type end,
+    const options::bulk_write& options) {
     class bulk_write writes(options.ordered().value_or(true));
 
     std::for_each(begin, end, [&](const model::write& current){
@@ -632,20 +598,16 @@ MONGOCXX_INLINE bsoncxx::stdx::optional<result::bulk_write> collection::bulk_wri
     return bulk_write(writes);
 }
 
-template<typename container_type>
-MONGOCXX_INLINE bsoncxx::stdx::optional<result::insert_many> collection::insert_many(
-    const container_type& container,
-    const options::insert& options
-) {
+template <typename container_type>
+MONGOCXX_INLINE stdx::optional<result::insert_many> collection::insert_many(
+    const container_type& container, const options::insert& options) {
     return insert_many(container.begin(), container.end(), options);
 }
 
-template<typename document_view_iterator_type>
-MONGOCXX_INLINE bsoncxx::stdx::optional<result::insert_many> collection::insert_many(
-    document_view_iterator_type begin,
-    document_view_iterator_type end,
-    const options::insert& options
-) {
+template <typename document_view_iterator_type>
+MONGOCXX_INLINE stdx::optional<result::insert_many> collection::insert_many(
+    document_view_iterator_type begin, document_view_iterator_type end,
+    const options::insert& options) {
     class bulk_write writes(options.ordered().value_or(true));
 
     result::insert_many::id_map inserted_ids{};
@@ -671,7 +633,8 @@ MONGOCXX_INLINE bsoncxx::stdx::optional<result::insert_many> collection::insert_
     if (options.write_concern())
         writes.write_concern(*options.write_concern());
     result::bulk_write res(std::move(bulk_write(writes).value()));
-    bsoncxx::stdx::optional<result::insert_many> result(result::insert_many(std::move(res), std::move(inserted_ids)));
+    stdx::optional<result::insert_many> result(
+        result::insert_many(std::move(res), std::move(inserted_ids)));
     return result;
 }
 

--- a/src/mongocxx/cursor.cpp
+++ b/src/mongocxx/cursor.cpp
@@ -31,7 +31,7 @@ namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 
 cursor::cursor(void* cursor_ptr)
-    : _impl(bsoncxx::stdx::make_unique<impl>(static_cast<mongoc_cursor_t*>(cursor_ptr))) {
+    : _impl(stdx::make_unique<impl>(static_cast<mongoc_cursor_t*>(cursor_ptr))) {
 }
 
 cursor::cursor(cursor&&) noexcept = default;

--- a/src/mongocxx/database.cpp
+++ b/src/mongocxx/database.cpp
@@ -36,8 +36,8 @@ database& database::operator=(database&&) noexcept = default;
 
 database::~database() = default;
 
-database::database(const class client& client, bsoncxx::stdx::string_view name)
-    : _impl(bsoncxx::stdx::make_unique<impl>(
+database::database(const class client& client, stdx::string_view name)
+    : _impl(stdx::make_unique<impl>(
           libmongoc::client_get_database(client._impl->client_t, name.data()), client._impl.get(),
           name.data())) {
 }
@@ -63,7 +63,7 @@ cursor database::list_collections(bsoncxx::document::view filter) {
 
     return cursor(result);
 }
-bsoncxx::stdx::string_view database::name() const {
+stdx::string_view database::name() const {
     return _impl->name;
 }
 
@@ -85,13 +85,13 @@ void database::read_preference(class read_preference rp) {
     libmongoc::database_set_read_prefs(_impl->database_t, rp._impl->read_preference_t);
 }
 
-bool database::has_collection(bsoncxx::stdx::string_view name) {
+bool database::has_collection(stdx::string_view name) {
     bson_error_t error;
     return libmongoc::database_has_collection(_impl->database_t, name.data(), &error);
 }
 
 class read_preference database::read_preference() const {
-    class read_preference rp(bsoncxx::stdx::make_unique<read_preference::impl>(
+    class read_preference rp(stdx::make_unique<read_preference::impl>(
         libmongoc::read_prefs_copy(libmongoc::database_get_read_prefs(_impl->database_t))));
     return rp;
 }
@@ -101,12 +101,12 @@ void database::write_concern(class write_concern wc) {
 }
 
 class write_concern database::write_concern() const {
-    class write_concern wc(bsoncxx::stdx::make_unique<write_concern::impl>(
+    class write_concern wc(stdx::make_unique<write_concern::impl>(
         libmongoc::write_concern_copy(libmongoc::database_get_write_concern(_impl->database_t))));
     return wc;
 }
 
-collection database::collection(bsoncxx::stdx::string_view name) const {
+collection database::collection(stdx::string_view name) const {
     return mongocxx::collection(*this, name);
 }
 

--- a/src/mongocxx/database.hpp
+++ b/src/mongocxx/database.hpp
@@ -91,10 +91,7 @@ class MONGOCXX_API database {
     /// @param name the new collection's name.
     /// @param options the options for the new collection.
     ///
-    class collection create_collection(
-        bsoncxx::stdx::string_view name,
-        bsoncxx::document::view options
-    );
+    class collection create_collection(stdx::string_view name, bsoncxx::document::view options);
 
     ///
     /// Drops the database and all its collections.
@@ -109,7 +106,7 @@ class MONGOCXX_API database {
     /// @param name the name of the collection.
     /// @return bool whether the collection exists in this database.
     ///
-    bool has_collection(bsoncxx::stdx::string_view name);
+    bool has_collection(stdx::string_view name);
 
     ///
     /// Gets a handle to the underlying implementation.
@@ -143,7 +140,7 @@ class MONGOCXX_API database {
     ///
     /// @return the name of this database.
     ///
-    bsoncxx::stdx::string_view name() const;
+    stdx::string_view name() const;
 
     ///
     /// Renames this database.
@@ -151,10 +148,7 @@ class MONGOCXX_API database {
     /// @param new_name the new name for the database.
     /// @param drop_target_before_rename whether to drop existing databases with the new name.
     ///
-    void rename(
-        bsoncxx::stdx::string_view new_name,
-        bool drop_target_before_rename
-    );
+    void rename(stdx::string_view new_name, bool drop_target_before_rename);
 
     ///
     /// Get server-side statistics for the database.
@@ -210,7 +204,7 @@ class MONGOCXX_API database {
     ///
     /// @return the collection.
     ///
-    class collection collection(bsoncxx::stdx::string_view name) const;
+    class collection collection(stdx::string_view name) const;
 
     ///
     /// Allows the db["collection_name"] syntax to be used to access a collection within this database.
@@ -219,20 +213,20 @@ class MONGOCXX_API database {
     ///
     /// @return the collection.
     ///
-    MONGOCXX_INLINE class collection operator[](bsoncxx::stdx::string_view name) const;
+    MONGOCXX_INLINE class collection operator[](stdx::string_view name) const;
 
    private:
     friend class client;
     friend class collection;
 
-    MONGOCXX_PRIVATE database(const class client& client, bsoncxx::stdx::string_view name);
+    MONGOCXX_PRIVATE database(const class client& client, stdx::string_view name);
 
     class MONGOCXX_PRIVATE impl;
     std::unique_ptr<impl> _impl;
 
 };
 
-MONGOCXX_INLINE collection database::operator[](bsoncxx::stdx::string_view name) const {
+MONGOCXX_INLINE collection database::operator[](stdx::string_view name) const {
     return collection(name);
 }
 

--- a/src/mongocxx/model/replace_one.cpp
+++ b/src/mongocxx/model/replace_one.cpp
@@ -36,7 +36,7 @@ const bsoncxx::document::view& replace_one::replacement() const {
     return _replacement;
 }
 
-const bsoncxx::stdx::optional<bool>& replace_one::upsert() const {
+const stdx::optional<bool>& replace_one::upsert() const {
     return _upsert;
 }
 

--- a/src/mongocxx/model/replace_one.hpp
+++ b/src/mongocxx/model/replace_one.hpp
@@ -19,6 +19,8 @@
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 
+#include <mongocxx/stdx.hpp>
+
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 namespace model {
@@ -72,7 +74,7 @@ class MONGOCXX_API replace_one {
     ///
     /// @return The optional value of the upsert option.
     ///
-    const bsoncxx::stdx::optional<bool>& upsert() const;
+    const stdx::optional<bool>& upsert() const;
 
    private:
     // Required
@@ -80,8 +82,7 @@ class MONGOCXX_API replace_one {
     bsoncxx::document::view _replacement;
 
     // Optional
-    bsoncxx::stdx::optional<bool> _upsert;
-
+    stdx::optional<bool> _upsert;
 };
 
 }  // namespace model

--- a/src/mongocxx/model/update_many.cpp
+++ b/src/mongocxx/model/update_many.cpp
@@ -27,7 +27,7 @@ update_many& update_many::upsert(bool upsert) {
     return *this;
 }
 
-const bsoncxx::stdx::optional<bool>& update_many::upsert() const {
+const stdx::optional<bool>& update_many::upsert() const {
     return _upsert;
 }
 

--- a/src/mongocxx/model/update_many.hpp
+++ b/src/mongocxx/model/update_many.hpp
@@ -19,6 +19,8 @@
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 
+#include <mongocxx/stdx.hpp>
+
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 namespace model {
@@ -74,7 +76,7 @@ class MONGOCXX_API update_many {
     ///
     /// @return The optional value of the upsert option.
     ///
-    const bsoncxx::stdx::optional<bool>& upsert() const;
+    const stdx::optional<bool>& upsert() const;
 
    private:
     // Required
@@ -82,8 +84,7 @@ class MONGOCXX_API update_many {
     bsoncxx::document::view _update;
 
     // Optional
-    bsoncxx::stdx::optional<bool> _upsert;
-
+    stdx::optional<bool> _upsert;
 };
 
 }  // namespace model

--- a/src/mongocxx/model/update_one.cpp
+++ b/src/mongocxx/model/update_one.cpp
@@ -27,7 +27,7 @@ update_one& update_one::upsert(bool upsert) {
     return *this;
 }
 
-const bsoncxx::stdx::optional<bool>& update_one::upsert() const {
+const stdx::optional<bool>& update_one::upsert() const {
     return _upsert;
 }
 

--- a/src/mongocxx/model/update_one.hpp
+++ b/src/mongocxx/model/update_one.hpp
@@ -19,6 +19,8 @@
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 
+#include <mongocxx/stdx.hpp>
+
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 namespace model {
@@ -74,7 +76,7 @@ class MONGOCXX_API update_one {
     ///
     /// @return The optional value of the upsert option.
     ///
-    const bsoncxx::stdx::optional<bool>& upsert() const;
+    const stdx::optional<bool>& upsert() const;
 
    private:
     // Required
@@ -82,8 +84,7 @@ class MONGOCXX_API update_one {
     bsoncxx::document::view _update;
 
     // Optional
-    bsoncxx::stdx::optional<bool> _upsert;
-
+    stdx::optional<bool> _upsert;
 };
 
 }  // namespace model

--- a/src/mongocxx/options/aggregate.cpp
+++ b/src/mongocxx/options/aggregate.cpp
@@ -35,19 +35,19 @@ void aggregate::read_preference(class read_preference rp) {
     _read_preference = std::move(rp);
 }
 
-const bsoncxx::stdx::optional<bool>& aggregate::allow_disk_use() const {
+const stdx::optional<bool>& aggregate::allow_disk_use() const {
     return _allow_disk_use;
 }
-const bsoncxx::stdx::optional<std::int32_t>& aggregate::batch_size() const {
+const stdx::optional<std::int32_t>& aggregate::batch_size() const {
     return _batch_size;
 }
-const bsoncxx::stdx::optional<std::int64_t>& aggregate::max_time_ms() const {
+const stdx::optional<std::int64_t>& aggregate::max_time_ms() const {
     return _max_time_ms;
 }
-const bsoncxx::stdx::optional<bool>& aggregate::use_cursor() const {
+const stdx::optional<bool>& aggregate::use_cursor() const {
     return _use_cursor;
 }
-const bsoncxx::stdx::optional<class read_preference>& aggregate::read_preference() const {
+const stdx::optional<class read_preference>& aggregate::read_preference() const {
     return _read_preference;
 }
 

--- a/src/mongocxx/options/aggregate.hpp
+++ b/src/mongocxx/options/aggregate.hpp
@@ -20,6 +20,7 @@
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/read_preference.hpp>
 
 namespace mongocxx {
@@ -47,7 +48,7 @@ class MONGOCXX_API aggregate {
     ///
     /// @return Whether disk use is allowed.
     ///
-    const bsoncxx::stdx::optional<bool>& allow_disk_use() const;
+    const stdx::optional<bool>& allow_disk_use() const;
 
     ///
     /// Sets the number of documents to return per batch.
@@ -62,7 +63,7 @@ class MONGOCXX_API aggregate {
     ///
     /// @return The current batch size.
     ///
-    const bsoncxx::stdx::optional<std::int32_t>& batch_size() const;
+    const stdx::optional<std::int32_t>& batch_size() const;
 
     ///
     /// Sets the maximum amount of time for this operation to run server-side in milliseconds.
@@ -82,7 +83,7 @@ class MONGOCXX_API aggregate {
     ///
     /// @see http://docs.mongodb.org/manual/reference/operator/meta/maxTimeMS
     ///
-    const bsoncxx::stdx::optional<std::int64_t>& max_time_ms() const;
+    const stdx::optional<std::int64_t>& max_time_ms() const;
 
     ///
     /// Sets whether the results of this aggregation should be returned via a cursor.
@@ -102,7 +103,7 @@ class MONGOCXX_API aggregate {
     ///
     /// @return the current use_cursor setting
     ///
-    const bsoncxx::stdx::optional<bool>& use_cursor() const;
+    const stdx::optional<bool>& use_cursor() const;
 
     ///
     /// Sets the read_preference for this operation.
@@ -120,15 +121,14 @@ class MONGOCXX_API aggregate {
     ///
     /// @see http://docs.mongodb.org/manual/core/read-preference/
     ///
-    const bsoncxx::stdx::optional<class read_preference>& read_preference() const;
+    const stdx::optional<class read_preference>& read_preference() const;
 
    private:
-    bsoncxx::stdx::optional<bool> _allow_disk_use;
-    bsoncxx::stdx::optional<std::int32_t> _batch_size;
-    bsoncxx::stdx::optional<std::int64_t> _max_time_ms;
-    bsoncxx::stdx::optional<bool> _use_cursor;
-    bsoncxx::stdx::optional<class read_preference> _read_preference;
-
+    stdx::optional<bool> _allow_disk_use;
+    stdx::optional<std::int32_t> _batch_size;
+    stdx::optional<std::int64_t> _max_time_ms;
+    stdx::optional<bool> _use_cursor;
+    stdx::optional<class read_preference> _read_preference;
 };
 
 }  // namespace options

--- a/src/mongocxx/options/bulk_write.cpp
+++ b/src/mongocxx/options/bulk_write.cpp
@@ -27,7 +27,7 @@ void bulk_write::write_concern(class write_concern wc) {
     _write_concern = std::move(wc);
 }
 
-const bsoncxx::stdx::optional<bool>& bulk_write::ordered() const {
+const stdx::optional<bool>& bulk_write::ordered() const {
     return _ordered;
 }
 

--- a/src/mongocxx/options/bulk_write.hpp
+++ b/src/mongocxx/options/bulk_write.hpp
@@ -47,7 +47,7 @@ class MONGOCXX_API bulk_write {
     ///
     /// @return The optional value of the ordered option.
     ///
-    const bsoncxx::stdx::optional<bool>& ordered() const;
+    const stdx::optional<bool>& ordered() const;
 
     ///
     /// Sets the write_concern for this operation.
@@ -67,12 +67,11 @@ class MONGOCXX_API bulk_write {
     ///
     /// @see http://docs.mongodb.org/manual/core/write-concern/
     ///
-    const bsoncxx::stdx::optional<class write_concern>& write_concern() const;
+    const stdx::optional<class write_concern>& write_concern() const;
 
    private:
-    bsoncxx::stdx::optional<bool> _ordered;
-    bsoncxx::stdx::optional<class write_concern> _write_concern;
-
+    stdx::optional<bool> _ordered;
+    stdx::optional<class write_concern> _write_concern;
 };
 
 }  // namespace options

--- a/src/mongocxx/options/client.cpp
+++ b/src/mongocxx/options/client.cpp
@@ -22,7 +22,7 @@ void client::ssl_opts(ssl ssl_opts) {
     _ssl_opts = ssl_opts;
 }
 
-const bsoncxx::stdx::optional<ssl>& client::ssl_opts() const {
+const stdx::optional<ssl>& client::ssl_opts() const {
     return _ssl_opts;
 }
 

--- a/src/mongocxx/options/client.hpp
+++ b/src/mongocxx/options/client.hpp
@@ -47,11 +47,10 @@ class MONGOCXX_API client {
     ///
     /// @return The SSL-related options.
     ///
-    const bsoncxx::stdx::optional<ssl>& ssl_opts() const;
+    const stdx::optional<ssl>& ssl_opts() const;
 
    private:
-    bsoncxx::stdx::optional<ssl> _ssl_opts;
-
+    stdx::optional<ssl> _ssl_opts;
 };
 
 }  // namespace options

--- a/src/mongocxx/options/count.cpp
+++ b/src/mongocxx/options/count.cpp
@@ -39,23 +39,23 @@ void count::read_preference(class read_preference rp) {
     _read_preference = std::move(rp);
 }
 
-const bsoncxx::stdx::optional<bsoncxx::document::view>& count::hint() const {
+const stdx::optional<bsoncxx::document::view>& count::hint() const {
     return _hint;
 }
 
-const bsoncxx::stdx::optional<std::int64_t>& count::limit() const {
+const stdx::optional<std::int64_t>& count::limit() const {
     return _limit;
 }
 
-const bsoncxx::stdx::optional<std::int64_t>& count::max_time_ms() const {
+const stdx::optional<std::int64_t>& count::max_time_ms() const {
     return _max_time_ms;
 }
 
-const bsoncxx::stdx::optional<std::int64_t>& count::skip() const {
+const stdx::optional<std::int64_t>& count::skip() const {
     return _skip;
 }
 
-const bsoncxx::stdx::optional<read_preference>& count::read_preference() const {
+const stdx::optional<read_preference>& count::read_preference() const {
     return _read_preference;
 }
 

--- a/src/mongocxx/options/count.hpp
+++ b/src/mongocxx/options/count.hpp
@@ -50,7 +50,7 @@ class MONGOCXX_API count {
     ///
     /// @return The current hint.
     ///
-    const bsoncxx::stdx::optional<bsoncxx::document::view>& hint() const;
+    const stdx::optional<bsoncxx::document::view>& hint() const;
 
     ///
     /// Sets the maximum number of documents to count.
@@ -65,7 +65,7 @@ class MONGOCXX_API count {
     ///
     /// @return The current limit.
     ///
-    const bsoncxx::stdx::optional<std::int64_t>& limit() const;
+    const stdx::optional<std::int64_t>& limit() const;
 
     ///
     /// Sets the maximum amount of time for this operation to run (server-side) in milliseconds.
@@ -84,7 +84,7 @@ class MONGOCXX_API count {
     ///
     /// @see http://docs.mongodb.org/manual/reference/operator/meta/maxTimeMS
     ///
-    const bsoncxx::stdx::optional<std::int64_t>& max_time_ms() const;
+    const stdx::optional<std::int64_t>& max_time_ms() const;
 
     ///
     /// Sets the number of documents to skip before counting documents.
@@ -103,7 +103,7 @@ class MONGOCXX_API count {
     ///
     /// @see http://docs.mongodb.org/manual/reference/method/cursor.skip/
     ///
-    const bsoncxx::stdx::optional<std::int64_t>& skip() const;
+    const stdx::optional<std::int64_t>& skip() const;
 
     ///
     /// Sets the read_preference for this operation.
@@ -122,15 +122,14 @@ class MONGOCXX_API count {
     ///
     /// @see http://docs.mongodb.org/manual/core/read-preference/
     ///
-    const bsoncxx::stdx::optional<class read_preference>& read_preference() const;
+    const stdx::optional<class read_preference>& read_preference() const;
 
    private:
-    bsoncxx::stdx::optional<bsoncxx::document::view> _hint;
-    bsoncxx::stdx::optional<std::int64_t> _limit;
-    bsoncxx::stdx::optional<std::int64_t> _max_time_ms;
-    bsoncxx::stdx::optional<std::int64_t> _skip;
-    bsoncxx::stdx::optional<class read_preference> _read_preference;
-
+    stdx::optional<bsoncxx::document::view> _hint;
+    stdx::optional<std::int64_t> _limit;
+    stdx::optional<std::int64_t> _max_time_ms;
+    stdx::optional<std::int64_t> _skip;
+    stdx::optional<class read_preference> _read_preference;
 };
 
 }  // namespace options

--- a/src/mongocxx/options/delete.cpp
+++ b/src/mongocxx/options/delete.cpp
@@ -22,7 +22,7 @@ void delete_options::write_concern(class write_concern wc) {
     _write_concern = std::move(wc);
 }
 
-const bsoncxx::stdx::optional<class write_concern>& delete_options::write_concern() const {
+const stdx::optional<class write_concern>& delete_options::write_concern() const {
     return _write_concern;
 }
 

--- a/src/mongocxx/options/delete.hpp
+++ b/src/mongocxx/options/delete.hpp
@@ -50,11 +50,10 @@ class MONGOCXX_API delete_options {
     /// @see http://docs.mongodb.org/manual/core/write-concern/
     ///
     ///
-    const bsoncxx::stdx::optional<class write_concern>& write_concern() const;
+    const stdx::optional<class write_concern>& write_concern() const;
 
    private:
-    bsoncxx::stdx::optional<class write_concern> _write_concern;
-
+    stdx::optional<class write_concern> _write_concern;
 };
 
 }  // namespace options

--- a/src/mongocxx/options/distinct.cpp
+++ b/src/mongocxx/options/distinct.cpp
@@ -27,10 +27,10 @@ void distinct::read_preference(class read_preference rp) {
     _read_preference = std::move(rp);
 }
 
-const bsoncxx::stdx::optional<std::int64_t>& distinct::max_time_ms() const {
+const stdx::optional<std::int64_t>& distinct::max_time_ms() const {
     return _max_time_ms;
 }
-const bsoncxx::stdx::optional<class read_preference>& distinct::read_preference() const {
+const stdx::optional<class read_preference>& distinct::read_preference() const {
     return _read_preference;
 }
 

--- a/src/mongocxx/options/distinct.hpp
+++ b/src/mongocxx/options/distinct.hpp
@@ -51,7 +51,7 @@ class MONGOCXX_API distinct {
     ///
     /// @see http://docs.mongodb.org/manual/reference/operator/meta/maxTimeMS
     ///
-    const bsoncxx::stdx::optional<std::int64_t>& max_time_ms() const;
+    const stdx::optional<std::int64_t>& max_time_ms() const;
 
     ///
     /// Sets the read_preference for this operation.
@@ -70,12 +70,11 @@ class MONGOCXX_API distinct {
     ///
     /// @see http://docs.mongodb.org/manual/core/read-preference/
     ///
-    const bsoncxx::stdx::optional<class read_preference>& read_preference() const;
+    const stdx::optional<class read_preference>& read_preference() const;
 
    private:
-    bsoncxx::stdx::optional<std::int64_t> _max_time_ms;
-    bsoncxx::stdx::optional<class read_preference> _read_preference;
-
+    stdx::optional<std::int64_t> _max_time_ms;
+    stdx::optional<class read_preference> _read_preference;
 };
 
 }  // namespace options

--- a/src/mongocxx/options/find.cpp
+++ b/src/mongocxx/options/find.cpp
@@ -69,47 +69,47 @@ void find::sort(bsoncxx::document::view ordering) {
     _ordering = ordering;
 }
 
-const bsoncxx::stdx::optional<bool>& find::allow_partial_results() const {
+const stdx::optional<bool>& find::allow_partial_results() const {
     return _allow_partial_results;
 }
 
-const bsoncxx::stdx::optional<std::int32_t>& find::batch_size() const {
+const stdx::optional<std::int32_t>& find::batch_size() const {
     return _batch_size;
 }
 
-const bsoncxx::stdx::optional<std::int32_t>& find::limit() const {
+const stdx::optional<std::int32_t>& find::limit() const {
     return _limit;
 }
 
-const bsoncxx::stdx::optional<std::int64_t>& find::max_time_ms() const {
+const stdx::optional<std::int64_t>& find::max_time_ms() const {
     return _max_time_ms;
 }
 
-const bsoncxx::stdx::optional<bsoncxx::document::view>& find::modifiers() const {
+const stdx::optional<bsoncxx::document::view>& find::modifiers() const {
     return _modifiers;
 }
 
-const bsoncxx::stdx::optional<bool>& find::no_cursor_timeout() const {
+const stdx::optional<bool>& find::no_cursor_timeout() const {
     return _no_cursor_timeout;
 }
 
-const bsoncxx::stdx::optional<bool>& find::oplog_replay() const {
+const stdx::optional<bool>& find::oplog_replay() const {
     return _oplog_replay;
 }
 
-const bsoncxx::stdx::optional<bsoncxx::document::view>& find::projection() const {
+const stdx::optional<bsoncxx::document::view>& find::projection() const {
     return _projection;
 }
 
-const bsoncxx::stdx::optional<std::int32_t>& find::skip() const {
+const stdx::optional<std::int32_t>& find::skip() const {
     return _skip;
 }
 
-const bsoncxx::stdx::optional<bsoncxx::document::view>& find::sort() const {
+const stdx::optional<bsoncxx::document::view>& find::sort() const {
     return _ordering;
 }
 
-const bsoncxx::stdx::optional<class read_preference>& find::read_preference() const {
+const stdx::optional<class read_preference>& find::read_preference() const {
     return _read_preference;
 }
 

--- a/src/mongocxx/options/find.hpp
+++ b/src/mongocxx/options/find.hpp
@@ -52,7 +52,7 @@ class MONGOCXX_API find {
     ///
     /// @see http://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#op-query
     ///
-    const bsoncxx::stdx::optional<bool>& allow_partial_results() const;
+    const stdx::optional<bool>& allow_partial_results() const;
 
     ///
     /// Sets the number of documents to return per batch.
@@ -71,7 +71,7 @@ class MONGOCXX_API find {
     ///
     /// @see http://docs.mongodb.org/manual/reference/method/cursor.batchSize/
     ///
-    const bsoncxx::stdx::optional<std::int32_t>& batch_size() const;
+    const stdx::optional<std::int32_t>& batch_size() const;
 
     ///
     /// Attaches a comment to the query. If $comment also exists in the modifiers document then
@@ -91,7 +91,7 @@ class MONGOCXX_API find {
     ///
     /// @see http://docs.mongodb.org/manual/reference/operator/meta/comment/
     ///
-    const bsoncxx::stdx::optional<std::string>& comment() const;
+    const stdx::optional<std::string>& comment() const;
 
     ///
     /// Indicates the type of cursor to use for this query.
@@ -110,7 +110,7 @@ class MONGOCXX_API find {
     ///
     /// @see http://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#op-query
     ///
-    const bsoncxx::stdx::optional<enum cursor_type>& cursor_type() const;
+    const stdx::optional<enum cursor_type>& cursor_type() const;
 
     ///
     /// Sets maximum number of documents to return.
@@ -125,7 +125,7 @@ class MONGOCXX_API find {
     ///
     /// @return The current limit.
     ///
-    const bsoncxx::stdx::optional<std::int32_t>& limit() const;
+    const stdx::optional<std::int32_t>& limit() const;
 
     ///
     /// Sets the maximum amount of time for this operation to run (server-side) in milliseconds.
@@ -144,7 +144,7 @@ class MONGOCXX_API find {
     ///
     /// @see http://docs.mongodb.org/manual/reference/operator/meta/maxTimeMS
     ///
-    const bsoncxx::stdx::optional<std::int64_t>& max_time_ms() const;
+    const stdx::optional<std::int64_t>& max_time_ms() const;
 
     ///
     /// Sets the meta-operators modifying the output or behavior of the query.
@@ -161,7 +161,7 @@ class MONGOCXX_API find {
     ///
     /// @return The current query modifiers.
     ///
-    const bsoncxx::stdx::optional<bsoncxx::document::view>& modifiers() const;
+    const stdx::optional<bsoncxx::document::view>& modifiers() const;
 
     ///
     /// Sets the cursor flag to prevent cursor from timing out server-side due to a period of
@@ -181,10 +181,10 @@ class MONGOCXX_API find {
     ///
     /// @see http://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#op-query
     ///
-    const bsoncxx::stdx::optional<bool>& no_cursor_timeout() const;
+    const stdx::optional<bool>& no_cursor_timeout() const;
 
     void oplog_replay(bool oplog_replay);
-    const bsoncxx::stdx::optional<bool>& oplog_replay() const;
+    const stdx::optional<bool>& oplog_replay() const;
 
     ///
     /// Sets a projection which limits the returned fields for all matching documents.
@@ -203,7 +203,7 @@ class MONGOCXX_API find {
     ///
     /// @see http://docs.mongodb.org/manual/tutorial/project-fields-from-query-results/
     ///
-    const bsoncxx::stdx::optional<bsoncxx::document::view>& projection() const;
+    const stdx::optional<bsoncxx::document::view>& projection() const;
 
     ///
     /// Sets the read_preference for this operation.
@@ -223,7 +223,7 @@ class MONGOCXX_API find {
     ///
     /// @see http://docs.mongodb.org/manual/core/read-preference/
     ///
-    const bsoncxx::stdx::optional<class read_preference>& read_preference() const;
+    const stdx::optional<class read_preference>& read_preference() const;
 
     ///
     /// Sets the number of documents to skip before returning results.
@@ -242,7 +242,7 @@ class MONGOCXX_API find {
     ///
     /// @see http://docs.mongodb.org/manual/reference/method/cursor.skip/
     ///
-    const bsoncxx::stdx::optional<std::int32_t>& skip() const;
+    const stdx::optional<std::int32_t>& skip() const;
 
     ///
     /// The order in which to return matching documents. If $orderby also exists in the modifiers
@@ -262,23 +262,22 @@ class MONGOCXX_API find {
     ///
     /// @see http://docs.mongodb.org/manual/reference/method/cursor.sort/
     ///
-    const bsoncxx::stdx::optional<bsoncxx::document::view>& sort() const;
+    const stdx::optional<bsoncxx::document::view>& sort() const;
 
    private:
-    bsoncxx::stdx::optional<bool> _allow_partial_results;
-    bsoncxx::stdx::optional<std::int32_t> _batch_size;
-    bsoncxx::stdx::optional<std::string> _comment;
-    bsoncxx::stdx::optional<enum cursor_type> _cursor_type;
-    bsoncxx::stdx::optional<std::int32_t> _limit;
-    bsoncxx::stdx::optional<std::int64_t> _max_time_ms;
-    bsoncxx::stdx::optional<bsoncxx::document::view> _modifiers;
-    bsoncxx::stdx::optional<bool> _no_cursor_timeout;
-    bsoncxx::stdx::optional<bool> _oplog_replay;
-    bsoncxx::stdx::optional<bsoncxx::document::view> _projection;
-    bsoncxx::stdx::optional<class read_preference> _read_preference;
-    bsoncxx::stdx::optional<std::int32_t> _skip;
-    bsoncxx::stdx::optional<bsoncxx::document::view> _ordering;
-
+    stdx::optional<bool> _allow_partial_results;
+    stdx::optional<std::int32_t> _batch_size;
+    stdx::optional<std::string> _comment;
+    stdx::optional<enum cursor_type> _cursor_type;
+    stdx::optional<std::int32_t> _limit;
+    stdx::optional<std::int64_t> _max_time_ms;
+    stdx::optional<bsoncxx::document::view> _modifiers;
+    stdx::optional<bool> _no_cursor_timeout;
+    stdx::optional<bool> _oplog_replay;
+    stdx::optional<bsoncxx::document::view> _projection;
+    stdx::optional<class read_preference> _read_preference;
+    stdx::optional<std::int32_t> _skip;
+    stdx::optional<bsoncxx::document::view> _ordering;
 };
 
 }  // namespace options

--- a/src/mongocxx/options/find_one_and_delete.cpp
+++ b/src/mongocxx/options/find_one_and_delete.cpp
@@ -26,11 +26,11 @@ void find_one_and_delete::sort(bsoncxx::document::view ordering) {
     _ordering = ordering;
 }
 
-const bsoncxx::stdx::optional<bsoncxx::document::view>& find_one_and_delete::projection() const {
+const stdx::optional<bsoncxx::document::view>& find_one_and_delete::projection() const {
     return _projection;
 }
 
-const bsoncxx::stdx::optional<bsoncxx::document::view>& find_one_and_delete::sort() const {
+const stdx::optional<bsoncxx::document::view>& find_one_and_delete::sort() const {
     return _ordering;
 }
 

--- a/src/mongocxx/options/find_one_and_delete.hpp
+++ b/src/mongocxx/options/find_one_and_delete.hpp
@@ -50,7 +50,7 @@ class MONGOCXX_API find_one_and_delete {
     ///
     /// @see http://docs.mongodb.org/manual/reference/operator/meta/maxTimeMS
     ///
-    const bsoncxx::stdx::optional<std::int64_t>& max_time_ms() const;
+    const stdx::optional<std::int64_t>& max_time_ms() const;
 
     ///
     /// Sets a projection that limits the fields to return.
@@ -69,7 +69,7 @@ class MONGOCXX_API find_one_and_delete {
     ///
     /// @see http://docs.mongodb.org/manual/tutorial/project-fields-from-query-results/
     ///
-    const bsoncxx::stdx::optional<bsoncxx::document::view>& projection() const;
+    const stdx::optional<bsoncxx::document::view>& projection() const;
 
     ///
     /// Sets the order to search for a matching document.
@@ -91,13 +91,12 @@ class MONGOCXX_API find_one_and_delete {
     ///
     /// @see http://docs.mongodb.org/manual/reference/method/db.collection.findAndModify/
     ///
-    const bsoncxx::stdx::optional<bsoncxx::document::view>& sort() const;
+    const stdx::optional<bsoncxx::document::view>& sort() const;
 
    private:
-    bsoncxx::stdx::optional<std::int64_t> _max_time_ms;
-    bsoncxx::stdx::optional<bsoncxx::document::view> _projection;
-    bsoncxx::stdx::optional<bsoncxx::document::view> _ordering;
-
+    stdx::optional<std::int64_t> _max_time_ms;
+    stdx::optional<bsoncxx::document::view> _projection;
+    stdx::optional<bsoncxx::document::view> _ordering;
 };
 
 }  // namespace options

--- a/src/mongocxx/options/find_one_and_replace.cpp
+++ b/src/mongocxx/options/find_one_and_replace.cpp
@@ -34,19 +34,19 @@ void find_one_and_replace::upsert(bool upsert) {
     _upsert = upsert;
 }
 
-const bsoncxx::stdx::optional<bsoncxx::document::view>& find_one_and_replace::projection() const {
+const stdx::optional<bsoncxx::document::view>& find_one_and_replace::projection() const {
     return _projection;
 }
 
-const bsoncxx::stdx::optional<enum return_document>& find_one_and_replace::return_document() const {
+const stdx::optional<enum return_document>& find_one_and_replace::return_document() const {
     return _return_document;
 }
 
-const bsoncxx::stdx::optional<bsoncxx::document::view>& find_one_and_replace::sort() const {
+const stdx::optional<bsoncxx::document::view>& find_one_and_replace::sort() const {
     return _ordering;
 }
 
-const bsoncxx::stdx::optional<bool>& find_one_and_replace::upsert() const {
+const stdx::optional<bool>& find_one_and_replace::upsert() const {
     return _upsert;
 }
 

--- a/src/mongocxx/options/find_one_and_replace.hpp
+++ b/src/mongocxx/options/find_one_and_replace.hpp
@@ -19,8 +19,10 @@
 #include <cstdint>
 
 #include <bsoncxx/document/view.hpp>
-#include <mongocxx/options/find_one_and_modify.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
+#include <mongocxx/options/find_one_and_modify.hpp>
+#include <mongocxx/stdx.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -50,7 +52,7 @@ class MONGOCXX_API find_one_and_replace {
     ///
     /// @see http://docs.mongodb.org/manual/reference/operator/meta/maxTimeMS
     ///
-    const bsoncxx::stdx::optional<std::int64_t>& max_time_ms() const;
+    const stdx::optional<std::int64_t>& max_time_ms() const;
 
     ///
     /// Sets a projection, which limits the fields to return.
@@ -70,7 +72,7 @@ class MONGOCXX_API find_one_and_replace {
     /// @see http://docs.mongodb.org/manual/tutorial/project-fields-from-query-results/
     ///
     ///
-    const bsoncxx::stdx::optional<bsoncxx::document::view>& projection() const;
+    const stdx::optional<bsoncxx::document::view>& projection() const;
 
     ///
     /// Set the desired version of the replaced document to return, either the original
@@ -92,7 +94,7 @@ class MONGOCXX_API find_one_and_replace {
     /// @see http://docs.mongodb.org/manual/reference/command/findAndModify/
     /// @see mongocxx::options::return_document
     ///
-    const bsoncxx::stdx::optional<enum return_document>& return_document() const;
+    const stdx::optional<enum return_document>& return_document() const;
 
     ///
     /// Sets the order by which to search the collection for a matching document.
@@ -114,7 +116,7 @@ class MONGOCXX_API find_one_and_replace {
     ///
     /// @see http://docs.mongodb.org/manual/reference/command/findAndModify/
     ///
-    const bsoncxx::stdx::optional<bsoncxx::document::view>& sort() const;
+    const stdx::optional<bsoncxx::document::view>& sort() const;
 
     ///
     /// Sets the upsert flag on the operation. When @c true, the operation creates a new document if
@@ -135,15 +137,14 @@ class MONGOCXX_API find_one_and_replace {
     ///
     /// @see http://docs.mongodb.org/manual/reference/command/findAndModify/
     ///
-    const bsoncxx::stdx::optional<bool>& upsert() const;
+    const stdx::optional<bool>& upsert() const;
 
    private:
-    bsoncxx::stdx::optional<std::int64_t> _max_time_ms;
-    bsoncxx::stdx::optional<bsoncxx::document::view> _projection;
-    bsoncxx::stdx::optional<enum return_document> _return_document;
-    bsoncxx::stdx::optional<bsoncxx::document::view> _ordering;
-    bsoncxx::stdx::optional<bool> _upsert;
-
+    stdx::optional<std::int64_t> _max_time_ms;
+    stdx::optional<bsoncxx::document::view> _projection;
+    stdx::optional<enum return_document> _return_document;
+    stdx::optional<bsoncxx::document::view> _ordering;
+    stdx::optional<bool> _upsert;
 };
 
 }  // namespace options

--- a/src/mongocxx/options/find_one_and_update.cpp
+++ b/src/mongocxx/options/find_one_and_update.cpp
@@ -34,19 +34,19 @@ void find_one_and_update::upsert(bool upsert) {
     _upsert = upsert;
 }
 
-const bsoncxx::stdx::optional<bsoncxx::document::view>& find_one_and_update::projection() const {
+const stdx::optional<bsoncxx::document::view>& find_one_and_update::projection() const {
     return _projection;
 }
 
-const bsoncxx::stdx::optional<return_document>& find_one_and_update::return_document() const {
+const stdx::optional<return_document>& find_one_and_update::return_document() const {
     return _return_document;
 }
 
-const bsoncxx::stdx::optional<bsoncxx::document::view>& find_one_and_update::sort() const {
+const stdx::optional<bsoncxx::document::view>& find_one_and_update::sort() const {
     return _ordering;
 }
 
-const bsoncxx::stdx::optional<bool>& find_one_and_update::upsert() const {
+const stdx::optional<bool>& find_one_and_update::upsert() const {
     return _upsert;
 }
 

--- a/src/mongocxx/options/find_one_and_update.hpp
+++ b/src/mongocxx/options/find_one_and_update.hpp
@@ -19,8 +19,10 @@
 #include <cstdint>
 
 #include <bsoncxx/document/view.hpp>
-#include <mongocxx/options/find_one_and_modify.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
+#include <mongocxx/options/find_one_and_modify.hpp>
+#include <mongocxx/stdx.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -50,7 +52,7 @@ class MONGOCXX_API find_one_and_update {
     ///
     /// @see http://docs.mongodb.org/manual/reference/operator/meta/maxTimeMS
     ///
-    const bsoncxx::stdx::optional<std::int64_t>& max_time_ms() const;
+    const stdx::optional<std::int64_t>& max_time_ms() const;
 
     ///
     /// Sets a projection which limits the fields to return.
@@ -69,7 +71,7 @@ class MONGOCXX_API find_one_and_update {
     ///
     /// @see http://docs.mongodb.org/manual/tutorial/project-fields-from-query-results/
     ///
-    const bsoncxx::stdx::optional<bsoncxx::document::view>& projection() const;
+    const stdx::optional<bsoncxx::document::view>& projection() const;
 
     ///
     /// Sets the state of the document to be returned by the operation, either the
@@ -91,7 +93,7 @@ class MONGOCXX_API find_one_and_update {
     /// @see http://docs.mongodb.org/manual/reference/command/findAndModify/
     /// @see mongocxx::options::return_document
     ///
-    const bsoncxx::stdx::optional<enum return_document>& return_document() const;
+    const stdx::optional<enum return_document>& return_document() const;
 
     ///
     /// Sets the order by which to search the collection for a matching document.
@@ -113,7 +115,7 @@ class MONGOCXX_API find_one_and_update {
     ///
     /// @see http://docs.mongodb.org/manual/reference/command/findAndModify/
     ///
-    const bsoncxx::stdx::optional<bsoncxx::document::view>& sort() const;
+    const stdx::optional<bsoncxx::document::view>& sort() const;
 
     ///
     /// Sets the upsert flag on the operation. When @c true, the operation creates a new document if
@@ -134,15 +136,14 @@ class MONGOCXX_API find_one_and_update {
     ///
     /// @see http://docs.mongodb.org/manual/reference/command/findAndModify/
     ///
-    const bsoncxx::stdx::optional<bool>& upsert() const;
+    const stdx::optional<bool>& upsert() const;
 
    private:
-    bsoncxx::stdx::optional<std::int64_t> _max_time_ms;
-    bsoncxx::stdx::optional<bsoncxx::document::view> _projection;
-    bsoncxx::stdx::optional<enum return_document> _return_document;
-    bsoncxx::stdx::optional<bsoncxx::document::view> _ordering;
-    bsoncxx::stdx::optional<bool> _upsert;
-
+    stdx::optional<std::int64_t> _max_time_ms;
+    stdx::optional<bsoncxx::document::view> _projection;
+    stdx::optional<enum return_document> _return_document;
+    stdx::optional<bsoncxx::document::view> _ordering;
+    stdx::optional<bool> _upsert;
 };
 
 }  // namespace options

--- a/src/mongocxx/options/ssl.cpp
+++ b/src/mongocxx/options/ssl.cpp
@@ -22,7 +22,7 @@ void ssl::pem_file(std::string pem_file) {
     _pem_file = std::move(pem_file);
 }
 
-const bsoncxx::stdx::optional<std::string>& ssl::pem_file() const {
+const stdx::optional<std::string>& ssl::pem_file() const {
     return _pem_file;
 }
 
@@ -30,7 +30,7 @@ void ssl::pem_password(std::string pem_password) {
     _pem_password = std::move(pem_password);
 }
 
-const bsoncxx::stdx::optional<std::string>& ssl::pem_password() const {
+const stdx::optional<std::string>& ssl::pem_password() const {
     return _pem_password;
 }
 
@@ -38,7 +38,7 @@ void ssl::ca_file(std::string ca_file) {
     _ca_file = std::move(ca_file);
 }
 
-const bsoncxx::stdx::optional<std::string>& ssl::ca_file() const {
+const stdx::optional<std::string>& ssl::ca_file() const {
     return _ca_file;
 }
 
@@ -46,7 +46,7 @@ void ssl::ca_dir(std::string ca_dir) {
     _ca_dir = std::move(ca_dir);
 }
 
-const bsoncxx::stdx::optional<std::string>& ssl::ca_dir() const {
+const stdx::optional<std::string>& ssl::ca_dir() const {
     return _ca_dir;
 }
 
@@ -54,7 +54,7 @@ void ssl::crl_file(std::string crl_file) {
     _crl_file = std::move(crl_file);
 }
 
-const bsoncxx::stdx::optional<std::string>& ssl::crl_file() const {
+const stdx::optional<std::string>& ssl::crl_file() const {
     return _crl_file;
 }
 
@@ -62,7 +62,7 @@ void ssl::allow_invalid_certificates(bool allow_invalid_certificates) {
     _allow_invalid_certificates = allow_invalid_certificates;
 }
 
-const bsoncxx::stdx::optional<bool>& ssl::allow_invalid_certificates() const {
+const stdx::optional<bool>& ssl::allow_invalid_certificates() const {
     return _allow_invalid_certificates;
 }
 

--- a/src/mongocxx/options/ssl.hpp
+++ b/src/mongocxx/options/ssl.hpp
@@ -20,6 +20,8 @@
 
 #include <bsoncxx/stdx/optional.hpp>
 
+#include <mongocxx/stdx.hpp>
+
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 namespace options {
@@ -43,7 +45,7 @@ class MONGOCXX_API ssl {
     ///
     /// @return The path to the .pem file.
     ///
-    const bsoncxx::stdx::optional<std::string>& pem_file() const;
+    const stdx::optional<std::string>& pem_file() const;
 
     ///
     /// The pass phrase used to decrypt an encrypted PEM file.
@@ -58,7 +60,7 @@ class MONGOCXX_API ssl {
     ///
     /// @return The pass phrase.
     ///
-    const bsoncxx::stdx::optional<std::string>& pem_password() const;
+    const stdx::optional<std::string>& pem_password() const;
 
     ///
     /// The path to the .pem file that contains the root certificate chain from the Certificate
@@ -74,7 +76,7 @@ class MONGOCXX_API ssl {
     ///
     /// @return The path to the CA file.
     ///
-    const bsoncxx::stdx::optional<std::string>& ca_file() const;
+    const stdx::optional<std::string>& ca_file() const;
 
     ///
     /// The path to the Certificate Authority directory.
@@ -89,7 +91,7 @@ class MONGOCXX_API ssl {
     ///
     /// @return The path to the CA directory.
     ///
-    const bsoncxx::stdx::optional<std::string>& ca_dir() const;
+    const stdx::optional<std::string>& ca_dir() const;
 
     ///
     /// The path to the .pem file that contains revoked certificates.
@@ -104,7 +106,7 @@ class MONGOCXX_API ssl {
     ///
     /// @return The path to the revoked certificates file.
     ///
-    const bsoncxx::stdx::optional<std::string>& crl_file() const;
+    const stdx::optional<std::string>& crl_file() const;
 
     ///
     /// If false, the driver will not verify the server's CA file.
@@ -119,15 +121,15 @@ class MONGOCXX_API ssl {
     ///
     /// @return Whether or not the driver will check the server's CA file.
     ///
-    const bsoncxx::stdx::optional<bool>& allow_invalid_certificates() const;
+    const stdx::optional<bool>& allow_invalid_certificates() const;
 
    private:
-    bsoncxx::stdx::optional<std::string> _pem_file;
-    bsoncxx::stdx::optional<std::string> _pem_password;
-    bsoncxx::stdx::optional<std::string> _ca_file;
-    bsoncxx::stdx::optional<std::string> _ca_dir;
-    bsoncxx::stdx::optional<std::string> _crl_file;
-    bsoncxx::stdx::optional<bool> _allow_invalid_certificates;
+    stdx::optional<std::string> _pem_file;
+    stdx::optional<std::string> _pem_password;
+    stdx::optional<std::string> _ca_file;
+    stdx::optional<std::string> _ca_dir;
+    stdx::optional<std::string> _crl_file;
+    stdx::optional<bool> _allow_invalid_certificates;
 };
 
 }  // namespace options

--- a/src/mongocxx/options/update.cpp
+++ b/src/mongocxx/options/update.cpp
@@ -26,11 +26,11 @@ void update::write_concern(class write_concern wc) {
     _write_concern = std::move(wc);
 }
 
-const bsoncxx::stdx::optional<bool>& update::upsert() const {
+const stdx::optional<bool>& update::upsert() const {
     return _upsert;
 }
 
-const bsoncxx::stdx::optional<class write_concern>& update::write_concern() const {
+const stdx::optional<class write_concern>& update::write_concern() const {
     return _write_concern;
 }
 

--- a/src/mongocxx/options/update.hpp
+++ b/src/mongocxx/options/update.hpp
@@ -50,7 +50,7 @@ class MONGOCXX_API update {
     ///
     /// @return The optional value of the upsert option.
     ///
-    const bsoncxx::stdx::optional<bool>& upsert() const;
+    const stdx::optional<bool>& upsert() const;
 
     ///
     /// Sets the write_concern for this operation.
@@ -70,12 +70,11 @@ class MONGOCXX_API update {
     ///
     /// @see http://docs.mongodb.org/manual/core/write-concern/
     ///
-    const bsoncxx::stdx::optional<class write_concern>& write_concern() const;
+    const stdx::optional<class write_concern>& write_concern() const;
 
    private:
-    bsoncxx::stdx::optional<bool> _upsert;
-    bsoncxx::stdx::optional<class write_concern> _write_concern;
-
+    stdx::optional<bool> _upsert;
+    stdx::optional<class write_concern> _write_concern;
 };
 
 }  // namespace options

--- a/src/mongocxx/pipeline.cpp
+++ b/src/mongocxx/pipeline.cpp
@@ -15,7 +15,9 @@
 #include <mongocxx/pipeline.hpp>
 
 #include <bsoncxx/stdx/make_unique.hpp>
+
 #include <mongocxx/private/pipeline.hpp>
+#include <mongocxx/stdx.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -23,7 +25,7 @@ MONGOCXX_INLINE_NAMESPACE_BEGIN
 using namespace bsoncxx::builder::stream;
 using namespace bsoncxx::types;
 
-pipeline::pipeline() : _impl(bsoncxx::stdx::make_unique<impl>()) {
+pipeline::pipeline() : _impl(stdx::make_unique<impl>()) {
 }
 
 pipeline::pipeline(pipeline&&) noexcept = default;

--- a/src/mongocxx/private/collection.hpp
+++ b/src/mongocxx/private/collection.hpp
@@ -34,15 +34,13 @@ MONGOCXX_INLINE_NAMESPACE_BEGIN
 class collection::impl {
 
    public:
-    impl(mongoc_collection_t* collection,
-         bsoncxx::stdx::string_view database_name,
-         const class client::impl* client,
-         bsoncxx::stdx::string_view name) :
-        collection_t(collection),
-        database_name(std::move(database_name)),
-        client_impl(client),
-        name(name)
-    {}
+    impl(mongoc_collection_t* collection, stdx::string_view database_name,
+         const class client::impl* client, stdx::string_view name)
+        : collection_t(collection),
+          database_name(std::move(database_name)),
+          client_impl(client),
+          name(name) {
+    }
 
     ~impl() { libmongoc::collection_destroy(collection_t); }
 

--- a/src/mongocxx/private/libbson.cpp
+++ b/src/mongocxx/private/libbson.cpp
@@ -22,14 +22,14 @@ static void doc_to_bson_t(const bsoncxx::document::view& doc, bson_t* bson) {
     bson_init_static(bson, doc.data(), doc.length());
 }
 
-static void optional_doc_to_bson_t(const bsoncxx::stdx::optional<bsoncxx::document::view>& doc,
+static void optional_doc_to_bson_t(const stdx::optional<bsoncxx::document::view>& doc,
                                    bson_t* bson) {
     if (doc) {
         doc_to_bson_t(*doc, bson);
     }
 }
 
-scoped_bson_t::scoped_bson_t(const bsoncxx::stdx::optional<bsoncxx::document::view>& doc)
+scoped_bson_t::scoped_bson_t(const stdx::optional<bsoncxx::document::view>& doc)
     : _is_initialized(doc) {
     optional_doc_to_bson_t(doc, &_bson);
 }
@@ -38,7 +38,7 @@ scoped_bson_t::scoped_bson_t(const bsoncxx::document::view& doc) : _is_initializ
     doc_to_bson_t(doc, &_bson);
 }
 
-void scoped_bson_t::init_from_static(const bsoncxx::stdx::optional<bsoncxx::document::view>& doc) {
+void scoped_bson_t::init_from_static(const stdx::optional<bsoncxx::document::view>& doc) {
     _is_initialized = static_cast<bool>(doc);
     optional_doc_to_bson_t(doc, &_bson);
 }

--- a/src/mongocxx/private/libbson.hpp
+++ b/src/mongocxx/private/libbson.hpp
@@ -20,8 +20,9 @@
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
-
 #include <bsoncxx/stdx/optional.hpp>
+
+#include <mongocxx/stdx.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -58,7 +59,7 @@ class scoped_bson_t {
     ///
     /// If the optional argument is engaged the internal bson_t is considered initialized.
     ///
-    scoped_bson_t(const bsoncxx::stdx::optional<bsoncxx::document::view>& doc);
+    scoped_bson_t(const stdx::optional<bsoncxx::document::view>& doc);
 
     ///
     /// Constructs a new scoped_bson_t from a document view.
@@ -72,7 +73,7 @@ class scoped_bson_t {
     ///
     /// If the optional argument is engaged the internal bson_t is considered initialized.
     ///
-    void init_from_static(const bsoncxx::stdx::optional<bsoncxx::document::view>& doc);
+    void init_from_static(const stdx::optional<bsoncxx::document::view>& doc);
 
     ///
     /// Constructs a read-only bson_t from the provided document.

--- a/src/mongocxx/read_preference.cpp
+++ b/src/mongocxx/read_preference.cpp
@@ -26,13 +26,12 @@ read_preference::read_preference(read_preference&&) noexcept = default;
 read_preference& read_preference::operator=(read_preference&&) noexcept = default;
 
 read_preference::read_preference(const read_preference& other)
-    : _impl(bsoncxx::stdx::make_unique<impl>(
-          libmongoc::read_prefs_copy(other._impl->read_preference_t))) {
+    : _impl(stdx::make_unique<impl>(libmongoc::read_prefs_copy(other._impl->read_preference_t))) {
 }
 
 read_preference& read_preference::operator=(const read_preference& other) {
-    _impl.reset(bsoncxx::stdx::make_unique<impl>(
-                    libmongoc::read_prefs_copy(other._impl->read_preference_t)).release());
+    _impl.reset(stdx::make_unique<impl>(libmongoc::read_prefs_copy(other._impl->read_preference_t))
+                    .release());
     return *this;
 }
 
@@ -41,7 +40,7 @@ read_preference::read_preference(std::unique_ptr<impl>&& implementation) {
 }
 
 read_preference::read_preference(read_mode mode)
-    : _impl(bsoncxx::stdx::make_unique<impl>(
+    : _impl(stdx::make_unique<impl>(
           libmongoc::read_prefs_new(static_cast<mongoc_read_mode_t>(mode)))) {
 }
 
@@ -69,13 +68,13 @@ read_preference::read_mode read_preference::mode() const {
     return static_cast<read_mode>(libmongoc::read_prefs_get_mode(_impl->read_preference_t));
 }
 
-bsoncxx::stdx::optional<bsoncxx::document::view> read_preference::tags() const {
+stdx::optional<bsoncxx::document::view> read_preference::tags() const {
     const bson_t* bson_tags = libmongoc::read_prefs_get_tags(_impl->read_preference_t);
 
     if (bson_count_keys(bson_tags))
         return bsoncxx::document::view(bson_get_data(bson_tags), bson_tags->len);
 
-    return bsoncxx::stdx::optional<bsoncxx::document::view>{};
+    return stdx::optional<bsoncxx::document::view>{};
 }
 
 bool read_preference::operator==(const read_preference& other) const {

--- a/src/mongocxx/read_preference.hpp
+++ b/src/mongocxx/read_preference.hpp
@@ -23,6 +23,8 @@
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 
+#include <mongocxx/stdx.hpp>
+
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 
@@ -176,7 +178,7 @@ class MONGOCXX_API read_preference {
     ///
     /// @return The optionally set current tags.
     ///
-    bsoncxx::stdx::optional<bsoncxx::document::view> tags() const;
+    stdx::optional<bsoncxx::document::view> tags() const;
 
     ///
     /// Comparison operator

--- a/src/mongocxx/result/insert_many.hpp
+++ b/src/mongocxx/result/insert_many.hpp
@@ -15,12 +15,13 @@
 #pragma once
 
 #include <mongocxx/config/prelude.hpp>
-#include <mongocxx/result/bulk_write.hpp>
 
 #include <cstdint>
 #include <map>
 
 #include <bsoncxx/types.hpp>
+
+#include <mongocxx/result/bulk_write.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/insert_one.hpp
+++ b/src/mongocxx/result/insert_one.hpp
@@ -18,6 +18,7 @@
 
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/value.hpp>
+
 #include <mongocxx/result/bulk_write.hpp>
 
 namespace mongocxx {

--- a/src/mongocxx/result/replace_one.cpp
+++ b/src/mongocxx/result/replace_one.cpp
@@ -33,7 +33,7 @@ std::int32_t replace_one::modified_count() const {
     return _result.modified_count();
 }
 
-bsoncxx::stdx::optional<bsoncxx::document::element> replace_one::upserted_id() const {
+stdx::optional<bsoncxx::document::element> replace_one::upserted_id() const {
     return _result.upserted_ids();
 }
 

--- a/src/mongocxx/result/replace_one.hpp
+++ b/src/mongocxx/result/replace_one.hpp
@@ -19,8 +19,10 @@
 #include <cstdint>
 
 #include <bsoncxx/types.hpp>
-#include <mongocxx/result/bulk_write.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
+#include <mongocxx/result/bulk_write.hpp>
+#include <mongocxx/stdx.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -59,7 +61,7 @@ class MONGOCXX_API replace_one {
     ///
     /// @return The value of the _id field for upserted document.
     ///
-    bsoncxx::stdx::optional<bsoncxx::document::element> upserted_id() const;
+    stdx::optional<bsoncxx::document::element> upserted_id() const;
 
    private:
     result::bulk_write _result;

--- a/src/mongocxx/result/update.cpp
+++ b/src/mongocxx/result/update.cpp
@@ -32,7 +32,7 @@ std::int32_t update::modified_count() const {
     return _result.modified_count();
 }
 
-bsoncxx::stdx::optional<bsoncxx::document::element> update::upserted_id() const {
+stdx::optional<bsoncxx::document::element> update::upserted_id() const {
     return _result.upserted_ids();
 }
 

--- a/src/mongocxx/result/update.hpp
+++ b/src/mongocxx/result/update.hpp
@@ -19,8 +19,10 @@
 #include <cstdint>
 
 #include <bsoncxx/types.hpp>
-#include <mongocxx/result/bulk_write.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
+#include <mongocxx/result/bulk_write.hpp>
+#include <mongocxx/stdx.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -58,7 +60,7 @@ class MONGOCXX_API update {
     ///
     /// @return The value of the _id field for upserted document.
     ///
-    bsoncxx::stdx::optional<bsoncxx::document::element> upserted_id() const;
+    stdx::optional<bsoncxx::document::element> upserted_id() const;
 
    private:
     result::bulk_write _result;

--- a/src/mongocxx/stdx.hpp
+++ b/src/mongocxx/stdx.hpp
@@ -21,7 +21,7 @@ MONGOCXX_INLINE_NAMESPACE_BEGIN
 namespace stdx {
 
 // We adopt all the bsoncxx polyfills
-using namespace bsoncxx::stdx;
+using namespace ::bsoncxx::stdx;
 
 } // namespace stdx;
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/test/client.cpp
+++ b/src/mongocxx/test/client.cpp
@@ -166,7 +166,7 @@ TEST_CASE("A client can create a named database object", "[client]") {
     database_set_concern->interpose([](mongoc_database_t*, const mongoc_write_concern_t*) {})
         .forever();
 
-    bsoncxx::stdx::string_view name("database");
+    stdx::string_view name("database");
 
     client mongo_client{uri{}};
     database obtained_database = mongo_client[name];

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -434,12 +434,12 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
 
         auto values_array = res_doc["values"].get_array().value;
 
-        std::vector<bsoncxx::stdx::string_view> distinct_values;
+        std::vector<stdx::string_view> distinct_values;
         for (auto&& value : values_array) {
             distinct_values.push_back(value.get_utf8().value);
         }
 
-        const auto assert_contains_one = [&](bsoncxx::stdx::string_view val) {
+        const auto assert_contains_one = [&](stdx::string_view val) {
             REQUIRE(std::count(distinct_values.begin(), distinct_values.end(), val) == 1);
         };
 

--- a/src/mongocxx/test/collection_mocked.cpp
+++ b/src/mongocxx/test/collection_mocked.cpp
@@ -75,12 +75,12 @@ TEST_CASE("Collection", "[collection]") {
                 bsoncxx::array::view p(bson_get_data(pipeline), pipeline->len);
                 bsoncxx::document::view o(bson_get_data(options), options->len);
 
-                bsoncxx::stdx::string_view bar(
+                mongocxx::stdx::string_view bar(
                     p[0].get_document().value["$match"].get_document().value["foo"].get_utf8());
                 std::int32_t one(
                     p[1].get_document().value["$sort"].get_document().value["foo"].get_int32());
 
-                REQUIRE(bar == bsoncxx::stdx::string_view("bar"));
+                REQUIRE(bar == mongocxx::stdx::string_view("bar"));
                 REQUIRE(one == 1);
 
                 if (opts.allow_disk_use())

--- a/src/mongocxx/test/database.cpp
+++ b/src/mongocxx/test/database.cpp
@@ -28,7 +28,7 @@ TEST_CASE("A default constructed database is false-ish", "[database]") {
 }
 
 TEST_CASE("A database", "[database]") {
-    bsoncxx::stdx::string_view database_name{"database"};
+    stdx::string_view database_name{"database"};
     MOCK_CLIENT
     MOCK_DATABASE
     client mongo_client{uri{}};
@@ -37,7 +37,7 @@ TEST_CASE("A database", "[database]") {
         bool called = false;
         get_database->interpose([&](mongoc_client_t* client, const char* d_name) {
             called = true;
-            REQUIRE(database_name == bsoncxx::stdx::string_view{d_name});
+            REQUIRE(database_name == stdx::string_view{d_name});
             return nullptr;
         });
 
@@ -149,7 +149,7 @@ TEST_CASE("A database", "[database]") {
 
     SECTION("may create a collection") {
         MOCK_COLLECTION
-        bsoncxx::stdx::string_view collection_name{"collection"};
+        stdx::string_view collection_name{"collection"};
         database database = mongo_client[database_name];
         collection obtained_collection = database[collection_name];
         REQUIRE(obtained_collection.name() == collection_name);

--- a/src/mongocxx/uri.cpp
+++ b/src/mongocxx/uri.cpp
@@ -28,8 +28,8 @@ uri::uri(std::unique_ptr<impl>&& implementation) {
     _impl.reset(implementation.release());
 }
 
-uri::uri(bsoncxx::stdx::string_view uri_string)
-    : _impl(bsoncxx::stdx::make_unique<impl>(mongoc_uri_new(uri_string.data()))) {
+uri::uri(stdx::string_view uri_string)
+    : _impl(stdx::make_unique<impl>(mongoc_uri_new(uri_string.data()))) {
 }
 
 uri::uri(uri&&) noexcept = default;

--- a/src/mongocxx/uri.hpp
+++ b/src/mongocxx/uri.hpp
@@ -58,7 +58,7 @@ class MONGOCXX_API uri {
     ///
     /// @todo this should really take a stringview (polyfilled)?
     ///
-    uri(bsoncxx::stdx::string_view uri_string = k_default_uri);
+    uri(stdx::string_view uri_string = k_default_uri);
 
     ///
     /// Move constructs a uri.

--- a/src/mongocxx/write_concern.hpp
+++ b/src/mongocxx/write_concern.hpp
@@ -23,6 +23,7 @@
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
+
 #include <mongocxx/stdx.hpp>
 
 namespace mongocxx {


### PR DESCRIPTION
switch all `bsconcxx::stdx` to be `mongocxx::stdx` under the mongocxx namespace