### PR TITLE
CXX-692 Check writeConcern errors in findAndModify

### DIFF
--- a/src/mongo/client/dbclient.cpp
+++ b/src/mongo/client/dbclient.cpp
@@ -1393,6 +1393,11 @@ void DBClientBase::_findAndModify(const StringData& ns,
     if (!ok)
         throw OperationException(result);
 
+    // Check for any write concern errors
+    WriteResult writeResult;
+    writeResult._mergeWriteConcern(result);
+    writeResult._check(true);
+
     out->appendElements(result.getObjectField("value"));
 }
 

--- a/src/mongo/client/dbclient_rs.h
+++ b/src/mongo/client/dbclient_rs.h
@@ -203,6 +203,14 @@ public:
      */
     static void setAuthPooledSecondaryConn(bool setting);
 
+    virtual int getMaxWireVersion() {
+        return checkMaster()->getMaxWireVersion();
+    }
+
+    virtual int getMinWireVersion() {
+        return checkMaster()->getMinWireVersion();
+    }
+
 protected:
     /** Authorize.  Authorizes all nodes as needed
     */

--- a/src/mongo/client/dbclientinterface.h
+++ b/src/mongo/client/dbclientinterface.h
@@ -1463,10 +1463,10 @@ public:
         _maxWireVersion = maxWireVersion;
     }
 
-    int getMinWireVersion() {
+    virtual int getMinWireVersion() {
         return _minWireVersion;
     }
-    int getMaxWireVersion() {
+    virtual int getMaxWireVersion() {
         return _maxWireVersion;
     }
     int getMaxBsonObjectSize() {

--- a/src/mongo/client/write_result.cpp
+++ b/src/mongo/client/write_result.cpp
@@ -125,6 +125,10 @@ void WriteResult::_mergeCommandResult(const std::vector<WriteOperation*>& ops,
             _createWriteError(arrayIterator.next().Obj(), ops);
     }
 
+    _mergeWriteConcern(result);
+}
+
+void WriteResult::_mergeWriteConcern(const BSONObj& result) {
     // Handle Write Concern Errors
     if (result.hasField("writeConcernError")) {
         BSONObj writeConcernError = result.getObjectField("writeConcernError");

--- a/src/mongo/client/write_result.h
+++ b/src/mongo/client/write_result.h
@@ -34,6 +34,7 @@ class MONGO_CLIENT_API WriteResult {
     friend class WireProtocolWriter;
     friend class CommandWriter;
     friend class BulkOperationBuilder;
+    friend class DBClientBase;
 
 public:
     /**
@@ -140,6 +141,7 @@ public:
     const std::vector<BSONObj>& writeConcernErrors() const;
 
 private:
+    void _mergeWriteConcern(const BSONObj& result);
     void _mergeCommandResult(const std::vector<WriteOperation*>& ops, const BSONObj& result);
     void _mergeGleResult(const std::vector<WriteOperation*>& ops, const BSONObj& result);
 


### PR DESCRIPTION
Per an update to DRIVERS-224, I added a test to verify `findAndModify` uses writeConcern correctly. This was important because `findAndModify` goes through a different code path the insert/update/delete.

Changes
1. Make `getMaxWireVersion` so that replica set connections can check it. This uses the primary. It is undefined if customers are using mixed version clusters.
2. Check `WriteResult` in `_findAndModify` to verify the writeConcern in this code path.