### PR TITLE
CXX-794 Clean up header ordering, grouping, and prelude/postlude

### DIFF
--- a/src/bsoncxx/array/element.cpp
+++ b/src/bsoncxx/array/element.cpp
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <bsoncxx/array/element.hpp>
+
 #include <cstdlib>
 #include <cstring>
 #include <stdexcept>
 
-#include <bsoncxx/config/prelude.hpp>
-
-#include <bsoncxx/array/element.hpp>
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/array/element.hpp
+++ b/src/bsoncxx/array/element.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <cstddef>
 #include <cstdint>
 
 #include <bsoncxx/document/element.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/array/value.cpp
+++ b/src/bsoncxx/array/value.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <bsoncxx/array/value.hpp>
+
 #include <cstdlib>
 #include <cstring>
 
-#include <bsoncxx/config/prelude.hpp>
-
-#include <bsoncxx/array/value.hpp>
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/array/value.hpp
+++ b/src/bsoncxx/array/value.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <cstdlib>
 #include <memory>
 
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/document/value.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/array/view.cpp
+++ b/src/bsoncxx/array/view.cpp
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <bsoncxx/array/view.hpp>
+
 #include <cstdlib>
 #include <cstring>
 #include <tuple>
 
 #include <bson.h>
 
-#include <bsoncxx/config/prelude.hpp>
-
-#include <bsoncxx/array/view.hpp>
 #include <bsoncxx/private/itoa.hpp>
 #include <bsoncxx/types.hpp>
+
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/array/view.hpp
+++ b/src/bsoncxx/array/view.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/array/element.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/array/view_or_value.hpp
+++ b/src/bsoncxx/array/view_or_value.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/view_or_value.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/basic/array.hpp
+++ b/src/bsoncxx/builder/basic/array.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/builder/basic/impl.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/builder/basic/sub_array.hpp>
 #include <bsoncxx/builder/core.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/basic/document.hpp
+++ b/src/bsoncxx/builder/basic/document.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bsoncxx/builder/basic/impl.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/builder/basic/sub_document.hpp>
 #include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/basic/helpers.hpp
+++ b/src/bsoncxx/builder/basic/helpers.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bsoncxx/builder/concatenate.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/basic/impl.hpp
+++ b/src/bsoncxx/builder/basic/impl.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bsoncxx/builder/basic/sub_array.hpp>
 #include <bsoncxx/builder/basic/sub_document.hpp>
 #include <bsoncxx/util/functor.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/basic/kvp.hpp
+++ b/src/bsoncxx/builder/basic/kvp.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <tuple>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/basic/sub_array.hpp
+++ b/src/bsoncxx/builder/basic/sub_array.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bsoncxx/builder/basic/helpers.hpp>
 #include <bsoncxx/builder/concatenate.hpp>
 #include <bsoncxx/builder/core.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/basic/sub_document.hpp
+++ b/src/bsoncxx/builder/basic/sub_document.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bsoncxx/builder/basic/helpers.hpp>
 #include <bsoncxx/builder/concatenate.hpp>
 #include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/concatenate.hpp
+++ b/src/bsoncxx/builder/concatenate.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/core.cpp
+++ b/src/bsoncxx/builder/core.cpp
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <bsoncxx/builder/core.hpp>
+
+#include <cstring>
+
 #include <bson.h>
 
-#include <bsoncxx/config/prelude.hpp>
-
-#include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/exception/error_code.hpp>
 #include <bsoncxx/exception/exception.hpp>
 #include <bsoncxx/private/error_code.hpp>
@@ -26,7 +27,7 @@
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/value.hpp>
 
-#include <cstring>
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/core.hpp
+++ b/src/bsoncxx/builder/core.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <memory>
 #include <stdexcept>
 #include <type_traits>
@@ -26,6 +24,8 @@
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/types.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/stream/array.hpp
+++ b/src/bsoncxx/builder/stream/array.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/builder/core.hpp>
@@ -23,6 +21,8 @@
 #include <bsoncxx/builder/stream/key_context.hpp>
 #include <bsoncxx/builder/stream/single_context.hpp>
 #include <bsoncxx/builder/stream/value_context.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/stream/array_context.hpp
+++ b/src/bsoncxx/builder/stream/array_context.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/builder/concatenate.hpp>
 #include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/builder/stream/closed_context.hpp>
 #include <bsoncxx/builder/stream/helpers.hpp>
 #include <bsoncxx/util/functor.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/stream/document.hpp
+++ b/src/bsoncxx/builder/stream/document.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/builder/stream/key_context.hpp>
 #include <bsoncxx/builder/stream/single_context.hpp>
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/stream/helpers.hpp
+++ b/src/bsoncxx/builder/stream/helpers.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bsoncxx/builder/concatenate.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/stream/key_context.hpp
+++ b/src/bsoncxx/builder/stream/key_context.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/builder/stream/closed_context.hpp>
 #include <bsoncxx/builder/stream/value_context.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/util/functor.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/stream/single_context.hpp
+++ b/src/bsoncxx/builder/stream/single_context.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/builder/stream/array_context.hpp>
 #include <bsoncxx/builder/stream/value_context.hpp>
 #include <bsoncxx/builder/stream/key_context.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/stream/value_context.hpp
+++ b/src/bsoncxx/builder/stream/value_context.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/builder/stream/array_context.hpp>
 #include <bsoncxx/builder/stream/closed_context.hpp>
 #include <bsoncxx/builder/stream/helpers.hpp>
 #include <bsoncxx/util/functor.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/config/postlude.hpp
+++ b/src/bsoncxx/config/postlude.hpp
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// src/bsoncxx/b64_ntop.h
-#undef BSONCXX_B64_ASSERT
-#pragma pop_macro("BSONCXX_B64_ASSERT")
-
 // compiler.hpp
 #undef BSONCXX_INLINE
 #pragma pop_macro("BSONCXX_INLINE")

--- a/src/bsoncxx/config/prelude.hpp
+++ b/src/bsoncxx/config/prelude.hpp
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// src/bsoncxx/b64_ntop.h
-#pragma push_macro("BSONCXX_B64_ASSERT")
-#undef BSONCXX_B64_ASSERT
-
 // compiler.hpp
 #pragma push_macro("BSONCXX_INLINE")
 #undef BSONCXX_INLINE

--- a/src/bsoncxx/config/private/postlude.hpp
+++ b/src/bsoncxx/config/private/postlude.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2016 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,27 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
+// NOTE: Pop any macros here that are defined by the headers included
+// in private/prelude.hpp.
 
-#include <system_error>
-
-#include <mongocxx/exception/error_code.hpp>
-
-#include <mongocxx/config/private/prelude.hpp>
-
-namespace mongocxx {
-MONGOCXX_INLINE_NAMESPACE_BEGIN
-
-///
-/// Translate a mongocxx::error_code into a std::error_code.
-///
-/// @param error A mongocxx::error_code
-///
-/// @return A std::error_code
-///
-std::error_code make_error_code(error_code error);
-
-MONGOCXX_INLINE_NAMESPACE_END
-}  // namespace mongocxx
-
-#include <mongocxx/config/private/postlude.hpp>
+#include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/config/private/prelude.hpp
+++ b/src/bsoncxx/config/private/prelude.hpp
@@ -13,4 +13,8 @@
 // limitations under the License.
 
 #include <bsoncxx/config/prelude.hpp>
+
+// NOTE: Push any macros here that are defined by the following
+// headers here.
+
 #include <bsoncxx/config/private/config.hpp>

--- a/src/bsoncxx/document/element.cpp
+++ b/src/bsoncxx/document/element.cpp
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <bsoncxx/document/element.hpp>
+
 #include <cstdlib>
 #include <cstring>
 
 #include <bson.h>
-
-#include <bsoncxx/config/prelude.hpp>
-
-#include <bsoncxx/document/element.hpp>
 
 #include <bsoncxx/exception/error_code.hpp>
 #include <bsoncxx/exception/exception.hpp>
@@ -27,6 +25,8 @@
 #include <bsoncxx/private/error_code.hpp>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/value.hpp>
+
+#include <bsoncxx/config/private/prelude.hpp>
 
 #define CITER                \
     bson_iter_t iter;        \

--- a/src/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/document/element.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <cstddef>
 #include <cstdint>
 
 #include <bsoncxx/stdx/string_view.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/document/value.cpp
+++ b/src/bsoncxx/document/value.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <bsoncxx/document/value.hpp>
+
 #include <cstdlib>
 #include <cstring>
 
-#include <bsoncxx/config/prelude.hpp>
-
-#include <bsoncxx/document/value.hpp>
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/document/value.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <cstdlib>
 #include <memory>
 
 #include <bsoncxx/document/view.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/document/view.cpp
+++ b/src/bsoncxx/document/view.cpp
@@ -12,16 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <bsoncxx/document/view.hpp>
+
 #include <cstdlib>
 #include <cstring>
 
 #include <bson.h>
 
-#include <bsoncxx/config/prelude.hpp>
-
-#include <bsoncxx/document/view.hpp>
-#include <bsoncxx/types.hpp>
 #include <bsoncxx/json.hpp>
+#include <bsoncxx/types.hpp>
+
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/document/view.hpp
+++ b/src/bsoncxx/document/view.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
 
 #include <bsoncxx/document/element.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/document/view_or_value.hpp
+++ b/src/bsoncxx/document/view_or_value.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/view_or_value.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/exception/error_code.hpp
+++ b/src/bsoncxx/exception/error_code.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {

--- a/src/bsoncxx/exception/exception.hpp
+++ b/src/bsoncxx/exception/exception.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <system_error>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/json.cpp
+++ b/src/bsoncxx/json.cpp
@@ -22,15 +22,14 @@
 
 #include <bson.h>
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bsoncxx/document/view.hpp>
+#include <bsoncxx/private/b64_ntop.h>
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/value.hpp>
 
-#include <bsoncxx/private/b64_ntop.h>
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/json.hpp
+++ b/src/bsoncxx/json.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <string>
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/oid.cpp
+++ b/src/bsoncxx/oid.cpp
@@ -19,7 +19,7 @@
 
 #include <bson.h>
 
-#include <bsoncxx/config/prelude.hpp>
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/oid.hpp
+++ b/src/bsoncxx/oid.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <iosfwd>
 #include <ctime>
 #include <string>
 
 #include <bsoncxx/string/view_or_value.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/private/error_category.cpp
+++ b/src/bsoncxx/private/error_category.cpp
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/config/prelude.hpp>
+#include <bsoncxx/private/error_category.hpp>
 
 #include <string>
 #include <system_error>
 
 #include <bson.h>
 
-#include <bsoncxx/private/error_category.hpp>
-
 #include <bsoncxx/exception/error_code.hpp>
 #include <bsoncxx/private/libbson_error.hpp>
+
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace {
 

--- a/src/bsoncxx/private/error_category.hpp
+++ b/src/bsoncxx/private/error_category.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <system_error>
+
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
@@ -40,4 +40,4 @@ const std::error_category& libbson_error_category(int domain);
 BSONCXX_INLINE_NAMESPACE_END
 }  // namespace bsoncxx
 
-#include <bsoncxx/config/postlude.hpp>
+#include <bsoncxx/config/private/postlude.hpp>

--- a/src/bsoncxx/private/error_code.cpp
+++ b/src/bsoncxx/private/error_code.cpp
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/config/prelude.hpp>
+#include <bsoncxx/exception/error_code.hpp>
 
 #include <system_error>
 
-#include <bsoncxx/exception/error_code.hpp>
 #include <bsoncxx/private/error_category.hpp>
+
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/private/error_code.hpp
+++ b/src/bsoncxx/private/error_code.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <limits>
 #include <system_error>
 
 #include <bsoncxx/exception/error_code.hpp>
+
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
@@ -35,4 +35,4 @@ std::error_code make_error_code(error_code error);
 BSONCXX_INLINE_NAMESPACE_END
 }  // namespace bsoncxx
 
-#include <bsoncxx/config/postlude.hpp>
+#include <bsoncxx/config/private/postlude.hpp>

--- a/src/bsoncxx/private/helpers.hpp
+++ b/src/bsoncxx/private/helpers.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bson.h>
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
+
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
@@ -38,4 +38,4 @@ inline document::value value_from_bson_t(const bson_t* bson) {
 BSONCXX_INLINE_NAMESPACE_END
 }  // namespace bsoncxx
 
-#include <bsoncxx/config/postlude.hpp>
+#include <bsoncxx/config/private/postlude.hpp>

--- a/src/bsoncxx/private/itoa.cpp
+++ b/src/bsoncxx/private/itoa.cpp
@@ -14,7 +14,7 @@
 
 #include <bsoncxx/private/itoa.hpp>
 
-#include <bsoncxx/config/prelude.hpp>
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/private/itoa.hpp
+++ b/src/bsoncxx/private/itoa.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <cstddef>
 #include <cstdint>
+
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
@@ -45,4 +45,4 @@ class itoa {
 BSONCXX_INLINE_NAMESPACE_END
 }  // namespace bsoncxx
 
-#include <bsoncxx/config/postlude.hpp>
+#include <bsoncxx/config/private/postlude.hpp>

--- a/src/bsoncxx/private/libbson_error.cpp
+++ b/src/bsoncxx/private/libbson_error.cpp
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/config/prelude.hpp>
+#include <bsoncxx/private/libbson_error.hpp>
 
 #include <bson.h>
 
-#include <bsoncxx/private/libbson_error.hpp>
-
 #include <bsoncxx/private/error_category.hpp>
+
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/private/libbson_error.hpp
+++ b/src/bsoncxx/private/libbson_error.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <limits>
 #include <system_error>
+
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
@@ -35,4 +35,4 @@ std::error_code make_error_code(int code, int domain);
 BSONCXX_INLINE_NAMESPACE_END
 }  // namespace bsoncxx
 
-#include <bsoncxx/config/postlude.hpp>
+#include <bsoncxx/config/private/postlude.hpp>

--- a/src/bsoncxx/private/stack.hpp
+++ b/src/bsoncxx/private/stack.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
-#include <type_traits>
-#include <memory>
 #include <list>
+#include <memory>
+#include <type_traits>
+
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
@@ -134,4 +134,4 @@ class stack {
 BSONCXX_INLINE_NAMESPACE_END
 }  // namespace bsoncxx
 
-#include <bsoncxx/config/postlude.hpp>
+#include <bsoncxx/config/private/postlude.hpp>

--- a/src/bsoncxx/string/view_or_value.cpp
+++ b/src/bsoncxx/string/view_or_value.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bsoncxx/string/view_or_value.hpp>
+
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/string/view_or_value.hpp
+++ b/src/bsoncxx/string/view_or_value.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <string>
 
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/view_or_value.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/types.cpp
+++ b/src/bsoncxx/types.cpp
@@ -14,9 +14,9 @@
 
 #include <bsoncxx/types.hpp>
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bsoncxx/json.hpp>
+
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/types.hpp
+++ b/src/bsoncxx/types.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <chrono>
 #include <cstring>
 
@@ -23,6 +21,8 @@
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/oid.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/types/value.cpp
+++ b/src/bsoncxx/types/value.cpp
@@ -19,9 +19,9 @@
 
 #include <bson.h>
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bsoncxx/json.hpp>
+
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/types/value.hpp
+++ b/src/bsoncxx/types/value.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
 
 #include <bsoncxx/types.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/util/functor.hpp
+++ b/src/bsoncxx/util/functor.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <type_traits>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/validate.cpp
+++ b/src/bsoncxx/validate.cpp
@@ -16,9 +16,9 @@
 
 #include <bson.h>
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <bsoncxx/stdx/make_unique.hpp>
+
+#include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/validate.hpp
+++ b/src/bsoncxx/validate.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <cstdint>
 #include <memory>
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/view_or_value.hpp
+++ b/src/bsoncxx/view_or_value.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
-#include <bsoncxx/config/prelude.hpp>
-
 #include <type_traits>
 
 #include <bsoncxx/stdx/optional.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/bulk_write.cpp
+++ b/src/mongocxx/bulk_write.cpp
@@ -15,13 +15,12 @@
 #include <mongocxx/bulk_write.hpp>
 
 #include <bsoncxx/stdx/make_unique.hpp>
-
-#include <mongocxx/config/prelude.hpp>
-
 #include <mongocxx/private/libbson.hpp>
 #include <mongocxx/private/bulk_write.hpp>
 #include <mongocxx/private/libmongoc.hpp>
 #include <mongocxx/private/write_concern.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/bulk_write.hpp
+++ b/src/mongocxx/bulk_write.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <mongocxx/options/bulk_write.hpp>
 #include <mongocxx/model/write.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/client.cpp
+++ b/src/mongocxx/client.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <mongocxx/client.hpp>
 
 #include <bsoncxx/stdx/make_unique.hpp>
@@ -29,6 +27,8 @@
 #include <mongocxx/private/ssl.hpp>
 #include <mongocxx/private/uri.hpp>
 #include <mongocxx/private/write_concern.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/client.hpp
+++ b/src/mongocxx/client.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <memory>
 
 #include <bsoncxx/string/view_or_value.hpp>
@@ -26,6 +24,8 @@
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/uri.hpp>
 #include <mongocxx/write_concern.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/collection.cpp
+++ b/src/mongocxx/collection.cpp
@@ -55,6 +55,8 @@
 #include <mongocxx/result/update.hpp>
 #include <mongocxx/write_concern.hpp>
 
+#include <mongocxx/config/private/prelude.hpp>
+
 using bsoncxx::document::view_or_value;
 using bsoncxx::builder::stream::concatenate;
 

--- a/src/mongocxx/collection.hpp
+++ b/src/mongocxx/collection.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <algorithm>
 #include <cstdint>
 #include <memory>
@@ -25,7 +23,6 @@
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
-
 #include <mongocxx/bulk_write.hpp>
 #include <mongocxx/cursor.hpp>
 #include <mongocxx/insert_many_builder.hpp>
@@ -50,6 +47,8 @@
 #include <mongocxx/result/replace_one.hpp>
 #include <mongocxx/result/update.hpp>
 #include <mongocxx/write_concern.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/config/private/postlude.hpp
+++ b/src/mongocxx/config/private/postlude.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2016 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,27 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
+// NOTE: Pop any macros here that are defined by the headers included
+// in private/prelude.hpp.
 
-#include <system_error>
-
-#include <mongocxx/exception/error_code.hpp>
-
-#include <mongocxx/config/private/prelude.hpp>
-
-namespace mongocxx {
-MONGOCXX_INLINE_NAMESPACE_BEGIN
-
-///
-/// Translate a mongocxx::error_code into a std::error_code.
-///
-/// @param error A mongocxx::error_code
-///
-/// @return A std::error_code
-///
-std::error_code make_error_code(error_code error);
-
-MONGOCXX_INLINE_NAMESPACE_END
-}  // namespace mongocxx
-
-#include <mongocxx/config/private/postlude.hpp>
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/config/private/prelude.hpp
+++ b/src/mongocxx/config/private/prelude.hpp
@@ -13,4 +13,8 @@
 // limitations under the License.
 
 #include <mongocxx/config/prelude.hpp>
+
+// NOTE: Push any macros here that are defined by the following
+// headers here.
+
 #include <mongocxx/config/private/config.hpp>

--- a/src/mongocxx/cursor.cpp
+++ b/src/mongocxx/cursor.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <mongocxx/cursor.hpp>
+
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -19,15 +21,14 @@
 
 #include <bson.h>
 
-#include <mongocxx/cursor.hpp>
-
+#include <bsoncxx/stdx/make_unique.hpp>
 #include <mongocxx/exception/private/error_category.hpp>
 #include <mongocxx/exception/private/mongoc_error.hpp>
 #include <mongocxx/exception/query_exception.hpp>
 #include <mongocxx/private/cursor.hpp>
 #include <mongocxx/private/libmongoc.hpp>
 
-#include <bsoncxx/stdx/make_unique.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/cursor.hpp
+++ b/src/mongocxx/cursor.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <memory>
 
 #include <bsoncxx/document/view.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/database.cpp
+++ b/src/mongocxx/database.cpp
@@ -32,6 +32,8 @@
 #include <mongocxx/private/read_concern.hpp>
 #include <mongocxx/private/read_preference.hpp>
 
+#include <mongocxx/config/private/prelude.hpp>
+
 using bsoncxx::builder::stream::concatenate;
 using bsoncxx::builder::stream::document;
 using bsoncxx::builder::stream::finalize;

--- a/src/mongocxx/database.hpp
+++ b/src/mongocxx/database.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <memory>
 #include <string>
 
@@ -26,6 +24,8 @@
 #include <mongocxx/options/create_collection.hpp>
 #include <mongocxx/write_concern.hpp>
 #include <mongocxx/read_preference.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/authentication_exception.hpp
+++ b/src/mongocxx/exception/authentication_exception.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/document/value.hpp>
 #include <mongocxx/exception/operation_exception.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/bulk_write_exception.hpp
+++ b/src/mongocxx/exception/bulk_write_exception.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/document/value.hpp>
 #include <mongocxx/exception/operation_exception.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/error_code.hpp
+++ b/src/mongocxx/exception/error_code.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <system_error>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/exception.hpp
+++ b/src/mongocxx/exception/exception.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <string>
 #include <system_error>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/logic_error.hpp
+++ b/src/mongocxx/exception/logic_error.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <mongocxx/exception/exception.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/operation_exception.cpp
+++ b/src/mongocxx/exception/operation_exception.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/exception/operation_exception.hpp>
 
 #include <string>
 #include <utility>
 
-#include <mongocxx/exception/operation_exception.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/operation_exception.hpp
+++ b/src/mongocxx/exception/operation_exception.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/stdx.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/private/error_category.cpp
+++ b/src/mongocxx/exception/private/error_category.cpp
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/exception/private/error_category.hpp>
 
 #include <string>
 #include <system_error>
 
-#include <mongocxx/exception/private/error_category.hpp>
-
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/private/libmongoc.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace {
 
@@ -503,5 +503,3 @@ const std::error_category& mongocxx_error_category() {
 
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx
-
-#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/exception/private/error_category.hpp
+++ b/src/mongocxx/exception/private/error_category.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <system_error>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -40,4 +40,4 @@ const std::error_category& mongocxx_error_category();
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx
 
-#include <mongocxx/config/postlude.hpp>
+#include <mongocxx/config/private/postlude.hpp>

--- a/src/mongocxx/exception/private/error_code.cpp
+++ b/src/mongocxx/exception/private/error_code.cpp
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/exception/private/error_code.hpp>
 
 #include <system_error>
 
-#include <mongocxx/exception/private/error_code.hpp>
-
 #include <mongocxx/exception/private/error_category.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -36,5 +36,3 @@ std::error_code make_error_code(mongocxx::error_code error) {
 
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx
-
-#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/exception/private/mongoc_error.cpp
+++ b/src/mongocxx/exception/private/mongoc_error.cpp
@@ -16,6 +16,8 @@
 
 #include <mongocxx/exception/private/error_category.hpp>
 
+#include <mongocxx/config/private/prelude.hpp>
+
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 

--- a/src/mongocxx/exception/private/mongoc_error.hpp
+++ b/src/mongocxx/exception/private/mongoc_error.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <system_error>
 
 #include <bsoncxx/document/value.hpp>
 #include <mongocxx/private/libmongoc.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -57,4 +57,4 @@ void throw_exception(bsoncxx::document::value raw_server_error, ::bson_error_t e
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx
 
-#include <mongocxx/config/postlude.hpp>
+#include <mongocxx/config/private/postlude.hpp>

--- a/src/mongocxx/exception/query_exception.hpp
+++ b/src/mongocxx/exception/query_exception.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <mongocxx/exception/operation_exception.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/write_exception.hpp
+++ b/src/mongocxx/exception/write_exception.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <mongocxx/exception/operation_exception.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/hint.cpp
+++ b/src/mongocxx/hint.cpp
@@ -14,9 +14,9 @@
 
 #include <mongocxx/hint.hpp>
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/stdx/make_unique.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/hint.hpp
+++ b/src/mongocxx/hint.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/builder/stream/document.hpp>
@@ -24,6 +22,8 @@
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
 #include <mongocxx/stdx.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/insert_many_builder.cpp
+++ b/src/mongocxx/insert_many_builder.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <mongocxx/insert_many_builder.hpp>
 
 #include <bsoncxx/builder/stream/document.hpp>
 #include <mongocxx/collection.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/insert_many_builder.hpp
+++ b/src/mongocxx/insert_many_builder.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/bulk_write.hpp>
 #include <mongocxx/options/insert.hpp>
 #include <mongocxx/result/insert_many.hpp>
 #include <mongocxx/stdx.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/instance.cpp
+++ b/src/mongocxx/instance.cpp
@@ -17,9 +17,10 @@
 #include <utility>
 
 #include <bsoncxx/stdx/make_unique.hpp>
-
 #include <mongocxx/logger.hpp>
 #include <mongocxx/private/libmongoc.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/instance.hpp
+++ b/src/mongocxx/instance.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <memory>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/logger.cpp
+++ b/src/mongocxx/logger.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/logger.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/logger.hpp
+++ b/src/mongocxx/logger.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <memory>
 
 #include <bsoncxx/stdx/string_view.hpp>
 #include <mongocxx/stdx.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/delete_many.cpp
+++ b/src/mongocxx/model/delete_many.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/model/delete_many.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/delete_many.hpp
+++ b/src/mongocxx/model/delete_many.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/document/view_or_value.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/delete_one.cpp
+++ b/src/mongocxx/model/delete_one.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/model/delete_one.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/delete_one.hpp
+++ b/src/mongocxx/model/delete_one.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/document/view_or_value.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/insert_one.cpp
+++ b/src/mongocxx/model/insert_one.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/model/insert_one.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/insert_one.hpp
+++ b/src/mongocxx/model/insert_one.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/document/view_or_value.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/replace_one.cpp
+++ b/src/mongocxx/model/replace_one.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/model/replace_one.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/replace_one.hpp
+++ b/src/mongocxx/model/replace_one.hpp
@@ -14,12 +14,11 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
-
 #include <mongocxx/stdx.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/update_many.cpp
+++ b/src/mongocxx/model/update_many.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/model/update_many.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/update_many.hpp
+++ b/src/mongocxx/model/update_many.hpp
@@ -14,12 +14,11 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
-
 #include <mongocxx/stdx.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/update_one.cpp
+++ b/src/mongocxx/model/update_one.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/model/update_one.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/update_one.hpp
+++ b/src/mongocxx/model/update_one.hpp
@@ -14,12 +14,11 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
-
 #include <mongocxx/stdx.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/write.cpp
+++ b/src/mongocxx/model/write.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <type_traits>
-
 #include <mongocxx/model/write.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <type_traits>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/write.hpp
+++ b/src/mongocxx/model/write.hpp
@@ -14,10 +14,9 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <cstdint>
 
+#include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/write_type.hpp>
 #include <mongocxx/model/insert_one.hpp>
 #include <mongocxx/model/delete_one.hpp>
@@ -25,7 +24,8 @@
 #include <mongocxx/model/update_one.hpp>
 #include <mongocxx/model/update_many.hpp>
 #include <mongocxx/model/replace_one.hpp>
-#include <bsoncxx/stdx/optional.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/aggregate.cpp
+++ b/src/mongocxx/options/aggregate.cpp
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 #include <mongocxx/options/aggregate.hpp>
+
 #include <mongocxx/private/read_preference.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/aggregate.hpp
+++ b/src/mongocxx/options/aggregate.hpp
@@ -14,16 +14,15 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <chrono>
 #include <cstdint>
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
-
 #include <mongocxx/read_preference.hpp>
 #include <mongocxx/stdx.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/bulk_write.cpp
+++ b/src/mongocxx/options/bulk_write.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/options/bulk_write.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/bulk_write.hpp
+++ b/src/mongocxx/options/bulk_write.hpp
@@ -14,11 +14,10 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/stdx/optional.hpp>
-
 #include <mongocxx/write_concern.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/client.cpp
+++ b/src/mongocxx/options/client.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/options/client.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/client.hpp
+++ b/src/mongocxx/options/client.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <string>
 
 #include <mongocxx/options/ssl.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/count.cpp
+++ b/src/mongocxx/options/count.cpp
@@ -14,9 +14,9 @@
 
 #include <mongocxx/options/count.hpp>
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <mongocxx/private/read_preference.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/count.hpp
+++ b/src/mongocxx/options/count.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <chrono>
 #include <cstdint>
 #include <string>
@@ -24,6 +22,8 @@
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/hint.hpp>
 #include <mongocxx/read_preference.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/create_collection.cpp
+++ b/src/mongocxx/options/create_collection.cpp
@@ -14,11 +14,11 @@
 
 #include <mongocxx/options/create_collection.hpp>
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/builder/stream/helpers.hpp>
 #include <bsoncxx/types.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/create_collection.hpp
+++ b/src/mongocxx/options/create_collection.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/validation_criteria.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/delete.cpp
+++ b/src/mongocxx/options/delete.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/options/delete.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/delete.hpp
+++ b/src/mongocxx/options/delete.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/write_concern.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/distinct.cpp
+++ b/src/mongocxx/options/distinct.cpp
@@ -14,9 +14,9 @@
 
 #include <mongocxx/options/distinct.hpp>
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <mongocxx/private/read_preference.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/distinct.hpp
+++ b/src/mongocxx/options/distinct.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <chrono>
 #include <cstdint>
 #include <string>
@@ -23,6 +21,8 @@
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/read_preference.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/find.cpp
+++ b/src/mongocxx/options/find.cpp
@@ -14,9 +14,9 @@
 
 #include <mongocxx/options/find.hpp>
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <mongocxx/private/read_preference.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/find.hpp
+++ b/src/mongocxx/options/find.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <chrono>
 #include <cstdint>
 
@@ -25,6 +23,8 @@
 #include <mongocxx/cursor.hpp>
 #include <mongocxx/hint.hpp>
 #include <mongocxx/read_preference.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/find_one_and_delete.cpp
+++ b/src/mongocxx/options/find_one_and_delete.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/options/find_one_and_delete.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/find_one_and_delete.hpp
+++ b/src/mongocxx/options/find_one_and_delete.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <chrono>
 #include <cstdint>
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/write_concern.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/find_one_and_replace.cpp
+++ b/src/mongocxx/options/find_one_and_replace.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/options/find_one_and_replace.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/find_one_and_replace.hpp
+++ b/src/mongocxx/options/find_one_and_replace.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <chrono>
 #include <cstdint>
 
@@ -23,6 +21,8 @@
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/options/find_one_common_options.hpp>
 #include <mongocxx/stdx.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/find_one_and_update.cpp
+++ b/src/mongocxx/options/find_one_and_update.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/options/find_one_and_update.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/find_one_and_update.hpp
+++ b/src/mongocxx/options/find_one_and_update.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <chrono>
 #include <cstdint>
 
@@ -23,6 +21,8 @@
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/options/find_one_common_options.hpp>
 #include <mongocxx/stdx.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/index.cpp
+++ b/src/mongocxx/options/index.cpp
@@ -17,6 +17,8 @@
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <mongocxx/private/libmongoc.hpp>
 
+#include <mongocxx/config/private/prelude.hpp>
+
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 namespace options {

--- a/src/mongocxx/options/index.hpp
+++ b/src/mongocxx/options/index.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <memory>
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
 #include <mongocxx/stdx.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/insert.cpp
+++ b/src/mongocxx/options/insert.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/options/insert.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/insert.hpp
+++ b/src/mongocxx/options/insert.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/write_concern.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/modify_collection.cpp
+++ b/src/mongocxx/options/modify_collection.cpp
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <mongocxx/options/modify_collection.hpp>
 
 #include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/builder/stream/helpers.hpp>
 #include <bsoncxx/types.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/modify_collection.hpp
+++ b/src/mongocxx/options/modify_collection.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <chrono>
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/validation_criteria.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/ssl.cpp
+++ b/src/mongocxx/options/ssl.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/options/ssl.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/ssl.hpp
+++ b/src/mongocxx/options/ssl.hpp
@@ -14,14 +14,13 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <string>
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
-
 #include <mongocxx/stdx.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/update.cpp
+++ b/src/mongocxx/options/update.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/options/update.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/update.hpp
+++ b/src/mongocxx/options/update.hpp
@@ -14,13 +14,12 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
-
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/write_concern.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/pipeline.cpp
+++ b/src/mongocxx/pipeline.cpp
@@ -15,9 +15,10 @@
 #include <mongocxx/pipeline.hpp>
 
 #include <bsoncxx/stdx/make_unique.hpp>
-#include <mongocxx/config/prelude.hpp>
 #include <mongocxx/private/pipeline.hpp>
 #include <mongocxx/stdx.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/pipeline.hpp
+++ b/src/mongocxx/pipeline.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <cstdint>
 #include <string>
 #include <memory>
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/pool.cpp
+++ b/src/mongocxx/pool.cpp
@@ -17,9 +17,6 @@
 #include <utility>
 
 #include <bsoncxx/stdx/make_unique.hpp>
-
-#include <mongocxx/config/prelude.hpp>
-
 #include <mongocxx/client.hpp>
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/exception.hpp>
@@ -28,6 +25,8 @@
 #include <mongocxx/private/pool.hpp>
 #include <mongocxx/private/ssl.hpp>
 #include <mongocxx/private/uri.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/pool.hpp
+++ b/src/mongocxx/pool.hpp
@@ -14,16 +14,15 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <functional>
 #include <memory>
 
 #include <bsoncxx/stdx/optional.hpp>
-
 #include <mongocxx/options/ssl.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/uri.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/private/bulk_write.hpp
+++ b/src/mongocxx/private/bulk_write.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <mongocxx/bulk_write.hpp>
 #include <mongocxx/private/libmongoc.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -40,4 +40,4 @@ class bulk_write::impl {
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx
 
-#include <mongocxx/config/postlude.hpp>
+#include <mongocxx/config/private/postlude.hpp>

--- a/src/mongocxx/private/client.hpp
+++ b/src/mongocxx/private/client.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <mongocxx/client.hpp>
 #include <mongocxx/private/libmongoc.hpp>
 #include <mongocxx/private/write_concern.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -37,4 +37,4 @@ class client::impl {
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx
 
-#include <mongocxx/config/postlude.hpp>
+#include <mongocxx/config/private/postlude.hpp>

--- a/src/mongocxx/private/collection.hpp
+++ b/src/mongocxx/private/collection.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/private/helpers.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
@@ -25,6 +23,8 @@
 #include <mongocxx/private/libbson.hpp>
 #include <mongocxx/private/read_preference.hpp>
 #include <mongocxx/private/write_concern.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -63,4 +63,4 @@ class collection::impl {
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx
 
-#include <mongocxx/config/postlude.hpp>
+#include <mongocxx/config/private/postlude.hpp>

--- a/src/mongocxx/private/cursor.hpp
+++ b/src/mongocxx/private/cursor.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <mongocxx/cursor.hpp>
 #include <mongocxx/private/libmongoc.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -40,4 +40,4 @@ class cursor::impl {
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx
 
-#include <mongocxx/config/postlude.hpp>
+#include <mongocxx/config/private/postlude.hpp>

--- a/src/mongocxx/private/database.hpp
+++ b/src/mongocxx/private/database.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <mongocxx/database.hpp>
 #include <mongocxx/client.hpp>
 #include <mongocxx/private/client.hpp>
 #include <mongocxx/private/libmongoc.hpp>
 #include <mongocxx/private/write_concern.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -52,4 +52,4 @@ class database::impl {
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx
 
-#include <mongocxx/config/postlude.hpp>
+#include <mongocxx/config/private/postlude.hpp>

--- a/src/mongocxx/private/libbson.cpp
+++ b/src/mongocxx/private/libbson.cpp
@@ -14,6 +14,8 @@
 
 #include <mongocxx/private/libbson.hpp>
 
+#include <mongocxx/config/private/prelude.hpp>
+
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 namespace libbson {

--- a/src/mongocxx/private/libbson.hpp
+++ b/src/mongocxx/private/libbson.hpp
@@ -14,16 +14,15 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bson.h>
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
-
 #include <mongocxx/stdx.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -125,3 +124,5 @@ class scoped_bson_t {
 }  // namespace libbson
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx
+
+#include <mongocxx/config/private/postlude.hpp>

--- a/src/mongocxx/private/libmongoc.cpp
+++ b/src/mongocxx/private/libmongoc.cpp
@@ -14,6 +14,8 @@
 
 #include "libmongoc.hpp"
 
+#include <mongocxx/config/private/prelude.hpp>
+
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 namespace libmongoc {

--- a/src/mongocxx/private/libmongoc.hpp
+++ b/src/mongocxx/private/libmongoc.hpp
@@ -14,10 +14,11 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <mongoc.h>
+
 #include <mongocxx/mock/mock.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -36,3 +37,5 @@ namespace libmongoc {
 }  // namespace libmongoc
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx
+
+#include <mongocxx/config/private/postlude.hpp>

--- a/src/mongocxx/private/pipeline.hpp
+++ b/src/mongocxx/private/pipeline.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/builder/stream/array.hpp>
 #include <bsoncxx/builder/stream/single_context.hpp>
 #include <mongocxx/pipeline.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -42,4 +42,4 @@ class pipeline::impl {
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx
 
-#include <mongocxx/config/postlude.hpp>
+#include <mongocxx/config/private/postlude.hpp>

--- a/src/mongocxx/private/pool.hpp
+++ b/src/mongocxx/private/pool.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <utility>
 
 #include <mongocxx/pool.hpp>
 #include <mongocxx/private/libmongoc.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -41,4 +41,4 @@ class pool::impl {
 MONGOCXX_INLINE_NAMESPACE_END
 };  // namespace mongocxx
 
-#include <mongocxx/config/postlude.hpp>
+#include <mongocxx/config/private/postlude.hpp>

--- a/src/mongocxx/private/read_concern.hpp
+++ b/src/mongocxx/private/read_concern.hpp
@@ -14,11 +14,10 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <mongocxx/read_concern.hpp>
-
 #include <mongocxx/private/libmongoc.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -39,4 +38,4 @@ class read_concern::impl {
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx
 
-#include <mongocxx/config/postlude.hpp>
+#include <mongocxx/config/private/postlude.hpp>

--- a/src/mongocxx/private/read_preference.hpp
+++ b/src/mongocxx/private/read_preference.hpp
@@ -14,11 +14,10 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <mongocxx/read_preference.hpp>
-
 #include <mongocxx/private/libmongoc.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -41,4 +40,4 @@ class read_preference::impl {
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx
 
-#include <mongocxx/config/postlude.hpp>
+#include <mongocxx/config/private/postlude.hpp>

--- a/src/mongocxx/private/ssl.hpp
+++ b/src/mongocxx/private/ssl.hpp
@@ -15,8 +15,9 @@
 #pragma once
 
 #include <mongocxx/options/ssl.hpp>
-
 #include <mongocxx/private/libmongoc.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -50,3 +51,5 @@ inline ::mongoc_ssl_opt_t make_ssl_opts(const ssl& ssl_opts) {
 }  // namespace options
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx
+
+#include <mongocxx/config/private/postlude.hpp>

--- a/src/mongocxx/private/uri.hpp
+++ b/src/mongocxx/private/uri.hpp
@@ -17,6 +17,8 @@
 #include <mongocxx/uri.hpp>
 #include <mongocxx/private/libmongoc.hpp>
 
+#include <mongocxx/config/private/prelude.hpp>
+
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 
@@ -31,4 +33,4 @@ class uri::impl {
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx
 
-#include <mongocxx/config/postlude.hpp>
+#include <mongocxx/config/private/postlude.hpp>

--- a/src/mongocxx/private/write_concern.hpp
+++ b/src/mongocxx/private/write_concern.hpp
@@ -14,11 +14,10 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <mongocxx/write_concern.hpp>
-
 #include <mongocxx/private/libmongoc.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -41,4 +40,4 @@ class write_concern::impl {
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx
 
-#include <mongocxx/config/postlude.hpp>
+#include <mongocxx/config/private/postlude.hpp>

--- a/src/mongocxx/read_concern.cpp
+++ b/src/mongocxx/read_concern.cpp
@@ -14,13 +14,14 @@
 
 #include <mongocxx/read_concern.hpp>
 
-#include <mongocxx/private/read_concern.hpp>
-
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/exception/private/error_code.hpp>
 #include <mongocxx/private/libmongoc.hpp>
+#include <mongocxx/private/read_concern.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/read_concern.hpp
+++ b/src/mongocxx/read_concern.hpp
@@ -16,11 +16,11 @@
 
 #include <memory>
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 #include <mongocxx/stdx.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/read_preference.cpp
+++ b/src/mongocxx/read_preference.cpp
@@ -15,12 +15,11 @@
 #include <mongocxx/read_preference.hpp>
 
 #include <bsoncxx/stdx/make_unique.hpp>
-
-#include <mongocxx/config/prelude.hpp>
-
 #include <mongocxx/private/libbson.hpp>
 #include <mongocxx/private/libmongoc.hpp>
 #include <mongocxx/private/read_preference.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/read_preference.hpp
+++ b/src/mongocxx/read_preference.hpp
@@ -14,16 +14,15 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <cstdint>
 #include <string>
 #include <memory>
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
-
 #include <mongocxx/stdx.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/bulk_write.cpp
+++ b/src/mongocxx/result/bulk_write.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/result/bulk_write.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/bulk_write.hpp
+++ b/src/mongocxx/result/bulk_write.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <cstdint>
 #include <map>
 #include <vector>
@@ -23,6 +21,8 @@
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/types.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/delete.cpp
+++ b/src/mongocxx/result/delete.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/result/delete.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/delete.hpp
+++ b/src/mongocxx/result/delete.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <cstdint>
 
 #include <mongocxx/result/bulk_write.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/insert_many.cpp
+++ b/src/mongocxx/result/insert_many.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/result/insert_many.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/insert_many.hpp
+++ b/src/mongocxx/result/insert_many.hpp
@@ -14,14 +14,13 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <cstdint>
 #include <map>
 
 #include <bsoncxx/types.hpp>
-
 #include <mongocxx/result/bulk_write.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/insert_one.cpp
+++ b/src/mongocxx/result/insert_one.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/result/insert_one.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/insert_one.hpp
+++ b/src/mongocxx/result/insert_one.hpp
@@ -14,12 +14,11 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/value.hpp>
-
 #include <mongocxx/result/bulk_write.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/replace_one.cpp
+++ b/src/mongocxx/result/replace_one.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/result/replace_one.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/replace_one.hpp
+++ b/src/mongocxx/result/replace_one.hpp
@@ -14,15 +14,14 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <cstdint>
 
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/stdx/optional.hpp>
-
 #include <mongocxx/result/bulk_write.hpp>
 #include <mongocxx/stdx.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/update.cpp
+++ b/src/mongocxx/result/update.cpp
@@ -14,7 +14,7 @@
 
 #include <mongocxx/result/update.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/update.hpp
+++ b/src/mongocxx/result/update.hpp
@@ -14,15 +14,14 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <cstdint>
 
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/stdx/optional.hpp>
-
 #include <mongocxx/result/bulk_write.hpp>
 #include <mongocxx/stdx.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/uri.cpp
+++ b/src/mongocxx/uri.cpp
@@ -14,14 +14,14 @@
 
 #include <mongocxx/uri.hpp>
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <mongocxx/private/libmongoc.hpp>
 #include <mongocxx/private/read_concern.hpp>
 #include <mongocxx/private/read_preference.hpp>
 #include <mongocxx/private/uri.hpp>
 #include <mongocxx/private/write_concern.hpp>
+
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/uri.hpp
+++ b/src/mongocxx/uri.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <memory>
 #include <string>
 #include <vector>
@@ -25,6 +23,8 @@
 #include <mongocxx/read_concern.hpp>
 #include <mongocxx/read_preference.hpp>
 #include <mongocxx/write_concern.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/validation_criteria.cpp
+++ b/src/mongocxx/validation_criteria.cpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/builder/stream/helpers.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <mongocxx/config/private/prelude.hpp>
 
 namespace {
 

--- a/src/mongocxx/validation_criteria.hpp
+++ b/src/mongocxx/validation_criteria.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/write_concern.cpp
+++ b/src/mongocxx/write_concern.cpp
@@ -28,6 +28,8 @@
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/stdx.hpp>
 
+#include <mongocxx/config/private/prelude.hpp>
+
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 

--- a/src/mongocxx/write_concern.hpp
+++ b/src/mongocxx/write_concern.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <mongocxx/config/prelude.hpp>
-
 #include <chrono>
 #include <cstdint>
 #include <stdexcept>
@@ -23,8 +21,9 @@
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
-
 #include <mongocxx/stdx.hpp>
+
+#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN


### PR DESCRIPTION
- The prelude/postlude should be scoped narrowly
- Use the private prelude/postlude for private files
- Group bsoncxx and mongocxx includes together
- Fix some header sorting where noticed
- Add some missing postludes
- Add some missing preludes exposed by adding missing postludes