### PR TITLE
CXX-522 Add calling convention tags where needed

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -22,6 +22,12 @@ add_custom_target(install_libs
     DEPENDS bsoncxx_built mongocxx_built
 )
 
+# Build the examples with vectorcall as the default on Windows
+# so that we shake out missing _CALL macros.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Gv")
+endif()
+
 add_subdirectory(bsoncxx)
 add_subdirectory(mongocxx)
 

--- a/src/bsoncxx/array/view.hpp
+++ b/src/bsoncxx/array/view.hpp
@@ -123,8 +123,8 @@ class BSONCXX_API view {
 
     operator document::view() const;
 
-    friend BSONCXX_API bool operator==(view, view);
-    friend BSONCXX_API bool operator!=(view, view);
+    friend BSONCXX_API bool BSONCXX_CALL operator==(view, view);
+    friend BSONCXX_API bool BSONCXX_CALL operator!=(view, view);
 
    private:
     document::view _view;
@@ -141,8 +141,8 @@ class BSONCXX_API view::iterator : public std::iterator<std::forward_iterator_ta
     iterator& operator++();
     iterator operator++(int);
 
-    friend BSONCXX_API bool operator==(const iterator&, const iterator&);
-    friend BSONCXX_API bool operator!=(const iterator&, const iterator&);
+    friend BSONCXX_API bool BSONCXX_CALL operator==(const iterator&, const iterator&);
+    friend BSONCXX_API bool BSONCXX_CALL operator!=(const iterator&, const iterator&);
 
    private:
     element _element;
@@ -160,8 +160,8 @@ class BSONCXX_API view::const_iterator : public std::iterator<std::forward_itera
     const_iterator& operator++();
     const_iterator operator++(int);
 
-    friend BSONCXX_API bool operator==(const const_iterator&, const const_iterator&);
-    friend BSONCXX_API bool operator!=(const const_iterator&, const const_iterator&);
+    friend BSONCXX_API bool BSONCXX_CALL operator==(const const_iterator&, const const_iterator&);
+    friend BSONCXX_API bool BSONCXX_CALL operator!=(const const_iterator&, const const_iterator&);
 
    private:
     element _element;

--- a/src/bsoncxx/builder/basic/impl.hpp
+++ b/src/bsoncxx/builder/basic/impl.hpp
@@ -26,8 +26,6 @@ namespace builder {
 namespace basic {
 namespace impl {
 
-namespace {
-
 template <typename T>
 using takes_document = typename util::is_functor<T, void(sub_document)>;
 
@@ -56,8 +54,6 @@ typename std::enable_if<!takes_document<T>::value && !takes_array<T>::value, voi
 generic_append(core* core, T&& t) {
     core->append(std::forward<T>(t));
 }
-
-}  // namespace
 
 template <typename T>
 BSONCXX_INLINE

--- a/src/bsoncxx/config/compiler.hpp
+++ b/src/bsoncxx/config/compiler.hpp
@@ -21,6 +21,12 @@
 
 #define BSONCXX_INLINE inline __forceinline BSONCXX_PRIVATE
 
+#define BSONCXX_CALL __cdecl
+
 #else
+
 #define BSONCXX_INLINE inline __attribute__((__always_inline__)) BSONCXX_PRIVATE
+
+#define BSONCXX_CALL
+
 #endif

--- a/src/bsoncxx/config/postlude.hpp
+++ b/src/bsoncxx/config/postlude.hpp
@@ -18,6 +18,8 @@
 #if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
+#undef BSONCXX_CALL
+#pragma pop_macro("BSONCXX_CALL")
 
 // src/bsoncxx/config/config.hpp.in
 #undef BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/config/prelude.hpp
+++ b/src/bsoncxx/config/prelude.hpp
@@ -15,6 +15,8 @@
 // compiler.hpp
 #pragma push_macro("BSONCXX_INLINE")
 #undef BSONCXX_INLINE
+#pragma push_macro("BSONCXX_CALL")
+#undef BSONCXX_CALL
 
 // src/bsoncxx/config/config.hpp.in
 #pragma push_macro("BSONCXX_INLINE_NAMESPACE_BEGIN")

--- a/src/bsoncxx/document/view.hpp
+++ b/src/bsoncxx/document/view.hpp
@@ -127,8 +127,8 @@ class BSONCXX_API view {
     ///
     bool empty() const;
 
-    friend BSONCXX_API bool operator==(view, view);
-    friend BSONCXX_API bool operator!=(view, view);
+    friend BSONCXX_API bool BSONCXX_CALL operator==(view, view);
+    friend BSONCXX_API bool BSONCXX_CALL operator!=(view, view);
 
    private:
     const std::uint8_t* _data;
@@ -146,8 +146,8 @@ class BSONCXX_API view::iterator : public std::iterator<std::forward_iterator_ta
     iterator& operator++();
     iterator operator++(int);
 
-    friend BSONCXX_API bool operator==(const iterator&, const iterator&);
-    friend BSONCXX_API bool operator!=(const iterator&, const iterator&);
+    friend BSONCXX_API bool BSONCXX_CALL operator==(const iterator&, const iterator&);
+    friend BSONCXX_API bool BSONCXX_CALL operator!=(const iterator&, const iterator&);
 
    private:
     element _element;
@@ -165,8 +165,8 @@ class BSONCXX_API view::const_iterator : public std::iterator<std::forward_itera
     const_iterator& operator++();
     const_iterator operator++(int);
 
-    friend BSONCXX_API bool operator==(const const_iterator&, const const_iterator&);
-    friend BSONCXX_API bool operator!=(const const_iterator&, const const_iterator&);
+    friend BSONCXX_API bool BSONCXX_CALL operator==(const const_iterator&, const const_iterator&);
+    friend BSONCXX_API bool BSONCXX_CALL operator!=(const const_iterator&, const const_iterator&);
 
    private:
     element _element;

--- a/src/bsoncxx/json.hpp
+++ b/src/bsoncxx/json.hpp
@@ -33,7 +33,7 @@ BSONCXX_INLINE_NAMESPACE_BEGIN
 ///
 /// @returns A JSON string.
 ///
-BSONCXX_API std::string to_json(document::view view);
+BSONCXX_API std::string BSONCXX_CALL to_json(document::view view);
 
 ///
 /// Converts an element (key-value pair) to a JSON key-value pair.
@@ -44,7 +44,7 @@ BSONCXX_API std::string to_json(document::view view);
 ///
 /// @returns A JSON key-value pair.
 ///
-BSONCXX_API std::string to_json(document::element element);
+BSONCXX_API std::string BSONCXX_CALL to_json(document::element element);
 
 ///
 /// Converts a BSON value to its JSON string representation.
@@ -55,7 +55,7 @@ BSONCXX_API std::string to_json(document::element element);
 ///
 /// @returns A JSON value.
 ///
-BSONCXX_API std::string to_json(types::value value);
+BSONCXX_API std::string BSONCXX_CALL to_json(types::value value);
 
 ///
 /// Constructs a new document::value from the provided JSON text
@@ -65,7 +65,7 @@ BSONCXX_API std::string to_json(types::value value);
 ///
 /// @returns An engaged optional containing a document::value if conversion worked.
 ///
-BSONCXX_API stdx::optional<document::value> from_json(stdx::string_view json);
+BSONCXX_API stdx::optional<document::value> BSONCXX_CALL from_json(stdx::string_view json);
 
 BSONCXX_INLINE_NAMESPACE_END
 }  // namespace bsoncxx

--- a/src/bsoncxx/oid.hpp
+++ b/src/bsoncxx/oid.hpp
@@ -84,12 +84,12 @@ class BSONCXX_API oid {
     ///
     std::string to_string() const;
 
-    friend BSONCXX_API bool operator<(const oid& lhs, const oid& rhs);
-    friend BSONCXX_API bool operator>(const oid& lhs, const oid& rhs);
-    friend BSONCXX_API bool operator<=(const oid& lhs, const oid& rhs);
-    friend BSONCXX_API bool operator>=(const oid& lhs, const oid& rhs);
-    friend BSONCXX_API bool operator==(const oid& lhs, const oid& rhs);
-    friend BSONCXX_API bool operator!=(const oid& lhs, const oid& rhs);
+    friend BSONCXX_API bool BSONCXX_CALL operator<(const oid& lhs, const oid& rhs);
+    friend BSONCXX_API bool BSONCXX_CALL operator>(const oid& lhs, const oid& rhs);
+    friend BSONCXX_API bool BSONCXX_CALL operator<=(const oid& lhs, const oid& rhs);
+    friend BSONCXX_API bool BSONCXX_CALL operator>=(const oid& lhs, const oid& rhs);
+    friend BSONCXX_API bool BSONCXX_CALL operator==(const oid& lhs, const oid& rhs);
+    friend BSONCXX_API bool BSONCXX_CALL operator!=(const oid& lhs, const oid& rhs);
 
     explicit operator bool() const;
 
@@ -100,12 +100,12 @@ class BSONCXX_API oid {
     ///
     std::time_t get_time_t() const;
 
-    friend BSONCXX_API std::ostream& operator<<(std::ostream& out, const oid& rhs);
+    friend BSONCXX_API std::ostream& BSONCXX_CALL operator<<(std::ostream& out, const oid& rhs);
 
     const char* bytes() const;
 
    private:
-    friend BSONCXX_API int oid_compare(const oid& lhs, const oid& rhs);
+    friend BSONCXX_PRIVATE int oid_compare(const oid& lhs, const oid& rhs);
 
     bool _is_valid;
     char _bytes[12];

--- a/src/bsoncxx/private/b64_ntop.h
+++ b/src/bsoncxx/private/b64_ntop.h
@@ -53,13 +53,9 @@ namespace b64 {
 
 #define BSONCXX_B64_ASSERT(Cond) if (!(Cond)) std::abort ()
 
-namespace {
-
 const char Base64[] =
    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 const char Pad64 = '=';
-
-}  // namespace
 
 /* (From RFC1521 and draft-ietf-dnssec-secext-03.txt)
  * The following encoding technique is taken from RFC 1521 by Borenstein

--- a/src/bsoncxx/types.hpp
+++ b/src/bsoncxx/types.hpp
@@ -56,8 +56,8 @@ enum class binary_sub_type : std::uint8_t {
 #undef BSONCXX_ENUM
 };
 
-BSONCXX_API std::string to_string(type rhs);
-BSONCXX_API std::string to_string(binary_sub_type rhs);
+BSONCXX_API std::string BSONCXX_CALL to_string(type rhs);
+BSONCXX_API std::string BSONCXX_CALL to_string(binary_sub_type rhs);
 
 namespace types {
 

--- a/src/bsoncxx/types/value.hpp
+++ b/src/bsoncxx/types/value.hpp
@@ -142,8 +142,8 @@ namespace types {
 
         ~value();
 
-        friend BSONCXX_API bool operator==(const value&, const value&);
-        friend BSONCXX_API bool operator!=(const value&, const value&);
+        friend BSONCXX_API bool BSONCXX_CALL operator==(const value&, const value&);
+        friend BSONCXX_API bool BSONCXX_CALL operator!=(const value&, const value&);
 
         ///
         /// @return The type of the underlying BSON value stored in this object.
@@ -331,7 +331,7 @@ namespace types {
         const b_maxkey& get_maxkey() const;
 
        private:
-        void destroy() noexcept;
+        void BSONCXX_PRIVATE destroy() noexcept;
 
         bsoncxx::type _type;
         union {
@@ -360,10 +360,8 @@ namespace types {
 
     // sfinae in the bool return to avoid competing with the value == value
     // operators
-    namespace {
-        template <typename T>
-        using not_value = typename std::enable_if<! std::is_same<typename std::remove_reference<T>::type, value>::value, bool>::type;
-    }  // namespace
+    template <typename T>
+    using not_value = typename std::enable_if<! std::is_same<typename std::remove_reference<T>::type, value>::value, bool>::type;
 
     // these all return bool
     template <typename T>

--- a/src/bsoncxx/validate.hpp
+++ b/src/bsoncxx/validate.hpp
@@ -41,8 +41,8 @@ class validator;
 ///   An engaged optional containing a view if the document is valid, or
 ///   an unengaged optional if the document is invalid.
 ///
-BSONCXX_API stdx::optional<document::view> validate(const std::uint8_t* data,
-                                                    std::size_t length);
+BSONCXX_API stdx::optional<document::view> BSONCXX_CALL validate(const std::uint8_t* data,
+                                                                     std::size_t length);
 
 ///
 /// Validates a BSON document. This overload provides additional control over the
@@ -64,10 +64,10 @@ BSONCXX_API stdx::optional<document::view> validate(const std::uint8_t* data,
 ///   An engaged optional containing a view if the document is valid, or
 ///   an unengaged optional if the document is invalid.
 ///
-BSONCXX_API stdx::optional<document::view> validate(const std::uint8_t* data,
-                                                    std::size_t length,
-                                                    const validator& validator,
-                                                    std::size_t* invalid_offset = nullptr);
+BSONCXX_API stdx::optional<document::view> BSONCXX_CALL validate(const std::uint8_t* data,
+                                                                     std::size_t length,
+                                                                     const validator& validator,
+                                                                     std::size_t* invalid_offset = nullptr);
 ///
 /// A validator is used to enable or disable specific checks that can be
 /// performed during BSON validation.

--- a/src/mongocxx/config/compiler.hpp
+++ b/src/mongocxx/config/compiler.hpp
@@ -23,6 +23,12 @@
 
 #define MONGOCXX_INLINE inline __forceinline MONGOCXX_PRIVATE
 
+#define MONGOCXX_CALL __cdecl
+
 #else
+
 #define MONGOCXX_INLINE inline __attribute__((__always_inline__)) MONGOCXX_PRIVATE
+
+#define MONGOCXX_CALL
+
 #endif

--- a/src/mongocxx/config/postlude.hpp
+++ b/src/mongocxx/config/postlude.hpp
@@ -18,6 +18,8 @@
 #if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
+#undef MONGOCXX_CALL
+#pragma pop_macro("MONGOCXX_CALL")
 
 // src/mongocxx/config/config.hpp.in
 #undef MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/config/prelude.hpp
+++ b/src/mongocxx/config/prelude.hpp
@@ -15,6 +15,8 @@
 // src/mongocxx/config/compiler.hpp
 #pragma push_macro("MONGOCXX_INLINE")
 #undef MONGOCXX_INLINE
+#pragma push_macro("MONGOCXX_CALL")
+#undef MONGOCXX_CALL
 
 // src/mongocxx/config/config.hpp.in
 #pragma push_macro("MONGOCXX_INLINE_NAMESPACE_BEGIN")

--- a/src/mongocxx/cursor.hpp
+++ b/src/mongocxx/cursor.hpp
@@ -109,8 +109,8 @@ class MONGOCXX_API cursor::iterator : public std::iterator<
 
    private:
     friend class cursor;
-    friend MONGOCXX_API bool operator==(const iterator&, const iterator&);
-    friend MONGOCXX_API bool operator!=(const iterator&, const iterator&);
+    friend MONGOCXX_API bool MONGOCXX_CALL operator==(const iterator&, const iterator&);
+    friend MONGOCXX_API bool MONGOCXX_CALL operator!=(const iterator&, const iterator&);
 
     MONGOCXX_PRIVATE explicit iterator(cursor* cursor);
 
@@ -118,9 +118,6 @@ class MONGOCXX_API cursor::iterator : public std::iterator<
     bsoncxx::document::view _doc;
 
 };
-
-MONGOCXX_API bool operator==(const cursor::iterator& lhs, const cursor::iterator& rhs);
-MONGOCXX_API bool operator!=(const cursor::iterator& lhs, const cursor::iterator& rhs);
 
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx

--- a/src/mongocxx/hint.hpp
+++ b/src/mongocxx/hint.hpp
@@ -52,8 +52,8 @@ class MONGOCXX_API hint {
     ///
     explicit hint(bsoncxx::string::view_or_value index);
 
-    friend bool operator==(const hint& index_hint, std::string index);
-    friend bool operator==(const hint& index_hint, bsoncxx::document::view index);
+    friend MONGOCXX_API bool MONGOCXX_CALL operator==(const hint& index_hint, std::string index);
+    friend MONGOCXX_API bool MONGOCXX_CALL operator==(const hint& index_hint, bsoncxx::document::view index);
 
     ///
     /// Return a bson document representing this hint.
@@ -73,20 +73,18 @@ class MONGOCXX_API hint {
 ///
 /// Return true if this hint contains an index name that matches.
 ///
-bool operator==(const hint& index_hint, std::string index);
-bool operator==(std::string index, const hint& index_hint);
-bool operator!=(const hint& index_hint, std::string index);
-bool operator!=(std::string index, const hint& index_index);
+MONGOCXX_API bool MONGOCXX_CALL operator==(std::string index, const hint& index_hint);
+MONGOCXX_API bool MONGOCXX_CALL operator!=(const hint& index_hint, std::string index);
+MONGOCXX_API bool MONGOCXX_CALL operator!=(std::string index, const hint& index_index);
 
 ///
 /// Convenience methods to compare for equality against an index document.
 ///
 /// Return true if this hint contains an index document that matches.
 ///
-bool operator==(const hint& index_hint, bsoncxx::document::view index);
-bool operator==(bsoncxx::document::view index, const hint& index_hint);
-bool operator!=(const hint& index_hint, bsoncxx::document::view index);
-bool operator!=(bsoncxx::document::view index, const hint& index_hint);
+MONGOCXX_API bool MONGOCXX_CALL operator==(bsoncxx::document::view index, const hint& index_hint);
+MONGOCXX_API bool MONGOCXX_CALL operator!=(const hint& index_hint, bsoncxx::document::view index);
+MONGOCXX_API bool MONGOCXX_CALL operator!=(bsoncxx::document::view index, const hint& index_hint);
 
 MONGOCXX_INLINE hint::operator bsoncxx::document::value() const {
     return to_document();

--- a/src/mongocxx/private/bulk_write.hpp
+++ b/src/mongocxx/private/bulk_write.hpp
@@ -35,7 +35,7 @@ class bulk_write::impl {
 
     mongoc_bulk_operation_t* operation_t;
 
-}; // class impl
+};
 
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx

--- a/src/mongocxx/private/client.hpp
+++ b/src/mongocxx/private/client.hpp
@@ -32,7 +32,7 @@ class client::impl {
 
     mongoc_client_t* client_t;
 
-}; // class impl
+};
 
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx

--- a/src/mongocxx/private/collection.hpp
+++ b/src/mongocxx/private/collection.hpp
@@ -58,7 +58,7 @@ class collection::impl {
     std::string database_name;
     const class client::impl* client_impl;
 
-};  // class impl
+};
 
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx

--- a/src/mongocxx/private/cursor.hpp
+++ b/src/mongocxx/private/cursor.hpp
@@ -35,7 +35,7 @@ class cursor::impl {
 
     mongoc_cursor_t* cursor_t;
 
-}; // class impl
+};
 
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx

--- a/src/mongocxx/private/pipeline.hpp
+++ b/src/mongocxx/private/pipeline.hpp
@@ -37,7 +37,7 @@ class pipeline::impl {
    private:
     bsoncxx::builder::stream::array _builder;
 
-}; // class impl
+};
 
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx

--- a/src/mongocxx/private/pool.hpp
+++ b/src/mongocxx/private/pool.hpp
@@ -36,7 +36,7 @@ class pool::impl {
 
     mongoc_client_pool_t* client_pool_t;
     stdx::optional<options::ssl> ssl_options;
-};  // class impl
+};
 
 MONGOCXX_INLINE_NAMESPACE_END
 };  // namespace mongocxx

--- a/src/mongocxx/private/read_concern.hpp
+++ b/src/mongocxx/private/read_concern.hpp
@@ -33,7 +33,7 @@ class read_concern::impl {
 
     ::mongoc_read_concern_t* read_concern_t;
 
-};  // class impl
+};
 
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx

--- a/src/mongocxx/private/read_preference.hpp
+++ b/src/mongocxx/private/read_preference.hpp
@@ -35,7 +35,7 @@ class read_preference::impl {
 
     mongoc_read_prefs_t* read_preference_t;
 
-}; // class impl
+};
 
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx

--- a/src/mongocxx/private/uri.hpp
+++ b/src/mongocxx/private/uri.hpp
@@ -28,7 +28,7 @@ class uri::impl {
     ~impl() { libmongoc::uri_destroy(uri_t); }
     mongoc_uri_t* uri_t;
 
-}; // class impl
+};
 
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx

--- a/src/mongocxx/private/write_concern.hpp
+++ b/src/mongocxx/private/write_concern.hpp
@@ -35,7 +35,7 @@ class write_concern::impl {
 
     mongoc_write_concern_t* write_concern_t;
 
-}; // class impl
+};
 
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx

--- a/src/mongocxx/read_preference.cpp
+++ b/src/mongocxx/read_preference.cpp
@@ -75,8 +75,8 @@ stdx::optional<bsoncxx::document::view> read_preference::tags() const {
     return stdx::optional<bsoncxx::document::view>{};
 }
 
-bool read_preference::operator==(const read_preference& other) const {
-    return mode() == other.mode() && tags() == other.tags();
+bool operator==(const read_preference& lhs, const read_preference& rhs) {
+    return (lhs.mode() == rhs.mode()) && (lhs.tags() == rhs.tags());
 }
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/read_preference.hpp
+++ b/src/mongocxx/read_preference.hpp
@@ -166,16 +166,12 @@ class MONGOCXX_API read_preference {
     ///
     stdx::optional<bsoncxx::document::view> tags() const;
 
-    ///
-    /// Comparison operator
-    ///
-    bool operator==(const read_preference&) const;
-
    private:
     friend client;
     friend collection;
     friend database;
     friend uri;
+    friend MONGOCXX_API bool MONGOCXX_CALL operator==(const read_preference&, const read_preference&);
 
     class MONGOCXX_PRIVATE impl;
 

--- a/src/mongocxx/result/bulk_write.hpp
+++ b/src/mongocxx/result/bulk_write.hpp
@@ -86,7 +86,7 @@ class MONGOCXX_API bulk_write {
 
     bsoncxx::document::value _response;
 
-}; // class bulk_write
+};
 
 }  // namespace result
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/result/delete.hpp
+++ b/src/mongocxx/result/delete.hpp
@@ -50,7 +50,7 @@ class MONGOCXX_API delete_result {
    private:
     result::bulk_write _result;
 
-}; // class delete_result
+};
 
 }  // namespace result
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/result/insert_many.hpp
+++ b/src/mongocxx/result/insert_many.hpp
@@ -69,7 +69,7 @@ class MONGOCXX_API insert_many {
     result::bulk_write _result;
     id_map _generated_ids;
 
-}; // class insert_many
+};
 
 }  // namespace result
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/result/insert_one.hpp
+++ b/src/mongocxx/result/insert_one.hpp
@@ -49,7 +49,7 @@ class MONGOCXX_API insert_one {
     result::bulk_write _result;
     bsoncxx::types::value _generated_id;
 
-}; // class insert_one
+};
 
 }  // namespace result
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/result/replace_one.hpp
+++ b/src/mongocxx/result/replace_one.hpp
@@ -65,7 +65,7 @@ class MONGOCXX_API replace_one {
    private:
     result::bulk_write _result;
 
-}; // class replace_one
+};
 
 }  // namespace result
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/result/update.hpp
+++ b/src/mongocxx/result/update.hpp
@@ -64,7 +64,7 @@ class MONGOCXX_API update {
    private:
     result::bulk_write _result;
 
-}; // class update
+};
 
 }  // namespace result
 MONGOCXX_INLINE_NAMESPACE_END


### PR DESCRIPTION
On Windows, non-inline non-member functions of non-template classes
need to have a calling convention explicitly specified, so that if the
consumer of the library isn't using cdecl as the default calling
convention, they can still link with the library.

Also a few drive-by fixes:

- Remove anon namespaces in headers, they don't do what is expected
- Remove some duplicated declarations when a 'friend' already declared
- Fix some visibility nits (missing API, missing PRIVATE)
- Remove trailing class comments - we don't do those
- Make read_preference comparator a free function as is our style