### PR TITLE
CXX-868 Fails to build on VS2015 with error C2719

### DIFF
--- a/src/mongocxx/exception/private/mongoc_error.hpp
+++ b/src/mongocxx/exception/private/mongoc_error.hpp
@@ -28,17 +28,17 @@ inline std::error_code make_error_code(int code, int) {
     return {code, server_error_category()};
 }
 
-inline std::error_code make_error_code(::bson_error_t error) {
+inline std::error_code make_error_code(const ::bson_error_t &error) {
     return make_error_code(error.code, error.domain);
 }
 
 template <typename exception_type>
-void throw_exception(::bson_error_t error) {
+void throw_exception(const ::bson_error_t &error) {
     throw exception_type{make_error_code(error), error.message};
 }
 
 template <typename exception_type>
-void throw_exception(bsoncxx::document::value raw_server_error, ::bson_error_t error) {
+void throw_exception(bsoncxx::document::value raw_server_error, const ::bson_error_t &error) {
     throw exception_type{make_error_code(error), std::move(raw_server_error), error.message};
 }
 


### PR DESCRIPTION
Hi!

Without these changes I got C2719 compiling mongocxx on Windows 10 with Visual Studio 2015 Update 1.

(full message: error C2719: 'error': formal parameter with requested alignment of 8 won't be aligned)

Maybe this is interesting for you.

BR,
Max