### PR TITLE
CXX-917 Make SSL actually work

### DIFF
--- a/examples/mongocxx/CMakeLists.txt
+++ b/examples/mongocxx/CMakeLists.txt
@@ -25,6 +25,7 @@ set(MONGOCXX_EXAMPLES
     aggregate.cpp
     bulk_write.cpp
     create.cpp
+    connect.cpp
     document_validation.cpp
     exception.cpp
     index.cpp

--- a/examples/mongocxx/connect.cpp
+++ b/examples/mongocxx/connect.cpp
@@ -1,0 +1,84 @@
+// Copyright 2015 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include <bsoncxx/builder/stream/document.hpp>
+#include <bsoncxx/json.hpp>
+#include <bsoncxx/stdx/make_unique.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/instance.hpp>
+#include <mongocxx/logger.hpp>
+#include <mongocxx/options/client.hpp>
+#include <mongocxx/uri.hpp>
+
+namespace {
+
+class logger final : public mongocxx::logger {
+   public:
+    explicit logger(std::ostream* stream) : _stream(stream) {
+    }
+
+    void operator()(mongocxx::log_level level, mongocxx::stdx::string_view domain,
+                    mongocxx::stdx::string_view message) noexcept override {
+        if (level >= mongocxx::log_level::k_trace) return;
+        *_stream << '[' << mongocxx::to_string(level) << '@' << domain << "] " << message << '\n';
+    }
+
+   private:
+    std::ostream* const _stream;
+};
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+    using bsoncxx::builder::stream::document;
+
+    mongocxx::instance inst{bsoncxx::stdx::make_unique<logger>(&std::cout)};
+
+    if (argc != 2) {
+        std::cout << "usage: " << argv[0] << " MONGODB_URI" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    try {
+        const auto uri = mongocxx::uri{argv[1]};
+
+        mongocxx::options::ssl ssl_options;
+        // NOTE: To test SSL, you may need to set options. The following
+        // would enable certificates for Homebrew OpenSSL on OS X.
+        // options.ca_file("/usr/local/etc/openssl/cert.pem");
+        // ssl_options.ca_file("/usr/local/etc/openssl/cert.pem");
+
+        auto client = mongocxx::client{uri, mongocxx::options::client{}.ssl_opts(ssl_options)};
+
+        auto admin = client["admin"];
+
+        document ismaster;
+        ismaster << "isMaster" << 1;
+
+        auto result = admin.run_command(ismaster.view());
+
+        std::cout << bsoncxx::to_json(result) << "\n";
+
+        return EXIT_SUCCESS;
+
+    } catch (const std::exception& xcp) {
+        std::cout << "connection failed: " << xcp.what() << "\n";
+        return EXIT_FAILURE;
+    }
+}

--- a/src/mongocxx/client.cpp
+++ b/src/mongocxx/client.cpp
@@ -37,9 +37,10 @@ client::client() noexcept = default;
 client::client(const class uri& uri, const options::client& options)
     : _impl(stdx::make_unique<impl>(libmongoc::client_new_from_uri(uri._impl->uri_t))) {
     if (options.ssl_opts()) {
-#if defined(MONGOC_HAVE_SSL)
+#if defined(MONGOC_ENABLE_SSL)
         auto mongoc_opts = options::make_ssl_opts(*options.ssl_opts());
-        libmongoc::client_set_ssl_opts(_get_impl().client_t, &mongoc_opts);
+        _impl->ssl_options = std::move(mongoc_opts.second);
+        libmongoc::client_set_ssl_opts(_get_impl().client_t, &mongoc_opts.first);
 #else
         throw exception{error_code::k_ssl_not_supported};
 #endif

--- a/src/mongocxx/instance.cpp
+++ b/src/mongocxx/instance.cpp
@@ -72,6 +72,7 @@ class instance::impl {
         libmongoc::init();
         if (_user_logger) {
             libmongoc::log_set_handler(user_log_handler, _user_logger.get());
+            mongoc_log(MONGOC_LOG_LEVEL_INFO, "mongocxx", "libmongoc logging callback enabled");
         } else {
             libmongoc::log_set_handler(null_log_handler, nullptr);
         }

--- a/src/mongocxx/logger.cpp
+++ b/src/mongocxx/logger.cpp
@@ -19,6 +19,27 @@
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 
+stdx::string_view to_string(log_level level) {
+    switch (level) {
+        case log_level::k_error:
+            return "error";
+        case log_level::k_critical:
+            return "critical";
+        case log_level::k_warning:
+            return "warning";
+        case log_level::k_message:
+            return "message";
+        case log_level::k_info:
+            return "info";
+        case log_level::k_debug:
+            return "debug";
+        case log_level::k_trace:
+            return "trace";
+        default:
+            return "unknown";
+    }
+}
+
 logger::logger() = default;
 logger::~logger() = default;
 

--- a/src/mongocxx/logger.hpp
+++ b/src/mongocxx/logger.hpp
@@ -38,6 +38,16 @@ enum class log_level {
 };
 
 ///
+/// Returns a stringification of the given log level.
+///
+/// @param rhs
+///   The type to stringify.
+///
+/// @return a std::string representation of the type.
+///
+MONGOCXX_API stdx::string_view MONGOCXX_CALL to_string(log_level level);
+
+///
 /// The interface that all user-defined loggers must implement.
 ///
 class MONGOCXX_API logger {

--- a/src/mongocxx/private/client.hpp
+++ b/src/mongocxx/private/client.hpp
@@ -33,6 +33,7 @@ class client::impl {
     }
 
     mongoc_client_t* client_t;
+    std::vector<bsoncxx::string::view_or_value> ssl_options;
 };
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/private/libmongoc_symbols.hpp
+++ b/src/mongocxx/private/libmongoc_symbols.hpp
@@ -138,7 +138,7 @@ MONGOCXX_LIBMONGOC_SYMBOL(write_concern_set_wmajority)
 MONGOCXX_LIBMONGOC_SYMBOL(write_concern_set_wtag)
 MONGOCXX_LIBMONGOC_SYMBOL(write_concern_set_wtimeout)
 
-#if defined(MONGOC_HAVE_SSL)
+#if defined(MONGOC_ENABLE_SSL)
 MONGOCXX_LIBMONGOC_SYMBOL(client_pool_set_ssl_opts)
 MONGOCXX_LIBMONGOC_SYMBOL(client_set_ssl_opts)
 #endif

--- a/src/mongocxx/private/pool.hpp
+++ b/src/mongocxx/private/pool.hpp
@@ -26,8 +26,7 @@ MONGOCXX_INLINE_NAMESPACE_BEGIN
 
 class pool::impl {
    public:
-    impl(mongoc_client_pool_t* pool, stdx::optional<options::ssl> ssl_opts)
-        : client_pool_t(pool), ssl_options(std::move(ssl_opts)) {
+    impl(mongoc_client_pool_t* pool) : client_pool_t(pool) {
     }
 
     ~impl() {
@@ -35,7 +34,7 @@ class pool::impl {
     }
 
     mongoc_client_pool_t* client_pool_t;
-    stdx::optional<options::ssl> ssl_options;
+    std::vector<bsoncxx::string::view_or_value> ssl_options;
 };
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/private/ssl.hpp
+++ b/src/mongocxx/private/ssl.hpp
@@ -23,28 +23,31 @@ namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 namespace options {
 
-#if defined(MONGOC_HAVE_SSL)
-inline ::mongoc_ssl_opt_t make_ssl_opts(const ssl& ssl_opts) {
+#if defined(MONGOC_ENABLE_SSL)
+inline std::pair<::mongoc_ssl_opt_t, std::vector<bsoncxx::string::view_or_value>> make_ssl_opts(
+    const ssl& ssl_opts) {
     ::mongoc_ssl_opt_t out{};
+    std::vector<bsoncxx::string::view_or_value> values;
+
     if (ssl_opts.pem_file()) {
-        out.pem_file = ssl_opts.pem_file()->terminated().data();
+        out.pem_file = values.emplace(values.end(), ssl_opts.pem_file()->terminated())->data();
     }
     if (ssl_opts.pem_password()) {
-        out.pem_pwd = ssl_opts.pem_password()->terminated().data();
+        out.pem_pwd = values.emplace(values.end(), ssl_opts.pem_password()->terminated())->data();
     }
     if (ssl_opts.ca_file()) {
-        out.ca_file = ssl_opts.ca_file()->terminated().data();
+        out.ca_file = values.emplace(values.end(), ssl_opts.ca_file()->terminated())->data();
     }
     if (ssl_opts.ca_dir()) {
-        out.ca_dir = ssl_opts.ca_dir()->terminated().data();
+        out.ca_dir = values.emplace(values.end(), ssl_opts.ca_dir()->terminated())->data();
     }
     if (ssl_opts.crl_file()) {
-        out.crl_file = ssl_opts.crl_file()->terminated().data();
+        out.crl_file = values.emplace(values.end(), ssl_opts.crl_file()->terminated())->data();
     }
     if (ssl_opts.allow_invalid_certificates()) {
         out.weak_cert_validation = *(ssl_opts.allow_invalid_certificates());
     }
-    return out;
+    return {out, std::move(values)};
 }
 #endif
 

--- a/src/mongocxx/test/pool.cpp
+++ b/src/mongocxx/test/pool.cpp
@@ -58,7 +58,7 @@ TEST_CASE("a pool is created with the correct MongoDB URI", "[pool]") {
     REQUIRE(destroy_called);
 }
 
-#if defined(MONGOC_HAVE_SSL)
+#if defined(MONGOC_ENABLE_SSL)
 TEST_CASE(
     "If we pass an engaged SSL options struct to the pool class, we will use it to configure the "
     "underlying mongoc pool",

--- a/src/third_party/catch/include/helpers.hpp
+++ b/src/third_party/catch/include/helpers.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/private/libmongoc.hpp>
+
 #define CHECK_OPTIONAL_ARGUMENT(OBJECT, NAME, VALUE) \
     SECTION("has NAME disengaged") {                 \
         REQUIRE(!OBJECT.NAME());                     \
@@ -46,7 +48,7 @@
     auto client_pool_try_pop = libmongoc::client_pool_try_pop.create_instance();               \
     client_pool_try_pop->interpose([](::mongoc_client_pool_t*) { return nullptr; }).forever();
 
-#if defined(MONGOC_HAVE_SSL)
+#if defined(MONGOC_ENABLE_SSL)
 #define MOCK_POOL                                                                          \
     MOCK_POOL_NOSSL                                                                        \
     auto client_pool_set_ssl_opts = libmongoc::client_pool_set_ssl_opts.create_instance(); \


### PR DESCRIPTION
@Machyne @xdg - please review.
@ajdavis - apparently, the C driver doesn't make owned copies of the strings passed in via http://api.mongodb.com/c/current/mongoc_client_set_ssl_opts.html. That is apparently documented, but pretty user hostile and definitely caused me some grief and time in the debugger. Any chance of changing that?