### PR TITLE
CXX-826 AppVeyor Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MongoDB C++ Driver [![Build Status](https://travis-ci.org/mongodb/mongo-cxx-driver.svg?branch=master)](https://travis-ci.org/mongodb/mongo-cxx-driver)
+# MongoDB C++ Driver [![Build Status](https://travis-ci.org/mongodb/mongo-cxx-driver.svg?branch=master)](https://travis-ci.org/mongodb/mongo-cxx-driver)[![Windows Build Status](https://ci.appveyor.com/api/projects/status/41dsiegqa004992e?svg=true)](https://ci.appveyor.com/project/markbenvenuto/mongo-cxx-driver)
 Welcome to the MongoDB C++ Driver!
 
 This branch contains active development on a new driver written in C++11.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+version: 3.0.0.{build}
+
+branches:
+    except:
+        - 26compat
+        - gh-pages
+        - legacy
+        - legacy-1.1-dev
+
+# Do not build on tags (GitHub only)
+skip_tags: true
+
+clone_folder: c:\build
+
+os: Visual Studio 2015
+
+test: off
+
+build_script:
+  - cmd: git clone -b master https://github.com/mongodb/mongo-c-driver.git
+  - cmd: cd mongo-c-driver
+  - cmd: git submodule init
+  - cmd: git submodule update
+  - cmd: cd src\libbson
+  - cmd: cmake.exe -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX=C:\usr
+  - cmd: msbuild INSTALL.vcxproj
+  - cmd: cd ..\..
+  - cmd: cmake.exe -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX=C:\usr -DBSON_ROOT_DIR=C:\usr
+  - cmd: msbuild INSTALL.vcxproj
+  - cmd: cd /d c:\build
+  - cmd: cmake.exe -G "Visual Studio 14 2015 Win64" -DLIBBSON_DIR=c:\usr -DLIBMONGOC_DIR=c:\usr -DBSONCXX_POLY_USE_BOOST=1 -DBOOST_ROOT=c:\Libraries\boost_1_59_0 -DCMAKE_BUILD_TYPE=Release
+  - cmd: msbuild.exe ALL_BUILD.vcxproj /p:Configuration=Release
+


### PR DESCRIPTION
This adds a simple Windows Builder to the C++ driver master branch. This is just the Release build for the moment to help ensure submissions build on Windows.

It uses VS 2015 Update 1.