### PR TITLE
CXX-680: Clang-Format integration

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -114,6 +114,7 @@ tasks:
               script: |
                   set -e
                   PKG_CONFIG_PATH="/data/tmp/c-driver-install/lib/pkgconfig" ${cmake_path} ${cmake_flags} -DCMAKE_BUILD_TYPE=${build_type} -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_C_FLAGS="-Wall -Wextra -Wno-attributes -Werror -Wno-error=missing-field-initializers" ..
+                  make format-lint
                   make
                   ${test_params} ./src/bsoncxx/test/test_bson
                   ${test_params} ./src/mongocxx/test/test_driver

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,8 @@ before_script:
     - ${CMAKE_BINARY} -DCMAKE_BUILD_TYPE=$CONFIG -DCMAKE_C_FLAGS="-Wall -Wextra -Wno-attributes -Werror -Wno-error=missing-field-initializers" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wno-attributes -Werror -Wno-error=missing-field-initializers" ..
 
 script:
+    - make format-lint
+
     - make
 
     # Run bsoncxx tests with catch

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,20 +79,13 @@ add_custom_target(docs
     VERBATIM
 )
 
-add_custom_target(modernize
-    clang-modernize
-        -p ${CMAKE_BINARY_DIR}/compile_commands.json
-        -include ${CMAKE_CURRENT_SOURCE_DIR}
-        -exclude ${CMAKE_CURRENT_SOURCE_DIR}/mongocxx/test ${CMAKE_CURRENT_SOURCE_DIR}/bsoncxx/test
-        -format
+add_custom_target(format
+    python ${CMAKE_SOURCE_DIR}/etc/clang_format.py format
     VERBATIM
 )
 
-add_custom_target(format
-    perl -nle "/file/ or next; print ((split /: (.*)/)[1])" ${CMAKE_BINARY_DIR}/compile_commands.json |
-    grep -v "catch.hpp" |
-    grep -v "examples" |
-    xargs clang-format -i
+add_custom_target(format-lint
+    python ${CMAKE_SOURCE_DIR}/etc/clang_format.py lint
     VERBATIM
 )
 

--- a/etc/clang_format.py
+++ b/etc/clang_format.py
@@ -1,0 +1,769 @@
+#! /usr/bin/env python
+"""
+A script that provides:
+1. Ability to grab binaries where possible from LLVM.
+2. Ability to download binaries from MongoDB cache for clang-format.
+3. Validates clang-format is the right version.
+4. Has support for checking which files are to be checked.
+5. Supports validating and updating a set of files to the right coding style.
+"""
+from __future__ import print_function, absolute_import
+
+import Queue
+import difflib
+import glob as _glob
+import itertools
+import os
+import os.path
+import re
+import shutil
+import string
+import subprocess
+import sys
+import tarfile
+import tempfile
+import threading
+import time
+import urllib
+from distutils import spawn
+from optparse import OptionParser
+from multiprocessing import cpu_count
+
+
+##############################################################################
+#
+# Constants for clang-format
+#
+#
+
+# Expected version of clang-format
+CLANG_FORMAT_VERSION = "3.6.0"
+
+# Name of clang-format as a binary
+CLANG_FORMAT_PROGNAME = "clang-format"
+
+# URL location of the "cached" copy of clang-format to download
+# for users which do not have clang-format installed
+CLANG_FORMAT_HTTP_LINUX_CACHE = "https://s3.amazonaws.com/boxes.10gen.com/build/clang-format-rhel55.tar.gz"
+
+# URL on LLVM's website to download the clang tarball
+CLANG_FORMAT_SOURCE_URL_BASE = string.Template("http://llvm.org/releases/$version/clang+llvm-$version-$llvm_distro.tar.xz")
+
+# Path in the tarball to the clang-format binary
+CLANG_FORMAT_SOURCE_TAR_BASE = string.Template("clang+llvm-$version-$tar_path/bin/" + CLANG_FORMAT_PROGNAME)
+
+# Copied from python 2.7 version of subprocess.py
+# Exception classes used by this module.
+class CalledProcessError(Exception):
+    """This exception is raised when a process run by check_call() or
+    check_output() returns a non-zero exit status.
+    The exit status will be stored in the returncode attribute;
+    check_output() will also store the output in the output attribute.
+    """
+    def __init__(self, returncode, cmd, output=None):
+        self.returncode = returncode
+        self.cmd = cmd
+        self.output = output
+    def __str__(self):
+        return ("Command '%s' returned non-zero exit status %d with output %s" %
+            (self.cmd, self.returncode, self.output))
+
+
+# Copied from python 2.7 version of subprocess.py
+def check_output(*popenargs, **kwargs):
+    r"""Run command with arguments and return its output as a byte string.
+
+    If the exit code was non-zero it raises a CalledProcessError.  The
+    CalledProcessError object will have the return code in the returncode
+    attribute and output in the output attribute.
+
+    The arguments are the same as for the Popen constructor.  Example:
+
+    >>> check_output(["ls", "-l", "/dev/null"])
+    'crw-rw-rw- 1 root root 1, 3 Oct 18  2007 /dev/null\n'
+
+    The stdout argument is not allowed as it is used internally.
+    To capture standard error in the result, use stderr=STDOUT.
+
+    >>> check_output(["/bin/sh", "-c",
+    ...               "ls -l non_existent_file ; exit 0"],
+    ...              stderr=STDOUT)
+    'ls: non_existent_file: No such file or directory\n'
+    """
+    if 'stdout' in kwargs:
+        raise ValueError('stdout argument not allowed, it will be overridden.')
+    process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
+    output, unused_err = process.communicate()
+    retcode = process.poll()
+    if retcode:
+        cmd = kwargs.get("args")
+        if cmd is None:
+            cmd = popenargs[0]
+        raise CalledProcessError(retcode, cmd, output)
+    return output
+
+def callo(args):
+    """Call a program, and capture its output
+    """
+    return check_output(args)
+
+# From https://github.com/mongodb/mongo/blob/master/buildscripts/resmokelib/utils/globstar.py
+_GLOBSTAR = "**"
+
+def iglob(globbed_pathname):
+    """
+    Emit a list of pathnames matching the 'globbed_pathname' pattern.
+
+    In addition to containing simple shell-style wildcards a la fnmatch,
+    the pattern may also contain globstars ("**"), which is recursively
+    expanded to match zero or more subdirectories.
+    """
+
+    parts = _split_path(globbed_pathname)
+    parts = _canonicalize(parts)
+
+    index = _find_globstar(parts)
+    if index == -1:
+        for pathname in _glob.iglob(globbed_pathname):
+            # Normalize 'pathname' so exact string comparison can be used later.
+            yield os.path.normpath(pathname)
+        return
+
+    # **, **/, or **/a
+    if index == 0:
+        expand = _expand_curdir
+
+    # a/** or a/**/ or a/**/b
+    else:
+        expand = _expand
+
+    prefix_parts = parts[:index]
+    suffix_parts = parts[index + 1:]
+
+    prefix = os.path.join(*prefix_parts) if prefix_parts else os.curdir
+    suffix = os.path.join(*suffix_parts) if suffix_parts else ""
+
+    for (kind, path) in expand(prefix):
+        if not suffix_parts:
+            yield path
+
+        # Avoid following symlinks to avoid an infinite loop
+        elif suffix_parts and kind == "dir" and not os.path.islink(path):
+            path = os.path.join(path, suffix)
+            for pathname in iglob(path):
+                yield pathname
+
+
+def _split_path(pathname):
+    """
+    Return 'pathname' as a list of path components.
+    """
+
+    parts = []
+
+    while True:
+        (dirname, basename) = os.path.split(pathname)
+        parts.append(basename)
+        if pathname == dirname:
+            parts.append(dirname)
+            break
+        if not dirname:
+            break
+        pathname = dirname
+
+    parts.reverse()
+    return parts
+
+
+def _canonicalize(parts):
+    """
+    Return a copy of 'parts' with consecutive "**"s coalesced.
+    Raise a ValueError for unsupported uses of "**".
+    """
+
+    res = []
+
+    prev_was_globstar = False
+    for p in parts:
+        if p == _GLOBSTAR:
+            # Skip consecutive **'s
+            if not prev_was_globstar:
+                prev_was_globstar = True
+                res.append(p)
+        elif _GLOBSTAR in p:  # a/b**/c or a/**b/c
+            raise ValueError("Can only specify glob patterns of the form a/**/b")
+        else:
+            prev_was_globstar = False
+            res.append(p)
+
+    return res
+
+
+def _find_globstar(parts):
+    """
+    Return the index of the first occurrence of "**" in 'parts'.
+    Return -1 if "**" is not found in the list.
+    """
+
+    for (i, p) in enumerate(parts):
+        if p == _GLOBSTAR:
+            return i
+    return -1
+
+
+def _list_dir(pathname):
+    """
+    Return a pair of the subdirectory names and filenames immediately
+    contained within the 'pathname' directory.
+
+    If 'pathname' does not exist, then None is returned.
+    """
+
+    try:
+        (_root, dirs, files) = os.walk(pathname).next()
+        return (dirs, files)
+    except StopIteration:
+        return None  # 'pathname' directory does not exist
+
+
+def _expand(pathname):
+    """
+    Emit tuples of the form ("dir", dirname) and ("file", filename)
+    of all directories and files contained within the 'pathname' directory.
+    """
+
+    res = _list_dir(pathname)
+    if res is None:
+        return
+
+    (dirs, files) = res
+
+    # Zero expansion
+    if os.path.basename(pathname):
+        yield ("dir", os.path.join(pathname, ""))
+
+    for f in files:
+        path = os.path.join(pathname, f)
+        yield ("file", path)
+
+    for d in dirs:
+        path = os.path.join(pathname, d)
+        for x in _expand(path):
+            yield x
+
+
+def _expand_curdir(pathname):
+    """
+    Emit tuples of the form ("dir", dirname) and ("file", filename)
+    of all directories and files contained within the 'pathname' directory.
+
+    The returned pathnames omit a "./" prefix.
+    """
+
+    res = _list_dir(pathname)
+    if res is None:
+        return
+
+    (dirs, files) = res
+
+    # Zero expansion
+    yield ("dir", "")
+
+    for f in files:
+        yield ("file", f)
+
+    for d in dirs:
+        for x in _expand(d):
+            yield x
+
+def get_llvm_url(version, llvm_distro):
+    """Get the url to download clang-format from llvm.org
+    """
+    return CLANG_FORMAT_SOURCE_URL_BASE.substitute(
+        version=version,
+        llvm_distro=llvm_distro)
+
+def get_tar_path(version, tar_path):
+    """ Get the path to clang-format in the llvm tarball
+    """
+    return CLANG_FORMAT_SOURCE_TAR_BASE.substitute(
+        version=version,
+        tar_path=tar_path)
+
+def extract_clang_format(tar_path):
+    # Extract just the clang-format binary
+    # On OSX, we shell out to tar because tarfile doesn't support xz compression
+    if sys.platform == 'darwin':
+         subprocess.call(['tar', '-xzf', tar_path, '*clang-format*'])
+    # Otherwise we use tarfile because some versions of tar don't support wildcards without
+    # a special flag
+    else:
+        tarfp = tarfile.open(tar_path)
+        for name in tarfp.getnames():
+            if name.endswith('clang-format'):
+                tarfp.extract(name)
+        tarfp.close()
+
+def get_clang_format_from_llvm(llvm_distro, tar_path, dest_file):
+    """Download clang-format from llvm.org, unpack the tarball,
+    and put clang-format in the specified place
+    """
+    # Build URL
+    url = get_llvm_url(CLANG_FORMAT_VERSION, llvm_distro)
+
+    dest_dir = tempfile.gettempdir()
+    temp_tar_file = os.path.join(dest_dir, "temp.tar.xz")
+
+    # Download from LLVM
+    print("Downloading clang-format %s from %s, saving to %s" % (CLANG_FORMAT_VERSION,
+            url, temp_tar_file))
+    urllib.urlretrieve(url, temp_tar_file)
+
+    extract_clang_format(temp_tar_file)
+
+    # Destination Path
+    shutil.move(get_tar_path(CLANG_FORMAT_VERSION, tar_path), dest_file)
+
+def get_clang_format_from_linux_cache(dest_file):
+    """Get clang-format from mongodb's cache
+    """
+    # Get URL
+    url = CLANG_FORMAT_HTTP_LINUX_CACHE
+
+    dest_dir = tempfile.gettempdir()
+    temp_tar_file = os.path.join(dest_dir, "temp.tar.xz")
+
+    # Download the file
+    print("Downloading clang-format %s from %s, saving to %s" % (CLANG_FORMAT_VERSION,
+            url, temp_tar_file))
+    urllib.urlretrieve(url, temp_tar_file)
+
+    extract_clang_format(temp_tar_file)
+
+    # Destination Path
+    shutil.move("llvm/Release/bin/clang-format", dest_file)
+
+
+class ClangFormat(object):
+    """Class encapsulates finding a suitable copy of clang-format,
+    and linting/formating an individual file
+    """
+    def __init__(self, path, cache_dir):
+        if os.path.exists('/usr/bin/clang-format-3.6'):
+            clang_format_progname = 'clang-format-3.6'
+        else:
+            clang_format_progname = CLANG_FORMAT_PROGNAME
+
+        # Initialize clang-format configuration information
+        if sys.platform.startswith("linux"):
+              #"3.6.0/clang+llvm-3.6.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+            self.platform = "linux_x64"
+            self.llvm_distro = "x86_64-linux-gnu-ubuntu"
+            self.tar_path = "x86_64-linux-gnu"
+        elif sys.platform == "win32":
+            self.platform = "windows_x64"
+            self.llvm_distro = "windows_x64"
+            self.tar_path = None
+            clang_format_progname += ".exe"
+        elif sys.platform == "darwin":
+             #"3.6.0/clang+llvm-3.6.0-x86_64-apple-darwin.tar.xz
+            self.platform = "darwin_x64"
+            self.llvm_distro = "x86_64-apple-darwin"
+            self.tar_path = "x86_64-apple-darwin"
+
+        self.path = None
+
+        # Find Clang-Format now
+        if path is not None:
+            if os.path.isfile(path):
+                self.path = path
+            else:
+                print("WARNING: Could not find clang-format %s" % (path))
+
+        # Check the envionrment variable
+        if "MONGO_CLANG_FORMAT" in os.environ:
+            self.path = os.environ["MONGO_CLANG_FORMAT"]
+
+            if self.path and not self._validate_version(warn=True):
+                self.path = None
+
+        # Check the users' PATH environment variable now
+        if self.path is None:
+            self.path = spawn.find_executable(clang_format_progname)
+
+            if self.path and not self._validate_version(warn=True):
+                self.path = None
+
+        # If Windows, try to grab it from Program Files
+        if sys.platform == "win32":
+            win32bin = os.path.join(os.environ["ProgramFiles(x86)"], "LLVM\\bin\\clang-format.exe")
+            if os.path.exists(win32bin):
+                self.path = win32bin
+
+        # Have not found it yet, download it from the web
+        if self.path is None:
+            if not os.path.isdir(cache_dir):
+                os.makedirs(cache_dir)
+
+            self.path = os.path.join(cache_dir, clang_format_progname)
+
+            if not os.path.isfile(self.path):
+                if sys.platform.startswith("linux"):
+                    get_clang_format_from_linux_cache(self.path)
+                elif sys.platform == "darwin":
+                    get_clang_format_from_llvm(self.llvm_distro, self.tar_path, self.path)
+                else:
+                    print("ERROR: clang-format.py does not support downloading clang-format " +
+                        " on this platform, please install clang-format " + CLANG_FORMAT_VERSION)
+
+        # Validate we have the correct version
+        self._validate_version()
+
+        self.print_lock = threading.Lock()
+
+    def _validate_version(self, warn=False):
+        """Validate clang-format is the expected version
+        """
+        try:
+            cf_version = callo([self.path, "--version"])
+        except CalledProcessError:
+            cf_version = "clang-format call failed."
+
+        if warn:
+            print("WARNING: clang-format found in path, but incorrect version found at " +
+                    self.path + " with version: " + cf_version)
+
+        return False
+
+    def _lint(self, file_name, print_diff):
+        """Check the specified file has the correct format
+        """
+        with open(file_name, 'rb') as original_text:
+            original_file = original_text.read()
+
+        # Get formatted file as clang-format would format the file
+        formatted_file = callo([self.path, "--style=file", file_name])
+
+        if original_file != formatted_file:
+            if print_diff:
+                original_lines = original_file.splitlines()
+                formatted_lines = formatted_file.splitlines()
+                result = difflib.unified_diff(original_lines, formatted_lines)
+
+                # Take a lock to ensure diffs do not get mixed when printed to the screen
+                with self.print_lock:
+                    print("ERROR: Found diff for " + file_name)
+                    print("To fix formatting errors, run %s --style=file -i %s" %
+                            (self.path, file_name))
+                    for line in result:
+                        print(line.rstrip())
+
+            return False
+
+        return True
+
+    def lint(self, file_name):
+        """Check the specified file has the correct format
+        """
+        return self._lint(file_name, print_diff=True)
+
+    def format(self, file_name):
+        """Update the format of the specified file
+        """
+        if self._lint(file_name, print_diff=False):
+            return True
+
+        # Update the file with clang-format
+        return not subprocess.call([self.path, "--style=file", "-i", file_name])
+
+
+def parallel_process(items, func):
+    """Run a set of work items to completion
+    """
+    try:
+        cpus = cpu_count()
+    except NotImplementedError:
+        cpus = 1
+
+    task_queue = Queue.Queue()
+
+    # Use a list so that worker function will capture this variable
+    pp_event = threading.Event()
+    pp_result = [True]
+    pp_lock = threading.Lock()
+
+    def worker():
+        """Worker thread to process work items in parallel
+        """
+        while not pp_event.is_set():
+            try:
+                item = task_queue.get_nowait()
+            except Queue.Empty:
+                # if the queue is empty, exit the worker thread
+                pp_event.set()
+                return
+
+            try:
+                ret = func(item)
+            finally:
+                # Tell the queue we finished with the item
+                task_queue.task_done()
+
+            # Return early if we fail, and signal we are done
+            if not ret:
+                with pp_lock:
+                    pp_result[0] = False
+
+                pp_event.set()
+                return
+
+    # Enqueue all the work we want to process
+    for item in items:
+        task_queue.put(item)
+
+    # Process all the work
+    threads = []
+    for cpu in range(cpus):
+        thread = threading.Thread(target=worker)
+
+        thread.daemon = True
+        thread.start()
+        threads.append(thread)
+
+    # Wait for the threads to finish
+    # Loop with a timeout so that we can process Ctrl-C interrupts
+    # Note: On Python 2.6 wait always returns None so we check is_set also,
+    #  This works because we only set the event once, and never reset it
+    while not pp_event.wait(1) and not pp_event.is_set():
+        time.sleep(1)
+
+    for thread in threads:
+        thread.join()
+
+    return pp_result[0]
+
+def get_base_dir():
+    """Get the base directory for mongo repo.
+        This script assumes that it is running in buildscripts/, and uses
+        that to find the base directory.
+    """
+    try:
+        return subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).rstrip()
+    except:
+        # We are not in a valid git directory. Use the script path instead.
+        return os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+
+def get_repos():
+    """Get a list of Repos to check clang-format for
+    """
+    base_dir = get_base_dir()
+
+    paths = [base_dir]
+
+    return [Repo(p) for p in paths]
+
+
+class Repo(object):
+    """Class encapsulates all knowledge about a git repository, and its metadata
+        to run clang-format.
+    """
+    def __init__(self, path):
+        self.path = path
+
+       # Get candidate files
+        self.candidate_files = self._get_candidate_files()
+
+        self.root = self._get_root()
+
+    def _callgito(self, args):
+        """Call git for this repository
+        """
+        # These two flags are the equivalent of -C in newer versions of Git
+        # but we use these to support versions back to ~1.8
+        return callo(['git', '--git-dir', os.path.join(self.path, ".git"),
+                        '--work-tree', self.path] + args)
+
+    def _get_local_dir(self, path):
+        """Get a directory path relative to the git root directory
+        """
+        if os.path.isabs(path):
+            return os.path.relpath(path, self.root)
+        return path
+
+    def get_candidates(self, candidates):
+        """Get the set of candidate files to check by doing an intersection
+        between the input list, and the list of candidates in the repository
+
+        Returns the full path to the file for clang-format to consume.
+        """
+        # NOTE: Files may have an absolute root (i.e. leading /)
+
+        if candidates is not None and len(candidates) > 0:
+            candidates = [self._get_local_dir(f) for f in candidates]
+            valid_files = list(set(candidates).intersection(self.get_candidate_files()))
+        else:
+            valid_files = list(self.get_candidate_files())
+
+        # Get the full file name here
+        valid_files = [os.path.normpath(os.path.join(self.root, f)) for f in valid_files]
+        return valid_files
+
+    def get_root(self):
+        """Get the root directory for this repository
+        """
+        return self.root
+
+    def _get_root(self):
+        """Gets the root directory for this repository from git
+        """
+        gito = self._callgito(['rev-parse', '--show-toplevel'])
+
+        return gito.rstrip()
+
+    def get_candidate_files(self):
+        """Get a list of candidate files
+        """
+        return self._get_candidate_files()
+
+    def _get_candidate_files(self):
+        """Query git to get a list of all files in the repo to consider for analysis
+        """
+        gito = self._callgito(["ls-files"])
+
+        # This allows us to pick all the interesting files
+        # in the mongo and mongo-enterprise repos
+        file_list = [line.rstrip()
+                for line in gito.splitlines() if "src" in line and
+                    not "examples" in line and
+                    not "third_party" in line]
+
+        files_match = re.compile('\\.(h|hpp|cpp)$')
+
+        file_list = [a for a in file_list if files_match.search(a)]
+
+        return file_list
+
+
+def expand_file_string(glob_pattern):
+    """Expand a string that represents a set of files
+    """
+    return [os.path.abspath(f) for f in iglob(glob_pattern)]
+
+def get_files_to_check(files):
+    """Filter the specified list of files to check down to the actual
+        list of files that need to be checked."""
+    candidates = []
+
+    # Get a list of candidate_files
+    candidates = [expand_file_string(f) for f in files]
+    candidates = list(itertools.chain.from_iterable(candidates))
+
+    repos = get_repos()
+
+    valid_files = list(itertools.chain.from_iterable([r.get_candidates(candidates) for r in repos]))
+
+    return valid_files
+
+def get_files_to_check_from_patch(patches):
+    """Take a patch file generated by git diff, and scan the patch for a list of files to check.
+    """
+    candidates = []
+
+    # Get a list of candidate_files
+    check = re.compile(r"^diff --git a\/([a-z\/\.\-_0-9]+) b\/[a-z\/\.\-_0-9]+")
+
+    lines = []
+    for patch in patches:
+        with open(patch, "rb") as infile:
+            lines += infile.readlines()
+
+    candidates = [check.match(line).group(1) for line in lines if check.match(line)]
+
+    repos = get_repos()
+
+    valid_files = list(itertools.chain.from_iterable([r.get_candidates(candidates) for r in repos]))
+
+    return valid_files
+
+def _get_build_dir():
+    """Get the location of the scons' build directory in case we need to download clang-format
+    """
+    return os.path.join(get_base_dir(), "build")
+
+def _lint_files(clang_format, files):
+    """Lint a list of files with clang-format
+    """
+    clang_format = ClangFormat(clang_format, _get_build_dir())
+
+    lint_clean = parallel_process([os.path.abspath(f) for f in files], clang_format.lint)
+
+    if not lint_clean:
+        print("ERROR: Code Style does not match coding style")
+        sys.exit(1)
+
+def lint_patch(clang_format, infile):
+    """Lint patch command entry point
+    """
+    files = get_files_to_check_from_patch(infile)
+
+    # Patch may have files that we do not want to check which is fine
+    if files:
+        _lint_files(clang_format, files)
+
+def lint(clang_format, glob):
+    """Lint files command entry point
+    """
+    files = get_files_to_check(glob)
+
+    _lint_files(clang_format, files)
+
+    return True
+
+def _format_files(clang_format, files):
+    """Format a list of files with clang-format
+    """
+    clang_format = ClangFormat(clang_format, _get_build_dir())
+
+    format_clean = parallel_process([os.path.abspath(f) for f in files], clang_format.format)
+
+    if not format_clean:
+        print("ERROR: failed to format files")
+        sys.exit(1)
+
+def format_func(clang_format, glob):
+    """Format files command entry point
+    """
+    files = get_files_to_check(glob)
+
+    _format_files(clang_format, files)
+
+def usage():
+    """Print usage
+    """
+    print("clang-format.py supports 3 commands [ lint, lint-patch, format ]. Run "
+            " <command> -? for more information")
+
+def main():
+    """Main entry point
+    """
+    parser = OptionParser()
+    parser.add_option("-c", "--clang-format", type="string", dest="clang_format")
+
+    (options, args) = parser.parse_args(args=sys.argv)
+
+    if len(args) > 1:
+        command = args[1]
+
+        if command == "lint":
+            lint(options.clang_format, args[2:])
+        elif command == "lint-patch":
+            lint_patch(options.clang_format, args[2:])
+        elif command == "format":
+            format_func(options.clang_format, args[2:])
+        else:
+            usage()
+    else:
+        usage()
+
+if __name__ == "__main__":
+    main()

--- a/src/bsoncxx/array/value.hpp
+++ b/src/bsoncxx/array/value.hpp
@@ -32,9 +32,8 @@ namespace array {
 /// sparingly; array::view should be used instead wherever possible.
 ///
 class BSONCXX_API value {
-
    public:
-    using deleter_type = void(*)(std::uint8_t*);
+    using deleter_type = void (*)(std::uint8_t*);
     using unique_ptr_type = std::unique_ptr<uint8_t, deleter_type>;
 
     ///

--- a/src/bsoncxx/array/view.hpp
+++ b/src/bsoncxx/array/view.hpp
@@ -148,8 +148,9 @@ class BSONCXX_API view::iterator : public std::iterator<std::forward_iterator_ta
     element _element;
 };
 
-class BSONCXX_API view::const_iterator : public std::iterator<std::forward_iterator_tag, element,
-                                                  std::ptrdiff_t, const element*, const element&> {
+class BSONCXX_API view::const_iterator
+    : public std::iterator<std::forward_iterator_tag, element, std::ptrdiff_t, const element*,
+                           const element&> {
    public:
     const_iterator();
     explicit const_iterator(const element& element);

--- a/src/bsoncxx/builder/basic/impl.hpp
+++ b/src/bsoncxx/builder/basic/impl.hpp
@@ -33,16 +33,16 @@ template <typename T>
 using takes_array = typename util::is_functor<T, void(sub_array)>;
 
 template <typename T>
-BSONCXX_INLINE
-typename std::enable_if<takes_document<T>::value, void>::type generic_append(core* core, T&& func) {
+BSONCXX_INLINE typename std::enable_if<takes_document<T>::value, void>::type generic_append(
+    core* core, T&& func) {
     core->open_document();
     func(sub_document(core));
     core->close_document();
 }
 
 template <typename T>
-BSONCXX_INLINE
-typename std::enable_if<takes_array<T>::value, void>::type generic_append(core* core, T&& func) {
+BSONCXX_INLINE typename std::enable_if<takes_array<T>::value, void>::type generic_append(core* core,
+                                                                                         T&& func) {
     core->open_array();
     func(sub_array(core));
     core->close_array();
@@ -50,14 +50,13 @@ typename std::enable_if<takes_array<T>::value, void>::type generic_append(core* 
 
 template <typename T>
 BSONCXX_INLINE
-typename std::enable_if<!takes_document<T>::value && !takes_array<T>::value, void>::type
-generic_append(core* core, T&& t) {
+    typename std::enable_if<!takes_document<T>::value && !takes_array<T>::value, void>::type
+    generic_append(core* core, T&& t) {
     core->append(std::forward<T>(t));
 }
 
 template <typename T>
-BSONCXX_INLINE
-void value_append(core* core, T&& t) {
+BSONCXX_INLINE void value_append(core* core, T&& t) {
     generic_append(core, std::forward<T>(t));
 }
 

--- a/src/bsoncxx/builder/basic/kvp.hpp
+++ b/src/bsoncxx/builder/basic/kvp.hpp
@@ -28,9 +28,8 @@ namespace basic {
 /// and a BSON value.
 ///
 template <typename T, typename U>
-BSONCXX_INLINE
-std::tuple<T&&, U&&> kvp(T&& t, U&& u) {
-    return std::tuple < T &&, U && > (std::forward<T>(t), std::forward<U>(u));
+BSONCXX_INLINE std::tuple<T&&, U&&> kvp(T&& t, U&& u) {
+    return std::tuple<T&&, U&&>(std::forward<T>(t), std::forward<U>(u));
 }
 
 }  // namespace basic

--- a/src/bsoncxx/builder/core.hpp
+++ b/src/bsoncxx/builder/core.hpp
@@ -40,7 +40,6 @@ namespace builder {
 ///   who wish to write their own abstractions may find this class useful.
 ///
 class BSONCXX_API core {
-
    public:
     class BSONCXX_PRIVATE impl;
 
@@ -230,8 +229,7 @@ class BSONCXX_API core {
     /// conversion to bool.
     ///
     template <typename T>
-    BSONCXX_INLINE
-    void append(T* v) {
+    BSONCXX_INLINE void append(T* v) {
         static_assert(std::is_same<typename std::remove_const<T>::type, char>::value,
                       "append is disabled for non-char pointer types");
         append(types::b_utf8{v});

--- a/src/bsoncxx/builder/stream/array.hpp
+++ b/src/bsoncxx/builder/stream/array.hpp
@@ -29,48 +29,49 @@ BSONCXX_INLINE_NAMESPACE_BEGIN
 namespace builder {
 namespace stream {
 
+///
+/// A streaming interface for constructing
+/// a BSON array.
+///
+class array : public array_context<> {
+   public:
+    BSONCXX_INLINE array() : array_context<>(&_core), _core(true) {
+    }
+
     ///
-    /// A streaming interface for constructing
-    /// a BSON array.
+    /// @return A view of the BSON array.
     ///
-    class array : public array_context<> {
-    public:
-        BSONCXX_INLINE array() : array_context<>(&_core), _core(true) {}
+    BSONCXX_INLINE bsoncxx::array::view view() const {
+        return _core.view_array();
+    }
 
-        ///
-        /// @return A view of the BSON array.
-        ///
-        BSONCXX_INLINE bsoncxx::array::view view() const {
-            return _core.view_array();
-        }
+    BSONCXX_INLINE operator bsoncxx::array::view() const {
+        return view();
+    }
 
-        BSONCXX_INLINE operator bsoncxx::array::view() const {
-            return view();
-        }
+    ///
+    /// Transfer ownership of the underlying array to the caller.
+    ///
+    /// @return An array::value with ownership of the array.
+    ///
+    /// @warning
+    ///  After calling extract() it is illegal to call any methods
+    ///  on this class, unless it is subsequenly moved into.
+    ///
+    BSONCXX_INLINE bsoncxx::array::value extract() {
+        return _core.extract_array();
+    }
 
-        ///
-        /// Transfer ownership of the underlying array to the caller.
-        ///
-        /// @return An array::value with ownership of the array.
-        ///
-        /// @warning
-        ///  After calling extract() it is illegal to call any methods
-        ///  on this class, unless it is subsequenly moved into.
-        ///
-        BSONCXX_INLINE bsoncxx::array::value extract() {
-            return _core.extract_array();
-        }
+    ///
+    /// Reset the underlying BSON to an empty array.
+    ///
+    BSONCXX_INLINE void clear() {
+        _core.clear();
+    }
 
-        ///
-        /// Reset the underlying BSON to an empty array.
-        ///
-        BSONCXX_INLINE void clear() {
-            _core.clear();
-        }
-
-    private:
-        core _core;
-    };
+   private:
+    core _core;
+};
 
 }  // namespace stream
 }  // namespace builder

--- a/src/bsoncxx/builder/stream/closed_context.hpp
+++ b/src/bsoncxx/builder/stream/closed_context.hpp
@@ -24,12 +24,13 @@ class core;
 
 namespace stream {
 
-    ///
-    /// An internal struct of builder::stream. Users should not use this directly.
-    ///
-    struct closed_context {
-        closed_context(core*) {}
-    };
+///
+/// An internal struct of builder::stream. Users should not use this directly.
+///
+struct closed_context {
+    closed_context(core*) {
+    }
+};
 
 }  // namespace stream
 }  // namespace builder

--- a/src/bsoncxx/builder/stream/document.hpp
+++ b/src/bsoncxx/builder/stream/document.hpp
@@ -27,48 +27,49 @@ BSONCXX_INLINE_NAMESPACE_BEGIN
 namespace builder {
 namespace stream {
 
+///
+/// A streaming interface for constructing
+/// a BSON document.
+///
+class document : public key_context<> {
+   public:
+    BSONCXX_INLINE document() : key_context<>(&_core), _core(false) {
+    }
+
     ///
-    /// A streaming interface for constructing
-    /// a BSON document.
+    /// @return A view of the BSON document.
     ///
-    class document : public key_context<> {
-    public:
-        BSONCXX_INLINE document() : key_context<>(&_core), _core(false) {}
+    BSONCXX_INLINE bsoncxx::document::view view() const {
+        return _core.view_document();
+    }
 
-        ///
-        /// @return A view of the BSON document.
-        ///
-        BSONCXX_INLINE bsoncxx::document::view view() const {
-            return _core.view_document();
-        }
+    BSONCXX_INLINE operator bsoncxx::document::view() const {
+        return view();
+    }
 
-        BSONCXX_INLINE operator bsoncxx::document::view() const {
-            return view();
-        }
+    ///
+    /// Transfer ownership of the underlying document to the caller.
+    ///
+    /// @return A document::value with ownership of the document.
+    ///
+    /// @warning
+    ///  After calling extract() it is illegal to call any methods
+    ///  on this class, unless it is subsequenly moved into.
+    ///
+    BSONCXX_INLINE bsoncxx::document::value extract() {
+        return _core.extract_document();
+    }
 
-        ///
-        /// Transfer ownership of the underlying document to the caller.
-        ///
-        /// @return A document::value with ownership of the document.
-        ///
-        /// @warning
-        ///  After calling extract() it is illegal to call any methods
-        ///  on this class, unless it is subsequenly moved into.
-        ///
-        BSONCXX_INLINE bsoncxx::document::value extract() {
-            return _core.extract_document();
-        }
+    ///
+    /// Reset the underlying BSON to an empty document.
+    ///
+    BSONCXX_INLINE void clear() {
+        _core.clear();
+    }
 
-        ///
-        /// Reset the underlying BSON to an empty document.
-        ///
-        BSONCXX_INLINE void clear() {
-            _core.clear();
-        }
-
-    private:
-        core _core;
-    };
+   private:
+    core _core;
+};
 
 }  // namespace stream
 }  // namespace builder

--- a/src/bsoncxx/builder/stream/single_context.hpp
+++ b/src/bsoncxx/builder/stream/single_context.hpp
@@ -28,10 +28,15 @@ namespace stream {
 
 class single_context {
    public:
-    BSONCXX_INLINE single_context(core* core) : _core(core) {}
+    BSONCXX_INLINE single_context(core* core) : _core(core) {
+    }
 
-    BSONCXX_INLINE array_context<single_context> wrap_array() { return array_context<single_context>(_core); }
-    BSONCXX_INLINE key_context<single_context> wrap_document() { return key_context<single_context>(_core); }
+    BSONCXX_INLINE array_context<single_context> wrap_array() {
+        return array_context<single_context>(_core);
+    }
+    BSONCXX_INLINE key_context<single_context> wrap_document() {
+        return key_context<single_context>(_core);
+    }
 
     BSONCXX_INLINE key_context<single_context> operator<<(open_document_type) {
         _core->open_document();
@@ -46,8 +51,7 @@ class single_context {
     }
 
     template <class T>
-    BSONCXX_INLINE
-    void operator<<(T&& t) {
+    BSONCXX_INLINE void operator<<(T&& t) {
         _core->append(std::forward<T>(t));
     }
 
@@ -56,14 +60,12 @@ class single_context {
 };
 
 template <class T>
-BSONCXX_INLINE
-array_context<T>::operator single_context() {
+BSONCXX_INLINE array_context<T>::operator single_context() {
     return single_context(_core);
 }
 
 template <class T>
-BSONCXX_INLINE
-value_context<T>::operator single_context() {
+BSONCXX_INLINE value_context<T>::operator single_context() {
     return single_context(_core);
 }
 

--- a/src/bsoncxx/builder/stream/value_context.hpp
+++ b/src/bsoncxx/builder/stream/value_context.hpp
@@ -30,20 +30,21 @@ namespace stream {
 template <class base>
 class value_context {
    public:
-    BSONCXX_INLINE value_context(core* core) : _core(core) {}
+    BSONCXX_INLINE value_context(core* core) : _core(core) {
+    }
 
     template <class T>
     BSONCXX_INLINE
-    typename std::enable_if<!util::is_functor<T, void(single_context)>::value, base>::type operator<<(
-        T&& t) {
+        typename std::enable_if<!util::is_functor<T, void(single_context)>::value, base>::type
+        operator<<(T&& t) {
         _core->append(std::forward<T>(t));
         return unwrap();
     }
 
     template <typename T>
     BSONCXX_INLINE
-    typename std::enable_if<util::is_functor<T, void(single_context)>::value, base>::type operator<<(
-        T&& func) {
+        typename std::enable_if<util::is_functor<T, void(single_context)>::value, base>::type
+        operator<<(T&& func) {
         func(*this);
         return unwrap();
     }
@@ -62,14 +63,21 @@ class value_context {
 
 #if !defined(_MSC_VER)
     // TODO(MSVC): Causes an ICE under VS2015U1
-    static_assert(std::is_same<value_context, decltype(std::declval<value_context>() << 1 << "str")>::value,
-                  "value_context must be templatized on a key_context");
+    static_assert(
+        std::is_same<value_context, decltype(std::declval<value_context>() << 1 << "str")>::value,
+        "value_context must be templatized on a key_context");
 #endif
 
    private:
-    BSONCXX_INLINE base unwrap() { return base(_core); }
-    BSONCXX_INLINE array_context<base> wrap_array() { return array_context<base>(_core); }
-    BSONCXX_INLINE key_context<base> wrap_document() { return key_context<base>(_core); }
+    BSONCXX_INLINE base unwrap() {
+        return base(_core);
+    }
+    BSONCXX_INLINE array_context<base> wrap_array() {
+        return array_context<base>(_core);
+    }
+    BSONCXX_INLINE key_context<base> wrap_document() {
+        return key_context<base>(_core);
+    }
 
     core* _core;
 };

--- a/src/bsoncxx/config/compiler.hpp
+++ b/src/bsoncxx/config/compiler.hpp
@@ -17,7 +17,7 @@
 // Disable MSVC warnings that cause a lot of noise related to DLL visibility
 // for types that we don't control (like std::unique_ptr).
 #pragma warning(push)
-#pragma warning(disable: 4251 4275)
+#pragma warning(disable : 4251 4275)
 
 #define BSONCXX_INLINE inline __forceinline BSONCXX_PRIVATE
 

--- a/src/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/document/value.hpp
@@ -31,9 +31,8 @@ namespace document {
 /// sparingly; document::view should be used instead wherever possible.
 ///
 class BSONCXX_API value {
-
    public:
-    using deleter_type = void(*)(std::uint8_t*);
+    using deleter_type = void (*)(std::uint8_t*);
     using unique_ptr_type = std::unique_ptr<uint8_t, deleter_type>;
 
     ///
@@ -98,7 +97,6 @@ class BSONCXX_API value {
    private:
     unique_ptr_type _data;
     std::size_t _length;
-
 };
 
 BSONCXX_INLINE document::view value::view() const noexcept {

--- a/src/bsoncxx/document/view.hpp
+++ b/src/bsoncxx/document/view.hpp
@@ -31,7 +31,6 @@ namespace document {
 /// A read-only, non-owning view of a BSON document.
 ///
 class BSONCXX_API view {
-
    public:
     class BSONCXX_API iterator;
     class BSONCXX_API const_iterator;
@@ -153,8 +152,9 @@ class BSONCXX_API view::iterator : public std::iterator<std::forward_iterator_ta
     element _element;
 };
 
-class BSONCXX_API view::const_iterator : public std::iterator<std::forward_iterator_tag, element, std::ptrdiff_t,
-                                                  const element*, const element&> {
+class BSONCXX_API view::const_iterator
+    : public std::iterator<std::forward_iterator_tag, element, std::ptrdiff_t, const element*,
+                           const element&> {
    public:
     const_iterator();
     explicit const_iterator(const element& element);

--- a/src/bsoncxx/private/b64_ntop.h
+++ b/src/bsoncxx/private/b64_ntop.h
@@ -51,10 +51,10 @@ namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
 namespace b64 {
 
-#define BSONCXX_B64_ASSERT(Cond) if (!(Cond)) std::abort ()
+#define BSONCXX_B64_ASSERT(Cond) \
+    if (!(Cond)) std::abort()
 
-const char Base64[] =
-   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+const char Base64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 const char Pad64 = '=';
 
 /* (From RFC1521 and draft-ietf-dnssec-secext-03.txt)
@@ -119,75 +119,71 @@ const char Pad64 = '=';
  *    characters followed by one "=" padding character.
  */
 
-BSONCXX_INLINE int
-ntop (std::uint8_t const *src,
-      std::size_t         srclength,
-      char          *target,
-      std::size_t         targsize)
-{
-   std::size_t datalength = 0;
-   std::uint8_t input[3];
-   std::uint8_t output[4];
-   std::size_t i;
+BSONCXX_INLINE int ntop(std::uint8_t const *src, std::size_t srclength, char *target,
+                        std::size_t targsize) {
+    std::size_t datalength = 0;
+    std::uint8_t input[3];
+    std::uint8_t output[4];
+    std::size_t i;
 
-   while (2 < srclength) {
-      input[0] = *src++;
-      input[1] = *src++;
-      input[2] = *src++;
-      srclength -= 3;
+    while (2 < srclength) {
+        input[0] = *src++;
+        input[1] = *src++;
+        input[2] = *src++;
+        srclength -= 3;
 
-      output[0] = input[0] >> 2;
-      output[1] = ((input[0] & 0x03) << 4) + (input[1] >> 4);
-      output[2] = ((input[1] & 0x0f) << 2) + (input[2] >> 6);
-      output[3] = input[2] & 0x3f;
-      BSONCXX_B64_ASSERT (output[0] < 64);
-      BSONCXX_B64_ASSERT (output[1] < 64);
-      BSONCXX_B64_ASSERT (output[2] < 64);
-      BSONCXX_B64_ASSERT (output[3] < 64);
+        output[0] = input[0] >> 2;
+        output[1] = ((input[0] & 0x03) << 4) + (input[1] >> 4);
+        output[2] = ((input[1] & 0x0f) << 2) + (input[2] >> 6);
+        output[3] = input[2] & 0x3f;
+        BSONCXX_B64_ASSERT(output[0] < 64);
+        BSONCXX_B64_ASSERT(output[1] < 64);
+        BSONCXX_B64_ASSERT(output[2] < 64);
+        BSONCXX_B64_ASSERT(output[3] < 64);
 
-      if (datalength + 4 > targsize) {
-         return -1;
-      }
-      target[datalength++] = Base64[output[0]];
-      target[datalength++] = Base64[output[1]];
-      target[datalength++] = Base64[output[2]];
-      target[datalength++] = Base64[output[3]];
-   }
+        if (datalength + 4 > targsize) {
+            return -1;
+        }
+        target[datalength++] = Base64[output[0]];
+        target[datalength++] = Base64[output[1]];
+        target[datalength++] = Base64[output[2]];
+        target[datalength++] = Base64[output[3]];
+    }
 
-   /* Now we worry about padding. */
-   if (0 != srclength) {
-      /* Get what's left. */
-      input[0] = input[1] = input[2] = '\0';
+    /* Now we worry about padding. */
+    if (0 != srclength) {
+        /* Get what's left. */
+        input[0] = input[1] = input[2] = '\0';
 
-      for (i = 0; i < srclength; i++) {
-         input[i] = *src++;
-      }
-      output[0] = input[0] >> 2;
-      output[1] = ((input[0] & 0x03) << 4) + (input[1] >> 4);
-      output[2] = ((input[1] & 0x0f) << 2) + (input[2] >> 6);
-      BSONCXX_B64_ASSERT (output[0] < 64);
-      BSONCXX_B64_ASSERT (output[1] < 64);
-      BSONCXX_B64_ASSERT (output[2] < 64);
+        for (i = 0; i < srclength; i++) {
+            input[i] = *src++;
+        }
+        output[0] = input[0] >> 2;
+        output[1] = ((input[0] & 0x03) << 4) + (input[1] >> 4);
+        output[2] = ((input[1] & 0x0f) << 2) + (input[2] >> 6);
+        BSONCXX_B64_ASSERT(output[0] < 64);
+        BSONCXX_B64_ASSERT(output[1] < 64);
+        BSONCXX_B64_ASSERT(output[2] < 64);
 
-      if (datalength + 4 > targsize) {
-         return -1;
-      }
-      target[datalength++] = Base64[output[0]];
-      target[datalength++] = Base64[output[1]];
+        if (datalength + 4 > targsize) {
+            return -1;
+        }
+        target[datalength++] = Base64[output[0]];
+        target[datalength++] = Base64[output[1]];
 
-      if (srclength == 1) {
-         target[datalength++] = Pad64;
-      } else{
-         target[datalength++] = Base64[output[2]];
-      }
-      target[datalength++] = Pad64;
-   }
+        if (srclength == 1) {
+            target[datalength++] = Pad64;
+        } else {
+            target[datalength++] = Base64[output[2]];
+        }
+        target[datalength++] = Pad64;
+    }
 
-   if (datalength >= targsize) {
-      return -1;
-   }
-   target[datalength] = '\0'; /* Returned value doesn't count \0. */
-   return (int)datalength;
+    if (datalength >= targsize) {
+        return -1;
+    }
+    target[datalength] = '\0'; /* Returned value doesn't count \0. */
+    return (int)datalength;
 }
 
 }  // namespace b64

--- a/src/bsoncxx/private/stack.hpp
+++ b/src/bsoncxx/private/stack.hpp
@@ -26,7 +26,8 @@ BSONCXX_INLINE_NAMESPACE_BEGIN
 template <typename T, std::size_t size>
 class stack {
    public:
-    stack() : _bucket_index(0), _bucket_size(size), _is_empty(true) {}
+    stack() : _bucket_index(0), _bucket_size(size), _is_empty(true) {
+    }
 
     ~stack() {
         while (!empty()) {
@@ -39,9 +40,13 @@ class stack {
         }
     }
 
-    bool empty() const { return _is_empty; }
+    bool empty() const {
+        return _is_empty;
+    }
 
-    T &back() { return *(_get_ptr()); }
+    T &back() {
+        return *(_get_ptr());
+    }
 
     template <typename... Args>
     void emplace_back(Args &&... args) {
@@ -54,7 +59,9 @@ class stack {
         new (_get_ptr()) T(std::forward<Args>(args)...);
     }
 
-    void pop_back() { _dec(); }
+    void pop_back() {
+        _dec();
+    }
 
     void unsafe_reset() {
         _bucket_index = 0;
@@ -69,7 +76,7 @@ class stack {
 
     std::list<T *> _buckets;
 
-    typename std::list<T*>::iterator _bucket_iter;
+    typename std::list<T *>::iterator _bucket_iter;
 
     int _bucket_index;
     int _bucket_size;

--- a/src/bsoncxx/test/bson_validate.cpp
+++ b/src/bsoncxx/test/bson_validate.cpp
@@ -80,24 +80,17 @@ TEST_CASE("configuring optional validations", "[bsoncxx::validate]") {
         vtor.check_dollar_keys(true);
 
         SECTION("at top level") {
-            doc << "$foo" << "bar";
+            doc << "$foo"
+                << "bar";
             auto view = doc.view();
             REQUIRE(is_disengaged(validate(view.data(), view.length(), vtor)));
         }
 
         SECTION("and in nested documents") {
             using namespace bsoncxx::builder::stream;
-            doc << "foo"
-                  << open_array
-                    << open_document
-                      << "garply"
-                        << open_array
-                          << open_document
-                            << "$bar" << "baz"
-                          << close_document
-                        << close_array
-                      << close_document
-                    << close_array;
+            doc << "foo" << open_array << open_document << "garply" << open_array << open_document
+                << "$bar"
+                << "baz" << close_document << close_array << close_document << close_array;
 
             auto view = doc.view();
             REQUIRE(is_disengaged(validate(view.data(), view.length(), vtor)));
@@ -108,25 +101,17 @@ TEST_CASE("configuring optional validations", "[bsoncxx::validate]") {
         vtor.check_dot_keys(true);
 
         SECTION("at top level") {
-            doc << "foo.noooo" << "bar";
+            doc << "foo.noooo"
+                << "bar";
             auto view = doc.view();
             REQUIRE(is_disengaged(validate(view.data(), view.length(), vtor)));
         }
 
-
         SECTION("and in nested documents") {
             using namespace bsoncxx::builder::stream;
-            doc << "foo"
-                  << open_array
-                    << open_document
-                      << "garply"
-                        << open_array
-                          << open_document
-                            << "bad.dot" << "baz"
-                          << close_document
-                        << close_array
-                      << close_document
-                    << close_array;
+            doc << "foo" << open_array << open_document << "garply" << open_array << open_document
+                << "bad.dot"
+                << "baz" << close_document << close_array << close_document << close_array;
 
             auto view = doc.view();
             REQUIRE(is_disengaged(validate(view.data(), view.length(), vtor)));
@@ -134,7 +119,10 @@ TEST_CASE("configuring optional validations", "[bsoncxx::validate]") {
     }
 
     SECTION("we can get the invalid offset") {
-        doc << "foo" << "bar" << "baz" << "garply";
+        doc << "foo"
+            << "bar"
+            << "baz"
+            << "garply";
         auto view = doc.view();
 
         // write a null byte at offset 9

--- a/src/bsoncxx/types/value.hpp
+++ b/src/bsoncxx/types/value.hpp
@@ -27,366 +27,363 @@ BSONCXX_INLINE_NAMESPACE_BEGIN
 
 namespace types {
 
+///
+/// A variant that can contain any BSON type.
+///
+/// @warning
+///   It is undefined behavior to call the wrong get_<type> method. Check
+///   the underlying type() first.
+///
+class BSONCXX_API value {
+   public:
     ///
-    /// A variant that can contain any BSON type.
+    /// Construct a value from a BSON double.
+    ///
+    explicit value(b_double) noexcept;
+
+    ///
+    /// Construct a value from a BSON UTF-8 string.
+    ///
+    explicit value(b_utf8) noexcept;
+
+    ///
+    /// Construct a value from a BSON document.
+    ///
+    explicit value(b_document) noexcept;
+
+    ///
+    /// Construct a value from a BSON array.
+    ///
+    explicit value(b_array) noexcept;
+
+    ///
+    /// Construct a value from a BSON binary datum.
+    ///
+    explicit value(b_binary) noexcept;
+
+    ///
+    /// Construct a value from a BSON undefined.
+    ///
+    explicit value(b_undefined) noexcept;
+
+    ///
+    /// Construct a value from a BSON ObjectId.
+    ///
+    explicit value(b_oid) noexcept;
+
+    ///
+    /// Construct a value from a BSON boolean.
+    ///
+    explicit value(b_bool) noexcept;
+
+    ///
+    /// Construct a value from a BSON date.
+    ///
+    explicit value(b_date) noexcept;
+
+    ///
+    /// Construct a value from a BSON null.
+    ///
+    explicit value(b_null) noexcept;
+
+    ///
+    /// Construct a value from a BSON regex.
+    ///
+    explicit value(b_regex) noexcept;
+
+    ///
+    /// Construct a value from a BSON DBPointer.
+    ///
+    explicit value(b_dbpointer) noexcept;
+
+    ///
+    /// Construct a value from a BSON JavaScript code.
+    ///
+    explicit value(b_code) noexcept;
+
+    ///
+    /// Construct a value from a BSON symbol.
+    ///
+    explicit value(b_symbol) noexcept;
+
+    ///
+    /// Construct a value from a BSON JavaScript code with scope.
+    ///
+    explicit value(b_codewscope) noexcept;
+
+    ///
+    /// Construct a value from a BSON 32-bit signed integer.
+    ///
+    explicit value(b_int32) noexcept;
+
+    ///
+    /// Construct a value from a BSON replication timestamp.
+    ///
+    explicit value(b_timestamp) noexcept;
+
+    ///
+    /// Construct a value from a BSON 64-bit signed integer.
+    ///
+    explicit value(b_int64) noexcept;
+
+    ///
+    /// Construct a value from a BSON min-key.
+    ///
+    explicit value(b_minkey) noexcept;
+
+    ///
+    /// Construct a value from a BSON max-key.
+    ///
+    explicit value(b_maxkey) noexcept;
+
+    value(const value&) noexcept;
+    value& operator=(const value&) noexcept;
+
+    ~value();
+
+    friend BSONCXX_API bool BSONCXX_CALL operator==(const value&, const value&);
+    friend BSONCXX_API bool BSONCXX_CALL operator!=(const value&, const value&);
+
+    ///
+    /// @return The type of the underlying BSON value stored in this object.
+    ///
+    bsoncxx::type type() const;
+
+    ///
+    /// @return The underlying BSON double value.
     ///
     /// @warning
     ///   It is undefined behavior to call the wrong get_<type> method. Check
     ///   the underlying type() first.
     ///
-    class BSONCXX_API value {
+    const b_double& get_double() const;
 
-       public:
-        ///
-        /// Construct a value from a BSON double.
-        ///
-        explicit value(b_double) noexcept;
+    ///
+    /// @return The underlying BSON UTF-8 string value.
+    ///
+    /// @warning
+    ///   It is undefined behavior to call the wrong get_<type> method. Check
+    ///   the underlying type() first.
+    ///
+    const b_utf8& get_utf8() const;
 
-        ///
-        /// Construct a value from a BSON UTF-8 string.
-        ///
-        explicit value(b_utf8) noexcept;
+    ///
+    /// @return The underlying BSON document value.
+    ///
+    /// @warning
+    ///   It is undefined behavior to call the wrong get_<type> method. Check
+    ///   the underlying type() first.
+    ///
+    const b_document& get_document() const;
 
-        ///
-        /// Construct a value from a BSON document.
-        ///
-        explicit value(b_document) noexcept;
+    ///
+    /// @return The underlying BSON array value.
+    ///
+    /// @warning
+    ///   It is undefined behavior to call the wrong get_<type> method. Check
+    ///   the underlying type() first.
+    ///
+    const b_array& get_array() const;
 
-        ///
-        /// Construct a value from a BSON array.
-        ///
-        explicit value(b_array) noexcept;
+    ///
+    /// @return The underlying BSON binary data value.
+    ///
+    /// @warning
+    ///   It is undefined behavior to call the wrong get_<type> method. Check
+    ///   the underlying type() first.
+    ///
+    const b_binary& get_binary() const;
 
-        ///
-        /// Construct a value from a BSON binary datum.
-        ///
-        explicit value(b_binary) noexcept;
+    ///
+    /// @return The underlying BSON undefined value.
+    ///
+    /// @warning
+    ///   It is undefined behavior to call the wrong get_<type> method. Check
+    ///   the underlying type() first.
+    ///
+    const b_undefined& get_undefined() const;
 
-        ///
-        /// Construct a value from a BSON undefined.
-        ///
-        explicit value(b_undefined) noexcept;
+    ///
+    /// @return The underlying BSON ObjectId value.
+    ///
+    /// @warning
+    ///   It is undefined behavior to call the wrong get_<type> method. Check
+    ///   the underlying type() first.
+    ///
+    const b_oid& get_oid() const;
 
-        ///
-        /// Construct a value from a BSON ObjectId.
-        ///
-        explicit value(b_oid) noexcept;
+    ///
+    /// @return The underlying BSON boolean value.
+    ///
+    /// @warning
+    ///   It is undefined behavior to call the wrong get_<type> method. Check
+    ///   the underlying type() first.
+    ///
+    const b_bool& get_bool() const;
 
-        ///
-        /// Construct a value from a BSON boolean.
-        ///
-        explicit value(b_bool) noexcept;
+    ///
+    /// @return The underlying BSON date value.
+    ///
+    /// @warning
+    ///   It is undefined behavior to call the wrong get_<type> method. Check
+    ///   the underlying type() first.
+    ///
+    const b_date& get_date() const;
 
-        ///
-        /// Construct a value from a BSON date.
-        ///
-        explicit value(b_date) noexcept;
+    ///
+    /// @return The underlying BSON null value.
+    ///
+    /// @warning
+    ///   It is undefined behavior to call the wrong get_<type> method. Check
+    ///   the underlying type() first.
+    ///
+    const b_null& get_null() const;
 
-        ///
-        /// Construct a value from a BSON null.
-        ///
-        explicit value(b_null) noexcept;
+    ///
+    /// @return The underlying BSON regex value.
+    ///
+    /// @warning
+    ///   It is undefined behavior to call the wrong get_<type> method. Check
+    ///   the underlying type() first.
+    ///
+    const b_regex& get_regex() const;
 
-        ///
-        /// Construct a value from a BSON regex.
-        ///
-        explicit value(b_regex) noexcept;
+    ///
+    /// @return The underlying BSON DBPointer value.
+    ///
+    /// @warning
+    ///   It is undefined behavior to call the wrong get_<type> method. Check
+    ///   the underlying type() first.
+    ///
+    const b_dbpointer& get_dbpointer() const;
 
-        ///
-        /// Construct a value from a BSON DBPointer.
-        ///
-        explicit value(b_dbpointer) noexcept;
+    ///
+    /// @return The underlying BSON JavaScript code value.
+    ///
+    /// @warning
+    ///   It is undefined behavior to call the wrong get_<type> method. Check
+    ///   the underlying type() first.
+    ///
+    const b_code& get_code() const;
 
-        ///
-        /// Construct a value from a BSON JavaScript code.
-        ///
-        explicit value(b_code) noexcept;
+    ///
+    /// @return The underlying BSON symbol value.
+    ///
+    /// @warning
+    ///   It is undefined behavior to call the wrong get_<type> method. Check
+    ///   the underlying type() first.
+    ///
+    const b_symbol& get_symbol() const;
 
-        ///
-        /// Construct a value from a BSON symbol.
-        ///
-        explicit value(b_symbol) noexcept;
+    ///
+    /// @return The underlying BSON JavaScript code with scope value.
+    ///
+    /// @warning
+    ///   It is undefined behavior to call the wrong get_<type> method. Check
+    ///   the underlying type() first.
+    ///
+    const b_codewscope& get_codewscope() const;
 
-        ///
-        /// Construct a value from a BSON JavaScript code with scope.
-        ///
-        explicit value(b_codewscope) noexcept;
+    ///
+    /// @return The underlying BSON 32-bit signed integer value.
+    ///
+    /// @warning
+    ///   It is undefined behavior to call the wrong get_<type> method. Check
+    ///   the underlying type() first.
+    ///
+    const b_int32& get_int32() const;
 
-        ///
-        /// Construct a value from a BSON 32-bit signed integer.
-        ///
-        explicit value(b_int32) noexcept;
+    ///
+    /// @return The underlying BSON replication timestamp value.
+    ///
+    /// @warning
+    ///   It is undefined behavior to call the wrong get_<type> method. Check
+    ///   the underlying type() first.
+    ///
+    const b_timestamp& get_timestamp() const;
 
-        ///
-        /// Construct a value from a BSON replication timestamp.
-        ///
-        explicit value(b_timestamp) noexcept;
+    ///
+    /// @return The underlying BSON 64-bit signed integer value.
+    ///
+    /// @warning
+    ///   It is undefined behavior to call the wrong get_<type> method. Check
+    ///   the underlying type() first.
+    ///
+    const b_int64& get_int64() const;
 
-        ///
-        /// Construct a value from a BSON 64-bit signed integer.
-        ///
-        explicit value(b_int64) noexcept;
+    ///
+    /// @return The underlying BSON min-key value.
+    ///
+    /// @warning
+    ///   It is undefined behavior to call the wrong get_<type> method. Check
+    ///   the underlying type() first.
+    ///
+    const b_minkey& get_minkey() const;
 
-        ///
-        /// Construct a value from a BSON min-key.
-        ///
-        explicit value(b_minkey) noexcept;
+    ///
+    /// @return The underlying BSON max-key value.
+    ///
+    /// @warning
+    ///   It is undefined behavior to call the wrong get_<type> method. Check
+    ///   the underlying type() first.
+    ///
+    const b_maxkey& get_maxkey() const;
 
-        ///
-        /// Construct a value from a BSON max-key.
-        ///
-        explicit value(b_maxkey) noexcept;
+   private:
+    void BSONCXX_PRIVATE destroy() noexcept;
 
-        value(const value&) noexcept;
-        value& operator=(const value&) noexcept;
-
-        ~value();
-
-        friend BSONCXX_API bool BSONCXX_CALL operator==(const value&, const value&);
-        friend BSONCXX_API bool BSONCXX_CALL operator!=(const value&, const value&);
-
-        ///
-        /// @return The type of the underlying BSON value stored in this object.
-        ///
-        bsoncxx::type type() const;
-
-        ///
-        /// @return The underlying BSON double value.
-        ///
-        /// @warning
-        ///   It is undefined behavior to call the wrong get_<type> method. Check
-        ///   the underlying type() first.
-        ///
-        const b_double& get_double() const;
-
-        ///
-        /// @return The underlying BSON UTF-8 string value.
-        ///
-        /// @warning
-        ///   It is undefined behavior to call the wrong get_<type> method. Check
-        ///   the underlying type() first.
-        ///
-        const b_utf8& get_utf8() const;
-
-        ///
-        /// @return The underlying BSON document value.
-        ///
-        /// @warning
-        ///   It is undefined behavior to call the wrong get_<type> method. Check
-        ///   the underlying type() first.
-        ///
-        const b_document& get_document() const;
-
-        ///
-        /// @return The underlying BSON array value.
-        ///
-        /// @warning
-        ///   It is undefined behavior to call the wrong get_<type> method. Check
-        ///   the underlying type() first.
-        ///
-        const b_array& get_array() const;
-
-        ///
-        /// @return The underlying BSON binary data value.
-        ///
-        /// @warning
-        ///   It is undefined behavior to call the wrong get_<type> method. Check
-        ///   the underlying type() first.
-        ///
-        const b_binary& get_binary() const;
-
-        ///
-        /// @return The underlying BSON undefined value.
-        ///
-        /// @warning
-        ///   It is undefined behavior to call the wrong get_<type> method. Check
-        ///   the underlying type() first.
-        ///
-        const b_undefined& get_undefined() const;
-
-        ///
-        /// @return The underlying BSON ObjectId value.
-        ///
-        /// @warning
-        ///   It is undefined behavior to call the wrong get_<type> method. Check
-        ///   the underlying type() first.
-        ///
-        const b_oid& get_oid() const;
-
-        ///
-        /// @return The underlying BSON boolean value.
-        ///
-        /// @warning
-        ///   It is undefined behavior to call the wrong get_<type> method. Check
-        ///   the underlying type() first.
-        ///
-        const b_bool& get_bool() const;
-
-        ///
-        /// @return The underlying BSON date value.
-        ///
-        /// @warning
-        ///   It is undefined behavior to call the wrong get_<type> method. Check
-        ///   the underlying type() first.
-        ///
-        const b_date& get_date() const;
-
-        ///
-        /// @return The underlying BSON null value.
-        ///
-        /// @warning
-        ///   It is undefined behavior to call the wrong get_<type> method. Check
-        ///   the underlying type() first.
-        ///
-        const b_null& get_null() const;
-
-        ///
-        /// @return The underlying BSON regex value.
-        ///
-        /// @warning
-        ///   It is undefined behavior to call the wrong get_<type> method. Check
-        ///   the underlying type() first.
-        ///
-        const b_regex& get_regex() const;
-
-        ///
-        /// @return The underlying BSON DBPointer value.
-        ///
-        /// @warning
-        ///   It is undefined behavior to call the wrong get_<type> method. Check
-        ///   the underlying type() first.
-        ///
-        const b_dbpointer& get_dbpointer() const;
-
-        ///
-        /// @return The underlying BSON JavaScript code value.
-        ///
-        /// @warning
-        ///   It is undefined behavior to call the wrong get_<type> method. Check
-        ///   the underlying type() first.
-        ///
-        const b_code& get_code() const;
-
-        ///
-        /// @return The underlying BSON symbol value.
-        ///
-        /// @warning
-        ///   It is undefined behavior to call the wrong get_<type> method. Check
-        ///   the underlying type() first.
-        ///
-        const b_symbol& get_symbol() const;
-
-        ///
-        /// @return The underlying BSON JavaScript code with scope value.
-        ///
-        /// @warning
-        ///   It is undefined behavior to call the wrong get_<type> method. Check
-        ///   the underlying type() first.
-        ///
-        const b_codewscope& get_codewscope() const;
-
-        ///
-        /// @return The underlying BSON 32-bit signed integer value.
-        ///
-        /// @warning
-        ///   It is undefined behavior to call the wrong get_<type> method. Check
-        ///   the underlying type() first.
-        ///
-        const b_int32& get_int32() const;
-
-        ///
-        /// @return The underlying BSON replication timestamp value.
-        ///
-        /// @warning
-        ///   It is undefined behavior to call the wrong get_<type> method. Check
-        ///   the underlying type() first.
-        ///
-        const b_timestamp& get_timestamp() const;
-
-        ///
-        /// @return The underlying BSON 64-bit signed integer value.
-        ///
-        /// @warning
-        ///   It is undefined behavior to call the wrong get_<type> method. Check
-        ///   the underlying type() first.
-        ///
-        const b_int64& get_int64() const;
-
-        ///
-        /// @return The underlying BSON min-key value.
-        ///
-        /// @warning
-        ///   It is undefined behavior to call the wrong get_<type> method. Check
-        ///   the underlying type() first.
-        ///
-        const b_minkey& get_minkey() const;
-
-        ///
-        /// @return The underlying BSON max-key value.
-        ///
-        /// @warning
-        ///   It is undefined behavior to call the wrong get_<type> method. Check
-        ///   the underlying type() first.
-        ///
-        const b_maxkey& get_maxkey() const;
-
-       private:
-        void BSONCXX_PRIVATE destroy() noexcept;
-
-        bsoncxx::type _type;
-        union {
-            struct b_double _b_double;
-            struct b_utf8 _b_utf8;
-            struct b_document _b_document;
-            struct b_array _b_array;
-            struct b_binary _b_binary;
-            struct b_undefined _b_undefined;
-            struct b_oid _b_oid;
-            struct b_bool _b_bool;
-            struct b_date _b_date;
-            struct b_null _b_null;
-            struct b_regex _b_regex;
-            struct b_dbpointer _b_dbpointer;
-            struct b_code _b_code;
-            struct b_symbol _b_symbol;
-            struct b_codewscope _b_codewscope;
-            struct b_int32 _b_int32;
-            struct b_timestamp _b_timestamp;
-            struct b_int64 _b_int64;
-            struct b_minkey _b_minkey;
-            struct b_maxkey _b_maxkey;
-        };
+    bsoncxx::type _type;
+    union {
+        struct b_double _b_double;
+        struct b_utf8 _b_utf8;
+        struct b_document _b_document;
+        struct b_array _b_array;
+        struct b_binary _b_binary;
+        struct b_undefined _b_undefined;
+        struct b_oid _b_oid;
+        struct b_bool _b_bool;
+        struct b_date _b_date;
+        struct b_null _b_null;
+        struct b_regex _b_regex;
+        struct b_dbpointer _b_dbpointer;
+        struct b_code _b_code;
+        struct b_symbol _b_symbol;
+        struct b_codewscope _b_codewscope;
+        struct b_int32 _b_int32;
+        struct b_timestamp _b_timestamp;
+        struct b_int64 _b_int64;
+        struct b_minkey _b_minkey;
+        struct b_maxkey _b_maxkey;
     };
+};
 
-    // sfinae in the bool return to avoid competing with the value == value
-    // operators
-    template <typename T>
-    using not_value = typename std::enable_if<! std::is_same<typename std::remove_reference<T>::type, value>::value, bool>::type;
+// sfinae in the bool return to avoid competing with the value == value
+// operators
+template <typename T>
+using not_value =
+    typename std::enable_if<!std::is_same<typename std::remove_reference<T>::type, value>::value,
+                            bool>::type;
 
-    // these all return bool
-    template <typename T>
-    BSONCXX_INLINE
-    not_value<T> operator==(const value& lhs, T&& rhs) {
-        return lhs == value{std::forward<T>(rhs)};
-    }
+// these all return bool
+template <typename T>
+BSONCXX_INLINE not_value<T> operator==(const value& lhs, T&& rhs) {
+    return lhs == value{std::forward<T>(rhs)};
+}
 
-    template <typename T>
-    BSONCXX_INLINE
-    not_value<T> operator==(T&& lhs, const value& rhs) {
-        return value{std::forward<T>(lhs)} == rhs;
-    }
+template <typename T>
+BSONCXX_INLINE not_value<T> operator==(T&& lhs, const value& rhs) {
+    return value{std::forward<T>(lhs)} == rhs;
+}
 
-    template <typename T>
-    BSONCXX_INLINE
-    not_value<T> operator!=(const value& lhs, T&& rhs) {
-        return lhs != value{std::forward<T>(rhs)};
-    }
+template <typename T>
+BSONCXX_INLINE not_value<T> operator!=(const value& lhs, T&& rhs) {
+    return lhs != value{std::forward<T>(rhs)};
+}
 
-    template <typename T>
-    BSONCXX_INLINE
-    not_value<T> operator!=(T&& lhs, const value& rhs) {
-        return value{std::forward<T>(lhs)} != rhs;
-    }
+template <typename T>
+BSONCXX_INLINE not_value<T> operator!=(T&& lhs, const value& rhs) {
+    return value{std::forward<T>(lhs)} != rhs;
+}
 
 }  // namespace types
 

--- a/src/bsoncxx/util/functor.hpp
+++ b/src/bsoncxx/util/functor.hpp
@@ -81,7 +81,7 @@ struct is_class_method_with_signature {
                                                        typename strip_cv_from_class_function<
                                                            decltype(&T::operator())>::type>::value,
                                    yes>::type
-        sfinae(void *);
+    sfinae(void *);
 
     template <typename>
     static no sfinae(...);

--- a/src/bsoncxx/validate.hpp
+++ b/src/bsoncxx/validate.hpp
@@ -41,8 +41,8 @@ class validator;
 ///   An engaged optional containing a view if the document is valid, or
 ///   an unengaged optional if the document is invalid.
 ///
-BSONCXX_API stdx::optional<document::view> BSONCXX_CALL validate(const std::uint8_t* data,
-                                                                     std::size_t length);
+BSONCXX_API stdx::optional<document::view> BSONCXX_CALL
+validate(const std::uint8_t* data, std::size_t length);
 
 ///
 /// Validates a BSON document. This overload provides additional control over the
@@ -64,10 +64,9 @@ BSONCXX_API stdx::optional<document::view> BSONCXX_CALL validate(const std::uint
 ///   An engaged optional containing a view if the document is valid, or
 ///   an unengaged optional if the document is invalid.
 ///
-BSONCXX_API stdx::optional<document::view> BSONCXX_CALL validate(const std::uint8_t* data,
-                                                                     std::size_t length,
-                                                                     const validator& validator,
-                                                                     std::size_t* invalid_offset = nullptr);
+BSONCXX_API stdx::optional<document::view> BSONCXX_CALL
+validate(const std::uint8_t* data, std::size_t length, const validator& validator,
+         std::size_t* invalid_offset = nullptr);
 ///
 /// A validator is used to enable or disable specific checks that can be
 /// performed during BSON validation.

--- a/src/mongocxx/bulk_write.hpp
+++ b/src/mongocxx/bulk_write.hpp
@@ -39,9 +39,7 @@ class collection;
 /// @see http://docs.mongodb.org/manual/core/bulk-write-operations/
 ///
 class MONGOCXX_API bulk_write {
-
    public:
-
     ///
     /// Initializes a new bulk operation to be executed against a mongocxx::collection.
     ///
@@ -92,7 +90,6 @@ class MONGOCXX_API bulk_write {
 
     class MONGOCXX_PRIVATE impl;
     std::unique_ptr<impl> _impl;
-
 };
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/config/compiler.hpp
+++ b/src/mongocxx/config/compiler.hpp
@@ -19,7 +19,7 @@
 // Disable MSVC warnings that cause a lot of noise related to DLL visibility
 // for types that we don't control (like std::unique_ptr).
 #pragma warning(push)
-#pragma warning(disable: 4251 4275)
+#pragma warning(disable : 4251 4275)
 
 #define MONGOCXX_INLINE inline __forceinline MONGOCXX_PRIVATE
 

--- a/src/mongocxx/cursor.hpp
+++ b/src/mongocxx/cursor.hpp
@@ -33,9 +33,7 @@ class collection;
 /// @note By default, cursors timeout after 10 minutes of inactivity.
 ///
 class MONGOCXX_API cursor {
-
    public:
-
     enum class type { k_non_tailable, k_tailable, k_tailable_await };
 
     class MONGOCXX_API iterator;
@@ -74,19 +72,14 @@ class MONGOCXX_API cursor {
 
     class MONGOCXX_PRIVATE impl;
     std::unique_ptr<impl> _impl;
-
 };
 
 ///
 /// Class representing an input iterator of documents in a MongoDB cursor result set.
 ///
-class MONGOCXX_API cursor::iterator : public std::iterator<
-    std::input_iterator_tag,
-    bsoncxx::document::view
-> {
-
+class MONGOCXX_API cursor::iterator
+    : public std::iterator<std::input_iterator_tag, bsoncxx::document::view> {
    public:
-
     ///
     /// Dereferences the view for the document currently being pointed to.
     ///
@@ -116,7 +109,6 @@ class MONGOCXX_API cursor::iterator : public std::iterator<
 
     cursor* _cursor;
     bsoncxx::document::view _doc;
-
 };
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/exception/authentication_exception.hpp
+++ b/src/mongocxx/exception/authentication_exception.hpp
@@ -24,7 +24,7 @@ MONGOCXX_INLINE_NAMESPACE_BEGIN
 
 class MONGOCXX_API authentication_exception : public operation_exception {
    public:
-   	using operation_exception::operation_exception;
+    using operation_exception::operation_exception;
 };
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/exception/exception.hpp
+++ b/src/mongocxx/exception/exception.hpp
@@ -26,7 +26,7 @@ MONGOCXX_INLINE_NAMESPACE_BEGIN
 /// A class to be used as the base class for all mongocxx exceptions.
 ///
 class MONGOCXX_API exception : public std::system_error {
-   using system_error::system_error;
+    using system_error::system_error;
 };
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/exception/logic_error.hpp
+++ b/src/mongocxx/exception/logic_error.hpp
@@ -23,7 +23,7 @@ MONGOCXX_INLINE_NAMESPACE_BEGIN
 
 class MONGOCXX_API logic_error : public exception {
    public:
-   	using exception::exception;
+    using exception::exception;
 };
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/exception/operation_exception.hpp
+++ b/src/mongocxx/exception/operation_exception.hpp
@@ -26,7 +26,7 @@ MONGOCXX_INLINE_NAMESPACE_BEGIN
 
 class MONGOCXX_API operation_exception : public exception {
    public:
-   	using exception::exception;
+    using exception::exception;
 
     ///
     /// Constructs a new operation exception.
@@ -39,7 +39,7 @@ class MONGOCXX_API operation_exception : public exception {
     ///   An optional message to be returned by `what`.
     ///
     operation_exception(std::error_code ec, bsoncxx::document::value&& raw_server_error,
-                  std::string what_arg = "");
+                        std::string what_arg = "");
 
     ///
     /// The optional raw bson error document from the server.

--- a/src/mongocxx/exception/private/mongoc_error.hpp
+++ b/src/mongocxx/exception/private/mongoc_error.hpp
@@ -50,8 +50,7 @@ void throw_exception(::bson_error_t error) {
 
 template <typename exception_type>
 void throw_exception(bsoncxx::document::value raw_server_error, ::bson_error_t error) {
-    throw exception_type{make_error_code(error), std::move(raw_server_error),
-                         error.message};
+    throw exception_type{make_error_code(error), std::move(raw_server_error), error.message};
 }
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/hint.hpp
+++ b/src/mongocxx/hint.hpp
@@ -53,7 +53,8 @@ class MONGOCXX_API hint {
     explicit hint(bsoncxx::string::view_or_value index);
 
     friend MONGOCXX_API bool MONGOCXX_CALL operator==(const hint& index_hint, std::string index);
-    friend MONGOCXX_API bool MONGOCXX_CALL operator==(const hint& index_hint, bsoncxx::document::view index);
+    friend MONGOCXX_API bool MONGOCXX_CALL
+    operator==(const hint& index_hint, bsoncxx::document::view index);
 
     ///
     /// Return a bson document representing this hint.

--- a/src/mongocxx/mock/mock.hpp
+++ b/src/mongocxx/mock/mock.hpp
@@ -83,7 +83,7 @@ class mock<R (*)(Args...)> {
 
         template <typename T, typename... U>
         typename std::enable_if<std::is_same<T, R>::value, rule&>::type interpose(T r, U... rs) {
-            std::array<R, sizeof...(rs)+1> vec = {r, rs...};
+            std::array<R, sizeof...(rs) + 1> vec = {r, rs...};
             std::size_t i = 0;
 
             _callbacks.emplace([vec, i](Args...) mutable -> R {

--- a/src/mongocxx/model/write.hpp
+++ b/src/mongocxx/model/write.hpp
@@ -32,7 +32,6 @@ MONGOCXX_INLINE_NAMESPACE_BEGIN
 namespace model {
 
 class MONGOCXX_API write {
-
    public:
     write(insert_one value);
     write(update_one value);

--- a/src/mongocxx/options/aggregate.hpp
+++ b/src/mongocxx/options/aggregate.hpp
@@ -32,9 +32,7 @@ namespace options {
 /// Class representing the optional arguments to a MongoDB aggregation operation.
 ///
 class MONGOCXX_API aggregate {
-
    public:
-
     ///
     /// Enables writing to temporary files. When set to @c true, aggregation stages can write data
     /// to the _tmp subdirectory in the dbPath directory. The server-side default is @c false.

--- a/src/mongocxx/options/bulk_write.hpp
+++ b/src/mongocxx/options/bulk_write.hpp
@@ -27,9 +27,7 @@ namespace options {
 /// Class representing the optional arguments to a MongoDB bulk write
 ///
 class MONGOCXX_API bulk_write {
-
    public:
-
     ///
     /// Constructs a new bulk_write object. By default, bulk writes are considered ordered
     /// as this is the only safe choice. If you want an unordered update, you must call

--- a/src/mongocxx/options/client.hpp
+++ b/src/mongocxx/options/client.hpp
@@ -31,9 +31,7 @@ namespace options {
 /// Class representing the optional arguments to a MongoDB driver client object.
 ///
 class MONGOCXX_API client {
-
    public:
-
     ///
     /// Sets the SSL-related options.
     ///

--- a/src/mongocxx/options/delete.hpp
+++ b/src/mongocxx/options/delete.hpp
@@ -28,9 +28,7 @@ namespace options {
 /// Class representing the optional arguments to a MongoDB delete operation
 ///
 class MONGOCXX_API delete_options {
-
    public:
-
     ///
     /// Sets the write_concern for this operation.
     ///

--- a/src/mongocxx/options/distinct.hpp
+++ b/src/mongocxx/options/distinct.hpp
@@ -32,9 +32,7 @@ namespace options {
 /// Class representing the optional arguments to a MongoDB distinct command.
 ///
 class MONGOCXX_API distinct {
-
    public:
-
     ///
     /// Sets the maximum amount of time for this operation to run (server-side) in milliseconds.
     ///

--- a/src/mongocxx/options/find.hpp
+++ b/src/mongocxx/options/find.hpp
@@ -35,7 +35,6 @@ namespace options {
 ///
 class MONGOCXX_API find {
    public:
-
     ///
     /// Sets whether to allow partial results from a mongos if some shards are down (instead of
     /// throwing an error).

--- a/src/mongocxx/options/insert.hpp
+++ b/src/mongocxx/options/insert.hpp
@@ -29,7 +29,6 @@ namespace options {
 /// Class representing the optional arguments to a MongoDB insert operation
 ///
 class MONGOCXX_API insert {
-
    public:
     ///
     /// Sets the bypass_document_validation option.

--- a/src/mongocxx/options/update.hpp
+++ b/src/mongocxx/options/update.hpp
@@ -29,9 +29,7 @@ namespace options {
 /// Class representing the optional arguments to a MongoDB update operation.
 ///
 class MONGOCXX_API update {
-
    public:
-
     ///
     /// Sets the upsert option.
     ///

--- a/src/mongocxx/private/bulk_write.hpp
+++ b/src/mongocxx/private/bulk_write.hpp
@@ -23,18 +23,15 @@ namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 
 class bulk_write::impl {
-
    public:
-    impl(mongoc_bulk_operation_t* op)
-        : operation_t(op)
-    {}
+    impl(mongoc_bulk_operation_t* op) : operation_t(op) {
+    }
 
     ~impl() {
         libmongoc::bulk_operation_destroy(operation_t);
     }
 
     mongoc_bulk_operation_t* operation_t;
-
 };
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/private/client.hpp
+++ b/src/mongocxx/private/client.hpp
@@ -24,14 +24,15 @@ namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 
 class client::impl {
-
    public:
-    impl(mongoc_client_t* client) : client_t(client) {}
+    impl(mongoc_client_t* client) : client_t(client) {
+    }
 
-    ~impl() { libmongoc::client_destroy(client_t); }
+    ~impl() {
+        libmongoc::client_destroy(client_t);
+    }
 
     mongoc_client_t* client_t;
-
 };
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/private/collection.hpp
+++ b/src/mongocxx/private/collection.hpp
@@ -57,7 +57,6 @@ class collection::impl {
     mongoc_collection_t* collection_t;
     std::string database_name;
     const class client::impl* client_impl;
-
 };
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/private/cursor.hpp
+++ b/src/mongocxx/private/cursor.hpp
@@ -23,18 +23,15 @@ namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 
 class cursor::impl {
-
    public:
-    impl(mongoc_cursor_t* cursor)
-        : cursor_t(cursor)
-    {}
+    impl(mongoc_cursor_t* cursor) : cursor_t(cursor) {
+    }
 
     ~impl() {
         libmongoc::cursor_destroy(cursor_t);
     }
 
     mongoc_cursor_t* cursor_t;
-
 };
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/private/pipeline.hpp
+++ b/src/mongocxx/private/pipeline.hpp
@@ -24,7 +24,6 @@ namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 
 class pipeline::impl {
-
    public:
     bsoncxx::builder::stream::single_context sink() {
         return _builder;
@@ -36,7 +35,6 @@ class pipeline::impl {
 
    private:
     bsoncxx::builder::stream::array _builder;
-
 };
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/private/read_concern.hpp
+++ b/src/mongocxx/private/read_concern.hpp
@@ -32,7 +32,6 @@ class read_concern::impl {
     }
 
     ::mongoc_read_concern_t* read_concern_t;
-
 };
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/private/read_preference.hpp
+++ b/src/mongocxx/private/read_preference.hpp
@@ -23,18 +23,15 @@ namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 
 class read_preference::impl {
-
    public:
-    impl(mongoc_read_prefs_t* read_pref)
-        : read_preference_t(read_pref)
-    {}
+    impl(mongoc_read_prefs_t* read_pref) : read_preference_t(read_pref) {
+    }
 
     ~impl() {
         libmongoc::read_prefs_destroy(read_preference_t);
     }
 
     mongoc_read_prefs_t* read_preference_t;
-
 };
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/private/uri.hpp
+++ b/src/mongocxx/private/uri.hpp
@@ -24,10 +24,12 @@ MONGOCXX_INLINE_NAMESPACE_BEGIN
 
 class uri::impl {
    public:
-    impl(mongoc_uri_t* uri) : uri_t(uri) {}
-    ~impl() { libmongoc::uri_destroy(uri_t); }
+    impl(mongoc_uri_t* uri) : uri_t(uri) {
+    }
+    ~impl() {
+        libmongoc::uri_destroy(uri_t);
+    }
     mongoc_uri_t* uri_t;
-
 };
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/private/write_concern.hpp
+++ b/src/mongocxx/private/write_concern.hpp
@@ -23,18 +23,15 @@ namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 
 class write_concern::impl {
-
    public:
-    impl(mongoc_write_concern_t* write_concern)
-        : write_concern_t(write_concern)
-    {}
+    impl(mongoc_write_concern_t* write_concern) : write_concern_t(write_concern) {
+    }
 
     ~impl() {
         libmongoc::write_concern_destroy(write_concern_t);
     }
 
     mongoc_write_concern_t* write_concern_t;
-
 };
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/read_concern.hpp
+++ b/src/mongocxx/read_concern.hpp
@@ -44,7 +44,6 @@ class uri;
 /// @TODO link to the docs when they exist.
 ///
 class MONGOCXX_API read_concern {
-
    public:
     ///
     /// A class to represent the read concern level.
@@ -132,7 +131,6 @@ class MONGOCXX_API read_concern {
     MONGOCXX_PRIVATE read_concern(std::unique_ptr<impl>&& implementation);
 
     std::unique_ptr<impl> _impl;
-
 };
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/read_preference.hpp
+++ b/src/mongocxx/read_preference.hpp
@@ -171,7 +171,8 @@ class MONGOCXX_API read_preference {
     friend collection;
     friend database;
     friend uri;
-    friend MONGOCXX_API bool MONGOCXX_CALL operator==(const read_preference&, const read_preference&);
+    friend MONGOCXX_API bool MONGOCXX_CALL
+    operator==(const read_preference&, const read_preference&);
 
     class MONGOCXX_PRIVATE impl;
 

--- a/src/mongocxx/result/bulk_write.hpp
+++ b/src/mongocxx/result/bulk_write.hpp
@@ -32,7 +32,6 @@ namespace result {
 /// Class representing the result of a MongoDB bulk write operation.
 ///
 class MONGOCXX_API bulk_write {
-
    public:
     using id_map = std::map<std::size_t, bsoncxx::document::element>;
 
@@ -85,7 +84,6 @@ class MONGOCXX_API bulk_write {
     MONGOCXX_PRIVATE bsoncxx::document::view view() const;
 
     bsoncxx::document::value _response;
-
 };
 
 }  // namespace result

--- a/src/mongocxx/result/delete.hpp
+++ b/src/mongocxx/result/delete.hpp
@@ -28,7 +28,6 @@ namespace result {
 /// Class representing the result of a MongoDB delete operation.
 ///
 class MONGOCXX_API delete_result {
-
    public:
     // This constructor is public for testing purposes only
     explicit delete_result(result::bulk_write result);
@@ -49,7 +48,6 @@ class MONGOCXX_API delete_result {
 
    private:
     result::bulk_write _result;
-
 };
 
 }  // namespace result

--- a/src/mongocxx/result/insert_many.hpp
+++ b/src/mongocxx/result/insert_many.hpp
@@ -35,7 +35,6 @@ namespace result {
 /// (executed as a bulk write).
 ///
 class MONGOCXX_API insert_many {
-
    public:
     using id_map = std::map<std::size_t, bsoncxx::document::element>;
 
@@ -68,7 +67,6 @@ class MONGOCXX_API insert_many {
 
     result::bulk_write _result;
     id_map _generated_ids;
-
 };
 
 }  // namespace result

--- a/src/mongocxx/result/insert_one.hpp
+++ b/src/mongocxx/result/insert_one.hpp
@@ -26,7 +26,6 @@ namespace result {
 
 /// Class representing the result of a MongoDB insert operation.
 class MONGOCXX_API insert_one {
-
    public:
     // This constructor is public for testing purposes only
     insert_one(result::bulk_write result, bsoncxx::types::value generated_id);
@@ -48,7 +47,6 @@ class MONGOCXX_API insert_one {
    private:
     result::bulk_write _result;
     bsoncxx::types::value _generated_id;
-
 };
 
 }  // namespace result

--- a/src/mongocxx/result/replace_one.hpp
+++ b/src/mongocxx/result/replace_one.hpp
@@ -29,7 +29,6 @@ namespace result {
 
 /// Class representing the result of a MongoDB replace_one operation.
 class MONGOCXX_API replace_one {
-
    public:
     // This constructor is public for testing purposes only
     explicit replace_one(result::bulk_write result);
@@ -64,7 +63,6 @@ class MONGOCXX_API replace_one {
 
    private:
     result::bulk_write _result;
-
 };
 
 }  // namespace result

--- a/src/mongocxx/result/update.hpp
+++ b/src/mongocxx/result/update.hpp
@@ -29,7 +29,6 @@ namespace result {
 
 /// Class representing the result of a MongoDB update operation.
 class MONGOCXX_API update {
-
    public:
     // This constructor is public for testing purposes only
     explicit update(result::bulk_write result);
@@ -63,7 +62,6 @@ class MONGOCXX_API update {
 
    private:
     result::bulk_write _result;
-
 };
 
 }  // namespace result

--- a/src/mongocxx/stdx.hpp
+++ b/src/mongocxx/stdx.hpp
@@ -23,7 +23,7 @@ namespace stdx {
 // We adopt all the bsoncxx polyfills
 using namespace ::bsoncxx::stdx;
 
-} // namespace stdx;
+}  // namespace stdx;
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx
 

--- a/src/mongocxx/test/pool.cpp
+++ b/src/mongocxx/test/pool.cpp
@@ -132,8 +132,9 @@ TEST_CASE(
     "[pool]") {
     MOCK_POOL
 
-    // GCC before 4.9.0 doesn't place max_align_t in the std namespace.
-#if defined(__clang__) || !defined(__GNUC__) || (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)
+// GCC before 4.9.0 doesn't place max_align_t in the std namespace.
+#if defined(__clang__) || !defined(__GNUC__) || (__GNUC__ > 4) || \
+    (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)
     std::max_align_t dummy_address;
 #else
     max_align_t dummy_address;

--- a/src/mongocxx/test/private/write_concern.cpp
+++ b/src/mongocxx/test/private/write_concern.cpp
@@ -23,7 +23,6 @@ using namespace mongocxx;
 
 TEST_CASE("creation of write_concern passes universal parameters to c-driver's methods",
           "[write_concern][base][c-driver]") {
-
     SECTION("when journal is requested, mongoc_write_concern_set_journal is called with true") {
         bool journal_called = false;
         bool journal_value = false;

--- a/src/mongocxx/uri.hpp
+++ b/src/mongocxx/uri.hpp
@@ -38,13 +38,11 @@ MONGOCXX_INLINE_NAMESPACE_BEGIN
 /// @see http://docs.mongodb.org/manual/reference/connection-string/
 ///
 class MONGOCXX_API uri {
-
    public:
-
     struct host {
-         std::string name;
-         std::uint16_t port;
-         std::int32_t family;
+        std::string name;
+        std::uint16_t port;
+        std::int32_t family;
     };
 
     static const std::string k_default_uri;

--- a/src/mongocxx/write_concern.hpp
+++ b/src/mongocxx/write_concern.hpp
@@ -52,7 +52,6 @@ class uri;
 /// @see http://docs.mongodb.org/manual/core/write-concern/
 ///
 class MONGOCXX_API write_concern {
-
    public:
     ///
     /// A class to represent the special case values for write_concern::nodes.
@@ -231,7 +230,6 @@ class MONGOCXX_API write_concern {
     MONGOCXX_PRIVATE write_concern(std::unique_ptr<impl>&& implementation);
 
     std::unique_ptr<impl> _impl;
-
 };
 
 MONGOCXX_INLINE_NAMESPACE_END


### PR DESCRIPTION
Clang-Format Integration
- Uses a modified version of clang-format.py from mongo master branch (merged in globstar.py from resmoke,py, adjustment for clang-format.py location)
- I filter out `examples` and `third-party`.
- I added `lint` integration into Travis and MCI.

Note: I will merge the changes before merge.
