### PR TITLE
CXX-774: Add dependencies to make paralleized build available

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,9 +1,11 @@
 add_custom_target(install_headers
     COMMAND "${CMAKE_COMMAND}" -DCMAKE_INSTALL_COMPONENT=dev -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
+    DEPENDS bsoncxx mongocxx
 )
 
 add_custom_target(install_libs
     COMMAND "${CMAKE_COMMAND}" -DCMAKE_INSTALL_COMPONENT=runtime -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
+    DEPENDS bsoncxx mongocxx
 )
 
 add_subdirectory(bsoncxx)


### PR DESCRIPTION
When generating makefiles with CMake, a paralleized build such as "make -j8" does not work because the examples try to compile over a local installation which is not finished yet.

This can be solved by adding the right dependencies.

Jira issue: https://jira.mongodb.org/browse/CXX-774
