### PR TITLE
CXX-928 Fix bad merge of SConstruct in dc6e44b

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1734,7 +1734,8 @@ def doConfigure(myenv):
 
     conf = Configure(myenv)
 
-    if has_option( "ssl" ):
+    conf.env["MONGO_SSL"] = bool(has_option("ssl"))
+    if conf.env["MONGO_SSL"]:
         sslLibName = "ssl"
         cryptoLibName = "crypto"
         if windows:
@@ -1783,8 +1784,6 @@ def doConfigure(myenv):
 
         if not conf.CheckLinkSSL():
             conf.env.ConfError("SSL is enabled, but is unavailable")
-
-        conf.env["MONGO_SSL"] = True
 
         if conf.CheckDeclaration(
             "FIPS_mode_set",


### PR DESCRIPTION
Initialization of `env["MONGO_SSL"]` on non-SSL builds was accidentally deleted when backporting `e5f5b4e` from the server repository, as part of legacy commit dc6e44b.  See the old initialization on the left-hand side of the diff at [SConstruct:935](https://github.com/mongodb/mongo-cxx-driver/commit/dc6e44bb#diff-cc8093822b396591a5530a463c87d048L935).