### PR TITLE
CXX-906 Fix null deref in getCollectionNames()/getCollectionInfos()

### DIFF
--- a/src/mongo/client/dbclient.cpp
+++ b/src/mongo/client/dbclient.cpp
@@ -1471,6 +1471,7 @@ list<string> DBClientWithCommands::getDatabaseNames() {
 
 list<string> DBClientWithCommands::getCollectionNames(const string& db, const BSONObj& filter) {
     auto_ptr<DBClientCursor> infos = enumerateCollections(db, filter);
+    uassert(0, "failed to read server response from socket when listing collections", infos.get());
     list<string> names;
 
     while (infos->more()) {
@@ -1482,6 +1483,9 @@ list<string> DBClientWithCommands::getCollectionNames(const string& db, const BS
 
 list<BSONObj> DBClientWithCommands::getCollectionInfos(const string& db, const BSONObj& filter) {
     auto_ptr<DBClientCursor> info_cursor = enumerateCollections(db, filter);
+    uassert(0,
+            "failed to read server response from socket when listing collections",
+            info_cursor.get());
     list<BSONObj> infos;
 
     while (info_cursor->more()) {
@@ -1585,6 +1589,8 @@ auto_ptr<DBClientCursor> DBClientWithCommands::enumerateCollections(const string
 bool DBClientWithCommands::exists(const string& ns) {
     BSONObj filter = BSON("name" << nsToCollectionSubstring(ns));
     auto_ptr<DBClientCursor> results = enumerateCollections(nsToDatabase(ns), filter);
+    uassert(
+        0, "failed to read server response from socket when listing collections", results.get());
     return results->more();
 }
 

--- a/src/mongo/integration/standalone/dbclient_test.cpp
+++ b/src/mongo/integration/standalone/dbclient_test.cpp
@@ -517,6 +517,7 @@ TEST_F(DBClientTest, EnumerateCollections) {
     BSONObjBuilder bob;
     bob.appendRegex("name", "COLL\\d$");
     auto_ptr<DBClientCursor> cursor = c->enumerateCollections(TEST_DB, bob.obj(), batch_size);
+    ASSERT(cursor.get());
 
     if (serverGTE(c.get(), 2, 8))
         ASSERT_EQUALS(cursor->getns(), TEST_DB + ".$cmd.listCollections");


### PR DESCRIPTION
I manually tested this by issuing a kill -9 to mongod right before a call to getCollectionNames(), and ditto with getCollectionInfos().  I assume that this particular fix should be committed without tests, but let me know.

The error message is copy-pasted from elsewhere in this file.

@acmorrow, PTAL.
