### PR TITLE
CXX-770: Add missing headers and fix enum typing

### DIFF
--- a/src/bsoncxx/array/view.cpp
+++ b/src/bsoncxx/array/view.cpp
@@ -14,6 +14,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <tuple>
 
 #include <bson.h>
 

--- a/src/mongocxx/collection.hpp
+++ b/src/mongocxx/collection.hpp
@@ -23,6 +23,7 @@
 
 #include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/document/view.hpp>
+#include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 
 #include <mongocxx/bulk_write.hpp>

--- a/src/mongocxx/options/find.cpp
+++ b/src/mongocxx/options/find.cpp
@@ -34,7 +34,7 @@ void find::comment(std::string comment) {
     _comment = comment;
 }
 
-void find::cursor_type(enum find::cursor_type cursor_type) {
+void find::cursor_type(enum class find::cursor_type cursor_type) {
     _cursor_type = cursor_type;
 }
 
@@ -90,7 +90,7 @@ const stdx::optional<std::string>& find::comment() const {
     return _comment;
 }
 
-const stdx::optional<enum find::cursor_type>& find::cursor_type() const {
+const stdx::optional<enum class find::cursor_type>& find::cursor_type() const {
     return _cursor_type;
 }
 

--- a/src/mongocxx/options/find.hpp
+++ b/src/mongocxx/options/find.hpp
@@ -100,7 +100,7 @@ class MONGOCXX_API find {
     ///
     /// @see http://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#op-query
     ///
-    void cursor_type(enum cursor_type cursor_type);
+    void cursor_type(enum class cursor_type cursor_type);
 
     ///
     /// Gets the current cursor type.
@@ -109,7 +109,7 @@ class MONGOCXX_API find {
     ///
     /// @see http://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#op-query
     ///
-    const stdx::optional<enum cursor_type>& cursor_type() const;
+    const stdx::optional<enum class cursor_type>& cursor_type() const;
 
     ///
     /// Sets maximum number of documents to return.
@@ -290,7 +290,7 @@ class MONGOCXX_API find {
     stdx::optional<bool> _allow_partial_results;
     stdx::optional<std::int32_t> _batch_size;
     stdx::optional<std::string> _comment;
-    stdx::optional<enum cursor_type> _cursor_type;
+    stdx::optional<enum class cursor_type> _cursor_type;
     stdx::optional<std::int32_t> _limit;
     stdx::optional<std::int64_t> _max_await_time_ms;
     stdx::optional<std::int64_t> _max_time_ms;

--- a/src/mongocxx/options/find_one_and_replace.cpp
+++ b/src/mongocxx/options/find_one_and_replace.cpp
@@ -32,7 +32,7 @@ void find_one_and_replace::projection(bsoncxx::document::view projection) {
     _projection = projection;
 }
 
-void find_one_and_replace::return_document(enum return_document return_document) {
+void find_one_and_replace::return_document(enum class return_document return_document) {
     _return_document = return_document;
 }
 
@@ -56,7 +56,7 @@ const stdx::optional<bsoncxx::document::view>& find_one_and_replace::projection(
     return _projection;
 }
 
-const stdx::optional<enum return_document>& find_one_and_replace::return_document() const {
+const stdx::optional<enum class return_document>& find_one_and_replace::return_document() const {
     return _return_document;
 }
 

--- a/src/mongocxx/options/find_one_and_replace.hpp
+++ b/src/mongocxx/options/find_one_and_replace.hpp
@@ -111,7 +111,7 @@ class MONGOCXX_API find_one_and_replace {
     /// @see http://docs.mongodb.org/manual/reference/command/findAndModify/
     /// @see mongocxx::options::return_document
     ///
-    const stdx::optional<enum return_document>& return_document() const;
+    const stdx::optional<enum class return_document>& return_document() const;
 
     ///
     /// Sets the order by which to search the collection for a matching document.
@@ -160,7 +160,7 @@ class MONGOCXX_API find_one_and_replace {
     stdx::optional<bool> _bypass_document_validation;
     stdx::optional<std::int64_t> _max_time_ms;
     stdx::optional<bsoncxx::document::view> _projection;
-    stdx::optional<enum return_document> _return_document;
+    stdx::optional<enum class return_document> _return_document;
     stdx::optional<bsoncxx::document::view> _ordering;
     stdx::optional<bool> _upsert;
 };

--- a/src/mongocxx/options/find_one_and_update.cpp
+++ b/src/mongocxx/options/find_one_and_update.cpp
@@ -32,7 +32,7 @@ void find_one_and_update::projection(bsoncxx::document::view projection) {
     _projection = projection;
 }
 
-void find_one_and_update::return_document(enum return_document return_document) {
+void find_one_and_update::return_document(enum class return_document return_document) {
     _return_document = return_document;
 }
 

--- a/src/mongocxx/options/find_one_and_update.hpp
+++ b/src/mongocxx/options/find_one_and_update.hpp
@@ -111,7 +111,7 @@ class MONGOCXX_API find_one_and_update {
     /// @see http://docs.mongodb.org/manual/reference/command/findAndModify/
     /// @see mongocxx::options::return_document
     ///
-    const stdx::optional<enum return_document>& return_document() const;
+    const stdx::optional<enum class return_document>& return_document() const;
 
     ///
     /// Sets the order by which to search the collection for a matching document.
@@ -160,7 +160,7 @@ class MONGOCXX_API find_one_and_update {
     stdx::optional<bool> _bypass_document_validation;
     stdx::optional<std::int64_t> _max_time_ms;
     stdx::optional<bsoncxx::document::view> _projection;
-    stdx::optional<enum return_document> _return_document;
+    stdx::optional<enum class return_document> _return_document;
     stdx::optional<bsoncxx::document::view> _ordering;
     stdx::optional<bool> _upsert;
 };

--- a/src/mongocxx/options/index.hpp
+++ b/src/mongocxx/options/index.hpp
@@ -19,6 +19,7 @@
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
+#include <memory>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN


### PR DESCRIPTION
Fix miscellaneous compilations issues for Windows
1. Missing headers for things that have a different include order in other compilers
2. Ensure `enum class` is used in all the right places since `enum` != `enum class`.