### PR TITLE
CXX-791 Options for bulk ops should be on the options::bulk_op type

### DIFF
--- a/src/mongocxx/bulk_write.hpp
+++ b/src/mongocxx/bulk_write.hpp
@@ -16,9 +16,8 @@
 
 #include <mongocxx/config/prelude.hpp>
 
-#include <mongocxx/write_concern.hpp>
+#include <mongocxx/options/bulk_write.hpp>
 #include <mongocxx/model/write.hpp>
-#include <bsoncxx/stdx/optional.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -53,7 +52,7 @@ class MONGOCXX_API bulk_write {
     ///   be reported after attempting all operations. Unordered bulk writes may be more efficient
     ///   than ordered bulk writes.
     ///
-    explicit bulk_write(bool ordered);
+    explicit bulk_write(options::bulk_write options = {});
 
     ///
     /// Move constructs a bulk write operation.
@@ -87,29 +86,6 @@ class MONGOCXX_API bulk_write {
     ///     - model::update_one
     ///
     void append(const model::write& operation);
-
-    ///
-    /// Whether or not to bypass document validation for this operation.
-    ///
-    /// @param bypass_document_validation
-    ///   Whether or not to bypass document validation.
-    ///
-    void bypass_document_validation(bool bypass_document_validation);
-
-    ///
-    /// Sets the write_concern for this operation.
-    ///
-    /// @param wc
-    ///   The write_concern to set
-    ///
-    void write_concern(class write_concern wc);
-
-    ///
-    /// Gets the write_concern for the bulk write.
-    ///
-    /// @return The current write_concern.
-    ///
-    class write_concern write_concern() const;
 
    private:
     friend class collection;

--- a/src/mongocxx/collection.hpp
+++ b/src/mongocxx/collection.hpp
@@ -614,7 +614,7 @@ template <typename write_model_iterator_type>
 MONGOCXX_INLINE stdx::optional<result::bulk_write> collection::bulk_write(
     write_model_iterator_type begin, write_model_iterator_type end,
     const options::bulk_write& options) {
-    class bulk_write writes(options.ordered().value_or(true));
+    class bulk_write writes(options);
 
     std::for_each(begin, end, [&](const model::write& current) { writes.append(current); });
 

--- a/src/mongocxx/insert_many_builder.cpp
+++ b/src/mongocxx/insert_many_builder.cpp
@@ -22,14 +22,24 @@
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 
+namespace {
+
+options::bulk_write make_bulk_write_options(const options::insert& insert_options) {
+    options::bulk_write bw;
+    bw.ordered(insert_options.ordered().value_or(true));
+    if (insert_options.write_concern()) {
+        bw.write_concern(*insert_options.write_concern());
+    }
+    if (insert_options.bypass_document_validation()) {
+        bw.bypass_document_validation(*insert_options.bypass_document_validation());
+    }
+    return bw;
+}
+
+} // namespace
+
 insert_many_builder::insert_many_builder(const options::insert& options)
-    : _writes{options.ordered().value_or(true)}, _inserted_ids{}, _index{0} {
-    if (options.write_concern()) {
-        _writes.write_concern(*options.write_concern());
-    }
-    if (options.bypass_document_validation()) {
-        _writes.bypass_document_validation(*options.bypass_document_validation());
-    }
+    : _writes{make_bulk_write_options(options)}, _inserted_ids{}, _index{0} {
 };
 
 void insert_many_builder::operator()(const bsoncxx::document::view& doc) {

--- a/src/mongocxx/options/bulk_write.cpp
+++ b/src/mongocxx/options/bulk_write.cpp
@@ -20,16 +20,31 @@ namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 namespace options {
 
+bulk_write::bulk_write()
+    : _ordered(true) {}
+
 void bulk_write::ordered(bool ordered) {
     _ordered = ordered;
+}
+
+bool bulk_write::ordered() const {
+    return _ordered;
 }
 
 void bulk_write::write_concern(class write_concern wc) {
     _write_concern = std::move(wc);
 }
 
-const stdx::optional<bool>& bulk_write::ordered() const {
-    return _ordered;
+const stdx::optional<class write_concern>& bulk_write::write_concern() const {
+    return _write_concern;
+}
+
+void bulk_write::bypass_document_validation(bool bypass_document_validation) {
+    _bypass_document_validation = bypass_document_validation;
+}
+
+const stdx::optional<bool> bulk_write::bypass_document_validation() const {
+    return _bypass_document_validation;
 }
 
 }  // namespace options

--- a/src/mongocxx/options/bulk_write.hpp
+++ b/src/mongocxx/options/bulk_write.hpp
@@ -32,6 +32,13 @@ class MONGOCXX_API bulk_write {
    public:
 
     ///
+    /// Constructs a new bulk_write object. By default, bulk writes are considered ordered
+    /// as this is the only safe choice. If you want an unordered update, you must call
+    /// ordered(false) to switch to unordered mode.
+    ///
+    bulk_write();
+
+    ///
     /// Sets whether the writes must be executed in order by the server.
     ///
     /// The server-side default is @c true.
@@ -47,9 +54,9 @@ class MONGOCXX_API bulk_write {
     ///
     /// Gets the current value of the ordered option.
     ///
-    /// @return The optional value of the ordered option.
+    /// @return The value of the ordered option.
     ///
-    const stdx::optional<bool>& ordered() const;
+    bool ordered() const;
 
     ///
     /// Sets the write_concern for this operation.
@@ -71,9 +78,26 @@ class MONGOCXX_API bulk_write {
     ///
     const stdx::optional<class write_concern>& write_concern() const;
 
+    ///
+    /// Set whether or not to bypass document validation for this operation.
+    ///
+    /// @param bypass_document_validation
+    ///   Whether or not to bypass document validation.
+    ///
+    void bypass_document_validation(bool bypass_document_validation);
+
+    ///
+    /// The current setting for bypassing document validation for this operation.
+    ///
+    /// @return
+    ///  The current document validation bypass setting.
+    ///
+    const stdx::optional<bool> bypass_document_validation() const;
+
    private:
-    stdx::optional<bool> _ordered;
+    bool _ordered;
     stdx::optional<class write_concern> _write_concern;
+    stdx::optional<bool> _bypass_document_validation;
 };
 
 }  // namespace options

--- a/src/mongocxx/test/bulk_write.cpp
+++ b/src/mongocxx/test/bulk_write.cpp
@@ -35,16 +35,19 @@ TEST_CASE("a bulk_write will setup a mongoc bulk operation", "[bulk_write]") {
     });
 
     SECTION("with an ordered bulk write") {
-        bulk_write(true);
+        { bulk_write bw; }
         REQUIRE(construct_called);
         REQUIRE(ordered_value);
     }
 
     SECTION("with an unordered bulk write") {
-        bulk_write(false);
+        options::bulk_write bw_opts;
+        bw_opts.ordered(false);
+        { bulk_write bw(bw_opts); }
         REQUIRE(construct_called);
         REQUIRE(!ordered_value);
     }
+
 }
 
 TEST_CASE("destruction of a bulk_write will destroy mongoc operation", "[bulk_write]") {
@@ -53,7 +56,7 @@ TEST_CASE("destruction of a bulk_write will destroy mongoc operation", "[bulk_wr
 
     destruct->visit([&destruct_called](mongoc_bulk_operation_t*) { destruct_called = true; });
 
-    bulk_write(true);
+    { bulk_write bw; }
     REQUIRE(destruct_called);
 }
 
@@ -102,7 +105,7 @@ class FilteredDocumentFun : public SingleDocumentFun {
 };
 
 TEST_CASE("passing write operations to append calls corresponding C function", "[bulk_write]") {
-    bulk_write bw(true);
+    bulk_write bw;
     bsoncxx::builder::stream::document filter_builder, doc_builder;
     filter_builder << "_id" << 1;
     doc_builder << "_id" << 2;

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -533,7 +533,9 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
                                << "quux"
                                << "garply" << 9 << finalize;
 
-        bulk_write bulk{false /* unordered */};
+        options::bulk_write bulk_opts;
+        bulk_opts.ordered(false);
+        bulk_write bulk{bulk_opts};
 
         bulk.append(model::insert_one{std::move(doc1)});
         bulk.append(model::insert_one{std::move(doc2)});


### PR DESCRIPTION
While looking into making an example for producing bulk writes per the user request in CXX-791, I noticed that the bulk write subsystem was a little broken.

The options for a bulk write belong on options::bulk_write, not on libmongocx::bulk_write, which should simply be an accumulator for model::write objects.

Instead, the options should be provided via options::bulk_write when creating a bulk_write object.