### PR TITLE
CXX-696: Add tests to verify spec compliance with unacknowledged write concerns

### DIFF
--- a/src/mongo/client/write_concern_test.cpp
+++ b/src/mongo/client/write_concern_test.cpp
@@ -92,6 +92,12 @@ TEST(WriteConcern, NeedsGLE) {
 TEST(WriteConcern, Unacknowledged) {
     ASSERT_FALSE(WriteConcern::unacknowledged.requiresConfirmation());
     ASSERT_EQUALS(WriteConcern::unacknowledged.nodes(), 0);
+
+    ASSERT_FALSE(WriteConcern().nodes(0).requiresConfirmation());
+
+    ASSERT_FALSE(WriteConcern().nodes(0).journal(false).requiresConfirmation());
+
+    ASSERT_FALSE(WriteConcern().nodes(0).timeout(100).requiresConfirmation());
 }
 
 TEST(WriteConcern, Acknowledged) {


### PR DESCRIPTION
According to the [read and write concern spec](https://github.com/mongodb/specifications/blob/master/source/read-write-concern/read-write-concern.rst):

> An `Unacknowledged WriteConcern` is when (`w` equals 0) AND (`journal` is not set or is `false`).

This change adds a few simple unit tests to ensure our compliance. There are no other changes.