### PR TITLE
CXX-1011: Support finding libbson and mongo_c on Windows when pkg-config is present

### DIFF
--- a/cmake/FindLibBSON.cmake
+++ b/cmake/FindLibBSON.cmake
@@ -22,17 +22,18 @@ include(FindPackageHandleStandardArgs)
 # Load up PkgConfig if we have it
 find_package(PkgConfig QUIET)
 
-if (PKG_CONFIG_FOUND)
-  pkg_check_modules(LIBBSON REQUIRED libbson-1.0>=${LibBSON_FIND_VERSION} )
-  # We don't reiterate the version information here because we assume that
-  # pkg_check_modules has honored our request.
-  find_package_handle_standard_args(LIBBSON DEFAULT_MSG LIBBSON_FOUND)
-elseif(LIBBSON_DIR)
-  # The best we can do until libbson starts installing a libbson-config.cmake file
+if(LIBBSON_DIR)
+  # Trust the user's override path by default
   set(LIBBSON_LIBRARIES bson-1.0 CACHE INTERNAL "")
   set(LIBBSON_LIBRARY_DIRS ${LIBBSON_DIR}/lib CACHE INTERNAL "")
   set(LIBBSON_INCLUDE_DIRS ${LIBBSON_DIR}/include/libbson-1.0 CACHE INTERNAL "")
   find_package_handle_standard_args(LIBBSON DEFAULT_MSG LIBBSON_LIBRARIES LIBBSON_LIBRARY_DIRS LIBBSON_INCLUDE_DIRS)
+elseif (PKG_CONFIG_FOUND)
+  # The best we can do until libbson starts installing a libbson-config.cmake file
+  pkg_check_modules(LIBBSON REQUIRED libbson-1.0>=${LibBSON_FIND_VERSION} )
+  # We don't reiterate the version information here because we assume that
+  # pkg_check_modules has honored our request.
+  find_package_handle_standard_args(LIBBSON DEFAULT_MSG LIBBSON_FOUND)
 else()
   message(FATAL_ERROR "Don't know how to find libbson; please set LIBBSON_DIR to the prefix directory with which libbson was configured.")
 endif()

--- a/cmake/FindLibMongoC.cmake
+++ b/cmake/FindLibMongoC.cmake
@@ -22,17 +22,18 @@ include(FindPackageHandleStandardArgs)
 # Load up PkgConfig if we have it
 find_package(PkgConfig QUIET)
 
-if (PKG_CONFIG_FOUND)
-  pkg_check_modules(LIBMONGOC REQUIRED libmongoc-1.0>=${LibMongoC_FIND_VERSION} )
-  # We don't reiterate the version information here because we assume that
-  # pkg_check_modules has honored our request.
-  find_package_handle_standard_args(LIBMONGOC DEFAULT_MSG LIBMONGOC_FOUND)
-elseif(LIBMONGOC_DIR)
-  # The best we can do until libMONGOC starts installing a libmongoc-config.cmake file
+if(LIBMONGOC_DIR)
+  # Trust the user's override path by default
   set(LIBMONGOC_LIBRARIES mongoc-1.0 CACHE INTERNAL "")
   set(LIBMONGOC_LIBRARY_DIRS ${LIBMONGOC_DIR}/lib CACHE INTERNAL "")
   set(LIBMONGOC_INCLUDE_DIRS ${LIBMONGOC_DIR}/include/libmongoc-1.0 CACHE INTERNAL "")
   find_package_handle_standard_args(LIBMONGOC DEFAULT_MSG LIBMONGOC_LIBRARIES LIBMONGOC_LIBRARY_DIRS LIBMONGOC_INCLUDE_DIRS)
+elseif (PKG_CONFIG_FOUND)
+  # The best we can do until libMONGOC starts installing a libmongoc-config.cmake file
+  pkg_check_modules(LIBMONGOC REQUIRED libmongoc-1.0>=${LibMongoC_FIND_VERSION} )
+  # We don't reiterate the version information here because we assume that
+  # pkg_check_modules has honored our request.
+  find_package_handle_standard_args(LIBMONGOC DEFAULT_MSG LIBMONGOC_FOUND)
 else()
     message(FATAL_ERROR "Don't know how to find libmongoc; please set LIBMONGOC_DIR to the prefix directory with which libbson was configured.")
 endif()


### PR DESCRIPTION
This PR enables a workaround for an upstream bug:  libbson and mongo_c's builds don't create .pc files on Windows.  As a result, pkg-config can't find them even if they exist and it is told where to look.

The workaround is as follows:  The existing cmake files always trust pkg-config if it is found -- if a user specifies a correct path to libbson, but pkg-config can't find libbson, then the cmake file reports that libbson can't be found.  This fix prioritizes the user-specified path so that it is always used if specified, even if pkg-config runs and can't find the package.
