### PR TITLE
CXX-759 working iterators for empty doc views

### DIFF
--- a/src/bsoncxx/array/view.cpp
+++ b/src/bsoncxx/array/view.cpp
@@ -137,7 +137,9 @@ view::const_iterator view::cbegin() const {
 
     bson_init_static(&b, data(), length());
     bson_iter_init(&iter, &b);
-    bson_iter_next(&iter);
+    if (!bson_iter_next(&iter)) {
+        return const_iterator{};
+    }
 
     return const_iterator(element{iter.raw, iter.len, iter.off});
 }
@@ -152,7 +154,9 @@ view::iterator view::begin() const {
 
     bson_init_static(&b, data(), length());
     bson_iter_init(&iter, &b);
-    bson_iter_next(&iter);
+    if (!bson_iter_next(&iter)) {
+        return iterator{};
+    }
 
     return iterator(element{iter.raw, iter.len, iter.off});
 }

--- a/src/bsoncxx/document/view.cpp
+++ b/src/bsoncxx/document/view.cpp
@@ -137,7 +137,10 @@ view::const_iterator view::cbegin() const {
 
     bson_init_static(&b, _data, _length);
     bson_iter_init(&iter, &b);
-    bson_iter_next(&iter);
+
+    if (!bson_iter_next(&iter)) {
+        return const_iterator{};
+    }
 
     return const_iterator(element{iter.raw, iter.len, iter.off});
 }
@@ -152,7 +155,9 @@ view::iterator view::begin() const {
 
     bson_init_static(&b, _data, _length);
     bson_iter_init(&iter, &b);
-    bson_iter_next(&iter);
+    if (!bson_iter_next(&iter)) {
+        return iterator{};
+    }
 
     return iterator(element{iter.raw, iter.len, iter.off});
 }

--- a/src/bsoncxx/test/bson_get_values.cpp
+++ b/src/bsoncxx/test/bson_get_values.cpp
@@ -1,5 +1,6 @@
 #include "catch.hpp"
 
+#include <bsoncxx/builder/stream/array.hpp>
 #include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/builder/stream/helpers.hpp>
 
@@ -204,4 +205,24 @@ TEST_CASE("[] with large nesting levels", "[bsoncxx]") {
         x = x["x"];
     }
     REQUIRE(x.get_int32() == nesting_level);
+}
+
+TEST_CASE("empty document view has working iterators", "[bsoncxx]") {
+    using namespace builder::stream;
+
+    auto value = builder::stream::document{} << finalize;
+    auto doc = value.view();
+
+    REQUIRE(doc.begin() == doc.end());
+    REQUIRE(doc.cbegin() == doc.cend());
+}
+
+TEST_CASE("empty array view has working iterators", "[bsoncxx]") {
+    using namespace builder::stream;
+
+    auto value = builder::stream::array{} << finalize;
+    auto doc = value.view();
+
+    REQUIRE(doc.begin() == doc.end());
+    REQUIRE(doc.cbegin() == doc.cend());
 }


### PR DESCRIPTION
We have to check the return value of iter_next, or we can hand out a begin() iterator that doesn't equal end(), but that you also can't read out of