### PR TITLE
CXX-781 CMake path incorrect when subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ add_custom_target(modernize
     clang-modernize
         -p ${CMAKE_BINARY_DIR}/compile_commands.json
         -include ${CMAKE_CURRENT_SOURCE_DIR}
-        -exclude ${CMAKE_CURRENT_SOURCE_DIR}/mongocxx/test ${CMAKE_CURRENT_SORUCE_DIR}/bsoncxx/test
+        -exclude ${CMAKE_CURRENT_SOURCE_DIR}/mongocxx/test ${CMAKE_CURRENT_SOURCE_DIR}/bsoncxx/test
         -format
     VERBATIM
 )
@@ -80,6 +80,8 @@ add_custom_target(format
     xargs clang-format -i
     VERBATIM
 )
+
+set(THIRD_PARTY_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party)
 
 enable_testing()
 

--- a/src/mongocxx/test/CMakeLists.txt
+++ b/src/mongocxx/test/CMakeLists.txt
@@ -35,13 +35,13 @@ set(mongocxx_test_sources
 )
 
 include_directories(
-    ${CMAKE_SOURCE_DIR}/src/third_party/catch/include
+    ${THIRD_PARTY_SOURCE_DIR}/catch/include
 )
 
 link_directories(${LIBMONGOC_LIBRARY_DIRS} ${LIBBSON_LIBRARY_DIRS})
 
 add_executable(test_driver
-    ${CMAKE_SOURCE_DIR}/src/third_party/catch/main.cpp
+    ${THIRD_PARTY_SOURCE_DIR}/catch/main.cpp
     ${mongocxx_test_sources}
 )
 


### PR DESCRIPTION
Fixes [CXX 781](https://jira.mongodb.org/browse/CXX-781) by introducing `THIRD_PARTY_SOURCE_DIR` variable set in root `CMakeLists.txt` file.

(Additionally corrects a typo in `clang-modernize` settings.)