### PR TITLE
CXX-939 Allow default constructed document and array views

### DIFF
--- a/src/bsoncxx/array/value.cpp
+++ b/src/bsoncxx/array/value.cpp
@@ -23,6 +23,15 @@ namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
 namespace array {
 
+namespace {
+const auto nop_deleter = [](uint8_t*){};
+}  // namespace
+
+
+value::value() noexcept
+    : _data(nullptr, nop_deleter), _length() {
+}
+
 value::value(std::uint8_t* data, std::size_t length, deleter_type dtor)
     : _data(data, dtor), _length(length) {
 }

--- a/src/bsoncxx/array/value.cpp
+++ b/src/bsoncxx/array/value.cpp
@@ -24,12 +24,10 @@ BSONCXX_INLINE_NAMESPACE_BEGIN
 namespace array {
 
 namespace {
-const auto nop_deleter = [](uint8_t*){};
+const auto nop_deleter = [](uint8_t*) {};
 }  // namespace
 
-
-value::value() noexcept
-    : _data(nullptr, nop_deleter), _length() {
+value::value() noexcept : _data(nullptr, nop_deleter), _length() {
 }
 
 value::value(std::uint8_t* data, std::size_t length, deleter_type dtor)

--- a/src/bsoncxx/array/value.hpp
+++ b/src/bsoncxx/array/value.hpp
@@ -37,6 +37,12 @@ class BSONCXX_API value {
     using unique_ptr_type = std::unique_ptr<uint8_t, deleter_type>;
 
     ///
+    /// Constructs a default value. The value is as if moved from. In particular
+    /// it is illegal to access the view of a default constructed value.
+    ///
+    value() noexcept;
+
+    ///
     /// Constructs a value from a buffer.
     /// This constructor transfers ownership of the buffer to the resulting
     /// value. A user-provided deleter is used to destroy the buffer.
@@ -76,6 +82,13 @@ class BSONCXX_API value {
 
     value(value&&) noexcept = default;
     value& operator=(value&&) noexcept = default;
+
+    ///
+    /// Returns true if this value is not default constructed or moved from.
+    ///
+    BSONCXX_INLINE explicit operator bool() const noexcept {
+        return static_cast<bool>(_data);
+    }
 
     ///
     /// Get a view over the document owned by this value.

--- a/src/bsoncxx/document/value.cpp
+++ b/src/bsoncxx/document/value.cpp
@@ -23,6 +23,14 @@ namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
 namespace document {
 
+namespace {
+const auto nop_deleter = [](uint8_t*){};
+}  // namespace
+
+value::value() noexcept
+    : _data(nullptr, nop_deleter), _length() {
+}
+
 value::value(std::uint8_t* data, std::size_t length, deleter_type dtor)
     : _data(data, dtor), _length(length) {
 }

--- a/src/bsoncxx/document/value.cpp
+++ b/src/bsoncxx/document/value.cpp
@@ -24,11 +24,10 @@ BSONCXX_INLINE_NAMESPACE_BEGIN
 namespace document {
 
 namespace {
-const auto nop_deleter = [](uint8_t*){};
+const auto nop_deleter = [](uint8_t*) {};
 }  // namespace
 
-value::value() noexcept
-    : _data(nullptr, nop_deleter), _length() {
+value::value() noexcept : _data(nullptr, nop_deleter), _length() {
 }
 
 value::value(std::uint8_t* data, std::size_t length, deleter_type dtor)

--- a/src/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/document/value.hpp
@@ -36,6 +36,12 @@ class BSONCXX_API value {
     using unique_ptr_type = std::unique_ptr<uint8_t, deleter_type>;
 
     ///
+    /// Constructs a default value. The value is as if moved from. In particular
+    /// it is illegal to access the view of a default constructed value.
+    ///
+    value() noexcept;
+
+    ///
     /// Constructs a value from a buffer.
     /// This constructor transfers ownership of the buffer to the resulting
     /// value. A user-provided deleter is used to destroy the buffer.
@@ -75,6 +81,13 @@ class BSONCXX_API value {
 
     value(value&&) noexcept = default;
     value& operator=(value&&) noexcept = default;
+
+    ///
+    /// Returns true if this value is not default constructed or moved from.
+    ///
+    BSONCXX_INLINE explicit operator bool() const noexcept {
+        return static_cast<bool>(_data);
+    }
 
     ///
     /// Get a view over the document owned by this value.

--- a/src/bsoncxx/test/CMakeLists.txt
+++ b/src/bsoncxx/test/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(test_bson
     bson_validate.cpp
     json.cpp
     new_tests.cpp
+    values.cpp
     view_or_value.cpp
 )
 

--- a/src/bsoncxx/test/values.cpp
+++ b/src/bsoncxx/test/values.cpp
@@ -1,0 +1,52 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "catch.hpp"
+
+#include <bsoncxx/builder/stream/array.hpp>
+#include <bsoncxx/builder/stream/document.hpp>
+
+using namespace bsoncxx;
+
+TEST_CASE("A default constructed document::value is falsy", "[bsoncxx]") {
+    document::value val;
+    REQUIRE(!val);
+}
+
+TEST_CASE("A default constructed array::value is falsy", "[bsoncxx]") {
+    array::value val;
+    REQUIRE(!val);
+}
+
+TEST_CASE("A populated document::value is truish", "[bsoncxx]") {
+    document::value val = builder::stream::document{} << builder::stream::finalize;
+    REQUIRE(val);
+}
+
+TEST_CASE("A populated array::value is truish", "[bsoncxx]") {
+    array::value val = builder::stream::array{} << builder::stream::finalize;
+    REQUIRE(val);
+}
+
+TEST_CASE("A moved-from document::value is falsy", "[bsoncxx]") {
+    document::value val = builder::stream::document{} << builder::stream::finalize;
+    document::value val2 = std::move(val);
+    REQUIRE(!val);
+}
+
+TEST_CASE("A moved-from array::value is falsy", "[bsoncxx]") {
+    array::value val = builder::stream::array{} << builder::stream::finalize;
+    array::value val2 = std::move(val);
+    REQUIRE(!val);
+}


### PR DESCRIPTION
@xdg @hanumantmk @Machyne - Adds the sharp edges to document::value and array::value. If you default construct one, you get a moved from state.

What do we think? See https://jira.mongodb.org/browse/CXX-939 for background.

CC @bazineta 