### PR TITLE
Add explicit path to PKG_CONFIG_PATH for BSON and MongoC libraries

### DIFF
--- a/cmake/FindLibBSON.cmake
+++ b/cmake/FindLibBSON.cmake
@@ -23,6 +23,11 @@ include(FindPackageHandleStandardArgs)
 find_package(PkgConfig QUIET)
 
 if (PKG_CONFIG_FOUND)
+  
+  if (LIBBSON_DIR) 
+      set( ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${LIBBSON_DIR}/lib/pkgconfig" )
+  endif()
+
   pkg_check_modules(LIBBSON REQUIRED libbson-1.0>=${LibBSON_FIND_VERSION} )
   # We don't reiterate the version information here because we assume that
   # pkg_check_modules has honored our request.

--- a/cmake/FindLibMongoC.cmake
+++ b/cmake/FindLibMongoC.cmake
@@ -23,6 +23,10 @@ include(FindPackageHandleStandardArgs)
 find_package(PkgConfig QUIET)
 
 if (PKG_CONFIG_FOUND)
+  if (LIBMONGOC_DIR) 
+      set( ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${LIBMONGOC_DIR}/lib/pkgconfig" )
+  endif()
+
   pkg_check_modules(LIBMONGOC REQUIRED libmongoc-1.0>=${LibMongoC_FIND_VERSION} )
   # We don't reiterate the version information here because we assume that
   # pkg_check_modules has honored our request.


### PR DESCRIPTION
Hello, folks!

I'm using Mongo C++ module with my own manually compiled version of mongo-c and bson driver.

I specified path to they manually with cmake flags:
```bash
/opt/fastnetmon/libraries/cmake-3.4.2/bin/cmake -DLIBMONGOC_DIR=/opt/fastnetmon/libraries/mongo_c_driver_1_3_0 -DLIBBSON_DIR=/opt/fastnetmon/libraries/mongo_c_driver_1_3_0
```

As you can see it should work. But in your code pkgconfig call are located before any attempts to locate bson and mongo-c from custom path.

So I have added option to set path for pkg-config toolkit to custom place if it's specified. 

Thanks!