### PR TITLE
CXX-865 Enable building with clang with libstdc++ from GCC 4.8

### DIFF
--- a/src/mongocxx/test/pool.cpp
+++ b/src/mongocxx/test/pool.cpp
@@ -140,13 +140,13 @@ TEST_CASE(
 
     instance::current();
 
-// GCC before 4.9.0 doesn't place max_align_t in the std namespace.
-#if defined(__clang__) || !defined(__GNUC__) || (__GNUC__ > 4) || \
-    (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)
-    std::max_align_t dummy_address;
-#else
-    max_align_t dummy_address;
-#endif
+    // libstdc++ before GCC 4.9 places max_align_t in the wrong
+    // namespace. Use a limited scope 'using namespace std' to name it
+    // in a way that always works.
+    auto dummy_address = []() {
+        using namespace std;
+        return max_align_t{};
+    }();
 
     bool try_pop_called = false;
 


### PR DESCRIPTION
This is hideous, but necessary when building with clang against libstdc++ from GCC 4.8.2. Fortunately it is:

- Only in a test
- Only needed in one place

So, I haven't bothered to try to macro it out.