### PR TITLE
CXX-957 Honor BUILD_SHARED_LIBS to a sufficient degree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,11 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 include(GenerateExportHeader)
 include(InstallRequiredSystemLibraries)
 
+# Allow the user to decie whether to install the shared libaries.  Note that we always build them,
+# since otherwise it makes the CMake logic very complex, but setting BUILD_SHARED_LIBS=Off will at
+# least disable installing them.
+option(BUILD_SHARED_LIBS "Install shared libraries" ON)
+
 # If the user did not customize the install prefix,
 # set it to live under build so we don't inadverently pollute /usr/local
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/src/bsoncxx/CMakeLists.txt
+++ b/src/bsoncxx/CMakeLists.txt
@@ -170,12 +170,14 @@ install(FILES
     COMPONENT dev
 )
 
-install(TARGETS
-    bsoncxx
-    RUNTIME DESTINATION bin COMPONENT runtime
-    LIBRARY DESTINATION lib COMPONENT runtime
-    ARCHIVE DESTINATION lib COMPONENT dev
-)
+if (BUILD_SHARED_LIBS)
+    install(TARGETS
+        bsoncxx
+        RUNTIME DESTINATION bin COMPONENT runtime
+        LIBRARY DESTINATION lib COMPONENT runtime
+        ARCHIVE DESTINATION lib COMPONENT dev
+    )
+endif()
 
 install(TARGETS
     bsoncxx_static

--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -178,12 +178,14 @@ install(FILES
     COMPONENT dev
 )
 
-install(TARGETS
-    mongocxx
-    RUNTIME DESTINATION bin COMPONENT runtime
-    LIBRARY DESTINATION lib COMPONENT runtime
-    ARCHIVE DESTINATION lib COMPONENT dev
-)
+if (BUILD_SHARED_LIBS)
+    install(TARGETS
+        mongocxx
+        RUNTIME DESTINATION bin COMPONENT runtime
+        LIBRARY DESTINATION lib COMPONENT runtime
+        ARCHIVE DESTINATION lib COMPONENT dev
+    )
+endif()
 
 install(TARGETS
     mongocxx_static


### PR DESCRIPTION
Not an ideal solution: we still actually build the shared libraries, we just don't install them. Otherwise, we would need to conditionalize every block that references the shared library target with if (BUILD_SHARED_LIBS), which seems pretty bad. Not wanting the shared library is a pretty special case, so I'm OK with requiring them to build them, but avoiding installing.