### PR TITLE
CXX-821 Add links to document validation documentation

### DIFF
--- a/src/mongocxx/options/create_collection.hpp
+++ b/src/mongocxx/options/create_collection.hpp
@@ -100,10 +100,10 @@ class MONGOCXX_API create_collection {
     ///
     /// Specify validation criteria for this collection.
     ///
-    /// TODO: link to documentation once it is published.
-    ///
     /// @param validation
     ///   Validation criteria for this collection.
+    ///
+    /// @see https://docs.mongodb.org/manual/core/document-validation/
     ///
     void validation_criteria(class validation_criteria validation);
 

--- a/src/mongocxx/options/find_one_and_replace.hpp
+++ b/src/mongocxx/options/find_one_and_replace.hpp
@@ -43,7 +43,7 @@ class MONGOCXX_API find_one_and_replace {
     /// @param bypass_document_validation
     ///   Whether or not to bypass document validation.
     ///
-    /// TODO add a link to the documentation when available.
+    /// @see https://docs.mongodb.org/manual/core/document-validation/#bypass-document-validation
     ///
     void bypass_document_validation(bool bypass_document_validation);
 

--- a/src/mongocxx/options/find_one_and_update.hpp
+++ b/src/mongocxx/options/find_one_and_update.hpp
@@ -43,7 +43,7 @@ class MONGOCXX_API find_one_and_update {
     /// @param bypass_document_validation
     ///   Whether or not to bypass document validation.
     ///
-    /// TODO add a link to the documentation when available.
+    /// @see https://docs.mongodb.org/manual/core/document-validation/#bypass-document-validation
     ///
     void bypass_document_validation(bool bypass_document_validation);
 

--- a/src/mongocxx/options/modify_collection.hpp
+++ b/src/mongocxx/options/modify_collection.hpp
@@ -55,10 +55,10 @@ class MONGOCXX_API modify_collection {
     ///
     /// Specify validation criteria for this collection.
     ///
-    /// TODO: link to documentation once it is published.
-    ///
     /// @param validation
     ///   Validation criteria for this collection.
+    ///
+    /// @see https://docs.mongodb.org/manual/core/document-validation/
     ///
     void validation_criteria(class validation_criteria validation);
 

--- a/src/mongocxx/validation_criteria.hpp
+++ b/src/mongocxx/validation_criteria.hpp
@@ -26,7 +26,7 @@ MONGOCXX_INLINE_NAMESPACE_BEGIN
 ///
 /// Class representing criteria for document validation, to be applied to a collection.
 ///
-/// TODO: add a link to documentation once it is published.
+/// @see https://docs.mongodb.org/manual/core/document-validation/
 ///
 class MONGOCXX_API validation_criteria {
    public:


### PR DESCRIPTION
Note: the todos related to read_concern are fixed in the read_concern pull request.