### PR TITLE
CXX-813 Fix memory errors exposed by ASAN and Valgrind

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -120,6 +120,8 @@ tasks:
                   make examples
                   ${test_params} ./src/bsoncxx/test/test_bson
                   ${test_params} ./src/mongocxx/test/test_driver
+                  ${test_params} ./src/mongocxx/test/test_instance
+
                   # The break -1 is a hack to cause us to have a bad
                   # exit status if any test exits with a bad exit
                   # status.

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,9 @@ script:
     # Run mongocxx tests with catch
     - ./src/mongocxx/test/test_driver
 
+    # Run mongocxx instance tests with catch
+    - ./src/mongocxx/test/test_instance
+
     # Install headers and libs for the examples
     - make install
 

--- a/src/mongocxx/exception/error_code.hpp
+++ b/src/mongocxx/exception/error_code.hpp
@@ -22,7 +22,8 @@ namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 
 enum class error_code : std::int32_t {
-    k_invalid_client_object = 1,
+    k_instance_already_exists = 1,
+    k_invalid_client_object,
     k_invalid_collection_object,
     k_invalid_database_object,
     k_invalid_parameter,

--- a/src/mongocxx/exception/private/error_category.cpp
+++ b/src/mongocxx/exception/private/error_category.cpp
@@ -401,6 +401,8 @@ class mongocxx_error_category_impl final : public std::error_category {
                 return "invalid attempt to set an unknown read concern level";
             case error_code::k_unknown_write_concern:
                 return "invalid attempt to set an unknown write concern level";
+            case error_code::k_instance_already_exists:
+                return "cannot create more than one mongocxx::instance object";
             default:
                 return "unknown mongocxx error";
         }

--- a/src/mongocxx/instance.hpp
+++ b/src/mongocxx/instance.hpp
@@ -26,7 +26,7 @@ class logger;
 ///
 /// Class representing an instance of the MongoDB driver.
 ///
-/// Life cycle: An instance of the driver *MUST* be kept around.
+/// Life cycle: A unique instance of the driver *MUST* be kept around.
 ///
 class MONGOCXX_API instance {
    public:
@@ -55,6 +55,14 @@ class MONGOCXX_API instance {
     /// Destroys an instance of the driver.
     ///
     ~instance();
+
+    ///
+    /// Returns the current unique instance of the driver. If an
+    /// instance was explicitly created, that will be returned. If no
+    /// instance has yet been created, a default instance will be
+    /// constructed and returned.
+    ///
+    static instance& current();
 
    private:
     class MONGOCXX_PRIVATE impl;

--- a/src/mongocxx/test/CMakeLists.txt
+++ b/src/mongocxx/test/CMakeLists.txt
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include_directories(
+    ${THIRD_PARTY_SOURCE_DIR}/catch/include
+)
+
+link_directories(${LIBMONGOC_LIBRARY_DIRS} ${LIBBSON_LIBRARY_DIRS})
+
 set(mongocxx_test_sources
     CMakeLists.txt
     bulk_write.cpp
@@ -20,7 +26,6 @@ set(mongocxx_test_sources
     collection_mocked.cpp
     database.cpp
     hint.cpp
-    instance.cpp
     model/update_many.cpp
     options/aggregate.cpp
     options/create_collection.cpp
@@ -45,12 +50,6 @@ set(mongocxx_test_sources
     write_concern.cpp
 )
 
-include_directories(
-    ${THIRD_PARTY_SOURCE_DIR}/catch/include
-)
-
-link_directories(${LIBMONGOC_LIBRARY_DIRS} ${LIBBSON_LIBRARY_DIRS})
-
 add_executable(test_driver
     ${THIRD_PARTY_SOURCE_DIR}/catch/main.cpp
     ${mongocxx_test_sources}
@@ -58,8 +57,16 @@ add_executable(test_driver
 
 target_link_libraries(test_driver mongocxx_mocked)
 
+add_executable(test_instance
+  ${THIRD_PARTY_SOURCE_DIR}/catch/main.cpp
+  instance.cpp
+)
+
+target_link_libraries(test_instance mongocxx_mocked)
+
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(test_driver PRIVATE /bigobj)
 endif()
 
 add_test(driver test_driver)
+add_test(instance test_instance)

--- a/src/mongocxx/test/bulk_write.cpp
+++ b/src/mongocxx/test/bulk_write.cpp
@@ -17,7 +17,7 @@
 
 #include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/types.hpp>
-
+#include <mongocxx/instance.hpp>
 #include <mongocxx/private/libmongoc.hpp>
 #include <mongocxx/bulk_write.hpp>
 #include <mongocxx/write_concern.hpp>
@@ -25,6 +25,8 @@
 using namespace mongocxx;
 
 TEST_CASE("a bulk_write will setup a mongoc bulk operation", "[bulk_write]") {
+    instance::current();
+
     auto construct = libmongoc::bulk_operation_new.create_instance();
     bool construct_called = false;
     bool ordered_value = false;
@@ -50,6 +52,8 @@ TEST_CASE("a bulk_write will setup a mongoc bulk operation", "[bulk_write]") {
 }
 
 TEST_CASE("destruction of a bulk_write will destroy mongoc operation", "[bulk_write]") {
+    instance::current();
+
     auto destruct = libmongoc::bulk_operation_destroy.create_instance();
     bool destruct_called = false;
 
@@ -104,6 +108,8 @@ class FilteredDocumentFun : public SingleDocumentFun {
 };
 
 TEST_CASE("passing write operations to append calls corresponding C function", "[bulk_write]") {
+    instance::current();
+
     bulk_write bw;
     bsoncxx::builder::stream::document filter_builder, doc_builder, update_doc_builder;
     filter_builder << "_id" << 1;

--- a/src/mongocxx/test/client.cpp
+++ b/src/mongocxx/test/client.cpp
@@ -17,6 +17,7 @@
 
 #include <mongocxx/client.hpp>
 #include <mongocxx/exception/logic_error.hpp>
+#include <mongocxx/instance.hpp>
 #include <mongocxx/private/libmongoc.hpp>
 #include <mongocxx/uri.hpp>
 
@@ -25,11 +26,15 @@ using namespace mongocxx;
 TEST_CASE("A default constructed client is false-ish", "[client]") {
     MOCK_CLIENT
 
+    instance::current();
+
     client a;
     REQUIRE(!a);
 }
 
 TEST_CASE("A default constructed client cannot perform operations", "[client]") {
+    instance::current();
+
     client a;
     REQUIRE_THROWS_AS(a.list_databases(), mongocxx::logic_error);
 }
@@ -37,12 +42,17 @@ TEST_CASE("A default constructed client cannot perform operations", "[client]") 
 TEST_CASE("A client constructed with a URI is truthy", "[client]") {
     MOCK_CLIENT
 
+    instance::current();
+
     client a{uri{}};
     REQUIRE(a);
 }
 
 TEST_CASE("A client connects to a provided mongodb uri", "[client]") {
     MOCK_CLIENT
+
+    instance::current();
+
     std::string expected_url("mongodb://mongodb.example.com:9999");
     uri mongodb_uri(expected_url);
     std::string actual_url{};
@@ -62,6 +72,9 @@ TEST_CASE("A client connects to a provided mongodb uri", "[client]") {
 
 TEST_CASE("A client cleans up its underlying mongoc client on destruction", "[client]") {
     MOCK_CLIENT
+
+    instance::current();
+
     bool destroy_called = false;
     client_destroy->interpose([&](mongoc_client_t*) { destroy_called = true; });
 
@@ -75,6 +88,8 @@ TEST_CASE("A client cleans up its underlying mongoc client on destruction", "[cl
 
 TEST_CASE("A client supports move operations", "[client]") {
     MOCK_CLIENT
+
+    instance::current();
 
     client a{uri{}};
 
@@ -93,6 +108,8 @@ TEST_CASE("A client supports move operations", "[client]") {
 
 TEST_CASE("A client has a settable Read Concern", "[collection]") {
     MOCK_CLIENT
+
+    instance::current();
 
     client mongo_client{uri{}};
 
@@ -115,6 +132,8 @@ TEST_CASE("A client has a settable Read Concern", "[collection]") {
 
 TEST_CASE("A client's read preferences may be set and obtained", "[client]") {
     MOCK_CLIENT
+
+    instance::current();
 
     client mongo_client{uri{}};
     read_preference preference{read_preference::read_mode::k_secondary_preferred};
@@ -142,6 +161,8 @@ TEST_CASE("A client's read preferences may be set and obtained", "[client]") {
 
 TEST_CASE("A client's write concern may be set and obtained", "[client]") {
     MOCK_CLIENT
+
+    instance::current();
 
     client mongo_client{uri{}};
     write_concern concern;
@@ -181,6 +202,9 @@ TEST_CASE("A client's write concern may be set and obtained", "[client]") {
 
 TEST_CASE("A client can create a named database object", "[client]") {
     MOCK_CLIENT
+
+    instance::current();
+
     auto database_get = libmongoc::client_get_database.create_instance();
     database_get->interpose([](mongoc_client_t*, const char*) { return nullptr; }).forever();
     auto database_destroy = libmongoc::database_destroy.create_instance();

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -21,10 +21,10 @@
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/types.hpp>
-
 #include <mongocxx/collection.hpp>
 #include <mongocxx/client.hpp>
 #include <mongocxx/exception/logic_error.hpp>
+#include <mongocxx/instance.hpp>
 #include <mongocxx/insert_many_builder.hpp>
 #include <mongocxx/pipeline.hpp>
 #include <mongocxx/read_concern.hpp>
@@ -33,11 +33,15 @@ using namespace bsoncxx::builder::stream;
 using namespace mongocxx;
 
 TEST_CASE("A default constructed collection cannot perform operations", "[collection]") {
+    instance::current();
+
     collection c;
     REQUIRE_THROWS_AS(c.name(), mongocxx::logic_error);
 }
 
 TEST_CASE("collection copy", "[collection]") {
+    instance::current();
+
     client mongodb_client{uri{}};
     database db = mongodb_client["test"];
 
@@ -54,6 +58,8 @@ TEST_CASE("collection copy", "[collection]") {
 }
 
 TEST_CASE("collection renaming", "[collection]") {
+    instance::current();
+
     client mongodb_client{uri{}};
     database db = mongodb_client["test"];
 
@@ -70,6 +76,8 @@ TEST_CASE("collection renaming", "[collection]") {
 }
 
 TEST_CASE("CRUD functionality", "[driver::collection]") {
+    instance::current();
+
     client mongodb_client{uri{}};
     database db = mongodb_client["test"];
     collection coll = db["mongo_cxx_driver"];
@@ -610,6 +618,8 @@ TEST_CASE("read_concern is inherited from parent", "[collection]") {
 }
 
 TEST_CASE("create_index returns index name", "[collection]") {
+    instance::current();
+
     client mongodb_client{uri{}};
     database db = mongodb_client["test"];
     collection coll = db["collection"];

--- a/src/mongocxx/test/hint.cpp
+++ b/src/mongocxx/test/hint.cpp
@@ -20,11 +20,14 @@
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/json.hpp>
 #include <mongocxx/hint.hpp>
+#include <mongocxx/instance.hpp>
 
 using namespace mongocxx;
 using namespace bsoncxx;
 
 TEST_CASE("Hint", "[hint]") {
+    instance::current();
+
     SECTION("Can be constructed with index name") {
         std::string index_name = "a_1";
         hint index_hint{index_name};

--- a/src/mongocxx/test/model/update_many.cpp
+++ b/src/mongocxx/test/model/update_many.cpp
@@ -15,9 +15,12 @@
 #include "catch.hpp"
 #include "helpers.hpp"
 
+#include <mongocxx/instance.hpp>
 #include <mongocxx/model/update_many.hpp>
 
 TEST_CASE("update_many", "[update_many][model]") {
+    mongocxx::instance::current();
+
     const bsoncxx::document::view a((std::uint8_t *)"", 0);
     const bsoncxx::document::view b((std::uint8_t *)"", 0);
 

--- a/src/mongocxx/test/options/aggregate.cpp
+++ b/src/mongocxx/test/options/aggregate.cpp
@@ -17,11 +17,14 @@
 #include "catch.hpp"
 #include "helpers.hpp"
 
+#include <mongocxx/instance.hpp>
 #include <mongocxx/options/aggregate.hpp>
 
 using namespace mongocxx;
 
 TEST_CASE("aggregate", "[aggregate][option]") {
+    instance::current();
+
     options::aggregate agg;
 
     CHECK_OPTIONAL_ARGUMENT(agg, allow_disk_use, true);

--- a/src/mongocxx/test/options/create_collection.cpp
+++ b/src/mongocxx/test/options/create_collection.cpp
@@ -20,7 +20,7 @@
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/value.hpp>
-
+#include <mongocxx/instance.hpp>
 #include <mongocxx/options/create_collection.hpp>
 
 using namespace bsoncxx;
@@ -31,6 +31,8 @@ using builder::stream::finalize;
 using builder::stream::open_document;
 
 TEST_CASE("create_collection", "[create_collection]") {
+    instance::current();
+
     options::create_collection cc;
 
     SECTION("Can be exported to a document") {

--- a/src/mongocxx/test/options/find.cpp
+++ b/src/mongocxx/test/options/find.cpp
@@ -18,11 +18,14 @@
 #include "helpers.hpp"
 
 #include <bsoncxx/document/view.hpp>
+#include <mongocxx/instance.hpp>
 #include <mongocxx/options/find.hpp>
 
 using namespace mongocxx;
 
 TEST_CASE("find", "[find][option]") {
+    instance::current();
+
     options::find find_opts{};
 
     CHECK_OPTIONAL_ARGUMENT(find_opts, allow_partial_results, true);

--- a/src/mongocxx/test/options/find_one_and_delete.cpp
+++ b/src/mongocxx/test/options/find_one_and_delete.cpp
@@ -18,12 +18,15 @@
 #include "helpers.hpp"
 
 #include <bsoncxx/builder/stream/document.hpp>
+#include <mongocxx/instance.hpp>
 #include <mongocxx/options/find_one_and_delete.hpp>
 
 using namespace bsoncxx::builder::stream;
 using namespace mongocxx;
 
 TEST_CASE("find_one_and_delete", "[find_one_and_delete][option]") {
+    instance::current();
+
     options::find_one_and_delete opts{};
 
     std::chrono::milliseconds ms{400};

--- a/src/mongocxx/test/options/find_one_and_replace.cpp
+++ b/src/mongocxx/test/options/find_one_and_replace.cpp
@@ -18,12 +18,15 @@
 #include "helpers.hpp"
 
 #include <bsoncxx/builder/stream/document.hpp>
+#include <mongocxx/instance.hpp>
 #include <mongocxx/options/find_one_and_replace.hpp>
 
 using namespace bsoncxx::builder::stream;
 using namespace mongocxx;
 
 TEST_CASE("find_one_and_replace", "[find_one_and_replace][option]") {
+    instance::current();
+
     options::find_one_and_replace opts{};
 
     std::chrono::milliseconds ms{400};

--- a/src/mongocxx/test/options/find_one_and_update.cpp
+++ b/src/mongocxx/test/options/find_one_and_update.cpp
@@ -19,11 +19,14 @@
 
 #include <bsoncxx/builder/stream/document.hpp>
 #include <mongocxx/options/find_one_and_update.hpp>
+#include <mongocxx/instance.hpp>
 
 using namespace bsoncxx::builder::stream;
 using namespace mongocxx;
 
 TEST_CASE("find_one_and_update", "[find_one_and_update][option]") {
+    instance::current();
+
     options::find_one_and_update opts{};
 
     std::chrono::milliseconds ms{400};

--- a/src/mongocxx/test/options/index.cpp
+++ b/src/mongocxx/test/options/index.cpp
@@ -16,6 +16,7 @@
 #include "helpers.hpp"
 
 #include <bsoncxx/stdx/make_unique.hpp>
+#include <mongocxx/instance.hpp>
 #include <mongocxx/options/index.hpp>
 #include <mongocxx/stdx.hpp>
 
@@ -23,6 +24,8 @@ using namespace mongocxx;
 using namespace mongocxx::options;
 
 TEST_CASE("index", "[index][option]") {
+    instance::current();
+
     options::index idx;
     std::unique_ptr<index::wiredtiger_storage_options> storage =
         stdx::make_unique<index::wiredtiger_storage_options>();

--- a/src/mongocxx/test/options/insert.cpp
+++ b/src/mongocxx/test/options/insert.cpp
@@ -15,11 +15,14 @@
 #include "catch.hpp"
 #include "helpers.hpp"
 
+#include <mongocxx/instance.hpp>
 #include <mongocxx/options/insert.hpp>
 
 using namespace mongocxx;
 
 TEST_CASE("insert opts", "[insert][option]") {
+    instance::current();
+
     options::insert ins;
 
     CHECK_OPTIONAL_ARGUMENT(ins, bypass_document_validation, true);

--- a/src/mongocxx/test/options/modify_collection.cpp
+++ b/src/mongocxx/test/options/modify_collection.cpp
@@ -21,7 +21,7 @@
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/value.hpp>
-
+#include <mongocxx/instance.hpp>
 #include <mongocxx/options/modify_collection.hpp>
 
 using namespace bsoncxx;
@@ -32,6 +32,8 @@ using builder::stream::finalize;
 using builder::stream::open_document;
 
 TEST_CASE("modify_collection", "[modify_collection]") {
+    instance::current();
+
     options::modify_collection cm;
 
     SECTION("Can be exported to a document") {

--- a/src/mongocxx/test/options/update.cpp
+++ b/src/mongocxx/test/options/update.cpp
@@ -15,11 +15,14 @@
 #include "catch.hpp"
 #include "helpers.hpp"
 
+#include <mongocxx/instance.hpp>
 #include <mongocxx/options/update.hpp>
 
 using namespace mongocxx;
 
 TEST_CASE("update opts", "[update][option]") {
+    instance::current();
+
     options::update updt;
 
     CHECK_OPTIONAL_ARGUMENT(updt, upsert, true);

--- a/src/mongocxx/test/pool.cpp
+++ b/src/mongocxx/test/pool.cpp
@@ -18,8 +18,8 @@
 #include <cstddef>
 #include <string>
 
+#include <mongocxx/instance.hpp>
 #include <mongocxx/private/libmongoc.hpp>
-
 #include <mongocxx/client.hpp>
 #include <mongocxx/options/ssl.hpp>
 #include <mongocxx/pool.hpp>
@@ -28,6 +28,8 @@ using namespace mongocxx;
 
 TEST_CASE("a pool is created with the correct MongoDB URI", "[pool]") {
     MOCK_POOL
+
+    instance::current();
 
     bool destroy_called = false;
     client_pool_destroy->interpose([&](::mongoc_client_pool_t*) { destroy_called = true; });
@@ -62,6 +64,8 @@ TEST_CASE(
     "underlying mongoc pool",
     "[pool]") {
     MOCK_POOL
+
+    instance::current();
 
     const std::string pem_file = "foo";
     const std::string pem_password = "bar";
@@ -105,6 +109,8 @@ TEST_CASE(
     "[pool]") {
     MOCK_POOL
 
+    instance::current();
+
     bool pop_called = false;
     client_pool_pop->interpose([&](::mongoc_client_pool_t*) {
         pop_called = true;
@@ -131,6 +137,8 @@ TEST_CASE(
     "returns a non-null pointer",
     "[pool]") {
     MOCK_POOL
+
+    instance::current();
 
 // GCC before 4.9.0 doesn't place max_align_t in the std namespace.
 #if defined(__clang__) || !defined(__GNUC__) || (__GNUC__ > 4) || \
@@ -163,6 +171,8 @@ TEST_CASE(
     "returns a null pointer",
     "[pool]") {
     MOCK_POOL
+
+    instance::current();
 
     client_pool_try_pop->interpose([](::mongoc_client_pool_t*) { return nullptr; });
 

--- a/src/mongocxx/test/private/write_concern.cpp
+++ b/src/mongocxx/test/private/write_concern.cpp
@@ -15,7 +15,7 @@
 #include "catch.hpp"
 
 #include <mongocxx/private/libmongoc.hpp>
-
+#include <mongocxx/instance.hpp>
 #include <mongocxx/write_concern.hpp>
 #include <mongocxx/private/write_concern.hpp>
 
@@ -23,6 +23,8 @@ using namespace mongocxx;
 
 TEST_CASE("creation of write_concern passes universal parameters to c-driver's methods",
           "[write_concern][base][c-driver]") {
+    instance::current();
+
     SECTION("when journal is requested, mongoc_write_concern_set_journal is called with true") {
         bool journal_called = false;
         bool journal_value = false;
@@ -55,6 +57,8 @@ TEST_CASE("creation of write_concern passes universal parameters to c-driver's m
 }
 
 TEST_CASE("write_concern is called with w MAJORITY", "[write_concern][base][c-driver]") {
+    instance::current();
+
     bool w_called = false, wmajority_called = false, wtag_called = false;
     auto w_instance = libmongoc::write_concern_set_w.create_instance();
     auto wmajority_instance = libmongoc::write_concern_set_wmajority.create_instance();
@@ -82,6 +86,8 @@ TEST_CASE("write_concern is called with w MAJORITY", "[write_concern][base][c-dr
 
 TEST_CASE("write_concern is called with a number of necessary confirmations",
           "[write_concern][base][c-driver]") {
+    instance::current();
+
     bool w_called = false, wmajority_called = false, wtag_called = false;
     int w_value = 0;
     const int expected_w = 5;
@@ -114,6 +120,8 @@ TEST_CASE("write_concern is called with a number of necessary confirmations",
 }
 
 TEST_CASE("write_concern is called with a tag", "[write_concern][base][c-driver]") {
+    instance::current();
+
     bool w_called = false, wmajority_called = false, wtag_called = false;
     std::string wtag_value;
     const std::string expected_wtag("MultiDataCenter");

--- a/src/mongocxx/test/read_concern.cpp
+++ b/src/mongocxx/test/read_concern.cpp
@@ -16,12 +16,15 @@
 #include "helpers.hpp"
 
 #include <bsoncxx/stdx/string_view.hpp>
+#include <mongocxx/instance.hpp>
 #include <mongocxx/read_concern.hpp>
 #include <mongocxx/stdx.hpp>
 
 using namespace mongocxx;
 
 TEST_CASE("a default read_concern", "[read_concern]") {
+    instance::current();
+
     read_concern rc{};
 
     SECTION("has level k_server_default") {
@@ -34,6 +37,8 @@ TEST_CASE("a default read_concern", "[read_concern]") {
 }
 
 TEST_CASE("read_concern fields may be set and retrieved", "[read_concern]") {
+    instance::current();
+
     read_concern rc{};
 
     REQUIRE_NOTHROW(rc.acknowledge_level(read_concern::level::k_majority));
@@ -44,6 +49,8 @@ TEST_CASE("read_concern fields may be set and retrieved", "[read_concern]") {
 }
 
 TEST_CASE("read_concern level and string affect each other", "[read_concern]") {
+    instance::current();
+
     read_concern rc{};
 
     SECTION("setting the level changes the string") {
@@ -63,6 +70,8 @@ TEST_CASE("read_concern level and string affect each other", "[read_concern]") {
 }
 
 TEST_CASE("read_concern throws when trying to set level to k_unknown", "[read_concern]") {
+    instance::current();
+
     read_concern rc{};
 
     REQUIRE_THROWS(rc.acknowledge_level(read_concern::level::k_unknown));

--- a/src/mongocxx/test/read_preference.cpp
+++ b/src/mongocxx/test/read_preference.cpp
@@ -16,12 +16,15 @@
 
 #include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/document/view.hpp>
+#include <mongocxx/instance.hpp>
 #include <mongocxx/read_preference.hpp>
 
 using namespace mongocxx;
 using namespace bsoncxx;
 
 TEST_CASE("Read Preference", "[read_preference]") {
+    instance::current();
+
     read_preference rp;
     auto tags = builder::stream::document{} << "blah"
                                             << "wow" << builder::stream::finalize;

--- a/src/mongocxx/test/result/delete.cpp
+++ b/src/mongocxx/test/result/delete.cpp
@@ -17,9 +17,12 @@
 
 #include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/json.hpp>
+#include <mongocxx/instance.hpp>
 #include <mongocxx/result/delete.hpp>
 
 TEST_CASE("delete", "[delete][result]") {
+    mongocxx::instance::current();
+
     bsoncxx::builder::stream::document build;
     build << "_id" << bsoncxx::oid{bsoncxx::oid::init_tag} << "nRemoved"
           << bsoncxx::types::b_int32{1};

--- a/src/mongocxx/test/result/insert_one.cpp
+++ b/src/mongocxx/test/result/insert_one.cpp
@@ -17,10 +17,14 @@
 
 #include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/types/value.hpp>
+#include <mongocxx/instance.hpp>
 #include <mongocxx/result/insert_one.hpp>
 
 TEST_CASE("insert_one", "[insert_one][result]") {
     using namespace bsoncxx;
+
+    mongocxx::instance::current();
+
     builder::stream::document build;
     auto oid = types::b_oid{bsoncxx::oid{bsoncxx::oid::init_tag}};
     build << "_id" << oid << "x" << 1;

--- a/src/mongocxx/test/result/replace_one.cpp
+++ b/src/mongocxx/test/result/replace_one.cpp
@@ -16,9 +16,12 @@
 #include "helpers.hpp"
 
 #include <bsoncxx/builder/stream/document.hpp>
+#include <mongocxx/instance.hpp>
 #include <mongocxx/result/replace_one.hpp>
 
 TEST_CASE("replace_one", "[replace_one][result]") {
+    mongocxx::instance::current();
+
     bsoncxx::builder::stream::document build;
     build << "_id" << bsoncxx::oid{bsoncxx::oid::init_tag} << "nMatched"
           << bsoncxx::types::b_int32{2} << "nModified" << bsoncxx::types::b_int32{1};

--- a/src/mongocxx/test/result/update.cpp
+++ b/src/mongocxx/test/result/update.cpp
@@ -16,9 +16,12 @@
 #include "helpers.hpp"
 
 #include <bsoncxx/builder/stream/document.hpp>
+#include <mongocxx/instance.hpp>
 #include <mongocxx/result/update.hpp>
 
 TEST_CASE("update", "[update][result]") {
+    mongocxx::instance::current();
+
     bsoncxx::builder::stream::document build;
     build << "_id" << bsoncxx::oid{bsoncxx::oid::init_tag} << "nMatched"
           << bsoncxx::types::b_int32{2} << "nModified" << bsoncxx::types::b_int32{1};

--- a/src/mongocxx/test/validation_criteria.cpp
+++ b/src/mongocxx/test/validation_criteria.cpp
@@ -16,6 +16,7 @@
 
 #include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/document/element.hpp>
+#include <mongocxx/instance.hpp>
 #include <mongocxx/validation_criteria.hpp>
 
 using namespace mongocxx;
@@ -26,6 +27,8 @@ using builder::stream::close_document;
 using builder::stream::finalize;
 
 TEST_CASE("validation_criteria", "[validation_criteria]") {
+    instance::current();
+
     validation_criteria criteria;
 
     auto doc = builder::stream::document{} << "email" << open_document << "$exists"

--- a/src/mongocxx/test/write_concern.cpp
+++ b/src/mongocxx/test/write_concern.cpp
@@ -15,11 +15,14 @@
 #include "catch.hpp"
 
 #include <mongocxx/exception/exception.hpp>
+#include <mongocxx/instance.hpp>
 #include <mongocxx/write_concern.hpp>
 
 using namespace mongocxx;
 
 TEST_CASE("a default write_concern", "[write_concern]") {
+    instance::current();
+
     write_concern wc{};
 
     SECTION("doesn't require the server to journal") {
@@ -48,6 +51,8 @@ TEST_CASE("a default write_concern", "[write_concern]") {
 }
 
 TEST_CASE("write_concern fields may be set and retrieved", "[write_concern]") {
+    instance::current();
+
     write_concern wc{};
 
     SECTION("journal may be configured") {
@@ -98,6 +103,8 @@ TEST_CASE("write_concern fields may be set and retrieved", "[write_concern]") {
 
 TEST_CASE("confirmation from tags, a repl-member count, and majority are mutually exclusive",
           "[write_concern]") {
+    instance::current();
+
     SECTION("setting the confirmation number unsets the confirmation tag") {
         write_concern wc{};
         wc.tag("MultipleDC");


### PR DESCRIPTION
- We can't assume that libmongoc has automatically called init/cleanup
  for us. It only does that on some platforms. That makes it mandatory
  to have an instance object. Many of our tests didn't do that, and it
  would be painful for users. Set things up so that an instance is
  implicitly created as needed, and provide ways to retrieve the
  instance. This required moving the tests for instance to its own
  process, among other nuisances.

- The collection::create_index method was not cleaning up the keys that
  had been allocated by libbson. Add the needed bson_free call.

- The collection::distinct method was not cleaning up the temorary
  database object that it constructs. Add the needed database_destroy
  call.

- Fix some mocks so that they write to the bson_error_t out parameter
  when returning a non-successful code, as otherwise these lead to
  read-from-uninit errors when we promote the uninitialized bson_error_t
  to an exception.