### PR TITLE
CXX-849 Verify range of std::chrono::duration options

### DIFF
--- a/src/mongocxx/options/aggregate.cpp
+++ b/src/mongocxx/options/aggregate.cpp
@@ -14,6 +14,9 @@
 
 #include <mongocxx/options/aggregate.hpp>
 
+#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/exception/logic_error.hpp>
+#include <mongocxx/private/constraints.hpp>
 #include <mongocxx/private/read_preference.hpp>
 
 #include <mongocxx/config/private/prelude.hpp>
@@ -33,6 +36,8 @@ aggregate& aggregate::batch_size(std::int32_t batch_size) {
 }
 
 aggregate& aggregate::max_time(std::chrono::milliseconds max_time) {
+    if (!is_int32_duration<std::chrono::milliseconds>(max_time))
+        throw logic_error{error_code::k_invalid_parameter};
     _max_time = std::move(max_time);
     return *this;
 }

--- a/src/mongocxx/options/count.cpp
+++ b/src/mongocxx/options/count.cpp
@@ -14,6 +14,9 @@
 
 #include <mongocxx/options/count.hpp>
 
+#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/exception/logic_error.hpp>
+#include <mongocxx/private/constraints.hpp>
 #include <mongocxx/private/read_preference.hpp>
 
 #include <mongocxx/config/private/prelude.hpp>
@@ -33,6 +36,8 @@ count& count::limit(std::int64_t limit) {
 }
 
 count& count::max_time(std::chrono::milliseconds max_time) {
+    if (!is_int32_duration<std::chrono::milliseconds>(max_time))
+        throw logic_error{error_code::k_invalid_parameter};
     _max_time = std::move(max_time);
     return *this;
 }

--- a/src/mongocxx/options/distinct.cpp
+++ b/src/mongocxx/options/distinct.cpp
@@ -14,6 +14,9 @@
 
 #include <mongocxx/options/distinct.hpp>
 
+#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/exception/logic_error.hpp>
+#include <mongocxx/private/constraints.hpp>
 #include <mongocxx/private/read_preference.hpp>
 
 #include <mongocxx/config/private/prelude.hpp>
@@ -23,6 +26,8 @@ MONGOCXX_INLINE_NAMESPACE_BEGIN
 namespace options {
 
 distinct& distinct::max_time(std::chrono::milliseconds max_time) {
+    if (!is_int32_duration<std::chrono::milliseconds>(max_time))
+        throw logic_error{error_code::k_invalid_parameter};
     _max_time = std::move(max_time);
     return *this;
 }

--- a/src/mongocxx/options/find.cpp
+++ b/src/mongocxx/options/find.cpp
@@ -14,6 +14,9 @@
 
 #include <mongocxx/options/find.hpp>
 
+#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/exception/logic_error.hpp>
+#include <mongocxx/private/constraints.hpp>
 #include <mongocxx/private/read_preference.hpp>
 
 #include <mongocxx/config/private/prelude.hpp>
@@ -53,11 +56,15 @@ find& find::limit(std::int32_t limit) {
 }
 
 find& find::max_await_time(std::chrono::milliseconds max_await_time) {
+    if (!is_int32_duration<std::chrono::milliseconds>(max_await_time))
+        throw logic_error{error_code::k_invalid_parameter};
     _max_await_time = std::move(max_await_time);
     return *this;
 }
 
 find& find::max_time(std::chrono::milliseconds max_time) {
+    if (!is_int32_duration<std::chrono::milliseconds>(max_time))
+        throw logic_error{error_code::k_invalid_parameter};
     _max_time = std::move(max_time);
     return *this;
 }

--- a/src/mongocxx/options/find_one_and_delete.cpp
+++ b/src/mongocxx/options/find_one_and_delete.cpp
@@ -14,6 +14,10 @@
 
 #include <mongocxx/options/find_one_and_delete.hpp>
 
+#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/exception/logic_error.hpp>
+#include <mongocxx/private/constraints.hpp>
+
 #include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
@@ -21,6 +25,8 @@ MONGOCXX_INLINE_NAMESPACE_BEGIN
 namespace options {
 
 find_one_and_delete& find_one_and_delete::max_time(std::chrono::milliseconds max_time) {
+    if (!is_int32_duration<std::chrono::milliseconds>(max_time))
+        throw logic_error{error_code::k_invalid_parameter};
     _max_time = std::move(max_time);
     return *this;
 }

--- a/src/mongocxx/options/find_one_and_replace.cpp
+++ b/src/mongocxx/options/find_one_and_replace.cpp
@@ -14,6 +14,10 @@
 
 #include <mongocxx/options/find_one_and_replace.hpp>
 
+#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/exception/logic_error.hpp>
+#include <mongocxx/private/constraints.hpp>
+
 #include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
@@ -27,6 +31,8 @@ find_one_and_replace& find_one_and_replace::bypass_document_validation(
 }
 
 find_one_and_replace& find_one_and_replace::max_time(std::chrono::milliseconds max_time) {
+    if (!is_int32_duration<std::chrono::milliseconds>(max_time))
+        throw logic_error{error_code::k_invalid_parameter};
     _max_time = std::move(max_time);
     return *this;
 }

--- a/src/mongocxx/options/find_one_and_update.cpp
+++ b/src/mongocxx/options/find_one_and_update.cpp
@@ -14,6 +14,10 @@
 
 #include <mongocxx/options/find_one_and_update.hpp>
 
+#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/exception/logic_error.hpp>
+#include <mongocxx/private/constraints.hpp>
+
 #include <mongocxx/config/private/prelude.hpp>
 
 namespace mongocxx {
@@ -27,6 +31,8 @@ find_one_and_update& find_one_and_update::bypass_document_validation(
 }
 
 find_one_and_update& find_one_and_update::max_time(std::chrono::milliseconds max_time) {
+    if (!is_int32_duration<std::chrono::milliseconds>(max_time))
+        throw logic_error{error_code::k_invalid_parameter};
     _max_time = std::move(max_time);
     return *this;
 }

--- a/src/mongocxx/options/index.cpp
+++ b/src/mongocxx/options/index.cpp
@@ -15,6 +15,9 @@
 #include <mongocxx/options/index.hpp>
 
 #include <bsoncxx/stdx/make_unique.hpp>
+#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/exception/logic_error.hpp>
+#include <mongocxx/private/constraints.hpp>
 #include <mongocxx/private/libmongoc.hpp>
 
 #include <mongocxx/config/private/prelude.hpp>
@@ -57,6 +60,8 @@ index& index::storage_options(std::unique_ptr<index::wiredtiger_storage_options>
 }
 
 index& index::expire_after(std::chrono::seconds expire_after) {
+    if (!is_int32_duration<std::chrono::seconds>(expire_after))
+        throw logic_error{error_code::k_invalid_parameter};
     _expire_after = expire_after;
     return *this;
 }

--- a/src/mongocxx/options/modify_collection.cpp
+++ b/src/mongocxx/options/modify_collection.cpp
@@ -17,6 +17,9 @@
 #include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/builder/stream/helpers.hpp>
 #include <bsoncxx/types.hpp>
+#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/exception/logic_error.hpp>
+#include <mongocxx/private/constraints.hpp>
 
 #include <mongocxx/config/private/prelude.hpp>
 
@@ -35,6 +38,8 @@ modify_collection& modify_collection::no_padding(bool no_padding) {
 
 modify_collection& modify_collection::index(bsoncxx::document::view_or_value index_spec,
                                             std::chrono::seconds seconds) {
+    if (!is_int32_duration<std::chrono::seconds>(seconds))
+        throw logic_error{error_code::k_invalid_parameter};
     _index.emplace(document{} << "keyPattern" << bsoncxx::types::b_document{std::move(index_spec)}
                               << "expireAfterSeconds" << bsoncxx::types::b_int64{seconds.count()}
                               << finalize);

--- a/src/mongocxx/private/constraints.hpp
+++ b/src/mongocxx/private/constraints.hpp
@@ -1,0 +1,34 @@
+// Copyright 2014 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/private/prelude.hpp>
+
+#include <cstdint>
+#include <limits>
+
+namespace mongocxx {
+MONGOCXX_INLINE_NAMESPACE_BEGIN
+
+template <typename T>
+bool is_int32_duration(const T& duration) {
+    const auto count = duration.count();
+    return (count >= 0) && (count <= std::numeric_limits<std::int32_t>::max());
+}
+
+MONGOCXX_INLINE_NAMESPACE_END
+}  // namespace mongocxx
+
+#include <mongocxx/config/private/postlude.hpp>

--- a/src/mongocxx/test/collection_mocked.cpp
+++ b/src/mongocxx/test/collection_mocked.cpp
@@ -322,14 +322,8 @@ TEST_CASE("Collection", "[collection]") {
 
         SECTION("Fails with Options") {
             success = false;
-            expected_expire_after =
-                std::chrono::seconds(static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1);
-            options.expire_after(expected_expire_after);
-            REQUIRE_THROWS_AS(mongo_coll.create_index(index_spec.view(), options), logic_error);
-
             expected_expire_after = std::chrono::seconds(-1);
-            options.expire_after(expected_expire_after);
-            REQUIRE_THROWS_AS(mongo_coll.create_index(index_spec.view(), options), logic_error);
+            REQUIRE_THROWS_AS(options.expire_after(expected_expire_after), logic_error);
 
             collection_create_index_called = true;  // mock for this section
         }


### PR DESCRIPTION
In many places, libmongoc only takes int32_t for certain duration options
even if the server could take an int64_t.  This commit verifies that
std::chrono::duration options are non-negative integers less than the
maximum int32_t or raises a parameter exception.

While some options and code paths could, in theory, take 64-bit values, in
practice, we don't expect users to set index expirations above billions of
seconds or operation timeouts above billions of milliseconds, so the
positive int32_t range should be more than sufficient and applying that
constraint everywhere provides a consistent, predictable interface for
users.

