### PR TITLE
CXX-911 Add clang-format version check

### DIFF
--- a/etc/clang_format.py
+++ b/etc/clang_format.py
@@ -429,6 +429,9 @@ class ClangFormat(object):
         except CalledProcessError:
             cf_version = "clang-format call failed."
 
+        if CLANG_FORMAT_VERSION in cf_version:
+            return True
+
         if warn:
             print("WARNING: clang-format found in path, but incorrect version found at " +
                     self.path + " with version: " + cf_version)


### PR DESCRIPTION
This commit adds the same version check as in the server build script.

Note: this only suppresses a warning if the version is correct; there is
still no assertion if the version is wrong.

