### PR TITLE
CXX-757 Fix value append on bson builder core

### DIFF
--- a/src/bsoncxx/builder/core.hpp
+++ b/src/bsoncxx/builder/core.hpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <stdexcept>
+#include <type_traits>
 
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/array/view.hpp>
@@ -216,15 +217,6 @@ class BSONCXX_API core {
     void append(const types::value& value);
 
     ///
-    /// Append a string literal as a BSON UTF-8 string.
-    ///
-    template <std::size_t n>
-    BSONCXX_INLINE
-    void append(const char (&v)[n]) {
-        append(types::b_utf8{v});
-    }
-
-    ///
     /// Append a STL string as a BSON UTF-8 string.
     ///
     void append(std::string str);
@@ -233,6 +225,20 @@ class BSONCXX_API core {
     /// Append a string view as a BSON UTF-8 string.
     ///
     void append(stdx::string_view str);
+
+    ///
+    /// Append a char* or const char*
+    ///
+    /// We disable all other pointer types to prevent the surprising implicit
+    /// conversion to bool.
+    ///
+    template <typename T>
+    BSONCXX_INLINE
+    void append(T* v) {
+        static_assert(std::is_same<typename std::remove_const<T>::type, char>::value,
+                      "append is disabled for non-char pointer types");
+        append(types::b_utf8{v});
+    }
 
     ///
     /// Append a native boolean as a BSON boolean.

--- a/src/bsoncxx/test/bson_builder.cpp
+++ b/src/bsoncxx/test/bson_builder.cpp
@@ -66,6 +66,27 @@ TEST_CASE("builder appends utf8", "[bsoncxx::builder::stream]") {
         bson_eq_stream(&expected, b);
     }
 
+    SECTION("works with const char*") {
+        const char* world = "world";
+        b << "hello" << world;
+
+        bson_eq_stream(&expected, b);
+    }
+
+    SECTION("works with char*") {
+        char* world = const_cast<char*>("world");
+        b << "hello" << world;
+
+        bson_eq_stream(&expected, b);
+    }
+
+    // SECTION("fails to compile with non-char*") {
+    //     int world = 10;
+    //     b << "hello" << &world;
+
+    //     bson_eq_stream(&expected, b);
+    // }
+
     bson_destroy(&expected);
 }
 


### PR DESCRIPTION
Disables append for non-char pointer types
- prevents implicit boolean conversion

removes appends for string literals && enables append for char pointers
- string literals still get their memchr inlined
- regular char*'s work