### PR TITLE
CXX-798 - Fix result::bulk_write::upserted_ids and remove inserted_ids

### DIFF
--- a/examples/mongocxx/bulk_write.cpp
+++ b/examples/mongocxx/bulk_write.cpp
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 #include <cstdlib>
+#include <iostream>
 
 #include <bsoncxx/builder/stream/document.hpp>
-
+#include <bsoncxx/json.hpp>
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>
@@ -98,7 +99,10 @@ int main(int, char**) {
         return EXIT_FAILURE;
     }
 
-    // TODO: print inserted and upserted IDs once CXX-798 is resolved
+    std::cout << "Upserted IDs" << std::endl;
+    for (const auto &id : result->upserted_ids()) {
+        std::cout << "Bulk write index: " << id.first << std::endl << bsoncxx::to_json(id.second) << std::endl;
+    }
 
     // The collection should contain two copies of {"a": 2}.
     auto cursor = coll.find({});

--- a/src/mongocxx/result/bulk_write.cpp
+++ b/src/mongocxx/result/bulk_write.cpp
@@ -43,12 +43,17 @@ std::int32_t bulk_write::upserted_count() const {
     return view()["nUpserted"].get_int32();
 }
 
-bsoncxx::document::element bulk_write::inserted_ids() const {
-    return view()["inserted_ids"];
-}
+bulk_write::id_map bulk_write::upserted_ids() const {
+    id_map upserted_ids;
 
-bsoncxx::document::element bulk_write::upserted_ids() const {
-    return view()["upserted_ids"];
+    if (!view()["upserted"]) {
+        return upserted_ids;
+    }
+
+    for (auto&& id : view()["upserted"].get_array().value) {
+        upserted_ids.emplace(id["index"].get_int32(), id["_id"]);
+    }
+    return upserted_ids;
 }
 
 bsoncxx::document::view bulk_write::view() const {

--- a/src/mongocxx/result/bulk_write.hpp
+++ b/src/mongocxx/result/bulk_write.hpp
@@ -17,6 +17,7 @@
 #include <mongocxx/config/prelude.hpp>
 
 #include <cstdint>
+#include <map>
 #include <vector>
 
 #include <bsoncxx/document/value.hpp>
@@ -33,6 +34,8 @@ namespace result {
 class MONGOCXX_API bulk_write {
 
    public:
+    using id_map = std::map<std::size_t, bsoncxx::document::element>;
+
     explicit bulk_write(bsoncxx::document::value raw_response);
 
     ///
@@ -71,18 +74,12 @@ class MONGOCXX_API bulk_write {
     std::int32_t upserted_count() const;
 
     ///
-    /// Gets the ids of the inserted documents.
-    ///
-    /// @return The values of the _id field for inserted documents.
-    ///
-    bsoncxx::document::element inserted_ids() const;
-
-    ///
     /// Gets the ids of the upserted documents.
     ///
-    /// @return The values of the _id field for upserted documents.
+    /// @note The returned id_map must not be accessed after the bulk_write object is destroyed.
+    /// @return A map from bulk write index to _id field for upserted documents.
     ///
-    bsoncxx::document::element upserted_ids() const;
+    id_map upserted_ids() const;
 
    private:
     MONGOCXX_PRIVATE bsoncxx::document::view view() const;

--- a/src/mongocxx/result/replace_one.cpp
+++ b/src/mongocxx/result/replace_one.cpp
@@ -36,7 +36,10 @@ std::int32_t replace_one::modified_count() const {
 }
 
 stdx::optional<bsoncxx::document::element> replace_one::upserted_id() const {
-    return _result.upserted_ids();
+	if (_result.upserted_ids().size() == 0) {
+		return stdx::nullopt;
+	}
+	return _result.upserted_ids()[0];
 }
 
 }  // namespace result

--- a/src/mongocxx/result/update.cpp
+++ b/src/mongocxx/result/update.cpp
@@ -35,7 +35,10 @@ std::int32_t update::modified_count() const {
 }
 
 stdx::optional<bsoncxx::document::element> update::upserted_id() const {
-    return _result.upserted_ids();
+    if (_result.upserted_ids().size() == 0) {
+		return stdx::nullopt;
+	}
+	return _result.upserted_ids()[0];
 }
 
 }  // namespace result

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -197,7 +197,8 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
         options::update options;
         options.upsert(true);
 
-        coll.update_one(b1.view(), update_doc.view(), options);
+        auto result = coll.update_one(b1.view(), update_doc.view(), options);
+        REQUIRE(result->upserted_id());
 
         auto updated = coll.find_one({});
 
@@ -218,7 +219,8 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
         options::update options;
         options.upsert(true);
 
-        coll.update_one(b1.view(), update_doc.view(), options);
+        auto result = coll.update_one(b1.view(), update_doc.view(), options);
+        REQUIRE(!(result->upserted_id()));
 
         auto updated = coll.find_one({});
 


### PR DESCRIPTION
The C driver does not return the inserted IDs in bulk_write results, so we won't either. It is not required by the CRUD spec (https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst).

I chose to have result::bulk_write::upserted_ids return a std::map<std::size_t, bsoncxx::document::element>, where the first element is the operation index in the bulk write, and the second is {"_id" : ...}. This is analogous to result::insert_many::inserted_ids.