### PR TITLE
CXX-986 Improve find_and_modify error handling

### DIFF
--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -702,3 +702,11 @@ TEST_CASE("create_index returns index name", "[collection]") {
     auto response2 = coll.create_index(index2.view(), options::index{});
     REQUIRE(response2.view()["name"].get_utf8().value == stdx::string_view{"b_1_c_-1"});
 }
+
+TEST_CASE("regressions", "CXX-986") {
+    instance::current();
+    mongocxx::uri mongo_uri{"mongodb://non-existent-host.invalid/"};
+    mongocxx::client client{mongo_uri};
+    REQUIRE_THROWS(client.database("irrelevant")["irrelevant"].find_one_and_update(
+        document{} << "irrelevant" << 1 << finalize, document{} << "irrelevant" << 2 << finalize));
+}


### PR DESCRIPTION
@xdg @jrassi @Machyne @bjori -

This improves the error handling after calling mongoc_collection_find_and_modify_with_opts. We need to handle two cases:

- The function returned false, but the 'reply' bson is not populated, in which case we simply throw an error wrapping the bson_error_t.
- The function returned false, but the reply bson IS populated, in which case we throw the raw server reply along with the bson_error_t.

I also added a regression test to verify the improvement, based on the repro in the original ticket. I was able to reproduce the original crash when running the test without the new error handling, and the fix does make the test pass and throw a meaningful exception.