### PR TITLE
CXX-777 Build with Wall, Wextra and Werror to hold the line on warnings

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -78,7 +78,7 @@ tasks:
           params:
               working_dir: "mongo-cxx-driver/build"
               script: |
-                  PKG_CONFIG_PATH="/data/tmp/c-driver-install/lib/pkgconfig" /opt/cmake/bin/cmake -DCMAKE_BUILD_TYPE=${build_type} -DCMAKE_INSTALL_PREFIX=./install ..
+                  PKG_CONFIG_PATH="/data/tmp/c-driver-install/lib/pkgconfig" /opt/cmake/bin/cmake -DCMAKE_BUILD_TYPE=${build_type} -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_C_FLAGS="-Wall -Wextra -Wno-attributes -Werror" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wno-attributes -Werror" ..
                   make
                   ./src/bsoncxx/test/test_bson
                   ./src/mongocxx/test/test_driver

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ before_script:
 
     # Build the driver and the tests
     - cd build
-    - ${CMAKE_BINARY} -DCMAKE_BUILD_TYPE=$CONFIG ..
+    - ${CMAKE_BINARY} -DCMAKE_BUILD_TYPE=$CONFIG -DCMAKE_C_FLAGS="-Wall -Wextra -Wno-attributes -Werror" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wno-attributes -Werror" ..
 
 script:
     - make

--- a/src/mongocxx/test/collection_mocked.cpp
+++ b/src/mongocxx/test/collection_mocked.cpp
@@ -125,8 +125,8 @@ TEST_CASE("Collection", "[collection]") {
         options::aggregate opts;
 
         collection_aggregate->interpose(
-            [&](mongoc_collection_t* collection, mongoc_query_flags_t flags, const bson_t* pipeline,
-                const bson_t* options, const mongoc_read_prefs_t* read_prefs) -> mongoc_cursor_t* {
+            [&](mongoc_collection_t*, mongoc_query_flags_t flags, const bson_t* pipeline,
+                const bson_t* options, const mongoc_read_prefs_t*) -> mongoc_cursor_t* {
                 collection_aggregate_called = true;
                 REQUIRE(flags == MONGOC_QUERY_NONE);
 
@@ -197,9 +197,9 @@ TEST_CASE("Collection", "[collection]") {
         const bson_t* expected_opts = nullptr;
 
         collection_count_with_opts->interpose(
-            [&](mongoc_collection_t* coll, mongoc_query_flags_t flags, const bson_t* query,
+            [&](mongoc_collection_t*, mongoc_query_flags_t flags, const bson_t* query,
                 int64_t skip, int64_t limit, const bson_t* cmd_opts,
-                const mongoc_read_prefs_t* read_prefs, bson_error_t*) {
+                const mongoc_read_prefs_t*, bson_error_t*) {
                 collection_count_called = true;
                 REQUIRE(flags == MONGOC_QUERY_NONE);
                 REQUIRE(bson_get_data(query) == filter_doc.view().data());
@@ -268,7 +268,7 @@ TEST_CASE("Collection", "[collection]") {
                                                       << "foo"
                                                       << "bar" << builder::stream::finalize;
 
-        collection_create_index->interpose([&](mongoc_collection_t* coll, const bson_t*,
+        collection_create_index->interpose([&](mongoc_collection_t*, const bson_t*,
                                                const mongoc_index_opt_t* opt, bson_error_t*) {
             collection_create_index_called = true;
             if (options.unique()) {
@@ -319,7 +319,7 @@ TEST_CASE("Collection", "[collection]") {
         auto collection_drop_called = false;
         bool success;
 
-        collection_drop->interpose([&](mongoc_collection_t* coll, bson_error_t*) {
+        collection_drop->interpose([&](mongoc_collection_t*, bson_error_t*) {
             collection_drop_called = true;
             return success;
         });
@@ -344,7 +344,7 @@ TEST_CASE("Collection", "[collection]") {
         mongocxx::stdx::optional<bsoncxx::document::view> expected_sort{};
         mongocxx::stdx::optional<bsoncxx::document::view> expected_hint{};
 
-        collection_find->interpose([&](mongoc_collection_t* coll, mongoc_query_flags_t flags,
+        collection_find->interpose([&](mongoc_collection_t*, mongoc_query_flags_t flags,
                                        uint32_t skip, uint32_t limit, uint32_t batch_size,
                                        const bson_t* query, const bson_t* fields,
                                        const mongoc_read_prefs_t* read_prefs) {
@@ -423,7 +423,7 @@ TEST_CASE("Collection", "[collection]") {
                 REQUIRE(expected_bypass_document_validation == bypass);
             });
 
-        bulk_operation_set_client->interpose([&](mongoc_bulk_operation_t*, void* client) {
+        bulk_operation_set_client->interpose([&](mongoc_bulk_operation_t*, void*) {
             bulk_operation_set_client_called = true;
         });
 


### PR DESCRIPTION
Note that we currently need -Wno-attributes to avoid being overwhelmed by warnings
generated by MNMLSTC core.