### PR TITLE
CXX-1010 Use a regular string rather than a raw string; fix Visual Studio 2015 build

### DIFF
--- a/src/bsoncxx/test/json.cpp
+++ b/src/bsoncxx/test/json.cpp
@@ -66,5 +66,5 @@ TEST_CASE("CXX-941 is resolved") {
     std::string obj_value = R"({"id1":"val1", "id2":"val2"})";
     docu << "obj_name" << obj_value;
     std::string output = bsoncxx::to_json(docu.view());
-    REQUIRE(output == R"({ "obj_name" : "{\"id1\":\"val1\", \"id2\":\"val2\"}" })");
+    REQUIRE(output == "{ \"obj_name\" : \"{\\\"id1\\\":\\\"val1\\\", \\\"id2\\\":\\\"val2\\\"}\" }");
 }


### PR DESCRIPTION
Visual Studio finds a bunch of syntax errors on this line with the raw string, so it fails to compile mongo_cxx's test suite.  It seems to start failing at "id1"; I'm guessing that it thinks the string ends at that point, maybe because of the escaped quote or because of the macro expansion or some combination of the above.  (There are several other raw strings in the file; they are all simpler strings, but they all compile fine.)

This fixes the test-build on Visual Studio by rewriting this string as a regular (non-raw) string.