### PR TITLE
CXX-734: 'make examples' will run all examples

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -78,7 +78,7 @@ tasks:
           params:
               working_dir: "mongo-cxx-driver/build"
               script: |
-                  PKG_CONFIG_PATH="/data/tmp/c-driver-install/lib/pkgconfig" /opt/cmake/bin/cmake -DBUILD_UNIT_TESTS=true -DBUILD_EXAMPLES=true -DCMAKE_BUILD_TYPE=${build_type} CMAKE_INSTALL_PREFIX=/data/tmp/cxx-driver-install ..
+                  PKG_CONFIG_PATH="/data/tmp/c-driver-install/lib/pkgconfig" /opt/cmake/bin/cmake -DCMAKE_BUILD_TYPE=${build_type} CMAKE_INSTALL_PREFIX=/data/tmp/cxx-driver-install ..
                   make
                   ./src/mongocxx/test/test_driver
         - func: "stop_mongod"

--- a/.mci.yml
+++ b/.mci.yml
@@ -78,8 +78,9 @@ tasks:
           params:
               working_dir: "mongo-cxx-driver/build"
               script: |
-                  PKG_CONFIG_PATH="/data/tmp/c-driver-install/lib/pkgconfig" /opt/cmake/bin/cmake -DCMAKE_BUILD_TYPE=${build_type} CMAKE_INSTALL_PREFIX=/data/tmp/cxx-driver-install ..
+                  PKG_CONFIG_PATH="/data/tmp/c-driver-install/lib/pkgconfig" /opt/cmake/bin/cmake -DCMAKE_BUILD_TYPE=${build_type} -DCMAKE_INSTALL_PREFIX=./install ..
                   make
+                  make run-examples
                   ./src/mongocxx/test/test_driver
         - func: "stop_mongod"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,10 @@ before_script:
     - ${CMAKE_BINARY} -DCMAKE_BUILD_TYPE=$CONFIG ..
 
 script:
-    - make -j3
+    - make
+
+    # Run all examples
+    - make run-examples
 
     # Run tests with catch
     - ./src/mongocxx/test/test_driver

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ project(MONGO_CXX_DRIVER LANGUAGES CXX)
 
 cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
 
+set (CMAKE_SKIP_BUILD_RPATH false)
+set (CMAKE_BUILD_WITH_INSTALL_RPATH false)
+set (CMAKE_INSTALL_RPATH_USE_LINK_PATH true)
+
 # Add in our modules
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
@@ -81,6 +85,4 @@ enable_testing()
 
 add_subdirectory(src)
 
-if(BUILD_EXAMPLES)
-    add_subdirectory(examples)
-endif()
+add_subdirectory(examples)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -9,4 +9,16 @@ add_custom_target(install_libs
 add_subdirectory(bsoncxx)
 add_subdirectory(mongocxx)
 
-add_custom_target(examples DEPENDS ${MONGOCXX_EXAMPLES} ${BSONCXX_EXAMPLES})
+add_custom_target(run-examples DEPENDS ${MONGOCXX_EXAMPLE_EXECUTABLES} ${BSONCXX_EXAMPLE_EXECUTABLES})
+
+# Run all mongocxx examples on `make examples`.
+foreach(EXAMPLE ${MONGOCXX_EXAMPLE_EXECUTABLES})
+    get_filename_component(EXAMPLE_EXECUTABLE "${CMAKE_BINARY_DIR}/examples/mongocxx/${EXAMPLE}" ABSOLUTE)
+    add_custom_command(TARGET run-examples POST_BUILD COMMAND ${EXAMPLE_EXECUTABLE})
+endforeach(EXAMPLE)
+
+# Run all bsoncxx examples on `make examples`.
+foreach(EXAMPLE ${BSONCXX_EXAMPLE_EXECUTABLES})
+    get_filename_component(EXAMPLE_EXECUTABLE "${CMAKE_BINARY_DIR}/examples/bsoncxx/${EXAMPLE}" ABSOLUTE)
+    add_custom_command(TARGET run-examples POST_BUILD COMMAND ${EXAMPLE_EXECUTABLE})
+endforeach(EXAMPLE)

--- a/examples/bsoncxx/CMakeLists.txt
+++ b/examples/bsoncxx/CMakeLists.txt
@@ -19,4 +19,7 @@ foreach(EXAMPLE_SRC ${BSONCXX_EXAMPLES})
     add_executable(${EXAMPLE_TARGET} ${EXAMPLE_SRC})
     add_dependencies(${EXAMPLE_TARGET} install_headers install_libs)
     target_link_libraries(${EXAMPLE_TARGET} bsoncxx ${bsoncxx_libs})
+    set(BSONCXX_EXAMPLE_EXECUTABLES ${BSONCXX_EXAMPLE_EXECUTABLES} ${EXAMPLE_TARGET})
 endforeach(EXAMPLE_SRC)
+
+set(BSONCXX_EXAMPLE_EXECUTABLES ${BSONCXX_EXAMPLE_EXECUTABLES} PARENT_SCOPE)

--- a/examples/mongocxx/CMakeLists.txt
+++ b/examples/mongocxx/CMakeLists.txt
@@ -21,4 +21,7 @@ foreach(EXAMPLE_SRC ${MONGOCXX_EXAMPLES})
     add_executable(${EXAMPLE_TARGET} ${EXAMPLE_SRC})
     add_dependencies(${EXAMPLE_TARGET} install_headers install_libs)
     target_link_libraries(${EXAMPLE_TARGET} mongocxx ${mongocxx_libs})
+    set(MONGOCXX_EXAMPLE_EXECUTABLES ${MONGOCXX_EXAMPLE_EXECUTABLES} ${EXAMPLE_TARGET})
 endforeach(EXAMPLE_SRC)
+
+set(MONGOCXX_EXAMPLE_EXECUTABLES ${MONGOCXX_EXAMPLE_EXECUTABLES} PARENT_SCOPE)


### PR DESCRIPTION
Note: cmake must be configured with `-DBUILD_EXAMPLES=true` in order to build the example executables.