### PR TITLE
CXX-893 Removed BSONCXX_API macro from non exported classes to fix link errors

### DIFF
--- a/src/bsoncxx/builder/basic/sub_array.hpp
+++ b/src/bsoncxx/builder/basic/sub_array.hpp
@@ -36,7 +36,7 @@ void value_append(core* core, T&& t);
 /// An internal class of builder::basic.
 /// Users should almost always construct a builder::basic::array instead.
 ///
-class BSONCXX_API sub_array {
+class sub_array {
    public:
     ///
     /// Default constructor

--- a/src/bsoncxx/builder/basic/sub_document.hpp
+++ b/src/bsoncxx/builder/basic/sub_document.hpp
@@ -35,7 +35,7 @@ void value_append(core* core, T&& t);
 /// An internal class of builder::basic.
 /// Users should almost always construct a builder::basic::document instead.
 ///
-class BSONCXX_API sub_document {
+class sub_document {
    public:
     BSONCXX_INLINE sub_document(core* core) : _core(core) {
     }


### PR DESCRIPTION
Linking to bsoncxx.dll (with VC++ 2015) fails because the `BSONCXX_API` macro instructs VC++ to `dllimport` the classes sub_array and sub_document while these classes are header only (and thus not exported by the dll).
Removing the macro fixes the issue.