### PR TITLE
minor: fixup clang compile

### DIFF
--- a/src/bsoncxx/exception/error_code.cpp
+++ b/src/bsoncxx/exception/error_code.cpp
@@ -14,6 +14,8 @@
 
 #include <bsoncxx/exception/error_code.hpp>
 
+#include <string>
+
 #include <bsoncxx/config/private/prelude.hpp>
 
 namespace bsoncxx {

--- a/src/mongocxx/exception/error_code.cpp
+++ b/src/mongocxx/exception/error_code.cpp
@@ -14,6 +14,8 @@
 
 #include <mongocxx/exception/error_code.hpp>
 
+#include <string>
+
 #include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {

--- a/src/mongocxx/exception/server_error_code.cpp
+++ b/src/mongocxx/exception/server_error_code.cpp
@@ -14,6 +14,8 @@
 
 #include <mongocxx/exception/server_error_code.hpp>
 
+#include <string>
+
 #include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {


### PR DESCRIPTION
I am using clang as a C++ compiler on OSX. However, the master branch is uncompilable because of some missing header files. I added them and would like to merge these minor changes into the upstream.