### PR TITLE
CXX-916 Fix documented exceptions

### DIFF
--- a/src/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/document/element.hpp
@@ -146,12 +146,16 @@ class BSONCXX_API element {
     ///
     /// @return the element's type.
     ///
+    /// @throws bsoncxx::exception if this element is invalid.
+    ///
     bsoncxx::type type() const;
 
     ///
     /// Getter for the element's key.
     ///
     /// @return the element's key.
+    ///
+    /// @throws bsoncxx::exception if this element is invalid.
     ///
     stdx::string_view key() const;
 

--- a/src/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/document/element.hpp
@@ -348,8 +348,6 @@ class BSONCXX_API element {
     /// key. If there is no such element, an invalid document::element will be returned. The
     /// runtime of operator[] is linear in the length of the document.
     ///
-    /// @throws bsoncxx::exception if this element is not a document.
-    ///
     /// @param key
     ///   The key to search for.
     ///
@@ -361,8 +359,6 @@ class BSONCXX_API element {
     /// If this element is an array, indexes into this BSON array. If the index is out-of-bounds,
     /// an invalid array::element will be returned. As BSON represents arrays as documents, the
     /// runtime of operator[] is linear in the length of the array.
-    ///
-    /// @throws bsoncxx::exception if this element is not an array.
     ///
     /// @param i
     ///   The index of the element.

--- a/src/bsoncxx/json.hpp
+++ b/src/bsoncxx/json.hpp
@@ -31,6 +31,8 @@ BSONCXX_INLINE_NAMESPACE_BEGIN
 /// @param view
 ///   A valid BSON document.
 ///
+/// @throws bsoncxx::exception with error details if the conversion failed.
+///
 /// @returns A JSON string.
 ///
 BSONCXX_API std::string BSONCXX_CALL to_json(document::view view);
@@ -43,8 +45,7 @@ BSONCXX_API std::string BSONCXX_CALL to_json(document::view view);
 ///
 /// @returns A document::value if conversion worked.
 ///
-/// @throws A bsoncxx::exception containing error details, if the
-/// conversion failed.
+/// @throws bsoncxx::exception with error details if the conversion failed.
 ///
 BSONCXX_API document::value BSONCXX_CALL from_json(stdx::string_view json);
 

--- a/src/bsoncxx/oid.hpp
+++ b/src/bsoncxx/oid.hpp
@@ -70,6 +70,8 @@ class BSONCXX_API oid {
     /// @param len
     ///   The length of the buffer. Should be 12.
     ///
+    /// @throws bsoncxx::exception if the length is not 12.
+    ///
     explicit oid(const char* bytes, std::size_t len);
 
     ///
@@ -77,6 +79,9 @@ class BSONCXX_API oid {
     ///
     /// @param str
     ///   A string of a hexadecimal representation of a valid ObjectId.
+    ///
+    /// @throws bsoncxx::exception if the string isn't an OID-sized hex
+    /// string.
     ///
     explicit oid(const bsoncxx::stdx::string_view& str);
 

--- a/src/mongocxx/client.hpp
+++ b/src/mongocxx/client.hpp
@@ -63,6 +63,9 @@ class MONGOCXX_API client {
     /// @param options
     ///   Additional options that cannot be specified via the mongodb_uri
     ///
+    /// @throws mongocxx::exception if invalid options are provided
+    /// (whether from the URI or provided client options).
+    ///
     client(const class uri& mongodb_uri, const options::client& options = options::client());
 
     ///
@@ -191,7 +194,7 @@ class MONGOCXX_API client {
     ///   disk in bytes, and an empty field specifying whether the database
     ///   has any data.
     ///
-    /// @throws exception::operation if the underlying 'listDatabases' command fails.
+    /// @throws mongocxx::operation_exception if the underlying 'listDatabases' command fails.
     ///
     /// @see http://docs.mongodb.org/manual/reference/command/listDatabases
     ///

--- a/src/mongocxx/collection.hpp
+++ b/src/mongocxx/collection.hpp
@@ -120,10 +120,9 @@ class MONGOCXX_API collection {
     /// @param options
     ///   Optional arguments, see mongocxx::options::aggregate.
     ///
-    /// @return A mongocxx::cursor with the results.
-    /// @throws
-    ///   If the operation failed, the returned cursor will throw an exception::query
-    ///   when it is iterated.
+    /// @return A mongocxx::cursor with the results.  If the query fails,
+    /// the cursor throws mongocxx::query_exception when the returned cursor
+    /// is iterated.
     ///
     /// @see http://docs.mongodb.org/manual/reference/command/aggregate/
     ///
@@ -143,7 +142,8 @@ class MONGOCXX_API collection {
     ///   Optional arguments, see options::bulk_write.
     ///
     /// @return The optional result of the bulk operation execution, a result::bulk_write.
-    /// @throws exception::bulk_write when there are errors processing the writes.
+    //
+    /// @throws mongocxx::bulk_write_exception when there are errors processing the writes.
     ///
     /// @see mongocxx::bulk_write
     /// @see http://docs.mongodb.org/manual/core/bulk-write-operations/
@@ -168,7 +168,8 @@ class MONGOCXX_API collection {
     ///   Optional arguments, see options::bulk_write.
     ///
     /// @return The optional result of the bulk operation execution, a result::bulk_write.
-    /// @throws exception::bulk_write when there are errors processing the writes.
+    ///
+    /// @throws mongocxx::bulk_write_exception when there are errors processing the writes.
     ///
     /// @see mongocxx::bulk_write
     /// @see http://docs.mongodb.org/manual/core/bulk-write-operations/
@@ -185,7 +186,8 @@ class MONGOCXX_API collection {
     ///   A bulk write which contains multiple write operations.
     ///
     /// @return The optional result of the bulk operation execution, a result::bulk_write.
-    /// @throws exception::bulk_write when there are errors processing the writes.
+    ///
+    /// @throws mongocxx::bulk_write_exception when there are errors processing the writes.
     ///
     /// @see http://docs.mongodb.org/manual/core/bulk-write-operations/
     ///
@@ -200,7 +202,8 @@ class MONGOCXX_API collection {
     ///   Optional arguments, see mongocxx::options::count.
     ///
     /// @return The count of the documents that matched the filter.
-    /// @throws exception::query if the count operation fails.
+    ///
+    /// @throws mongocxx::query_exception if the count operation fails.
     ///
     /// @see http://docs.mongodb.org/manual/reference/command/count/
     ///
@@ -215,7 +218,8 @@ class MONGOCXX_API collection {
     /// @param options
     ///   Optional arguments, see mongocxx::options::index.
     ///
-    /// @throws exception::operation if index creation fails.
+    /// @throws mongocxx::logic_error if the options are invalid.
+    /// @throws mongocxx::operation_exception if index creation fails.
     ///
     /// @see http://docs.mongodb.org/manual/reference/method/db.collection.createIndex/
     ///
@@ -231,7 +235,8 @@ class MONGOCXX_API collection {
     ///   Optional arguments, see mongocxx::options::delete_options.
     ///
     /// @return The optional result of performing the deletion, a result::delete_result.
-    /// @throws exception::write if the delete fails.
+    ///
+    /// @throws mongocxx::bulk_write_exception if the delete fails.
     ///
     /// @see http://docs.mongodb.org/manual/reference/command/delete/
     ///
@@ -248,7 +253,8 @@ class MONGOCXX_API collection {
     ///   Optional arguments, see mongocxx::options::delete_options.
     ///
     /// @return The optional result of performing the deletion, a result::delete_result.
-    /// @throws exception::write if the delete fails.
+    ///
+    /// @throws mongocxx::bulk_write_exception if the delete fails.
     ///
     /// @see http://docs.mongodb.org/manual/reference/command/delete/
     ///
@@ -265,12 +271,11 @@ class MONGOCXX_API collection {
     ///   Document view representing the documents for which the distinct operation will apply.
     /// @param options
     ///   Optional arguments, see options::distinct.
-    ///
-    /// @return Cursor having the distinct values for the specified field, a driver::cursor.
-    /// @throws
-    ///   If the operation failed, the returned cursor will throw exception::query
-    ///   when it is iterated.
-    ///
+
+    /// @return mongocxx::cursor having the distinct values for the specified
+    /// field.  If the operation fails, the cursor throws
+    /// mongocxx::query_exception when the returned cursor is iterated.
+
     /// @see http://docs.mongodb.org/manual/reference/command/distinct/
     ///
     cursor distinct(bsoncxx::string::view_or_value name, bsoncxx::document::view_or_value filter,
@@ -278,7 +283,7 @@ class MONGOCXX_API collection {
 
     /// Drops this collection and all its contained documents from the database.
     ///
-    /// @throws exception::operation if the operation fails.
+    /// @throws mongocxx::operation_exception if the operation fails.
     ///
     /// @see http://docs.mongodb.org/manual/reference/method/db.collection.drop/
     ///
@@ -292,10 +297,11 @@ class MONGOCXX_API collection {
     /// @param options
     ///   Optional arguments, see options::find
     ///
-    /// @return Cursor with the matching documents from the collection, a driver::cursor.
-    /// @throws
-    ///   If the find failed, the returned cursor will throw exception::query when it
-    ///   is iterated.
+    /// @return A mongocxx::cursor with the results.  If the query fails,
+    /// the cursor throws mongocxx::query_exception when the returned cursor
+    /// is iterated.
+    ///
+    /// @throws mongocxx::logic_error if the options are invalid.
     ///
     /// @see http://docs.mongodb.org/manual/core/read-operations-introduction/
     ///
@@ -311,7 +317,8 @@ class MONGOCXX_API collection {
     ///   Optional arguments, see options::find
     ///
     /// @return An optional document that matched the filter.
-    /// @throws exception::query if the operation fails.
+    ///
+    /// @throws mongocxx::query_exception if the operation fails.
     ///
     /// @see http://docs.mongodb.org/manual/core/read-operations-introduction/
     ///
@@ -327,7 +334,8 @@ class MONGOCXX_API collection {
     ///   Optional arguments, see options::find_one_and_delete
     ///
     /// @return The document that was deleted.
-    /// @throws exception::write if the operation fails.
+    ///
+    /// @throws mongocxx::write_exception if the operation fails.
     ///
     stdx::optional<bsoncxx::document::value> find_one_and_delete(
         bsoncxx::document::view_or_value filter,
@@ -345,7 +353,8 @@ class MONGOCXX_API collection {
     ///   Optional arguments, see options::find_one_and_replace.
     ///
     /// @return The original or replaced document.
-    /// @throws exception::write if the operation fails.
+    ///
+    /// @throws mongocxx::write_exception if the operation fails.
     ///
     /// @note
     ///   In order to pass a write concern to this, you must use the collection
@@ -367,7 +376,8 @@ class MONGOCXX_API collection {
     ///   Optional arguments, see options::find_one_and_update.
     ///
     /// @return The original or updated document.
-    /// @throws exception::write when the operation fails.
+    ///
+    /// @throws mongocxx::write_exception when the operation fails.
     ///
     /// @note
     ///   In order to pass a write concern to this, you must use the collection
@@ -387,7 +397,8 @@ class MONGOCXX_API collection {
     ///   Optional arguments, see options::insert.
     ///
     /// @return The result of attempting to perform the insert.
-    /// @throws exception::write if the operation fails.
+    ///
+    /// @throws mongocxx::bulk_write_exception if the operation fails.
     ///
     stdx::optional<result::insert_one> insert_one(
         bsoncxx::document::view_or_value document,
@@ -411,7 +422,8 @@ class MONGOCXX_API collection {
     ///   Optional arguments, see options::insert.
     ///
     /// @return The result of attempting to performing the insert.
-    /// @throws exception::write when the operation fails.
+    ///
+    /// @throws mongocxx::bulk_write_exception when the operation fails.
     ///
     template <typename container_type>
     MONGOCXX_INLINE stdx::optional<result::insert_many> insert_many(
@@ -437,7 +449,8 @@ class MONGOCXX_API collection {
     ///   Optional arguments, see options::insert.
     ///
     /// @return The result of attempting to performing the insert.
-    /// @throws exception::write if the operation fails.
+    ///
+    /// @throws mongocxx::bulk_write_exception if the operation fails.
     ///
     /// TODO: document DocumentViewIterator concept or static assert
     template <typename document_view_iterator_type>
@@ -449,7 +462,8 @@ class MONGOCXX_API collection {
     /// Returns a list of the indexes currently on this collection.
     ///
     /// @return Cursor yielding the index specifications.
-    /// @throws exception::operation if the operation fails.
+    ///
+    /// @throws mongocxx::operation_exception if the operation fails.
     ///
     /// @see http://docs.mongodb.org/manual/reference/command/listIndexes/
     ///
@@ -469,7 +483,7 @@ class MONGOCXX_API collection {
     /// @param drop_target_before_rename Whether to overwrite any
     ///   existing collections called new_name. The default is false.
     ///
-    /// @throws exception::operation if the operation fails.
+    /// @throws mongocxx::operation_exception if the operation fails.
     ///
     /// @see https://docs.mongodb.org/manual/reference/command/renameCollection/
     ///
@@ -527,7 +541,8 @@ class MONGOCXX_API collection {
     ///   Optional arguments, see options::update.
     ///
     /// @return The result of attempting to replace a document.
-    /// @throws exception::write if the operation fails.
+    ///
+    /// @throws mongocxx::bulk_write_exception if the operation fails.
     ///
     /// @see http://docs.mongodb.org/manual/reference/command/update/
     ///
@@ -546,7 +561,8 @@ class MONGOCXX_API collection {
     ///   Optional arguments, see options::update.
     ///
     /// @return The result of attempting to update multiple documents.
-    /// @throws exception::write if the update operation fails.
+    ///
+    /// @throws mongocxx::bulk_write_exception if the update operation fails.
     ///
     /// @see http://docs.mongodb.org/manual/reference/command/update/
     ///
@@ -565,7 +581,8 @@ class MONGOCXX_API collection {
     ///   Optional arguments, see options::update.
     ///
     /// @return The result of attempting to update a document.
-    /// @throws exception::write if the update operation fails.
+    ///
+    /// @throws mongocxx::bulk_write_exception if the update operation fails.
     ///
     /// @see http://docs.mongodb.org/manual/reference/command/update/
     ///

--- a/src/mongocxx/cursor.hpp
+++ b/src/mongocxx/cursor.hpp
@@ -56,11 +56,15 @@ class MONGOCXX_API cursor {
     /// A cursor::iterator that points to the begining of the results.
     ///
     /// @return the cursor::iterator
+    ///
+    /// @throws mongocxx::query_exception if the query failed
+    ///
     iterator begin();
 
     /// A cursor::iterator that points to the end of the results.
     ///
     /// @return the cursor::iterator
+    ///
     iterator end();
 
    private:
@@ -93,10 +97,14 @@ class MONGOCXX_API cursor::iterator
     ///
     /// Postfix increments the iterator to move to the next document.
     ///
+    /// @throws mongocxx::query_exception if the query failed
+    ///
     iterator& operator++();
 
     ///
     /// Prefix increments the iterator to move to the next document.
+    ///
+    /// @throws mongocxx::query_exception if the query failed
     ///
     void operator++(int);
 

--- a/src/mongocxx/database.hpp
+++ b/src/mongocxx/database.hpp
@@ -87,7 +87,8 @@ class MONGOCXX_API database {
     ///
     /// @param command document representing the command to be run.
     /// @return the result of executing the command.
-    /// @throws exception::operation if the operation fails.
+    ///
+    /// @throws mongocxx::operation_exception if the operation fails.
     ///
     bsoncxx::document::value run_command(bsoncxx::document::view_or_value command);
 
@@ -98,6 +99,8 @@ class MONGOCXX_API database {
     ///
     /// @param name the new collection's name.
     /// @param options the options for the new collection.
+    ///
+    /// @throws mongocxx::operation_exception if the operation fails.
     ///
     class collection create_collection(
         bsoncxx::string::view_or_value name,
@@ -120,6 +123,8 @@ class MONGOCXX_API database {
     ///
     /// Drops the database and all its collections.
     ///
+    /// @throws mongocxx::operation_exception if the operation fails.
+    //
     /// @see http://docs.mongodb.org/manual/reference/method/db.dropDatabase/
     ///
     void drop();
@@ -131,8 +136,8 @@ class MONGOCXX_API database {
     ///
     /// @return bool whether the collection exists in this database.
     ///
-    /// @throws exception::operation if the underlying 'listCollections'
-    ///   command fails.
+    /// @throws mongocxx::operation_exception if the underlying 'listCollections'
+    /// command fails.
     ///
     bool has_collection(bsoncxx::string::view_or_value name) const;
 
@@ -144,8 +149,8 @@ class MONGOCXX_API database {
     ///
     /// @return mongocxx::cursor containing the collection information.
     ///
-    /// @throws exception::operation if the underlying 'listCollections'
-    ///   command fails.
+    /// @throws mongocxx::operation_exception if the underlying 'listCollections'
+    /// command fails.
     ///
     /// @see http://docs.mongodb.org/manual/reference/command/listCollections/
     ///

--- a/src/mongocxx/instance.hpp
+++ b/src/mongocxx/instance.hpp
@@ -39,6 +39,8 @@ class MONGOCXX_API instance {
     /// Creates an instance of the driver with a user provided log handler.
     ///  @param logger The logger that the driver will direct log messages to.
     ///
+    /// @throws mongocxx::logic_error if an instance already exists.
+    ///
     instance(std::unique_ptr<logger> logger);
 
     ///

--- a/src/mongocxx/pool.hpp
+++ b/src/mongocxx/pool.hpp
@@ -55,6 +55,10 @@ class MONGOCXX_API pool {
     ///  A MongoDB URI representing the connection parameters
     /// @param ssl_options
     ///  Optional SSL options to use when connecting to the MongoDB deployment.
+    ///
+    /// @throws mongocxx::exception if SSL is enabled and ssl_options are
+    /// invalid, or if SSL is not enabled and ssl_options is engaged.
+    ///
     pool(const uri& mongodb_uri = mongocxx::uri(),
          stdx::optional<options::ssl> ssl_options = stdx::nullopt);
 

--- a/src/mongocxx/write_concern.hpp
+++ b/src/mongocxx/write_concern.hpp
@@ -134,6 +134,8 @@ class MONGOCXX_API write_concern {
     /// @warning Setting this to level::k_unacknowledged disables write acknowledgment and all other
     /// write concern options.
     ///
+    /// @throws mongocxx::exception for an unknown confirm_level.
+    ///
     void acknowledge_level(level confirm_level);
 
     ///
@@ -144,6 +146,8 @@ class MONGOCXX_API write_concern {
     ///   The amount of time to wait before the write operation times out if it cannot reach
     ///   the majority of nodes in the replica set.
     ///
+    /// @throws mongocxx::logic_error for an invalid timeout value.
+    //
     void majority(std::chrono::milliseconds timeout);
 
     ///
@@ -164,7 +168,7 @@ class MONGOCXX_API write_concern {
     /// @param timeout
     ///   The timeout (in milliseconds) for this write concern.
     ///
-    /// @throw exception::write
+    /// @throws mongocxx::logic_error for an invalid timeout value.
     ///
     void timeout(std::chrono::milliseconds timeout);
 


### PR DESCRIPTION
This commit updates all the documented exception names to the current types
and adds 'throws' entries to several methods where they were omitted.

Also includes CXX-988 (Fix documentation of element::operator[]).

