### PR TITLE
CXX-969 appveyor.yml - pin C driver to 1.3.4

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ os: Visual Studio 2015
 test: off
 
 build_script:
-  - cmd: git clone -b master https://github.com/mongodb/mongo-c-driver.git
+  - cmd: git clone -b "1.3.4" --single-branch https://github.com/mongodb/mongo-c-driver.git
   - cmd: cd mongo-c-driver
   - cmd: git submodule init
   - cmd: git submodule update


### PR DESCRIPTION
Pin the C driver to 1.3.4 in Appveyor to match travis.