### PR TITLE
CXX-762 - Implement bsoncxx::v0::types::value::value()

### DIFF
--- a/src/bsoncxx/builder/core.cpp
+++ b/src/bsoncxx/builder/core.cpp
@@ -410,7 +410,7 @@ void core::concatenate(const bsoncxx::document::view& view) {
 }
 
 void core::append(const bsoncxx::types::value& value) {
-    if (!value.type()) {
+    if (!value) {
         // TODO: use bsoncxx error category
         throw std::runtime_error("invalid value");
     }

--- a/src/bsoncxx/builder/core.cpp
+++ b/src/bsoncxx/builder/core.cpp
@@ -410,7 +410,12 @@ void core::concatenate(const bsoncxx::document::view& view) {
 }
 
 void core::append(const bsoncxx::types::value& value) {
-    switch (static_cast<int>(value.type())) {
+    if (!value.type()) {
+        // TODO: use bsoncxx error category
+        throw std::runtime_error("invalid value");
+    }
+
+    switch (static_cast<typename std::underlying_type<bsoncxx::type>::type>(*(value.type()))) {
 #define BSONCXX_ENUM(type, val)     \
     case val:                       \
         append(value.get_##type()); \

--- a/src/bsoncxx/json.cpp
+++ b/src/bsoncxx/json.cpp
@@ -274,7 +274,12 @@ std::string to_json(types::value value) {
 
     json_visitor v(ss, false, 0);
 
-    switch ((int)value.type()) {
+    if (!value.type()) {
+        // TODO: use bsoncxx error category
+        throw std::runtime_error("invalid value");
+    }
+
+    switch (static_cast<typename std::underlying_type<bsoncxx::type>::type>(*(value.type()))) {
 #define BSONCXX_ENUM(name, val)            \
     case val:                              \
         v.visit_value(value.get_##name()); \

--- a/src/bsoncxx/json.cpp
+++ b/src/bsoncxx/json.cpp
@@ -274,7 +274,7 @@ std::string to_json(types::value value) {
 
     json_visitor v(ss, false, 0);
 
-    if (!value.type()) {
+    if (!value) {
         // TODO: use bsoncxx error category
         throw std::runtime_error("invalid value");
     }

--- a/src/bsoncxx/types/value.cpp
+++ b/src/bsoncxx/types/value.cpp
@@ -22,14 +22,19 @@
 #include <bsoncxx/config/prelude.hpp>
 
 #include <bsoncxx/json.hpp>
+#include <bsoncxx/stdx/optional.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
 namespace types {
 
+// The default constructor does not initialize the value union.
+value::value() : _type(stdx::nullopt) {
+}
+
 #define BSONCXX_ENUM(name, val)                                                 \
     value::value(b_##name value)                                                \
-        : _type(static_cast<bsoncxx::type>(val)), _b_##name(std::move(value)) { \
+        : _type(stdx::optional<bsoncxx::type>(static_cast<bsoncxx::type>(val))), _b_##name(std::move(value)) { \
     }
 
 #include <bsoncxx/enums/type.hpp>
@@ -40,15 +45,28 @@ value::value(const value& rhs) {
 }
 
 value& value::operator=(const value& rhs) {
-    _type = rhs._type;
-
-    switch (static_cast<int>(_type)) {
-#define BSONCXX_ENUM(type, val)       \
-    case val:                         \
-        _b_##type = rhs.get_##type(); \
-        break;
+    if(_type && !rhs._type) {
+            switch (static_cast<typename std::underlying_type<bsoncxx::type>::type>(*_type)) {
+#define BSONCXX_ENUM(type, val)     \
+        case val:                   \
+            _b_##type.~b_##type();  \
+            break;
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
+        }
+    }
+
+    _type = rhs._type;
+ 
+    if(_type) {
+        switch (static_cast<typename std::underlying_type<bsoncxx::type>::type>(*_type)) {
+#define BSONCXX_ENUM(type, val)           \
+        case val:                         \
+            _b_##type = rhs.get_##type(); \
+            break;
+#include <bsoncxx/enums/type.hpp>
+#undef BSONCXX_ENUM
+        }
     }
 
     return *this;
@@ -56,35 +74,52 @@ value& value::operator=(const value& rhs) {
 
 value::value(value&& rhs) noexcept {
     *this = std::move(rhs);
+    rhs._type = stdx::nullopt;
 }
 
 value& value::operator=(value&& rhs) noexcept {
-    _type = rhs._type;
-
-    switch (static_cast<int>(_type)) {
-#define BSONCXX_ENUM(type, val)               \
-    case val:                                 \
-        _b_##type = std::move(rhs._b_##type); \
-        break;
+    if(_type && !rhs._type) {
+            switch (static_cast<typename std::underlying_type<bsoncxx::type>::type>(*_type)) {
+#define BSONCXX_ENUM(type, val)     \
+        case val:                   \
+            _b_##type.~b_##type();  \
+            break;
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
+        }
+    }
+
+    _type = rhs._type;
+    rhs._type = stdx::nullopt;
+
+    if(_type) {
+        switch (static_cast<typename std::underlying_type<bsoncxx::type>::type>(*_type)) {
+#define BSONCXX_ENUM(type, val)                   \
+        case val:                                 \
+            _b_##type = std::move(rhs._b_##type); \
+            break;
+#include <bsoncxx/enums/type.hpp>
+#undef BSONCXX_ENUM
+        }
     }
 
     return *this;
 }
 
 value::~value() {
-    switch (static_cast<int>(_type)) {
-#define BSONCXX_ENUM(type, val) \
-    case val:                   \
-        _b_##type.~b_##type();  \
-        break;
+    if(_type) {
+            switch (static_cast<typename std::underlying_type<bsoncxx::type>::type>(*_type)) {
+#define BSONCXX_ENUM(type, val)     \
+        case val:                   \
+            _b_##type.~b_##type();  \
+            break;
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
+        }
     }
 }
 
-bsoncxx::type value::type() const {
+stdx::optional<bsoncxx::type> value::type() const {
     return _type;
 }
 
@@ -96,11 +131,19 @@ bsoncxx::type value::type() const {
 #undef BSONCXX_ENUM
 
 bool operator==(const value& lhs, const value& rhs) {
+    if(!lhs.type() && !rhs.type()) {
+        return true;
+    }
+
+    if(!lhs.type() || !rhs.type()) {
+        return false;
+    }
+
     if (lhs.type() != rhs.type()) {
         return false;
     }
 
-    switch (static_cast<int>(lhs.type())) {
+    switch (static_cast<typename std::underlying_type<bsoncxx::type>::type>(*(lhs.type()))) {
 #define BSONCXX_ENUM(type, val) \
     case val:                   \
         return lhs.get_##type() == rhs.get_##type();

--- a/src/bsoncxx/types/value.hpp
+++ b/src/bsoncxx/types/value.hpp
@@ -23,6 +23,7 @@
 #include <type_traits>
 
 #include <bsoncxx/types.hpp>
+#include <bsoncxx/stdx/optional.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
@@ -154,8 +155,9 @@ namespace types {
 
         ///
         /// @return The type of the underlying BSON value stored in this object.
+        /// If the type is invalid, a disengaged optional is returned.
         ///
-        bsoncxx::type type() const;
+        stdx::optional<bsoncxx::type> type() const;
 
         ///
         /// @return The underlying BSON double value.
@@ -338,7 +340,7 @@ namespace types {
         const b_maxkey& get_maxkey() const;
 
        private:
-        bsoncxx::type _type;
+        stdx::optional<bsoncxx::type> _type;
         union {
             struct b_double _b_double;
             struct b_utf8 _b_utf8;

--- a/src/bsoncxx/types/value.hpp
+++ b/src/bsoncxx/types/value.hpp
@@ -160,6 +160,11 @@ namespace types {
         stdx::optional<bsoncxx::type> type() const;
 
         ///
+        /// @return Whether the underlying BSON value is engaged.
+        ///
+        BSONCXX_INLINE explicit operator bool() const { return type() ? true : false; }
+
+        ///
         /// @return The underlying BSON double value.
         ///
         /// @warning


### PR DESCRIPTION
This PR is to try having _type in value be an optional bsoncxx::type instead of an int.