### PR TITLE
CXX-825 Use bigobj for the mocked library as well

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -115,7 +115,9 @@ tasks:
                   set -e
                   PKG_CONFIG_PATH="/data/tmp/c-driver-install/lib/pkgconfig" ${cmake_path} ${cmake_flags} -DCMAKE_BUILD_TYPE=${build_type} -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_C_FLAGS="-Wall -Wextra -Wno-attributes -Werror -Wno-error=missing-field-initializers" ..
                   make format-lint
-                  make
+                  make all
+                  make install
+                  make examples
                   ${test_params} ./src/bsoncxx/test/test_bson
                   ${test_params} ./src/mongocxx/test/test_driver
                   # The break -1 is a hack to cause us to have a bad

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ before_script:
 script:
     - make format-lint
 
-    - make
+    - make all
 
     # Run bsoncxx tests with catch
     - ./src/bsoncxx/test/test_bson
@@ -80,5 +80,11 @@ script:
     # Run mongocxx tests with catch
     - ./src/mongocxx/test/test_driver
 
-    # Run all examples
+    # Install headers and libs for the examples
+    - make install
+
+    # Make the examples
+    - make examples
+
+    # Run the examples
     - make run-examples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,4 +95,4 @@ enable_testing()
 
 add_subdirectory(src)
 
-add_subdirectory(examples)
+add_subdirectory(examples EXCLUDE_FROM_ALL)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,7 @@ build_script:
   - cmd: cmake.exe -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX=C:\usr -DBSON_ROOT_DIR=C:\usr
   - cmd: msbuild INSTALL.vcxproj
   - cmd: cd /d c:\build
-  - cmd: cmake.exe -G "Visual Studio 14 2015 Win64" -DLIBBSON_DIR=c:\usr -DLIBMONGOC_DIR=c:\usr -DBSONCXX_POLY_USE_BOOST=1 -DBOOST_ROOT=c:\Libraries\boost_1_59_0 -DCMAKE_BUILD_TYPE=Release
+  - cmd: cmake.exe -G "Visual Studio 14 2015 Win64" -DLIBBSON_DIR=c:\usr -DLIBMONGOC_DIR=c:\usr -DBSONCXX_POLY_USE_BOOST=1 -DBOOST_ROOT=c:\Libraries\boost_1_59_0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=.\install
   - cmd: msbuild.exe ALL_BUILD.vcxproj /p:Configuration=Release
-
+  - cmd: msbuild.exe INSTALL.vcxproj /p:Configuration=Release
+  - cmd: msbuild.exe examples\examples.vcxproj /p:Configuration=Release

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,15 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_custom_target(install_headers
-    COMMAND "${CMAKE_COMMAND}" -DCMAKE_INSTALL_COMPONENT=dev -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
-    DEPENDS bsoncxx_built mongocxx_built
-)
+# NOTE: The targets in this directory will only build if you have
+# installed the bsoncxx and mongocxx libraries via the 'install'
+# targets.
 
-add_custom_target(install_libs
-    COMMAND "${CMAKE_COMMAND}" -DCMAKE_INSTALL_COMPONENT=runtime -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
-    DEPENDS bsoncxx_built mongocxx_built
-)
+# TODO: Ideally, there would be dependencies here on the install targets
+# for bsoncxx and mongocxx. However, there is currently no way to express
+# that dependency in CMake (see https://cmake.org/Bug/view.php?id=8438)
 
 # Build the examples with vectorcall as the default on Windows
 # so that we shake out missing _CALL macros.
@@ -31,15 +29,17 @@ endif()
 add_subdirectory(bsoncxx)
 add_subdirectory(mongocxx)
 
-add_custom_target(run-examples DEPENDS ${MONGOCXX_EXAMPLE_EXECUTABLES} ${BSONCXX_EXAMPLE_EXECUTABLES})
+add_custom_target(examples DEPENDS ${MONGOCXX_EXAMPLE_EXECUTABLES} ${BSONCXX_EXAMPLE_EXECUTABLES})
 
-# Run all mongocxx examples on `make examples`.
+add_custom_target(run-examples DEPENDS examples)
+
+# Run all mongocxx examples on `make run-examples`.
 foreach(EXAMPLE ${MONGOCXX_EXAMPLE_EXECUTABLES})
     get_filename_component(EXAMPLE_EXECUTABLE "${CMAKE_BINARY_DIR}/examples/mongocxx/${EXAMPLE}" ABSOLUTE)
     add_custom_command(TARGET run-examples POST_BUILD COMMAND ${EXAMPLE_EXECUTABLE})
 endforeach(EXAMPLE)
 
-# Run all bsoncxx examples on `make examples`.
+# Run all bsoncxx examples on `make run-examples`.
 foreach(EXAMPLE ${BSONCXX_EXAMPLE_EXECUTABLES})
     get_filename_component(EXAMPLE_EXECUTABLE "${CMAKE_BINARY_DIR}/examples/bsoncxx/${EXAMPLE}" ABSOLUTE)
     add_custom_command(TARGET run-examples POST_BUILD COMMAND ${EXAMPLE_EXECUTABLE})

--- a/examples/bsoncxx/CMakeLists.txt
+++ b/examples/bsoncxx/CMakeLists.txt
@@ -31,8 +31,7 @@ set(BSONCXX_EXAMPLES
 foreach(EXAMPLE_SRC ${BSONCXX_EXAMPLES})
     get_filename_component(EXAMPLE_TARGET ${EXAMPLE_SRC} NAME_WE)
     add_executable(${EXAMPLE_TARGET} ${EXAMPLE_SRC})
-    add_dependencies(${EXAMPLE_TARGET} install_headers install_libs)
-    target_link_libraries(${EXAMPLE_TARGET} bsoncxx ${bsoncxx_libs})
+    target_link_libraries(${EXAMPLE_TARGET} bsoncxx)
     set(BSONCXX_EXAMPLE_EXECUTABLES ${BSONCXX_EXAMPLE_EXECUTABLES} ${EXAMPLE_TARGET})
 endforeach(EXAMPLE_SRC)
 

--- a/examples/mongocxx/CMakeLists.txt
+++ b/examples/mongocxx/CMakeLists.txt
@@ -36,8 +36,7 @@ set(MONGOCXX_EXAMPLES
 foreach(EXAMPLE_SRC ${MONGOCXX_EXAMPLES})
     get_filename_component(EXAMPLE_TARGET ${EXAMPLE_SRC} NAME_WE)
     add_executable(${EXAMPLE_TARGET} ${EXAMPLE_SRC})
-    add_dependencies(${EXAMPLE_TARGET} install_headers install_libs)
-    target_link_libraries(${EXAMPLE_TARGET} mongocxx ${mongocxx_libs})
+    target_link_libraries(${EXAMPLE_TARGET} mongocxx)
     set(MONGOCXX_EXAMPLE_EXECUTABLES ${MONGOCXX_EXAMPLE_EXECUTABLES} ${EXAMPLE_TARGET})
 endforeach(EXAMPLE_SRC)
 

--- a/src/bsoncxx/CMakeLists.txt
+++ b/src/bsoncxx/CMakeLists.txt
@@ -206,19 +206,4 @@ install(
   DESTINATION lib/cmake/libbsoncxx-${BSONCXX_VERSION}
 )
 
-# Add all generated targets as dependencies here. This is a proxy
-# to allow the examples build to be sequenced after the mongocxx build
-# since you can't currently depend on an install target in CMake.
-add_custom_target(bsoncxx_built
-  DEPENDS
-  bsoncxx
-  bsoncxx_static
-  ${CMAKE_CURRENT_BINARY_DIR}/config/export.hpp
-  ${CMAKE_CURRENT_BINARY_DIR}/config/version.hpp
-  ${CMAKE_CURRENT_BINARY_DIR}/config/config.hpp
-  ${CMAKE_CURRENT_BINARY_DIR}/config/private/config.hpp
-  ${CMAKE_CURRENT_BINARY_DIR}/libbsoncxx-config.cmake
-  ${CMAKE_CURRENT_BINARY_DIR}/libbsoncxx-config-version.cmake
-)
-
 add_subdirectory(test)

--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -124,6 +124,10 @@ add_library(mongocxx_mocked STATIC
 
 target_compile_definitions(mongocxx_mocked PUBLIC MONGOCXX_STATIC MONGOCXX_TESTING)
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(mongocxx_mocked PRIVATE /bigobj)
+endif()
+
 set_target_properties(mongocxx_mocked PROPERTIES
     OUTPUT_NAME mongocxx_mocked
     VERSION ${MONGOCXX_VERSION}
@@ -206,21 +210,6 @@ write_basic_package_version_file(
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/libmongocxx-config.cmake ${CMAKE_CURRENT_BINARY_DIR}/libmongocxx-config-version.cmake
   DESTINATION lib/cmake/libmongocxx-${MONGOCXX_VERSION}
-)
-
-# Add all generated targets as dependencies here. This is a proxy
-# to allow the examples build to be sequenced after the mongocxx build
-# since you can't currently depend on an install target in CMake.
-add_custom_target(mongocxx_built
-  DEPENDS
-  mongocxx
-  mongocxx_static
-  ${CMAKE_CURRENT_BINARY_DIR}/config/export.hpp
-  ${CMAKE_CURRENT_BINARY_DIR}/config/version.hpp
-  ${CMAKE_CURRENT_BINARY_DIR}/config/config.hpp
-  ${CMAKE_CURRENT_BINARY_DIR}/config/private/config.hpp
-  ${CMAKE_CURRENT_BINARY_DIR}/libmongocxx-config.cmake
-  ${CMAKE_CURRENT_BINARY_DIR}/libmongocxx-config-version.cmake
 )
 
 add_subdirectory(test)

--- a/src/mongocxx/test/CMakeLists.txt
+++ b/src/mongocxx/test/CMakeLists.txt
@@ -58,7 +58,7 @@ add_executable(test_driver
 
 target_link_libraries(test_driver mongocxx_mocked)
 
-if (WIN32)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(test_driver PRIVATE /bigobj)
 endif()
 


### PR DESCRIPTION
Also, don't build the examples as part of the 'all' target. Instead
require users to build them explicitly by building the 'examples'
target.