### PR TITLE
Use correct unique_ptr types for document and array values

### DIFF
--- a/src/bsoncxx/array/value.hpp
+++ b/src/bsoncxx/array/value.hpp
@@ -34,7 +34,7 @@ namespace array {
 class BSONCXX_API value {
    public:
     using deleter_type = void (*)(std::uint8_t*);
-    using unique_ptr_type = std::unique_ptr<uint8_t, deleter_type>;
+    using unique_ptr_type = std::unique_ptr<uint8_t[], deleter_type>;
 
     ///
     /// Constructs a value from a buffer.

--- a/src/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/document/value.hpp
@@ -33,7 +33,7 @@ namespace document {
 class BSONCXX_API value {
    public:
     using deleter_type = void (*)(std::uint8_t*);
-    using unique_ptr_type = std::unique_ptr<uint8_t, deleter_type>;
+    using unique_ptr_type = std::unique_ptr<uint8_t[], deleter_type>;
 
     ///
     /// Constructs a value from a buffer.


### PR DESCRIPTION
This is mostly academic as we are controlling the deleter here, so the wrong thing wasn't happening. However, there is at least one other difference between unique_ptr<T> and unique_ptr<T[]> (the existence of operator[]), and there may be others in the future. It seems better to say what we mean here. @hanumantmk PTAL.