### PR TITLE
CXX-991 Always include CMake modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ set(CMAKE_MACOSX_RPATH 1)
 
 # Add in our modules, we write FindX modules for libbson and libmongoc
 # since they don't currently install them.
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 
 # Enforce the C++ standard, and disable extensions
 if(NOT DEFINED CMAKE_CXX_STANDARD)
@@ -80,12 +80,12 @@ add_custom_target(docs
 )
 
 add_custom_target(format
-    python ${CMAKE_SOURCE_DIR}/etc/clang_format.py format
+    python ${CMAKE_CURRENT_SOURCE_DIR}/etc/clang_format.py format
     VERBATIM
 )
 
 add_custom_target(format-lint
-    python ${CMAKE_SOURCE_DIR}/etc/clang_format.py lint
+    python ${CMAKE_CURRENT_SOURCE_DIR}/etc/clang_format.py lint
     VERBATIM
 )
 

--- a/src/bsoncxx/CMakeLists.txt
+++ b/src/bsoncxx/CMakeLists.txt
@@ -89,8 +89,8 @@ set(bsoncxx_sources
 
 include_directories(
     ${LIBBSON_INCLUDE_DIRS}
-    ${CMAKE_SOURCE_DIR}/src
-    ${CMAKE_BINARY_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${CMAKE_CURRENT_BINARY_DIR}/..
 )
 
 link_directories(${LIBBSON_LIBRARY_DIRS})

--- a/src/bsoncxx/test/CMakeLists.txt
+++ b/src/bsoncxx/test/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 include_directories(
-    ${CMAKE_SOURCE_DIR}/src/third_party/catch/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/catch/include
 )
 
 add_executable(test_bson

--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -92,8 +92,8 @@ set(mongocxx_sources
 include_directories(
     ${LIBBSON_INCLUDE_DIRS}
     ${LIBMONGOC_INCLUDE_DIRS}
-    ${CMAKE_SOURCE_DIR}/src
-    ${CMAKE_BINARY_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${CMAKE_CURRENT_BINARY_DIR}/..
 )
 
 link_directories(


### PR DESCRIPTION
Even when the driver is a submodule of another project.
