### PR TITLE
CXX-739 string::view_or_value

### DIFF
--- a/src/bsoncxx/CMakeLists.txt
+++ b/src/bsoncxx/CMakeLists.txt
@@ -41,6 +41,7 @@ set(bsoncxx_sources
     private/error_code.cpp
     private/itoa.cpp
     private/libbson_error.cpp
+    string/view_or_value.cpp
     types.cpp
     types/value.cpp
     validate.cpp

--- a/src/bsoncxx/string/view_or_value.cpp
+++ b/src/bsoncxx/string/view_or_value.cpp
@@ -1,0 +1,36 @@
+// Copyright 2015 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/config/prelude.hpp>
+
+#include <bsoncxx/string/view_or_value.hpp>
+
+namespace bsoncxx {
+BSONCXX_INLINE_NAMESPACE_BEGIN
+namespace string {
+
+const char* view_or_value::c_str() {
+    // If we do not own our string, we cannot guarantee that it is null-terminated,
+    // so make an owned copy.
+    if (!_value) {
+        _value = std::move(_view.to_string());
+        _view = *_value;
+    }
+
+    return _value->c_str();
+}
+
+}  // namespace string
+BSONCXX_INLINE_NAMESPACE_END
+}  // namespace bsoncxx

--- a/src/bsoncxx/string/view_or_value.hpp
+++ b/src/bsoncxx/string/view_or_value.hpp
@@ -1,0 +1,104 @@
+// Copyright 2015 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/config/prelude.hpp>
+
+#include <string>
+
+#include <bsoncxx/stdx/string_view.hpp>
+#include <bsoncxx/view_or_value.hpp>
+
+namespace bsoncxx {
+BSONCXX_INLINE_NAMESPACE_BEGIN
+namespace string {
+
+///
+/// Class representing a view-or-value variant type for strings.
+///
+/// This class adds several string-specific methods to the bsoncxx::view_or_value template:
+/// - a constructor overload for const char*
+/// - a constructor overload for std::string by l-value reference
+/// - a safe c_str() operation to return null-terminated c-style strings.
+///
+class BSONCXX_API view_or_value : public bsoncxx::view_or_value<stdx::string_view, std::string> {
+   public:
+    ///
+    /// Forward all bsoncxx::view_or_value constructors.
+    ///
+    using bsoncxx::view_or_value<stdx::string_view, std::string>::view_or_value;
+
+    ///
+    /// Construct a string::view_or_value using a null-terminated const char *.
+    /// The resulting view_or_value will keep a string_view of 'str', so it is
+    /// important that the passed-in string outlive this object.
+    ///
+    /// @param str A null-terminated string
+    ///
+    BSONCXX_INLINE view_or_value(const char* str)
+        : bsoncxx::view_or_value<stdx::string_view, std::string>(stdx::string_view(str)) {
+    }
+
+    ///
+    /// Allow construction with an l-value reference to a std::string. The resulting
+    /// view_or_value will keep a string_view of 'str', so it is important that the
+    /// passed-in string outlive this object.
+    ///
+    /// Construction calls passing a std::string by r-value reference will use the
+    /// constructor defined in the parent view_or_value class.
+    ///
+    /// @param str A std::string l-value reference.
+    ///
+    BSONCXX_INLINE view_or_value(const std::string& str)
+        : bsoncxx::view_or_value<stdx::string_view, std::string>(stdx::string_view(str)) {
+    }
+
+    ///
+    /// Return a null-terminated string from this string::view_or_value.
+    ///
+    /// @note if we are non-owning, we cannot assume our string_view is null-terminated.
+    /// In this case we must make a new, owning view_or_value with a null-terminated
+    /// copy of our view.
+    ///
+    /// @return A pointer to the original string, or a null-terminated copy.
+    ///
+    const char* c_str();
+};
+
+///
+/// Compare string::view_or_value directly with const char *.
+///
+
+BSONCXX_INLINE bool operator==(const view_or_value& lhs, const char* rhs) {
+    return lhs.view() == stdx::string_view(rhs);
+}
+
+BSONCXX_INLINE bool operator!=(const view_or_value& lhs, const char* rhs) {
+    return !(lhs == rhs);
+}
+
+BSONCXX_INLINE bool operator==(const char* lhs, const view_or_value& rhs) {
+    return rhs == lhs;
+}
+
+BSONCXX_INLINE bool operator!=(const char* lhs, const view_or_value& rhs) {
+    return !(rhs == lhs);
+}
+
+}  // namespace string
+BSONCXX_INLINE_NAMESPACE_END
+}  // namespace bsoncxx
+
+#include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/test/view_or_value.cpp
+++ b/src/bsoncxx/test/view_or_value.cpp
@@ -20,54 +20,55 @@
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/json.hpp>
+#include <bsoncxx/string/view_or_value.hpp>
+
+using namespace bsoncxx;
 
 using bsoncxx::to_json;
-using bsoncxx::builder::stream::document;
 using bsoncxx::builder::stream::finalize;
-using bsoncxx::document::view_or_value;
 
-TEST_CASE("view_or_value", "[bsoncxx::document::view_or_value]") {
-    auto empty = document{} << finalize;
-    auto doc = document{} << "a" << 1 << finalize;
+TEST_CASE("document::view_or_value", "[bsoncxx::document::view_or_value]") {
+    auto empty = builder::stream::document{} << finalize;
+    auto doc = builder::stream::document{} << "a" << 1 << finalize;
     auto json = to_json(doc.view());
 
     SECTION("can be default-constructed") {
-        view_or_value variant{};
+        document::view_or_value variant{};
         REQUIRE(to_json(variant) == to_json(empty));
     }
 
     SECTION("can be constructed with a view") {
-        view_or_value variant{doc.view()};
+        document::view_or_value variant{doc.view()};
 
         SECTION("can be used as a view") {
             REQUIRE(to_json(variant) == json);
         }
 
         SECTION("can be copy constructed") {
-            view_or_value copied{variant};
+            document::view_or_value copied{variant};
             REQUIRE(to_json(copied) == json);
         }
 
         SECTION("can be copy assigned") {
-            view_or_value copied{empty.view()};
+            document::view_or_value copied{empty.view()};
             {
-                view_or_value temp{doc.view()};
+                document::view_or_value temp{doc.view()};
                 copied = temp;
             }
             REQUIRE(to_json(copied) == json);
         }
 
         SECTION("can be move constructed") {
-            view_or_value temp{doc.view()};
-            view_or_value moved{std::move(temp)};
+            document::view_or_value temp{doc.view()};
+            document::view_or_value moved{std::move(temp)};
             REQUIRE(to_json(moved) == json);
             REQUIRE(to_json(temp) == to_json(empty));
         }
 
         SECTION("can be move assigned") {
-            view_or_value moved{variant.view()};
+            document::view_or_value moved{variant.view()};
             {
-                view_or_value temp{doc.view()};
+                document::view_or_value temp{doc.view()};
                 moved = std::move(temp);
                 REQUIRE(to_json(temp) == to_json(empty));
             }
@@ -77,43 +78,152 @@ TEST_CASE("view_or_value", "[bsoncxx::document::view_or_value]") {
 
     SECTION("can be constructed with a value") {
         auto move_doc = doc;
-        view_or_value variant{std::move(move_doc)};
+        document::view_or_value variant{std::move(move_doc)};
 
         SECTION("can be used as a view") {
             REQUIRE(to_json(variant) == json);
         }
 
         SECTION("can be copy constructed") {
-            view_or_value copied{variant};
+            document::view_or_value copied{variant};
             REQUIRE(to_json(copied) == json);
         }
 
         SECTION("can be copy assigned") {
-            view_or_value copied{empty};
+            document::view_or_value copied{empty};
             {
                 auto temp_doc = doc;
-                view_or_value temp{std::move(temp_doc)};
+                document::view_or_value temp{std::move(temp_doc)};
                 copied = temp;
             }
             REQUIRE(to_json(copied) == json);
         }
 
         SECTION("can be move constructed") {
-            view_or_value temp{doc.view()};
-            view_or_value moved{std::move(temp)};
+            document::view_or_value temp{doc.view()};
+            document::view_or_value moved{std::move(temp)};
             REQUIRE(to_json(moved) == json);
             REQUIRE(to_json(temp) == to_json(empty));
         }
 
         SECTION("can be move assigned") {
-            view_or_value moved{empty};
+            document::view_or_value moved{empty};
             {
                 auto temp_doc = doc;
-                view_or_value temp{std::move(temp_doc)};
+                document::view_or_value temp{std::move(temp_doc)};
                 moved = std::move(temp);
                 REQUIRE(to_json(temp) == to_json(empty));
             }
             REQUIRE(to_json(moved) == json);
         }
+    }
+
+    SECTION("Can be compared to another view_or_value") {
+        SECTION("Compares equal with equal views, regardless of ownership") {
+            document::value temp{doc};
+            document::view_or_value a{std::move(temp)};
+            document::view_or_value b{doc.view()};
+
+            REQUIRE(b == a);
+        }
+
+        SECTION("Compares inequal with different views") {
+            auto temp_a = builder::stream::document{} << "a" << 1 << finalize;
+            auto temp_b = builder::stream::document{} << "b" << 1 << finalize;
+            document::view_or_value a{std::move(temp_a)};
+            document::view_or_value b{std::move(temp_b)};
+
+            REQUIRE(a != b);
+        }
+    }
+
+    SECTION("Can be compared to a plain View") {
+        auto bad_doc = builder::stream::document{} << "blah" << 1 << finalize;
+        document::view_or_value variant(doc.view());
+        REQUIRE(variant == doc.view());
+        REQUIRE(doc.view() == variant);
+        REQUIRE(variant != bad_doc.view());
+        REQUIRE(bad_doc.view() != variant);
+    }
+
+    SECTION("Can be compared to a plain Value") {
+        auto bad_doc = builder::stream::document{} << "blah" << 1 << finalize;
+        document::view_or_value variant(doc.view());
+        REQUIRE(variant == doc);
+        REQUIRE(doc == variant);
+        REQUIRE(variant != bad_doc);
+        REQUIRE(bad_doc != variant);
+    }
+}
+
+TEST_CASE("string::document::view_or_value", "[bsoncxx::string::view_or_value]") {
+    SECTION("can be constructed with a moved-in std::string") {
+        std::string name{"Sally"};
+        string::view_or_value sally{std::move(name)};
+    }
+
+    SECTION("can be constructed with a const std::string&") {
+        std::string name{"Jonny"};
+        string::view_or_value jonny{name};
+
+        SECTION("is non-owning") {
+            REQUIRE(jonny == "Jonny");
+            name[1] = 'e';
+            REQUIRE(jonny == "Jenny");
+        }
+    }
+
+    SECTION("can be constructed with a const char*") {
+        std::string name = "Julia";
+        string::view_or_value julia{name.c_str()};
+
+        SECTION("is non-owning") {
+            REQUIRE(julia == "Julia");
+            name[4] = 'o';
+            REQUIRE(julia == "Julio");
+        }
+    }
+
+    SECTION("can be constructed with a stdx::string_view") {
+        std::string name{"Mike"};
+        stdx::string_view name_view{name};
+        string::view_or_value mike{name_view};
+
+        SECTION("is non-owning") {
+            REQUIRE(mike == "Mike");
+            name[3] = 'a';
+            REQUIRE(mike == "Mika");
+        }
+    }
+
+    SECTION("can be compared to a std::string") {
+        std::string name{"Theo"};
+        std::string other_name{"Tad"};
+        string::view_or_value theo{name};
+
+        REQUIRE(theo == name);
+        REQUIRE(name == theo);
+        REQUIRE(theo != other_name);
+        REQUIRE(other_name != theo);
+    }
+
+    SECTION("can be compared to a const char*") {
+        string::view_or_value bess{"Bess"};
+
+        REQUIRE(bess == "Bess");
+        REQUIRE("Bess" == bess);
+        REQUIRE(bess != "Betty");
+        REQUIRE("Betty" != bess);
+    }
+
+    SECTION("can be compared to a stdx::string_view") {
+        stdx::string_view name{"Carlin"};
+        stdx::string_view other_name{"Cailin"};
+        string::view_or_value carlin{name};
+
+        REQUIRE(carlin == name);
+        REQUIRE(name == carlin);
+        REQUIRE(carlin != other_name);
+        REQUIRE(other_name != carlin);
     }
 }

--- a/src/bsoncxx/view_or_value.hpp
+++ b/src/bsoncxx/view_or_value.hpp
@@ -128,6 +128,22 @@ class view_or_value {
 };
 
 ///
+/// Compare view_or_value objects.
+///
+
+template <typename View, typename Value>
+BSONCXX_INLINE bool operator==(const view_or_value<View, Value>& lhs,
+                               const view_or_value<View, Value>& rhs) {
+    return lhs.view() == rhs.view();
+}
+
+template <typename View, typename Value>
+BSONCXX_INLINE bool operator!=(const view_or_value<View, Value>& lhs,
+                               const view_or_value<View, Value>& rhs) {
+    return !(lhs == rhs);
+}
+
+///
 /// Equality operators for comparison with plain Views.
 ///
 
@@ -148,6 +164,30 @@ BSONCXX_INLINE bool operator!=(const view_or_value<View, Value>& lhs, View rhs) 
 
 template <typename View, typename Value>
 BSONCXX_INLINE bool operator!=(View lhs, const view_or_value<View, Value>& rhs) {
+    return !(rhs == lhs);
+}
+
+///
+/// Equality operators for comparison with plain Values.
+///
+
+template <typename View, typename Value>
+BSONCXX_INLINE bool operator==(const view_or_value<View, Value>& lhs, const Value& rhs) {
+    return lhs.view() == View(rhs);
+}
+
+template <typename View, typename Value>
+BSONCXX_INLINE bool operator==(const Value& lhs, const view_or_value<View, Value>& rhs) {
+    return rhs == lhs;
+}
+
+template <typename View, typename Value>
+BSONCXX_INLINE bool operator!=(const view_or_value<View, Value>& lhs, const Value& rhs) {
+    return !(lhs == rhs);
+}
+
+template <typename View, typename Value>
+BSONCXX_INLINE bool operator!=(const Value& lhs, const view_or_value<View, Value>& rhs) {
     return !(rhs == lhs);
 }
 

--- a/src/bsoncxx/view_or_value.hpp
+++ b/src/bsoncxx/view_or_value.hpp
@@ -66,14 +66,14 @@ class view_or_value {
     /// @param value
     ///   A Value type.
     ///
-    BSONCXX_INLINE view_or_value(Value&& value) : _value{std::move(value)}, _view{_value->view()} {
+    BSONCXX_INLINE view_or_value(Value&& value) : _value(std::move(value)), _view(*_value) {
     }
 
     ///
     /// Construct a view_or_value from a copied view_or_value.
     ///
     BSONCXX_INLINE view_or_value(const view_or_value& other)
-        : _value{other._value}, _view{_value ? _value->view() : other._view} {
+        : _value(other._value), _view(_value ? *_value : other._view) {
     }
 
     ///
@@ -81,16 +81,17 @@ class view_or_value {
     ///
     BSONCXX_INLINE view_or_value& operator=(const view_or_value& other) {
         _value = other._value;
-        _view = _value ? _value->view() : other._view;
+        _view = _value ? *_value : other._view;
         return *this;
     }
 
     ///
     /// Construct a view_or_value from a moved-in view_or_value.
     ///
+
     /// TODO CXX-800: Create a noexcept expression to check the conditions that must be met.
     BSONCXX_INLINE view_or_value(view_or_value&& other) noexcept
-        : _value{std::move(other._value)}, _view{_value ? _value->view() : std::move(other._view)} {
+        : _value{std::move(other._value)}, _view(_value ? *_value : std::move(other._view)) {
         other._view = View();
         other._value = stdx::nullopt;
     }
@@ -101,7 +102,7 @@ class view_or_value {
     /// TODO CXX-800: Create a noexcept expression to check the conditions that must be met.
     BSONCXX_INLINE view_or_value& operator=(view_or_value&& other) noexcept {
         _value = std::move(other._value);
-        _view = _value ? _value->view() : std::move(other._view);
+        _view = _value ? *_value : std::move(other._view);
         other._view = View();
         other._value = stdx::nullopt;
         return *this;
@@ -120,7 +121,8 @@ class view_or_value {
         return _view;
     }
 
-   private:
+    // TODO: make these private again (CXX-801)
+   protected:
     stdx::optional<Value> _value;
     View _view;
 };

--- a/src/mongocxx/client.cpp
+++ b/src/mongocxx/client.cpp
@@ -69,9 +69,8 @@ stdx::optional<class read_concern> client::read_concern() const {
     if (!libmongoc::read_concern_get_level(rc)) {
         return stdx::nullopt;
     }
-
     return {(class read_concern){
-            stdx::make_unique<read_concern::impl>(libmongoc::read_concern_copy(rc))}};
+        stdx::make_unique<read_concern::impl>(libmongoc::read_concern_copy(rc))}};
 }
 
 void client::read_preference(class read_preference rp) {
@@ -100,8 +99,8 @@ class write_concern client::write_concern() const {
     return wc;
 }
 
-class database client::database(stdx::string_view name) const & {
-    return mongocxx::database(*this, name);
+class database client::database(bsoncxx::string::view_or_value name) const & {
+    return mongocxx::database(*this, std::move(name));
 }
 
 cursor client::list_databases() const {
@@ -116,7 +115,7 @@ cursor client::list_databases() const {
 }
 
 const client::impl& client::_get_impl() const {
-    if(!_impl) {
+    if (!_impl) {
         throw logic_error{make_error_code(error_code::k_invalid_client_object)};
     }
     return *_impl;

--- a/src/mongocxx/client.hpp
+++ b/src/mongocxx/client.hpp
@@ -18,8 +18,7 @@
 
 #include <memory>
 
-#include <bsoncxx/stdx/string_view.hpp>
-
+#include <bsoncxx/string/view_or_value.hpp>
 #include <mongocxx/database.hpp>
 #include <mongocxx/options/client.hpp>
 #include <mongocxx/read_concern.hpp>
@@ -48,9 +47,7 @@ MONGOCXX_INLINE_NAMESPACE_BEGIN
 /// @endcode
 ///
 class MONGOCXX_API client {
-
    public:
-
     ///
     /// Default constructs a new client. The client is not connected and is equivalent to the
     /// state of a moved-from client. The only valid actions to take with a default constructed
@@ -66,10 +63,7 @@ class MONGOCXX_API client {
     /// @param options
     ///   Additional options that cannot be specified via the mongodb_uri
     ///
-    client(
-        const class uri& mongodb_uri,
-        const options::client& options = options::client()
-    );
+    client(const class uri& mongodb_uri, const options::client& options = options::client());
 
     ///
     /// Move constructs a client.
@@ -171,8 +165,8 @@ class MONGOCXX_API client {
     ///
     /// @return The database
     ///
-    class database database(stdx::string_view name) const&;
-    class database database(stdx::string_view name) const&& = delete;
+    class database database(bsoncxx::string::view_or_value name) const&;
+    class database database(bsoncxx::string::view_or_value name) const&& = delete;
 
     ///
     /// Allows the syntax @c client["db_name"] as a convenient shorthand for the client::database()
@@ -185,8 +179,8 @@ class MONGOCXX_API client {
     ///
     /// @return Client side representation of a server side database
     ///
-    MONGOCXX_INLINE class database operator[](stdx::string_view name) const&;
-    MONGOCXX_INLINE class database operator[](stdx::string_view name) const&& = delete;
+    MONGOCXX_INLINE class database operator[](bsoncxx::string::view_or_value name) const&;
+    MONGOCXX_INLINE class database operator[](bsoncxx::string::view_or_value name) const&& = delete;
 
     ///
     /// Enumerates the databases in the client.
@@ -218,7 +212,7 @@ class MONGOCXX_API client {
     std::unique_ptr<impl> _impl;
 };
 
-MONGOCXX_INLINE database client::operator[](stdx::string_view name) const & {
+MONGOCXX_INLINE database client::operator[](bsoncxx::string::view_or_value name) const & {
     return database(name);
 }
 

--- a/src/mongocxx/collection.hpp
+++ b/src/mongocxx/collection.hpp
@@ -24,7 +24,7 @@
 #include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
-#include <bsoncxx/stdx/string_view.hpp>
+#include <bsoncxx/string/view_or_value.hpp>
 
 #include <mongocxx/bulk_write.hpp>
 #include <mongocxx/cursor.hpp>
@@ -274,10 +274,9 @@ class MONGOCXX_API collection {
     ///
     /// @see http://docs.mongodb.org/manual/reference/command/distinct/
     ///
-    cursor distinct(stdx::string_view name, bsoncxx::document::view_or_value filter,
+    cursor distinct(bsoncxx::string::view_or_value name, bsoncxx::document::view_or_value filter,
                     const options::distinct& options = options::distinct());
 
-    ///
     /// Drops this collection and all its contained documents from the database.
     ///
     /// @throws exception::operation if the operation fails.
@@ -458,7 +457,7 @@ class MONGOCXX_API collection {
     cursor list_indexes() const;
 
     ///
-    /// Returns the name of this collection.
+    /// Returns the name of this collection as a view of a null-terminated string.
     ///
     /// @return The name of the collection.
     ///
@@ -475,7 +474,7 @@ class MONGOCXX_API collection {
     ///
     /// @see https://docs.mongodb.org/manual/reference/command/renameCollection/
     ///
-    void rename(stdx::string_view new_name, bool drop_target_before_rename = false);
+    void rename(bsoncxx::string::view_or_value new_name, bool drop_target_before_rename = false);
 
     ///
     /// Sets the read_concern for this collection. Changes will not have any effect on existing
@@ -592,7 +591,8 @@ class MONGOCXX_API collection {
    private:
     friend class database;
 
-    MONGOCXX_PRIVATE collection(const database& database, stdx::string_view collection_name);
+    MONGOCXX_PRIVATE collection(const database& database,
+                                bsoncxx::string::view_or_value collection_name);
 
     MONGOCXX_PRIVATE collection(const database& database, void* collection);
 

--- a/src/mongocxx/database.cpp
+++ b/src/mongocxx/database.cpp
@@ -46,10 +46,10 @@ database& database::operator=(database&&) noexcept = default;
 
 database::~database() = default;
 
-database::database(const class client& client, stdx::string_view name)
+database::database(const class client& client, bsoncxx::string::view_or_value name)
     : _impl(stdx::make_unique<impl>(
-          libmongoc::client_get_database(client._get_impl().client_t, name.data()), &client._get_impl(),
-          name.data())) {
+          libmongoc::client_get_database(client._get_impl().client_t, name.c_str()),
+          &client._get_impl(), name.c_str())) {
 }
 
 database::database(const database& d) {
@@ -82,6 +82,7 @@ cursor database::list_collections(bsoncxx::document::view_or_value filter) {
 
     return cursor(result);
 }
+
 stdx::string_view database::name() const {
     return _get_impl().name;
 }
@@ -92,8 +93,8 @@ bsoncxx::document::value database::run_command(bsoncxx::document::view_or_value 
     bson_error_t error;
 
     reply_bson.flag_init();
-    auto result = libmongoc::database_command_simple(_get_impl().database_t, command_bson.bson(), NULL,
-                                                     reply_bson.bson(), &error);
+    auto result = libmongoc::database_command_simple(_get_impl().database_t, command_bson.bson(),
+                                                     NULL, reply_bson.bson(), &error);
 
     if (!result) {
         throw_exception<operation_exception>(std::move(reply_bson.steal()), error);
@@ -109,12 +110,12 @@ bsoncxx::document::value database::modify_collection(stdx::string_view name,
     return run_command(doc.view());
 }
 
-class collection database::create_collection(stdx::string_view name,
+class collection database::create_collection(bsoncxx::string::view_or_value name,
                                              const options::create_collection& options) {
     bson_error_t error;
 
     libbson::scoped_bson_t opts_bson{options.to_document()};
-    auto result = libmongoc::database_create_collection(_get_impl().database_t, name.data(),
+    auto result = libmongoc::database_create_collection(_get_impl().database_t, name.c_str(),
                                                         opts_bson.bson(), &error);
 
     if (!result) {
@@ -140,16 +141,17 @@ stdx::optional<class read_concern> database::read_concern() const {
     if (!libmongoc::read_concern_get_level(rc)) {
         return stdx::nullopt;
     }
-    return {(class read_concern){stdx::make_unique<read_concern::impl>(libmongoc::read_concern_copy(rc))}};
+    return {(class read_concern){
+        stdx::make_unique<read_concern::impl>(libmongoc::read_concern_copy(rc))}};
 }
 
 void database::read_preference(class read_preference rp) {
     libmongoc::database_set_read_prefs(_get_impl().database_t, rp._impl->read_preference_t);
 }
 
-bool database::has_collection(stdx::string_view name) const {
+bool database::has_collection(bsoncxx::string::view_or_value name) const {
     bson_error_t error;
-    return libmongoc::database_has_collection(_get_impl().database_t, name.data(), &error);
+    return libmongoc::database_has_collection(_get_impl().database_t, name.c_str(), &error);
 }
 
 class read_preference database::read_preference() const {
@@ -163,17 +165,17 @@ void database::write_concern(class write_concern wc) {
 }
 
 class write_concern database::write_concern() const {
-    class write_concern wc(stdx::make_unique<write_concern::impl>(
-        libmongoc::write_concern_copy(libmongoc::database_get_write_concern(_get_impl().database_t))));
+    class write_concern wc(stdx::make_unique<write_concern::impl>(libmongoc::write_concern_copy(
+        libmongoc::database_get_write_concern(_get_impl().database_t))));
     return wc;
 }
 
-collection database::collection(stdx::string_view name) const {
-    return mongocxx::collection(*this, name);
+collection database::collection(bsoncxx::string::view_or_value name) const {
+    return mongocxx::collection(*this, std::move(name));
 }
 
 const database::impl& database::_get_impl() const {
-    if(!_impl) {
+    if (!_impl) {
         throw logic_error{make_error_code(error_code::k_invalid_database_object)};
     }
     return *_impl;

--- a/src/mongocxx/database.hpp
+++ b/src/mongocxx/database.hpp
@@ -20,7 +20,7 @@
 #include <string>
 
 #include <bsoncxx/document/view_or_value.hpp>
-#include <bsoncxx/stdx/string_view.hpp>
+#include <bsoncxx/string/view_or_value.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/options/modify_collection.hpp>
 #include <mongocxx/options/create_collection.hpp>
@@ -100,7 +100,7 @@ class MONGOCXX_API database {
     /// @param options the options for the new collection.
     ///
     class collection create_collection(
-        stdx::string_view name,
+        bsoncxx::string::view_or_value name,
         const options::create_collection& options = options::create_collection());
 
     ///
@@ -130,7 +130,7 @@ class MONGOCXX_API database {
     /// @param name the name of the collection.
     /// @return bool whether the collection exists in this database.
     ///
-    bool has_collection(stdx::string_view name) const;
+    bool has_collection(bsoncxx::string::view_or_value name) const;
 
     ///
     /// Enumerates the collections in this database.
@@ -230,7 +230,7 @@ class MONGOCXX_API database {
     ///
     /// @return the collection.
     ///
-    class collection collection(stdx::string_view name) const;
+    class collection collection(bsoncxx::string::view_or_value name) const;
 
     ///
     /// Allows the db["collection_name"] syntax to be used to access a collection within this
@@ -240,13 +240,13 @@ class MONGOCXX_API database {
     ///
     /// @return the collection.
     ///
-    MONGOCXX_INLINE class collection operator[](stdx::string_view name) const;
+    MONGOCXX_INLINE class collection operator[](bsoncxx::string::view_or_value name) const;
 
    private:
     friend class client;
     friend class collection;
 
-    MONGOCXX_PRIVATE database(const class client& client, stdx::string_view name);
+    MONGOCXX_PRIVATE database(const class client& client, bsoncxx::string::view_or_value name);
 
     class MONGOCXX_PRIVATE impl;
 
@@ -256,7 +256,7 @@ class MONGOCXX_API database {
     std::unique_ptr<impl> _impl;
 };
 
-MONGOCXX_INLINE collection database::operator[](stdx::string_view name) const {
+MONGOCXX_INLINE collection database::operator[](bsoncxx::string::view_or_value name) const {
     return collection(name);
 }
 

--- a/src/mongocxx/private/collection.hpp
+++ b/src/mongocxx/private/collection.hpp
@@ -30,25 +30,24 @@ namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 
 class collection::impl {
-
    public:
     impl(mongoc_collection_t* collection, stdx::string_view database_name,
          const class client::impl* client)
-        : collection_t(collection),
-          database_name(std::move(database_name)),
-          client_impl(client) {
+        : collection_t(collection), database_name(std::move(database_name)), client_impl(client) {
     }
 
-    impl(const impl& i) : 
-      collection_t{libmongoc::collection_copy(i.collection_t)},
-      database_name{i.database_name},
-      client_impl{i.client_impl}
-    {}
+    impl(const impl& i)
+        : collection_t{libmongoc::collection_copy(i.collection_t)},
+          database_name{i.database_name},
+          client_impl{i.client_impl} {
+    }
 
     // This method is deleted because we only use the copy constructor.
     impl& operator=(const impl& i) = delete;
 
-    ~impl() { libmongoc::collection_destroy(collection_t); }
+    ~impl() {
+        libmongoc::collection_destroy(collection_t);
+    }
 
     bsoncxx::document::value gle() {
         auto gle = libmongoc::collection_get_last_error(collection_t);
@@ -59,7 +58,7 @@ class collection::impl {
     std::string database_name;
     const class client::impl* client_impl;
 
-}; // class impl
+};  // class impl
 
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx

--- a/src/mongocxx/private/database.hpp
+++ b/src/mongocxx/private/database.hpp
@@ -27,17 +27,15 @@ MONGOCXX_INLINE_NAMESPACE_BEGIN
 
 class database::impl {
    public:
-    impl(mongoc_database_t* db, const class client::impl* client, std::string name) :
-        database_t(db),
-        client_impl(client),
-        name(std::move(name))
-    {}
+    impl(mongoc_database_t* db, const class client::impl* client, std::string name)
+        : database_t(db), client_impl(client), name(std::move(name)) {
+    }
 
-    impl(const impl& i) : 
-        database_t{libmongoc::database_copy(i.database_t)},
-        client_impl{i.client_impl},
-        name{i.name} 
-    {}
+    impl(const impl& i)
+        : database_t{libmongoc::database_copy(i.database_t)},
+          client_impl{i.client_impl},
+          name{i.name} {
+    }
 
     // This method is deleted because we only use the copy constructor.
     impl& operator=(const impl& i) = delete;
@@ -49,7 +47,6 @@ class database::impl {
     mongoc_database_t* database_t;
     const class client::impl* client_impl;
     std::string name;
-
 };
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -25,6 +25,7 @@
 #include <mongocxx/collection.hpp>
 #include <mongocxx/client.hpp>
 #include <mongocxx/exception/logic_error.hpp>
+#include <mongocxx/insert_many_builder.hpp>
 #include <mongocxx/pipeline.hpp>
 
 using namespace bsoncxx::builder::stream;
@@ -132,7 +133,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
 
         coll.insert_one(b1.view());
 
-        auto doc = coll.find_one(bsoncxx::document::view());
+        auto doc = coll.find_one({});
         REQUIRE(doc);
         REQUIRE(doc->view()["_id"].get_int32() == 1);
 
@@ -141,7 +142,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
 
         coll.update_one(b1.view(), update_doc.view());
 
-        auto updated = coll.find_one(bsoncxx::document::view());
+        auto updated = coll.find_one({});
         REQUIRE(updated);
         REQUIRE(updated->view()["changed"].get_bool() == true);
     }
@@ -198,11 +199,11 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
 
         coll.update_one(b1.view(), update_doc.view(), options);
 
-        auto updated = coll.find_one(bsoncxx::document::view());
+        auto updated = coll.find_one({});
 
         REQUIRE(updated);
         REQUIRE(updated->view()["changed"].get_bool() == true);
-        REQUIRE(coll.count(bsoncxx::document::view()) == (std::int64_t)1);
+        REQUIRE(coll.count({}) == (std::int64_t)1);
     }
 
     SECTION("matching upsert updates document", "[collection]") {
@@ -219,13 +220,14 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
 
         coll.update_one(b1.view(), update_doc.view(), options);
 
-        auto updated = coll.find_one(bsoncxx::document::view());
+        auto updated = coll.find_one({});
 
         REQUIRE(updated);
         REQUIRE(updated->view()["changed"].get_bool() == true);
-        REQUIRE(coll.count(bsoncxx::document::view()) == 1);
+        REQUIRE(coll.count({}) == 1);
     }
 
+    // TODO: CXX-799 update this test
     // SECTION("matching upsert updates document", "[collection]") {
     // bsoncxx::builder::stream::document b1;
     // b1 << "x" << 1;
@@ -250,7 +252,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
         auto replaced = coll.find_one(b2.view());
 
         REQUIRE(replaced);
-        REQUIRE(coll.count(bsoncxx::document::view()) == 1);
+        REQUIRE(coll.count({}) == 1);
     }
 
     SECTION("filtered document delete one works", "[collection]") {
@@ -265,13 +267,13 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
         coll.insert_one(b2.view());
         coll.insert_one(b2.view());
 
-        REQUIRE(coll.count(bsoncxx::document::view()) == 3);
+        REQUIRE(coll.count({}) == 3);
 
         coll.delete_one(b2.view());
 
-        REQUIRE(coll.count(bsoncxx::document::view()) == (std::int64_t)2);
+        REQUIRE(coll.count({}) == (std::int64_t)2);
 
-        auto cursor = coll.find(bsoncxx::document::view());
+        auto cursor = coll.find({});
 
         unsigned seen = 0;
         for (auto&& x : cursor) {
@@ -282,9 +284,9 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
 
         coll.delete_one(b2.view());
 
-        REQUIRE(coll.count(bsoncxx::document::view()) == 1);
+        REQUIRE(coll.count({}) == 1);
 
-        cursor = coll.find(bsoncxx::document::view());
+        cursor = coll.find({});
 
         seen = 0;
         for (auto&& x : cursor) {
@@ -295,9 +297,9 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
 
         coll.delete_one(b2.view());
 
-        REQUIRE(coll.count(bsoncxx::document::view()) == 1);
+        REQUIRE(coll.count({}) == 1);
 
-        cursor = coll.find(bsoncxx::document::view());
+        cursor = coll.find({});
 
         seen = 0;
         for (auto&& x : cursor) {
@@ -319,13 +321,13 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
         coll.insert_one(b2.view());
         coll.insert_one(b2.view());
 
-        REQUIRE(coll.count(bsoncxx::document::view()) == 3);
+        REQUIRE(coll.count({}) == 3);
 
         coll.delete_many(b2.view());
 
-        REQUIRE(coll.count(bsoncxx::document::view()) == 1);
+        REQUIRE(coll.count({}) == 1);
 
-        auto cursor = coll.find(bsoncxx::document::view());
+        auto cursor = coll.find({});
 
         unsigned seen = 0;
         for (auto&& x : cursor) {
@@ -336,9 +338,9 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
 
         coll.delete_many(b2.view());
 
-        REQUIRE(coll.count(bsoncxx::document::view()) == 1);
+        REQUIRE(coll.count({}) == 1);
 
-        cursor = coll.find(bsoncxx::document::view());
+        cursor = coll.find({});
 
         seen = 0;
         for (auto&& x : cursor) {
@@ -400,7 +402,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
         coll.insert_one(b1.view());
         coll.insert_one(b1.view());
 
-        REQUIRE(coll.count(bsoncxx::document::view()) == 2);
+        REQUIRE(coll.count({}) == 2);
 
         document criteria;
         document replacement;
@@ -439,7 +441,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
         coll.insert_one(b1.view());
         coll.insert_one(b1.view());
 
-        REQUIRE(coll.count(bsoncxx::document::view()) == 2);
+        REQUIRE(coll.count({}) == 2);
 
         document criteria;
         document update;
@@ -481,7 +483,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
         coll.insert_one(b1.view());
         coll.insert_one(b1.view());
 
-        REQUIRE(coll.count(bsoncxx::document::view()) == 2);
+        REQUIRE(coll.count({}) == 2);
 
         document criteria;
 
@@ -493,7 +495,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
             REQUIRE(doc);
 
             REQUIRE(doc->view()["x"].get_int32() == 1);
-            REQUIRE(coll.count(bsoncxx::document::view()) == 1);
+            REQUIRE(coll.count({}) == 1);
         }
     }
 

--- a/src/mongocxx/test/collection_mocked.cpp
+++ b/src/mongocxx/test/collection_mocked.cpp
@@ -432,11 +432,10 @@ TEST_CASE("Collection", "[collection]") {
             REQUIRE(database_name == db);
         });
 
-        bulk_operation_set_collection->interpose(
-            [&](mongoc_bulk_operation_t*, const char* coll) {
-                bulk_operation_set_collection_called = true;
-                REQUIRE(collection_name == coll);
-            });
+        bulk_operation_set_collection->interpose([&](mongoc_bulk_operation_t*, const char* coll) {
+            bulk_operation_set_collection_called = true;
+            REQUIRE(collection_name == coll);
+        });
 
         bulk_operation_set_write_concern->interpose(
             [&](mongoc_bulk_operation_t*, const mongoc_write_concern_t*) {
@@ -484,9 +483,8 @@ TEST_CASE("Collection", "[collection]") {
         SECTION("Update One", "[collection::update_one]") {
             bool upsert_option = false;
 
-            bulk_operation_update_one->interpose([&](mongoc_bulk_operation_t*,
-                                                     const bson_t* query, const bson_t* update,
-                                                     bool upsert) {
+            bulk_operation_update_one->interpose([&](mongoc_bulk_operation_t*, const bson_t* query,
+                                                     const bson_t* update, bool upsert) {
                 bulk_operation_op_called = true;
                 REQUIRE(upsert == upsert_option);
                 REQUIRE(bson_get_data(query) == filter_doc.view().data());
@@ -555,9 +553,8 @@ TEST_CASE("Collection", "[collection]") {
         SECTION("Replace One", "[collection::replace_one]") {
             bool upsert_option;
 
-            bulk_operation_replace_one->interpose([&](mongoc_bulk_operation_t*,
-                                                      const bson_t* query, const bson_t* update,
-                                                      bool upsert) {
+            bulk_operation_replace_one->interpose([&](mongoc_bulk_operation_t*, const bson_t* query,
+                                                      const bson_t* update, bool upsert) {
                 bulk_operation_op_called = true;
                 REQUIRE(upsert == upsert_option);
                 REQUIRE(bson_get_data(query) == filter_doc.view().data());
@@ -584,11 +581,10 @@ TEST_CASE("Collection", "[collection]") {
         }
 
         SECTION("Delete One", "[collection::delete_one]") {
-            bulk_operation_remove_one->interpose(
-                [&](mongoc_bulk_operation_t*, const bson_t* doc) {
-                    bulk_operation_op_called = true;
-                    REQUIRE(bson_get_data(doc) == filter_doc.view().data());
-                });
+            bulk_operation_remove_one->interpose([&](mongoc_bulk_operation_t*, const bson_t* doc) {
+                bulk_operation_op_called = true;
+                REQUIRE(bson_get_data(doc) == filter_doc.view().data());
+            });
 
             mongo_coll.delete_one(filter_doc.view());
         }

--- a/src/mongocxx/test/database.cpp
+++ b/src/mongocxx/test/database.cpp
@@ -116,8 +116,7 @@ TEST_CASE("A database", "[database]") {
     }
 
     SECTION("throws an exception when dropping causes an error") {
-        database_drop->interpose(
-            [&](mongoc_database_t*, bson_error_t*) { return false; });
+        database_drop->interpose([&](mongoc_database_t*, bson_error_t*) { return false; });
 
         database database = mongo_client["database"];
         REQUIRE_THROWS(database.drop());
@@ -147,14 +146,14 @@ TEST_CASE("A database", "[database]") {
         read_concern rc{};
         rc.acknowledge_level(read_concern::level::k_majority);
 
-        database_set_read_concern->interpose([&database_set_rc_called](
-            ::mongoc_database_t*, const ::mongoc_read_concern_t* rc_t) {
-            REQUIRE(rc_t);
-            const auto result = libmongoc::read_concern_get_level(rc_t);
-            REQUIRE(result);
-            REQUIRE(strcmp(result, "majority") == 0);
-            database_set_rc_called = true;
-        });
+        database_set_read_concern->interpose(
+            [&database_set_rc_called](::mongoc_database_t*, const ::mongoc_read_concern_t* rc_t) {
+                REQUIRE(rc_t);
+                const auto result = libmongoc::read_concern_get_level(rc_t);
+                REQUIRE(result);
+                REQUIRE(strcmp(result, "majority") == 0);
+                database_set_rc_called = true;
+            });
 
         mongo_database.read_concern(rc);
         REQUIRE(database_set_rc_called);
@@ -232,7 +231,6 @@ TEST_CASE("A database", "[database]") {
 
     SECTION("may create a collection") {
         MOCK_COLLECTION
-        // dummy_collection is the name the mocked collection_get_name returns
         stdx::string_view collection_name{"dummy_collection"};
         database database = mongo_client[database_name];
         collection obtained_collection = database[collection_name];
@@ -265,9 +263,9 @@ TEST_CASE("A database", "[database]") {
 
 TEST_CASE("Database integration tests", "[database]") {
     client mongo_client{uri{}};
-    bsoncxx::stdx::string_view database_name{"database"};
+    stdx::string_view database_name{"database"};
     database database = mongo_client[database_name];
-    bsoncxx::stdx::string_view collection_name{"collection"};
+    stdx::string_view collection_name{"collection"};
 
     SECTION("A database may create a collection via create_collection") {
         SECTION("without any options") {


### PR DESCRIPTION
A new bsoncxx::string::view_or_value type that provides safe (null-terminated) conversion to const char*.