### PR TITLE
CXX-835 Support lint when run from non-repository root

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -114,7 +114,10 @@ tasks:
               script: |
                   set -e
                   PKG_CONFIG_PATH="/data/tmp/c-driver-install/lib/pkgconfig" ${cmake_path} ${cmake_flags} -DCMAKE_BUILD_TYPE=${build_type} -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_C_FLAGS="-Wall -Wextra -Wno-attributes -Werror -Wno-error=missing-field-initializers" ..
-                  make format-lint
+                  if [ `uname` != 'Darwin' ]; then
+                      # Evergreen OS X 10.6 does not have tar that can untar tar.bz2 files
+                      make format-lint
+                  fi
                   make all
                   make install
                   make examples

--- a/etc/clang_format.py
+++ b/etc/clang_format.py
@@ -579,9 +579,15 @@ class Repo(object):
         """Call git for this repository
         """
         # These two flags are the equivalent of -C in newer versions of Git
-        # but we use these to support versions back to ~1.8
-        return callo(['git', '--git-dir', os.path.join(self.path, ".git"),
-                        '--work-tree', self.path] + args)
+        # but we use these to support versions pre 1.8.5 but it depends on the command
+        # and what the current directory is
+        if "ls-files" in args:
+            # This command depends on the current directory and works better if not run with
+            # work-tree
+            return callo(['git', '--git-dir', os.path.join(self.path, ".git")] + args)
+        else:
+            return callo(['git', '--git-dir', os.path.join(self.path, ".git"),
+                                '--work-tree', self.path] + args)
 
     def _get_local_dir(self, path):
         """Get a directory path relative to the git root directory

--- a/src/bsoncxx/builder/basic/array.hpp
+++ b/src/bsoncxx/builder/basic/array.hpp
@@ -34,7 +34,6 @@ namespace basic {
 ///
 class array : public sub_array {
    public:
-
     ///
     /// Default constructor
     ///

--- a/src/bsoncxx/builder/basic/sub_array.hpp
+++ b/src/bsoncxx/builder/basic/sub_array.hpp
@@ -38,7 +38,6 @@ void value_append(core* core, T&& t);
 ///
 class BSONCXX_API sub_array {
    public:
-
     ///
     /// Default constructor
     ///

--- a/src/bsoncxx/builder/core.cpp
+++ b/src/bsoncxx/builder/core.cpp
@@ -297,7 +297,8 @@ void core::append(const types::b_dbpointer& value) {
     bson_oid_t oid;
     std::memcpy(&oid.bytes, value.value.bytes(), sizeof(oid.bytes));
 
-    bson_append_dbpointer(_impl->back(), key.data(), key.length(), value.collection.to_string().data(), &oid);
+    bson_append_dbpointer(_impl->back(), key.data(), key.length(),
+                          value.collection.to_string().data(), &oid);
 }
 
 void core::append(const types::b_code& value) {
@@ -319,7 +320,8 @@ void core::append(const types::b_codewscope& value) {
     bson_t bson;
     bson_init_static(&bson, value.scope.data(), value.scope.length());
 
-    bson_append_code_with_scope(_impl->back(), key.data(), key.length(), value.code.to_string().data(), &bson);
+    bson_append_code_with_scope(_impl->back(), key.data(), key.length(),
+                                value.code.to_string().data(), &bson);
 }
 
 void core::append(const types::b_int32& value) {

--- a/src/bsoncxx/builder/stream/array.hpp
+++ b/src/bsoncxx/builder/stream/array.hpp
@@ -35,7 +35,6 @@ namespace stream {
 ///
 class array : public array_context<> {
    public:
-
     ///
     /// Default constructor.
     ///

--- a/src/bsoncxx/builder/stream/array_context.hpp
+++ b/src/bsoncxx/builder/stream/array_context.hpp
@@ -51,7 +51,6 @@ class single_context;
 template <class base = closed_context>
 class array_context {
    public:
-
     ///
     /// Create an array_context given a core builder
     ///

--- a/src/bsoncxx/builder/stream/document.hpp
+++ b/src/bsoncxx/builder/stream/document.hpp
@@ -33,7 +33,6 @@ namespace stream {
 ///
 class document : public key_context<> {
    public:
-
     ///
     /// Default constructor.
     ///

--- a/src/bsoncxx/builder/stream/key_context.hpp
+++ b/src/bsoncxx/builder/stream/key_context.hpp
@@ -47,7 +47,6 @@ namespace stream {
 template <class base = closed_context>
 class key_context {
    public:
-
     ///
     /// Create a key_context given a core builder
     ///

--- a/src/bsoncxx/builder/stream/single_context.hpp
+++ b/src/bsoncxx/builder/stream/single_context.hpp
@@ -35,7 +35,6 @@ namespace stream {
 ///
 class single_context {
    public:
-
     ///
     /// Create a single_context given a core builder
     ///

--- a/src/bsoncxx/builder/stream/value_context.hpp
+++ b/src/bsoncxx/builder/stream/value_context.hpp
@@ -47,7 +47,6 @@ namespace stream {
 template <class base>
 class value_context {
    public:
-
     ///
     /// Create a value_context given a core builder
     ///

--- a/src/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/document/element.hpp
@@ -69,7 +69,6 @@ namespace document {
 ///
 class BSONCXX_API element {
    public:
-
     ///
     /// Construct an invalid element.
     ///

--- a/src/bsoncxx/exception/error_code.hpp
+++ b/src/bsoncxx/exception/error_code.hpp
@@ -66,6 +66,6 @@ BSONCXX_INLINE_NAMESPACE_END
 
 namespace std {
 // Specialize is_error_code_enum so we get simpler std::error_code construction
-template<>
-struct is_error_code_enum<bsoncxx::error_code> : public true_type{};
+template <>
+struct is_error_code_enum<bsoncxx::error_code> : public true_type {};
 }  // namespace std

--- a/src/bsoncxx/json.cpp
+++ b/src/bsoncxx/json.cpp
@@ -292,8 +292,7 @@ document::value from_json(stdx::string_view json) {
     bson_t* result =
         bson_new_from_json(reinterpret_cast<const uint8_t*>(json.data()), json.size(), &error);
 
-    if (!result)
-        throw exception(error_code::k_json_parse_failure, error.message);
+    if (!result) throw exception(error_code::k_json_parse_failure, error.message);
 
     std::uint32_t length;
     std::uint8_t* buf = bson_destroy_with_steal(result, true, &length);

--- a/src/mongocxx/cursor.hpp
+++ b/src/mongocxx/cursor.hpp
@@ -103,7 +103,7 @@ class MONGOCXX_API cursor::iterator
    private:
     friend class cursor;
 
-    /// 
+    ///
     /// @{
     ///
     /// Compare two iterators for (in)-equality

--- a/src/mongocxx/exception/error_code.cpp
+++ b/src/mongocxx/exception/error_code.cpp
@@ -58,7 +58,7 @@ class error_category final : public std::error_category {
 }  // namespace
 
 const std::error_category& error_category() {
-    static const class error_category category{};
+    static const class error_category category {};
     return category;
 }
 

--- a/src/mongocxx/exception/error_code.hpp
+++ b/src/mongocxx/exception/error_code.hpp
@@ -60,6 +60,6 @@ MONGOCXX_INLINE_NAMESPACE_END
 
 namespace std {
 // Specialize is_error_code_enum so we get simpler std::error_code construction
-template<>
-struct is_error_code_enum<mongocxx::error_code> : public true_type{};
+template <>
+struct is_error_code_enum<mongocxx::error_code> : public true_type {};
 }  // namespace std

--- a/src/mongocxx/exception/server_error_code.cpp
+++ b/src/mongocxx/exception/server_error_code.cpp
@@ -38,7 +38,7 @@ class server_error_category final : public std::error_category {
 }  // namespace
 
 const std::error_category& server_error_category() {
-    static const class server_error_category category{};
+    static const class server_error_category category {};
     return category;
 }
 

--- a/src/mongocxx/exception/server_error_code.hpp
+++ b/src/mongocxx/exception/server_error_code.hpp
@@ -53,6 +53,6 @@ MONGOCXX_INLINE_NAMESPACE_END
 
 namespace std {
 // Specialize is_error_code_enum so we get simpler std::error_code construction
-template<>
-struct is_error_code_enum<mongocxx::server_error_code> : public true_type{};
+template <>
+struct is_error_code_enum<mongocxx::server_error_code> : public true_type {};
 }  // namespace std

--- a/src/mongocxx/private/libmongoc.cpp
+++ b/src/mongocxx/private/libmongoc.cpp
@@ -21,7 +21,9 @@ MONGOCXX_INLINE_NAMESPACE_BEGIN
 namespace libmongoc {
 
 #ifdef MONGOCXX_TESTING
-#define MONGOCXX_LIBMONGOC_SYMBOL(name) mock::mock<decltype(&mongoc_##name)>& name = *new mock::mock<decltype(&mongoc_##name)>(mongoc_##name);
+#define MONGOCXX_LIBMONGOC_SYMBOL(name)          \
+    mock::mock<decltype(&mongoc_##name)>& name = \
+        *new mock::mock<decltype(&mongoc_##name)>(mongoc_##name);
 #include "libmongoc_symbols.hpp"
 #undef MONGOCXX_LIBMONGOC_SYMBOL
 #endif  // MONGOCXX_TESTING


### PR DESCRIPTION
Since Travis runs on Ubuntu 12.04, we cannot use `-C` with `git` so we must continue to work around it.

Mac OS X 10.6 `tar` does not support `bzip2` compressed files.