### PR TITLE
CXX-793 Audit all files checked in to git for copyright header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Copyright 2016 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
 
 if(POLICY CMP0025)

--- a/cmake/FindLibBSON.cmake
+++ b/cmake/FindLibBSON.cmake
@@ -1,3 +1,17 @@
+# Copyright 2016 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Find libbson, either via pkg-config, find-package in config mode,
 # or other less admirable jiggery-pokery
 

--- a/cmake/FindLibMongoC.cmake
+++ b/cmake/FindLibMongoC.cmake
@@ -1,3 +1,17 @@
+# Copyright 2016 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Find libmongo-c, either via pkg-config, find-package in config mode,
 # or other less admirable jiggery-pokery
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Copyright 2016 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 add_custom_target(install_headers
     COMMAND "${CMAKE_COMMAND}" -DCMAKE_INSTALL_COMPONENT=dev -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
     DEPENDS bsoncxx_built mongocxx_built

--- a/examples/bsoncxx/CMakeLists.txt
+++ b/examples/bsoncxx/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Copyright 2016 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 include_directories(
     ${CMAKE_INSTALL_PREFIX}/${BSONCXX_HEADER_INSTALL_DIR}
 )

--- a/examples/bsoncxx/view_and_value.cpp
+++ b/examples/bsoncxx/view_and_value.cpp
@@ -1,3 +1,17 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <algorithm>
 #include <iostream>
 #include <iterator>

--- a/examples/mongocxx/CMakeLists.txt
+++ b/examples/mongocxx/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Copyright 2016 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 include_directories(
     ${CMAKE_INSTALL_PREFIX}/${BSONCXX_HEADER_INSTALL_DIR}
     ${CMAKE_INSTALL_PREFIX}/${MONGOCXX_HEADER_INSTALL_DIR}

--- a/examples/mongocxx/document_validation.cpp
+++ b/examples/mongocxx/document_validation.cpp
@@ -1,3 +1,17 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <iostream>
 
 #include <bsoncxx/builder/stream/document.hpp>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Copyright 2016 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 add_definitions(-DMONGO_CXX_DRIVER_COMPILING)
 add_subdirectory(bsoncxx)
 add_subdirectory(mongocxx)

--- a/src/bsoncxx/CMakeLists.txt
+++ b/src/bsoncxx/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Copyright 2016 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 project(BSONCXX)
 
 set(LIBBSON_REQUIRED_ABI_VERSION 1.0)

--- a/src/bsoncxx/cmake/libbsoncxx-config.cmake.in
+++ b/src/bsoncxx/cmake/libbsoncxx-config.cmake.in
@@ -1,3 +1,17 @@
+# Copyright 2016 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set(LIBBSONCXX_VERSION_MAJOR @BSONCXX_VERSION_MAJOR@)
 set(LIBBSONCXX_VERSION_MINOR @BSONCXX_VERSION_MINOR@)
 set(LIBBSONCXX_VERSION_PATCH @BSONCXX_VERSION_PATCH@)

--- a/src/bsoncxx/config/CMakeLists.txt
+++ b/src/bsoncxx/config/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Copyright 2016 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/config.hpp.in
     ${CMAKE_CURRENT_BINARY_DIR}/config.hpp

--- a/src/bsoncxx/config/libbsoncxx.pc.in
+++ b/src/bsoncxx/config/libbsoncxx.pc.in
@@ -1,3 +1,17 @@
+# Copyright 2016 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 prefix=@CMAKE_INSTALL_PREFIX@
 includedir=${prefix}/include
 libdir=${prefix}/lib

--- a/src/bsoncxx/test/CMakeLists.txt
+++ b/src/bsoncxx/test/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Copyright 2016 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 include_directories(
     ${CMAKE_SOURCE_DIR}/src/third_party/catch/include
 )

--- a/src/bsoncxx/test/bson_b_date.cpp
+++ b/src/bsoncxx/test/bson_b_date.cpp
@@ -1,3 +1,17 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "catch.hpp"
 
 #include <bsoncxx/types.hpp>

--- a/src/bsoncxx/test/bson_builder.cpp
+++ b/src/bsoncxx/test/bson_builder.cpp
@@ -1,3 +1,17 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "catch.hpp"
 
 #include <cstring>

--- a/src/bsoncxx/test/bson_get_values.cpp
+++ b/src/bsoncxx/test/bson_get_values.cpp
@@ -1,3 +1,17 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "catch.hpp"
 
 #include <bsoncxx/builder/stream/array.hpp>

--- a/src/bsoncxx/test/bson_util_itoa.cpp
+++ b/src/bsoncxx/test/bson_util_itoa.cpp
@@ -1,3 +1,17 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "catch.hpp"
 
 #include <bsoncxx/private/itoa.hpp>

--- a/src/bsoncxx/test/bson_validate.cpp
+++ b/src/bsoncxx/test/bson_validate.cpp
@@ -1,3 +1,17 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "catch.hpp"
 
 #include <bsoncxx/validate.hpp>

--- a/src/bsoncxx/test/json.cpp
+++ b/src/bsoncxx/test/json.cpp
@@ -1,3 +1,17 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "catch.hpp"
 
 #include <bsoncxx/builder/stream/document.hpp>

--- a/src/bsoncxx/test/new_tests.cpp
+++ b/src/bsoncxx/test/new_tests.cpp
@@ -1,3 +1,17 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
 

--- a/src/bsoncxx/third_party/CMakeLists.txt
+++ b/src/bsoncxx/third_party/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Copyright 2016 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 include(ExternalProject)
 

--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Copyright 2016 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 project(MONGOCXX)
 
 set(LIBBSON_REQUIRED_ABI_VERSION 1.0)

--- a/src/mongocxx/cmake/libmongocxx-config.cmake.in
+++ b/src/mongocxx/cmake/libmongocxx-config.cmake.in
@@ -1,3 +1,17 @@
+# Copyright 2016 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set(LIBMONGOCXX_VERSION_MAJOR @MONGOCXX_VERSION_MAJOR@)
 set(LIBMONGOCXX_VERSION_MINOR @MONGOCXX_VERSION_MINOR@)
 set(LIBMONGOCXX_VERSION_PATCH @MONGOCXX_VERSION_PATCH@)

--- a/src/mongocxx/config/CMakeLists.txt
+++ b/src/mongocxx/config/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Copyright 2016 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/version.hpp.in
     ${CMAKE_CURRENT_BINARY_DIR}/version.hpp

--- a/src/mongocxx/config/libmongocxx.pc.in
+++ b/src/mongocxx/config/libmongocxx.pc.in
@@ -1,3 +1,17 @@
+# Copyright 2016 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 prefix=@CMAKE_INSTALL_PREFIX@
 includedir=${prefix}/include
 libdir=${prefix}/lib

--- a/src/mongocxx/test/CMakeLists.txt
+++ b/src/mongocxx/test/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Copyright 2016 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set(mongocxx_test_sources
     CMakeLists.txt
     bulk_write.cpp

--- a/src/mongocxx/test/model/update_many.cpp
+++ b/src/mongocxx/test/model/update_many.cpp
@@ -1,3 +1,17 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "catch.hpp"
 #include "helpers.hpp"
 

--- a/src/mongocxx/test/options/aggregate.cpp
+++ b/src/mongocxx/test/options/aggregate.cpp
@@ -1,3 +1,17 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <chrono>
 
 #include "catch.hpp"

--- a/src/mongocxx/test/options/find.cpp
+++ b/src/mongocxx/test/options/find.cpp
@@ -1,3 +1,17 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <chrono>
 
 #include "catch.hpp"

--- a/src/mongocxx/test/options/find_one_and_delete.cpp
+++ b/src/mongocxx/test/options/find_one_and_delete.cpp
@@ -1,3 +1,17 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <chrono>
 
 #include "catch.hpp"

--- a/src/mongocxx/test/options/find_one_and_replace.cpp
+++ b/src/mongocxx/test/options/find_one_and_replace.cpp
@@ -1,3 +1,17 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <chrono>
 
 #include "catch.hpp"

--- a/src/mongocxx/test/options/find_one_and_update.cpp
+++ b/src/mongocxx/test/options/find_one_and_update.cpp
@@ -1,3 +1,17 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <chrono>
 
 #include "catch.hpp"

--- a/src/mongocxx/test/options/index.cpp
+++ b/src/mongocxx/test/options/index.cpp
@@ -1,3 +1,17 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "catch.hpp"
 #include "helpers.hpp"
 

--- a/src/mongocxx/test/options/insert.cpp
+++ b/src/mongocxx/test/options/insert.cpp
@@ -1,3 +1,17 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "catch.hpp"
 #include "helpers.hpp"
 

--- a/src/mongocxx/test/options/update.cpp
+++ b/src/mongocxx/test/options/update.cpp
@@ -1,3 +1,17 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "catch.hpp"
 #include "helpers.hpp"
 

--- a/src/third_party/catch/main.cpp
+++ b/src/third_party/catch/main.cpp
@@ -1,2 +1,16 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"


### PR DESCRIPTION
I did not add copyright headers to the following files. Let me know if I was mistaken for any of them:

.clang-format
.gitignore
.mci.yml
.travis.yml
.ycm_extra_conf.py
Contributing.md
Doxyfile
LICENSE
README.md
TODO.md
build/.gitignore
examples/README.md
src/third_party/catch/include/catch.hpp
src/bsoncxx/b64_ntop.h