### PR TITLE
CXX-795 - Add bsoncxx unit tests to evergreen builds

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -80,8 +80,9 @@ tasks:
               script: |
                   PKG_CONFIG_PATH="/data/tmp/c-driver-install/lib/pkgconfig" /opt/cmake/bin/cmake -DCMAKE_BUILD_TYPE=${build_type} -DCMAKE_INSTALL_PREFIX=./install ..
                   make
-                  make run-examples
+                  ./src/bsoncxx/test/test_bson
                   ./src/mongocxx/test/test_driver
+                  make run-examples
         - func: "stop_mongod"
 
 #######################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,8 +72,11 @@ before_script:
 script:
     - make
 
+    # Run bsoncxx tests with catch
+    - ./src/bsoncxx/test/test_bson
+
+    # Run mongocxx tests with catch
+    - ./src/mongocxx/test/test_driver
+
     # Run all examples
     - make run-examples
-
-    # Run tests with catch
-    - ./src/mongocxx/test/test_driver


### PR DESCRIPTION
https://evergreen.mongodb.com/version/568ab75a3ff1222e7e0002c6_0

Do I need to do anything separate for travis?