### PR TITLE
CXX-630 - bulk_write::append needs to handle k_uninitialized

### DIFF
--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -26,6 +26,7 @@ set(mongocxx_sources
     database.cpp
     exception/operation_exception.cpp
     exception/private/error_category.cpp
+    exception/private/error_code.cpp
     exception/private/mongoc_error.cpp
     hint.cpp
     insert_many_builder.cpp

--- a/src/mongocxx/bulk_write.cpp
+++ b/src/mongocxx/bulk_write.cpp
@@ -18,6 +18,9 @@
 
 #include <mongocxx/config/prelude.hpp>
 
+#include <mongocxx/exception/bulk_write_exception.hpp>
+#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/exception/private/error_code.hpp>
 #include <mongocxx/private/libbson.hpp>
 #include <mongocxx/private/bulk_write.hpp>
 #include <mongocxx/private/libmongoc.hpp>
@@ -83,7 +86,7 @@ void bulk_write::append(const model::write& operation) {
             break;
         }
         case write_type::k_uninitialized:
-            break;  // TODO: something exceptiony
+            throw bulk_write_exception{make_error_code(error_code::k_bulk_write_type_uninitialized)};
     }
 }
 

--- a/src/mongocxx/exception/error_code.hpp
+++ b/src/mongocxx/exception/error_code.hpp
@@ -22,6 +22,7 @@ namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 
 enum class error_code : std::int32_t {
+	k_bulk_write_type_uninitialized = 1,
 };
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/exception/private/error_category.cpp
+++ b/src/mongocxx/exception/private/error_category.cpp
@@ -19,6 +19,7 @@
 
 #include <mongocxx/exception/private/error_category.hpp>
 
+#include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/private/libmongoc.hpp>
 
 namespace {
@@ -382,7 +383,12 @@ class mongocxx_error_category_impl final : public std::error_category {
     }
 
     std::string message(int code) const noexcept override {
-        return "unknown mongocxx error";
+        switch(static_cast<error_code>(code)) {
+        case error_code::k_bulk_write_type_uninitialized:
+            return "bulk write type was k_uninitialized";
+        default:
+            return "unknown mongocxx error";
+        }
     }
 };
 }  // namespace

--- a/src/mongocxx/exception/private/error_category.cpp
+++ b/src/mongocxx/exception/private/error_category.cpp
@@ -385,7 +385,7 @@ class mongocxx_error_category_impl final : public std::error_category {
     std::string message(int code) const noexcept override {
         switch(static_cast<error_code>(code)) {
         case error_code::k_bulk_write_type_uninitialized:
-            return "bulk write type was k_uninitialized";
+            return "cannot operate on uninitialized bulk write";
         default:
             return "unknown mongocxx error";
         }

--- a/src/mongocxx/exception/private/error_code.cpp
+++ b/src/mongocxx/exception/private/error_code.cpp
@@ -18,7 +18,7 @@
 
 #include <mongocxx/exception/private/error_code.hpp>
 
-#include <mongocxx/exception/error_category.hpp>
+#include <mongocxx/exception/private/error_category.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN


### PR DESCRIPTION
I wasn't able to test, since I'm not sure it's possible to create a model::write with type k_uninitialized. There is no default constructor, and a moved-from model::write keeps its original type.