### PR TITLE
CXX-939 Default constructed values view the empty view

### DIFF
--- a/src/bsoncxx/array/value.cpp
+++ b/src/bsoncxx/array/value.cpp
@@ -29,7 +29,7 @@ void uint8_t_deleter(const std::uint8_t* ptr) {
     delete[] ptr;
 }
 
-void noop_deleter(const std::uint8_t* ptr) {
+void noop_deleter(const std::uint8_t*) {
 }
 
 }  // namespace

--- a/src/bsoncxx/array/value.cpp
+++ b/src/bsoncxx/array/value.cpp
@@ -23,25 +23,32 @@ namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
 namespace array {
 
-value::value(std::uint8_t* data, std::size_t length, deleter_type dtor)
+namespace {
+
+void uint8_t_deleter(const std::uint8_t* ptr) {
+    delete[] ptr;
+}
+
+void noop_deleter(const std::uint8_t* ptr) {
+}
+
+}  // namespace
+
+value::value() noexcept
+    : _data(array::view().data(), noop_deleter)
+    , _length(array::view().length()) {}
+
+value::value(const std::uint8_t* data, std::size_t length, deleter_type dtor)
     : _data(data, dtor), _length(length) {
 }
 
 value::value(unique_ptr_type ptr, std::size_t length) : _data(std::move(ptr)), _length(length) {
 }
 
-namespace {
-
-void uint8_t_deleter(std::uint8_t* ptr) {
-    delete[] ptr;
-}
-
-}  // namespace
-
 value::value(array::view view)
     : _data(new std::uint8_t[static_cast<std::size_t>(view.length())], uint8_t_deleter),
       _length(view.length()) {
-    std::copy(view.data(), view.data() + view.length(), _data.get());
+    std::copy(view.data(), view.data() + view.length(), const_cast<std::uint8_t*>(_data.get()));
 }
 
 value::value(const value& rhs) : value(rhs.view()) {
@@ -53,11 +60,7 @@ value& value::operator=(const value& rhs) {
 }
 
 value::unique_ptr_type value::release() {
-    auto x = std::move(_data);
-
-    _data.release();
-
-    return x;
+    return std::move(_data);
 }
 
 }  // namespace array

--- a/src/bsoncxx/array/value.cpp
+++ b/src/bsoncxx/array/value.cpp
@@ -34,9 +34,9 @@ void noop_deleter(const std::uint8_t* ptr) {
 
 }  // namespace
 
-value::value() noexcept
-    : _data(array::view().data(), noop_deleter)
-    , _length(array::view().length()) {}
+value::value() noexcept : _data(array::view().data(), noop_deleter),
+                          _length(array::view().length()) {
+}
 
 value::value(const std::uint8_t* data, std::size_t length, deleter_type dtor)
     : _data(data, dtor), _length(length) {

--- a/src/bsoncxx/array/value.hpp
+++ b/src/bsoncxx/array/value.hpp
@@ -33,8 +33,11 @@ namespace array {
 ///
 class BSONCXX_API value {
    public:
-    using deleter_type = void (*)(std::uint8_t*);
-    using unique_ptr_type = std::unique_ptr<uint8_t, deleter_type>;
+    using deleter_type = void (*)(const std::uint8_t*);
+    using unique_ptr_type = std::unique_ptr<const uint8_t, deleter_type>;
+
+
+    value() noexcept;
 
     ///
     /// Constructs a value from a buffer.
@@ -48,7 +51,7 @@ class BSONCXX_API value {
     /// @param dtor
     ///   A user provided deleter.
     ///
-    value(std::uint8_t* data, std::size_t length, deleter_type dtor);
+    value(const std::uint8_t* data, std::size_t length, deleter_type dtor);
 
     ///
     /// Constructs a value from a std::unique_ptr to a buffer. The ownership
@@ -106,7 +109,7 @@ class BSONCXX_API value {
 };
 
 BSONCXX_INLINE array::view value::view() const noexcept {
-    return array::view{static_cast<uint8_t*>(_data.get()), _length};
+    return array::view{static_cast<const uint8_t*>(_data.get()), _length};
 }
 
 BSONCXX_INLINE value::operator array::view() const noexcept {

--- a/src/bsoncxx/array/value.hpp
+++ b/src/bsoncxx/array/value.hpp
@@ -36,7 +36,6 @@ class BSONCXX_API value {
     using deleter_type = void (*)(const std::uint8_t*);
     using unique_ptr_type = std::unique_ptr<const uint8_t, deleter_type>;
 
-
     value() noexcept;
 
     ///

--- a/src/bsoncxx/array/view.cpp
+++ b/src/bsoncxx/array/view.cpp
@@ -184,27 +184,6 @@ element view::operator[](std::uint32_t i) const {
     return *(this->find(i));
 }
 
-view::view(const std::uint8_t* data, std::size_t length) : _view(data, length) {
-}
-
-view::view() : _view() {
-}
-
-const std::uint8_t* view::data() const {
-    return _view.data();
-}
-std::size_t view::length() const {
-    return _view.length();
-}
-
-bool view::empty() const {
-    return _view.empty();
-}
-
-view::operator document::view() const {
-    return _view;
-}
-
 bool operator==(view lhs, view rhs) {
     return (lhs.length() == rhs.length()) &&
            (std::memcmp(lhs.data(), rhs.data(), lhs.length()) == 0);

--- a/src/bsoncxx/array/view.hpp
+++ b/src/bsoncxx/array/view.hpp
@@ -36,6 +36,25 @@ class BSONCXX_API view {
     class BSONCXX_API const_iterator;
 
     ///
+    /// Default constructs a view. The resulting view will be initialized to point at
+    /// an empty BSON array.
+    ///
+    BSONCXX_INLINE constexpr view() noexcept
+        : _view() {}
+
+    ///
+    /// Constructs a view from a buffer. The caller is responsible for ensuring that
+    /// the lifetime of the resulting view is a subset of the buffer's.
+    ///
+    /// @param data
+    ///   A buffer containing a valid BSON array.
+    /// @param length
+    ///   The size of the buffer, in bytes.
+    ///
+    BSONCXX_INLINE constexpr view(const std::uint8_t* data, std::size_t length)
+        : _view(data, length) {}
+
+    ///
     /// @returns An const_iterator to the first element of the array.
     ///
     const_iterator cbegin() const;
@@ -80,28 +99,13 @@ class BSONCXX_API view {
     element operator[](std::uint32_t i) const;
 
     ///
-    /// Default constructs a view. The resulting view will be initialized to point at
-    /// an empty BSON array.
-    ///
-    view();
-
-    ///
-    /// Constructs a view from a buffer. The caller is responsible for ensuring that
-    /// the lifetime of the resulting view is a subset of the buffer's.
-    ///
-    /// @param data
-    ///   A buffer containing a valid BSON array.
-    /// @param length
-    ///   The size of the buffer, in bytes.
-    ///
-    view(const std::uint8_t* data, std::size_t length);
-
-    ///
     /// Access the raw bytes of the underlying array.
     ///
     /// @return A (non-owning) pointer to the view's buffer.
     ///
-    const std::uint8_t* data() const;
+    BSONCXX_INLINE constexpr const std::uint8_t* data() const noexcept {
+        return _view.data();
+    }
 
     ///
     /// Gets the length of the underlying buffer.
@@ -111,7 +115,9 @@ class BSONCXX_API view {
     ///
     /// @return The length of the array, in bytes.
     ///
-    std::size_t length() const;
+    BSONCXX_INLINE constexpr std::size_t length() const noexcept {
+        return _view.length();
+    }
 
     ///
     /// Checks if the underlying buffer is empty, i.e. it is equivalent to
@@ -119,9 +125,13 @@ class BSONCXX_API view {
     ///
     /// @return true if the underlying document is empty.
     ///
-    bool empty() const;
+    BSONCXX_INLINE constexpr bool empty() const noexcept {
+        return _view.empty();
+    }
 
-    operator document::view() const;
+    BSONCXX_INLINE constexpr operator document::view() const noexcept {
+        return _view;
+    }
 
     ///
     /// @{

--- a/src/bsoncxx/array/view.hpp
+++ b/src/bsoncxx/array/view.hpp
@@ -39,8 +39,8 @@ class BSONCXX_API view {
     /// Default constructs a view. The resulting view will be initialized to point at
     /// an empty BSON array.
     ///
-    BSONCXX_INLINE constexpr view() noexcept
-        : _view() {}
+    BSONCXX_INLINE constexpr view() noexcept : _view() {
+    }
 
     ///
     /// Constructs a view from a buffer. The caller is responsible for ensuring that
@@ -52,7 +52,8 @@ class BSONCXX_API view {
     ///   The size of the buffer, in bytes.
     ///
     BSONCXX_INLINE constexpr view(const std::uint8_t* data, std::size_t length)
-        : _view(data, length) {}
+        : _view(data, length) {
+    }
 
     ///
     /// @returns An const_iterator to the first element of the array.

--- a/src/bsoncxx/builder/core.cpp
+++ b/src/bsoncxx/builder/core.cpp
@@ -34,8 +34,8 @@ namespace builder {
 
 namespace {
 
-void bson_free_deleter(std::uint8_t* ptr) {
-    bson_free(ptr);
+void bson_free_deleter(const std::uint8_t* ptr) {
+    bson_free(const_cast<std::uint8_t*>(ptr));
 }
 
 }  // namespace

--- a/src/bsoncxx/document/value.cpp
+++ b/src/bsoncxx/document/value.cpp
@@ -29,7 +29,7 @@ void uint8_t_deleter(const std::uint8_t* ptr) {
     delete[] ptr;
 }
 
-void noop_deleter(const std::uint8_t* ptr) {
+void noop_deleter(const std::uint8_t*) {
 }
 
 }  // namespace

--- a/src/bsoncxx/document/value.cpp
+++ b/src/bsoncxx/document/value.cpp
@@ -34,9 +34,9 @@ void noop_deleter(const std::uint8_t* ptr) {
 
 }  // namespace
 
-value::value() noexcept
-    : _data(document::view().data(), noop_deleter)
-    , _length(document::view().length()) {}
+value::value() noexcept : _data(document::view().data(), noop_deleter),
+                          _length(document::view().length()) {
+}
 
 value::value(const std::uint8_t* data, std::size_t length, deleter_type dtor)
     : _data(data, dtor), _length(length) {

--- a/src/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/document/value.hpp
@@ -32,8 +32,10 @@ namespace document {
 ///
 class BSONCXX_API value {
    public:
-    using deleter_type = void (*)(std::uint8_t*);
-    using unique_ptr_type = std::unique_ptr<uint8_t, deleter_type>;
+    using deleter_type = void (*)(const std::uint8_t*);
+    using unique_ptr_type = std::unique_ptr<const uint8_t, deleter_type>;
+
+    value() noexcept;
 
     ///
     /// Constructs a value from a buffer.
@@ -47,7 +49,7 @@ class BSONCXX_API value {
     /// @param dtor
     ///   A user provided deleter.
     ///
-    value(std::uint8_t* data, std::size_t length, deleter_type dtor);
+    value(const std::uint8_t* data, std::size_t length, deleter_type dtor);
 
     ///
     /// Constructs a value from a std::unique_ptr to a buffer. The ownership
@@ -105,7 +107,7 @@ class BSONCXX_API value {
 };
 
 BSONCXX_INLINE document::view value::view() const noexcept {
-    return document::view{static_cast<uint8_t*>(_data.get()), _length};
+    return document::view{static_cast<const uint8_t*>(_data.get()), _length};
 }
 
 BSONCXX_INLINE value::operator document::view() const noexcept {

--- a/src/bsoncxx/document/view.cpp
+++ b/src/bsoncxx/document/view.cpp
@@ -16,6 +16,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <type_traits>
 
 #include <bson.h>
 
@@ -38,7 +39,7 @@ bson_iter_t to_bson_iter_t(element e) {
 }
 }  // namespace
 
-constexpr uint8_t view::k_empty[std::extent<decltype(view::k_empty)>];
+constexpr std::uint8_t view::k_empty[std::extent<decltype(view::k_empty)>::value];
 
 view::iterator::iterator() {
 }

--- a/src/bsoncxx/document/view.cpp
+++ b/src/bsoncxx/document/view.cpp
@@ -38,6 +38,8 @@ bson_iter_t to_bson_iter_t(element e) {
 }
 }  // namespace
 
+constexpr uint8_t view::k_empty[];
+
 view::iterator::iterator() {
 }
 
@@ -182,27 +184,6 @@ view::iterator view::find(stdx::string_view key) const {
 
 element view::operator[](stdx::string_view key) const {
     return *(this->find(key));
-}
-
-view::view(const std::uint8_t* data, std::size_t length) : _data(data), _length(length) {
-}
-
-namespace {
-const uint8_t k_default_view[5] = {5, 0, 0, 0, 0};
-}
-
-view::view() : _data(k_default_view), _length(sizeof(k_default_view)) {
-}
-
-const std::uint8_t* view::data() const {
-    return _data;
-}
-std::size_t view::length() const {
-    return _length;
-}
-
-bool view::empty() const {
-    return _length == 5;
 }
 
 bool operator==(view lhs, view rhs) {

--- a/src/bsoncxx/document/view.cpp
+++ b/src/bsoncxx/document/view.cpp
@@ -38,7 +38,7 @@ bson_iter_t to_bson_iter_t(element e) {
 }
 }  // namespace
 
-constexpr uint8_t view::k_empty[];
+constexpr uint8_t view::k_empty[std::extent<decltype(view::k_empty)>];
 
 view::iterator::iterator() {
 }

--- a/src/bsoncxx/document/view.hpp
+++ b/src/bsoncxx/document/view.hpp
@@ -152,7 +152,7 @@ class BSONCXX_API view {
    private:
     // The magic representation of an empty BSON document. The first four bytes
     // are the number 5 in little endian, the last byte is a terminating zero byte.
-    static constexpr uint8_t k_empty[] = {5, 0, 0, 0, 0};
+    static constexpr std::uint8_t k_empty[] = {5, 0, 0, 0, 0};
 
     const std::uint8_t* _data;
     std::size_t _length;

--- a/src/bsoncxx/document/view.hpp
+++ b/src/bsoncxx/document/view.hpp
@@ -39,8 +39,8 @@ class BSONCXX_API view {
     /// Default constructs a view. The resulting view will be initialized to point at
     /// an empty BSON document.
     ///
-    BSONCXX_INLINE constexpr view() noexcept
-        : view(k_empty, sizeof(k_empty)) {}
+    BSONCXX_INLINE constexpr view() noexcept : view(k_empty, sizeof(k_empty)) {
+    }
 
     ///
     /// Constructs a view from a buffer. The caller is responsible for ensuring that
@@ -52,8 +52,9 @@ class BSONCXX_API view {
     ///   The size of the buffer, in bytes.
     ///
     BSONCXX_INLINE constexpr view(const std::uint8_t* data, std::size_t length) noexcept
-        : _data(data)
-        , _length(length) {}
+        : _data(data),
+          _length(length) {
+    }
 
     ///
     /// @returns A const_iterator to the first element of the document.

--- a/src/bsoncxx/document/view.hpp
+++ b/src/bsoncxx/document/view.hpp
@@ -39,7 +39,8 @@ class BSONCXX_API view {
     /// Default constructs a view. The resulting view will be initialized to point at
     /// an empty BSON document.
     ///
-    view();
+    BSONCXX_INLINE constexpr view() noexcept
+        : view(k_empty, sizeof(k_empty)) {}
 
     ///
     /// Constructs a view from a buffer. The caller is responsible for ensuring that
@@ -50,7 +51,9 @@ class BSONCXX_API view {
     /// @param length
     ///   The size of the buffer, in bytes.
     ///
-    view(const std::uint8_t* data, std::size_t length);
+    BSONCXX_INLINE constexpr view(const std::uint8_t* data, std::size_t length) noexcept
+        : _data(data)
+        , _length(length) {}
 
     ///
     /// @returns A const_iterator to the first element of the document.
@@ -106,7 +109,9 @@ class BSONCXX_API view {
     ///
     /// @return A (non-owning) pointer to the view's buffer.
     ///
-    const std::uint8_t* data() const;
+    BSONCXX_INLINE constexpr const std::uint8_t* data() const noexcept {
+        return _data;
+    }
 
     ///
     /// Gets the length of the underlying buffer.
@@ -116,7 +121,9 @@ class BSONCXX_API view {
     ///
     /// @return The length of the document, in bytes.
     ///
-    std::size_t length() const;
+    BSONCXX_INLINE constexpr std::size_t length() const noexcept {
+        return _length;
+    }
 
     ///
     /// Checks if the underlying document is empty, i.e. it is equivalent to
@@ -124,7 +131,9 @@ class BSONCXX_API view {
     ///
     /// @return true if the underlying document is empty.
     ///
-    bool empty() const;
+    BSONCXX_INLINE constexpr bool empty() const noexcept {
+        return _length == sizeof(k_empty);
+    }
 
     ///
     /// @{
@@ -140,6 +149,10 @@ class BSONCXX_API view {
     ///
 
    private:
+    // The magic representation of an empty BSON document. The first four bytes
+    // are the number 5 in little endian, the last byte is a terminating zero byte.
+    static constexpr uint8_t k_empty[] = {5, 0, 0, 0, 0};
+
     const std::uint8_t* _data;
     std::size_t _length;
 };

--- a/src/bsoncxx/json.cpp
+++ b/src/bsoncxx/json.cpp
@@ -38,8 +38,8 @@ BSONCXX_INLINE_NAMESPACE_BEGIN
 
 namespace {
 
-void bson_free_deleter(std::uint8_t* ptr) {
-    bson_free(ptr);
+void bson_free_deleter(const std::uint8_t* ptr) {
+    bson_free(const_cast<std::uint8_t*>(ptr));
 }
 
 class json_visitor {

--- a/src/bsoncxx/test/bson_get_values.cpp
+++ b/src/bsoncxx/test/bson_get_values.cpp
@@ -235,3 +235,15 @@ TEST_CASE("empty array view has working iterators", "[bsoncxx]") {
     REQUIRE(doc.begin() == doc.end());
     REQUIRE(doc.cbegin() == doc.cend());
 }
+
+TEST_CASE("default constructed document value represents an empty range", "[bsoncxx]") {
+    const document::value value;
+    REQUIRE(value.view().begin() == value.view().end());
+    REQUIRE(value.view().cbegin() == value.view().cend());
+}
+
+TEST_CASE("default constructed array value represents an empty range", "[bsoncxx]") {
+    const array::value value;
+    REQUIRE(value.view().begin() == value.view().end());
+    REQUIRE(value.view().cbegin() == value.view().cend());
+}

--- a/src/mongocxx/private/libbson.cpp
+++ b/src/mongocxx/private/libbson.cpp
@@ -93,8 +93,8 @@ bsoncxx::document::view scoped_bson_t::view() {
 
 namespace {
 
-void bson_free_deleter(std::uint8_t* ptr) {
-    bson_free(ptr);
+void bson_free_deleter(const std::uint8_t* ptr) {
+    bson_free(const_cast<std::uint8_t*>(ptr));
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
Here is an alternative to https://github.com/mongodb/mongo-cxx-driver/pull/511. It represents a compromise:

- Default constructed values for document and array can exist.
- The view from a default constructed document or array is to the same object as a default constructed array::view or document::view
- Moved from document or array values are invalid to use.

In addition, I've plumbed through constexpr and noexcept where appropriate, such that constexpr array and document views can be constructed against static buffers at constexpr time. You can't actually *do* that much with the resulting view, but it is a nice PoC.
