### PR TITLE
CXX-786 Remove deprecated 'implementation' methods

### DIFF
--- a/src/mongocxx/bulk_write.cpp
+++ b/src/mongocxx/bulk_write.cpp
@@ -87,10 +87,6 @@ void bulk_write::append(const model::write& operation) {
     }
 }
 
-void* bulk_write::implementation() const {
-    return _impl->operation_t;
-}
-
 void bulk_write::bypass_document_validation(bool bypass_document_validation) {
     libmongoc::bulk_operation_set_bypass_document_validation(_impl->operation_t,
                                                              bypass_document_validation);

--- a/src/mongocxx/bulk_write.hpp
+++ b/src/mongocxx/bulk_write.hpp
@@ -89,18 +89,6 @@ class MONGOCXX_API bulk_write {
     void append(const model::write& operation);
 
     ///
-    /// Gets a handle to the underlying implementation.
-    ///
-    /// Returned pointer is only valid for the lifetime of this object.
-    ///
-    /// @deprecated Future versions of the driver reserve the right to change the implementation
-    ///   and remove this interface entirely.
-    ///
-    /// @return Pointer to implementation of this object, or nullptr if not available.
-    ///
-    MONGOCXX_DEPRECATED void* implementation() const;
-
-    ///
     /// Whether or not to bypass document validation for this operation.
     ///
     /// @param bypass_document_validation

--- a/src/mongocxx/client.cpp
+++ b/src/mongocxx/client.cpp
@@ -60,10 +60,6 @@ client::operator bool() const noexcept {
     return static_cast<bool>(_impl);
 }
 
-void* client::implementation() const {
-    return _get_impl().client_t;
-}
-
 void client::read_concern(class read_concern rc) {
     libmongoc::client_set_read_concern(_get_impl().client_t, rc._impl->read_concern_t);
 }

--- a/src/mongocxx/client.hpp
+++ b/src/mongocxx/client.hpp
@@ -93,18 +93,6 @@ class MONGOCXX_API client {
     explicit operator bool() const noexcept;
 
     ///
-    /// Gets a handle to the underlying implementation.
-    ///
-    /// Returned pointer is only valid for the lifetime of this object.
-    ///
-    /// @deprecated Future versions of the driver reserve the right to change the implementation
-    ///   and remove this interface entirely.
-    ///
-    /// @return Pointer to implementation of this object, or nullptr if not available.
-    ///
-    MONGOCXX_DEPRECATED void* implementation() const;
-
-    ///
     /// Sets the read concern for this client.
     ///
     /// Modifications at this level do not affect existing databases instances that have have been

--- a/src/mongocxx/collection.cpp
+++ b/src/mongocxx/collection.cpp
@@ -283,10 +283,6 @@ cursor collection::aggregate(const pipeline& pipeline, const options::aggregate&
                                                   stages.bson(), options_bson.bson(), rp_ptr));
 }
 
-void* collection::implementation() const {
-    return _get_impl().collection_t;
-}
-
 stdx::optional<result::insert_one> collection::insert_one(view_or_value document,
                                                           const options::insert& options) {
     class bulk_write bulk_op(false);

--- a/src/mongocxx/collection.hpp
+++ b/src/mongocxx/collection.hpp
@@ -380,18 +380,6 @@ class MONGOCXX_API collection {
         const options::find_one_and_update& options = options::find_one_and_update());
 
     ///
-    /// Gets a handle to the underlying implementation.
-    ///
-    /// Returned pointer is only valid for the lifetime of this object.
-    ///
-    /// @deprecated Future versions of the driver reserve the right to change the implementation
-    ///   and remove this interface entirely.
-    ///
-    /// @return Pointer to implementation of this object, or nullptr if not available.
-    ///
-    MONGOCXX_DEPRECATED void* implementation() const;
-
-    ///
     /// Inserts a single document into the collection. If the document is missing an identifier
     /// (@c _id field) one will be generated for it.
     ///

--- a/src/mongocxx/cursor.cpp
+++ b/src/mongocxx/cursor.cpp
@@ -70,10 +70,6 @@ cursor::iterator cursor::end() {
     return iterator(nullptr);
 }
 
-void* cursor::implementation() const {
-    return _impl->cursor_t;
-}
-
 cursor::iterator::iterator(cursor* cursor) : _cursor(cursor) {
     if (cursor) operator++();
 }

--- a/src/mongocxx/cursor.hpp
+++ b/src/mongocxx/cursor.hpp
@@ -63,18 +63,6 @@ class MONGOCXX_API cursor {
     /// @return the cursor::iterator
     iterator end();
 
-    ///
-    /// Gets a handle to the underlying implementation.
-    ///
-    /// Returned pointer is only valid for the lifetime of this object.
-    ///
-    /// @deprecated Future versions of the driver reserve the right to change the implementation
-    ///   and remove this interface entirely.
-    ///
-    /// @return Pointer to implementation of this object, or nullptr if not available.
-    ///
-    MONGOCXX_DEPRECATED void* implementation() const;
-
    private:
     friend class collection;
     friend class client;

--- a/src/mongocxx/database.cpp
+++ b/src/mongocxx/database.cpp
@@ -69,10 +69,6 @@ database::operator bool() const noexcept {
     return static_cast<bool>(_impl);
 }
 
-void* database::implementation() const {
-    return _get_impl().database_t;
-}
-
 cursor database::list_collections(bsoncxx::document::view_or_value filter) {
     libbson::scoped_bson_t filter_bson{filter};
     bson_error_t error;

--- a/src/mongocxx/database.hpp
+++ b/src/mongocxx/database.hpp
@@ -133,18 +133,6 @@ class MONGOCXX_API database {
     bool has_collection(stdx::string_view name) const;
 
     ///
-    /// Gets a handle to the underlying implementation.
-    ///
-    /// Returned pointer is only valid for the lifetime of this object.
-    ///
-    /// @deprecated Future versions of the driver reserve the right to change the implementation
-    ///   and remove this interface entirely.
-    ///
-    /// @return Pointer to implementation of this object, or nullptr if not available.
-    ///
-    MONGOCXX_DEPRECATED void* implementation() const;
-
-    ///
     /// Enumerates the collections in this database.
     ///
     /// @param filter

--- a/src/mongocxx/pool.cpp
+++ b/src/mongocxx/pool.cpp
@@ -72,9 +72,5 @@ stdx::optional<pool::entry> pool::try_acquire() {
         }};
 }
 
-void* pool::implementation() const {
-    return _impl->client_pool_t;
-}
-
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx

--- a/src/mongocxx/pool.hpp
+++ b/src/mongocxx/pool.hpp
@@ -84,18 +84,6 @@ class MONGOCXX_API pool {
     ///
     stdx::optional<entry> try_acquire();
 
-    ///
-    /// Gets a handle to the underlying implementation.
-    ///
-    /// Returned pointer is only valid for the lifetime of this object.
-    ///
-    /// @deprecated Future versions of the driver reserve the right to change the implementation
-    ///   and remove this interface entirely.
-    ///
-    /// @return Pointer to implementation of this object, or nullptr if not available.
-    ///
-    MONGOCXX_DEPRECATED void* implementation() const;
-
    private:
     MONGOCXX_PRIVATE void _release(client* client);
 

--- a/src/mongocxx/read_preference.cpp
+++ b/src/mongocxx/read_preference.cpp
@@ -54,10 +54,6 @@ read_preference::read_preference(read_mode mode, bsoncxx::document::view_or_valu
 
 read_preference::~read_preference() = default;
 
-void* read_preference::implementation() const {
-    return _impl->read_preference_t;
-}
-
 void read_preference::mode(read_mode mode) {
     libmongoc::read_prefs_set_mode(_impl->read_preference_t, static_cast<mongoc_read_mode_t>(mode));
 }

--- a/src/mongocxx/read_preference.hpp
+++ b/src/mongocxx/read_preference.hpp
@@ -138,18 +138,6 @@ class MONGOCXX_API read_preference {
     ~read_preference();
 
     ///
-    /// Gets a handle to the underlying implementation.
-    ///
-    /// Returned pointer is only valid for the lifetime of this object.
-    ///
-    /// @deprecated Future versions of the driver reserve the right to change the implementation
-    ///   and remove this interface entirely.
-    ///
-    /// @return Pointer to implementation of this object, or nullptr if not available.
-    ///
-    MONGOCXX_DEPRECATED void* implementation() const;
-
-    ///
     /// Sets a new mode for this read_preference.
     ///
     /// @param mode

--- a/src/mongocxx/test/collection_mocked.cpp
+++ b/src/mongocxx/test/collection_mocked.cpp
@@ -128,7 +128,6 @@ TEST_CASE("Collection", "[collection]") {
             [&](mongoc_collection_t* collection, mongoc_query_flags_t flags, const bson_t* pipeline,
                 const bson_t* options, const mongoc_read_prefs_t* read_prefs) -> mongoc_cursor_t* {
                 collection_aggregate_called = true;
-                REQUIRE(collection == mongo_coll.implementation());
                 REQUIRE(flags == MONGOC_QUERY_NONE);
 
                 bsoncxx::array::view p(bson_get_data(pipeline), pipeline->len);
@@ -166,8 +165,6 @@ TEST_CASE("Collection", "[collection]") {
                 else
                     REQUIRE(!o["bypassDocumentValidation"]);
 
-                REQUIRE(read_prefs == mongo_coll.read_preference().implementation());
-
                 return NULL;
             });
 
@@ -196,7 +193,6 @@ TEST_CASE("Collection", "[collection]") {
         bool success = true;
         std::int64_t expected_skip = 0;
         std::int64_t expected_limit = 0;
-        auto expected_read_pref = mongo_coll.read_preference().implementation();
 
         const bson_t* expected_opts = nullptr;
 
@@ -205,14 +201,10 @@ TEST_CASE("Collection", "[collection]") {
                 int64_t skip, int64_t limit, const bson_t* cmd_opts,
                 const mongoc_read_prefs_t* read_prefs, bson_error_t*) {
                 collection_count_called = true;
-                REQUIRE(coll == mongo_coll.implementation());
                 REQUIRE(flags == MONGOC_QUERY_NONE);
                 REQUIRE(bson_get_data(query) == filter_doc.view().data());
                 REQUIRE(skip == expected_skip);
                 REQUIRE(limit == expected_limit);
-                if (expected_read_pref) {
-                    REQUIRE(MONGOC_READ_SECONDARY == mongoc_read_prefs_get_mode(read_prefs));
-                }
                 if (expected_opts) {
                     REQUIRE(bson_equal(cmd_opts, expected_opts));
                 }
@@ -279,7 +271,6 @@ TEST_CASE("Collection", "[collection]") {
         collection_create_index->interpose([&](mongoc_collection_t* coll, const bson_t*,
                                                const mongoc_index_opt_t* opt, bson_error_t*) {
             collection_create_index_called = true;
-            REQUIRE(coll == mongo_coll.implementation());
             if (options.unique()) {
                 REQUIRE(opt->unique == expected_unique);
             }
@@ -330,7 +321,6 @@ TEST_CASE("Collection", "[collection]") {
 
         collection_drop->interpose([&](mongoc_collection_t* coll, bson_error_t*) {
             collection_drop_called = true;
-            REQUIRE(coll == mongo_coll.implementation());
             return success;
         });
 
@@ -360,7 +350,6 @@ TEST_CASE("Collection", "[collection]") {
                                        const mongoc_read_prefs_t* read_prefs) {
             collection_find_called = true;
 
-            REQUIRE(coll == mongo_coll.implementation());
             REQUIRE(flags == MONGOC_QUERY_NONE);
             REQUIRE(skip == skip);
             REQUIRE(limit == limit);
@@ -436,7 +425,6 @@ TEST_CASE("Collection", "[collection]") {
 
         bulk_operation_set_client->interpose([&](mongoc_bulk_operation_t*, void* client) {
             bulk_operation_set_client_called = true;
-            REQUIRE(client == mongo_client.implementation());
         });
 
         bulk_operation_set_database->interpose([&](mongoc_bulk_operation_t*, const char* db) {
@@ -454,7 +442,6 @@ TEST_CASE("Collection", "[collection]") {
             [&](mongoc_bulk_operation_t*, const mongoc_write_concern_t*) {
                 bulk_operation_set_write_concern_called = true;
                 // TODO: actually test the write concern setting is correct or default
-                // REQUIRE(wc == concern.implementation());
             });
 
         bulk_operation_execute->interpose(

--- a/src/mongocxx/test/pool.cpp
+++ b/src/mongocxx/test/pool.cpp
@@ -148,7 +148,6 @@ TEST_CASE(
 
         REQUIRE(!!client);
         REQUIRE(try_pop_called);
-        REQUIRE(client->get()->implementation() == fake);
     }
 }
 

--- a/src/mongocxx/uri.cpp
+++ b/src/mongocxx/uri.cpp
@@ -64,10 +64,6 @@ std::vector<uri::host> uri::hosts() const {
     return result;
 }
 
-void* uri::implementation() const {
-    return _impl->uri_t;
-}
-
 bsoncxx::document::view uri::options() const {
     auto opts_bson = libmongoc::uri_get_options(_impl->uri_t);
     return bsoncxx::document::view{::bson_get_data(opts_bson), opts_bson->len};

--- a/src/mongocxx/uri.hpp
+++ b/src/mongocxx/uri.hpp
@@ -104,18 +104,6 @@ class MONGOCXX_API uri {
     std::string database() const;
 
     ///
-    /// Gets a handle to the underlying implementation.
-    ///
-    /// Returned pointer is only valid for the lifetime of this object.
-    ///
-    /// @deprecated Future versions of the driver reserve the right to change the implementation
-    ///   and remove this interface entirely.
-    ///
-    /// @return Pointer to implementation of this object, or nullptr if not available.
-    ///
-    MONGOCXX_DEPRECATED void* implementation() const;
-
-    ///
     /// Returns other uri options.
     ///
     /// @return A document view containing other options.

--- a/src/mongocxx/write_concern.cpp
+++ b/src/mongocxx/write_concern.cpp
@@ -59,10 +59,6 @@ void write_concern::fsync(bool fsync) {
     libmongoc::write_concern_set_fsync(_impl->write_concern_t, fsync);
 }
 
-void* write_concern::implementation() const {
-    return _impl->write_concern_t;
-}
-
 void write_concern::journal(bool journal) {
     libmongoc::write_concern_set_journal(_impl->write_concern_t, journal);
 }

--- a/src/mongocxx/write_concern.hpp
+++ b/src/mongocxx/write_concern.hpp
@@ -109,18 +109,6 @@ class MONGOCXX_API write_concern {
     void fsync(bool fsync);
 
     ///
-    /// Gets a handle to the underlying implementation.
-    ///
-    /// Returned pointer is only valid for the lifetime of this object.
-    ///
-    /// @deprecated Future versions of the driver reserve the right to change the implementation
-    ///   and remove this interface entirely.
-    ///
-    /// @return Pointer to implementation of this object, or nullptr if not available.
-    ///
-    MONGOCXX_DEPRECATED void* implementation() const;
-
-    ///
     /// Sets the journal parameter for this write concern.
     ///
     /// @param journal


### PR DESCRIPTION
This weakens some tests. @Machyne I think maybe these were tests you added? I'd like to understand how much we think we have lost.

Also, I'm puzzled why we didn't get deprecation warnings for use in the tests. I will look into that .