### PR TITLE
CXX-971 (part 2) Add collation to options::find

### DIFF
--- a/src/mongocxx/options/aggregate.cpp
+++ b/src/mongocxx/options/aggregate.cpp
@@ -55,6 +55,7 @@ aggregate& aggregate::bypass_document_validation(bool bypass_document_validation
 const stdx::optional<bool>& aggregate::allow_disk_use() const {
     return _allow_disk_use;
 }
+
 const stdx::optional<std::int32_t>& aggregate::batch_size() const {
     return _batch_size;
 }
@@ -66,9 +67,11 @@ const stdx::optional<std::chrono::milliseconds>& aggregate::max_time() const {
 const stdx::optional<bool>& aggregate::use_cursor() const {
     return _use_cursor;
 }
+
 const stdx::optional<class read_preference>& aggregate::read_preference() const {
     return _read_preference;
 }
+
 const stdx::optional<bool>& aggregate::bypass_document_validation() const {
     return _bypass_document_validation;
 }

--- a/src/mongocxx/options/aggregate.hpp
+++ b/src/mongocxx/options/aggregate.hpp
@@ -17,7 +17,6 @@
 #include <chrono>
 #include <cstdint>
 
-#include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/read_preference.hpp>
 #include <mongocxx/stdx.hpp>

--- a/src/mongocxx/options/count.hpp
+++ b/src/mongocxx/options/count.hpp
@@ -18,7 +18,6 @@
 #include <cstdint>
 #include <string>
 
-#include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/hint.hpp>
 #include <mongocxx/read_preference.hpp>

--- a/src/mongocxx/options/delete.hpp
+++ b/src/mongocxx/options/delete.hpp
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/write_concern.hpp>
 

--- a/src/mongocxx/options/distinct.cpp
+++ b/src/mongocxx/options/distinct.cpp
@@ -35,6 +35,7 @@ distinct& distinct::read_preference(class read_preference rp) {
 const stdx::optional<std::chrono::milliseconds>& distinct::max_time() const {
     return _max_time;
 }
+
 const stdx::optional<class read_preference>& distinct::read_preference() const {
     return _read_preference;
 }

--- a/src/mongocxx/options/distinct.hpp
+++ b/src/mongocxx/options/distinct.hpp
@@ -18,7 +18,6 @@
 #include <cstdint>
 #include <string>
 
-#include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/read_preference.hpp>
 

--- a/src/mongocxx/options/find.cpp
+++ b/src/mongocxx/options/find.cpp
@@ -32,6 +32,11 @@ find& find::batch_size(std::int32_t batch_size) {
     return *this;
 }
 
+find& find::collation(bsoncxx::document::view_or_value collation) {
+    _collation = std::move(collation);
+    return *this;
+}
+
 find& find::comment(bsoncxx::string::view_or_value comment) {
     _comment = std::move(comment);
     return *this;
@@ -98,6 +103,10 @@ const stdx::optional<bool>& find::allow_partial_results() const {
 
 const stdx::optional<std::int32_t>& find::batch_size() const {
     return _batch_size;
+}
+
+const stdx::optional<bsoncxx::document::view_or_value>& find::collation() const {
+    return _collation;
 }
 
 const stdx::optional<bsoncxx::string::view_or_value>& find::comment() const {

--- a/src/mongocxx/options/find.hpp
+++ b/src/mongocxx/options/find.hpp
@@ -75,6 +75,28 @@ class MONGOCXX_API find {
     const stdx::optional<std::int32_t>& batch_size() const;
 
     ///
+    /// Sets the collation for this operation.
+    ///
+    /// @param collation
+    ///   The new collation.
+    ///
+    /// @see
+    ///   https://docs.mongodb.com/manual/release-notes/3.3-dev-series-collation/#collation-option
+    ///
+    find& collation(bsoncxx::document::view_or_value collation);
+
+    ///
+    /// Retrieves the current collation for this operation.
+    ///
+    /// @return
+    ///   The current collation.
+    ///
+    /// @see
+    ///   https://docs.mongodb.com/manual/release-notes/3.3-dev-series-collation/#collation-option
+    ///
+    const stdx::optional<bsoncxx::document::view_or_value>& collation() const;
+
+    ///
     /// Attaches a comment to the query. If $comment also exists in the modifiers document then
     /// the comment field overwrites $comment.
     ///
@@ -308,6 +330,7 @@ class MONGOCXX_API find {
    private:
     stdx::optional<bool> _allow_partial_results;
     stdx::optional<std::int32_t> _batch_size;
+    stdx::optional<bsoncxx::document::view_or_value> _collation;
     stdx::optional<bsoncxx::string::view_or_value> _comment;
     stdx::optional<cursor::type> _cursor_type;
     stdx::optional<class hint> _hint;

--- a/src/mongocxx/options/update.cpp
+++ b/src/mongocxx/options/update.cpp
@@ -20,13 +20,13 @@ namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 namespace options {
 
-update& update::upsert(bool upsert) {
-    _upsert = upsert;
+update& update::bypass_document_validation(bool bypass_document_validation) {
+    _bypass_document_validation = bypass_document_validation;
     return *this;
 }
 
-update& update::bypass_document_validation(bool bypass_document_validation) {
-    _bypass_document_validation = bypass_document_validation;
+update& update::upsert(bool upsert) {
+    _upsert = upsert;
     return *this;
 }
 
@@ -35,12 +35,12 @@ update& update::write_concern(class write_concern wc) {
     return *this;
 }
 
-const stdx::optional<bool>& update::upsert() const {
-    return _upsert;
-}
-
 const stdx::optional<bool>& update::bypass_document_validation() const {
     return _bypass_document_validation;
+}
+
+const stdx::optional<bool>& update::upsert() const {
+    return _upsert;
 }
 
 const stdx::optional<class write_concern>& update::write_concern() const {

--- a/src/mongocxx/options/update.hpp
+++ b/src/mongocxx/options/update.hpp
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/write_concern.hpp>
@@ -30,6 +29,26 @@ namespace options {
 ///
 class MONGOCXX_API update {
    public:
+    ///
+    /// Sets the bypass_document_validation option.
+    /// If true, allows the write to opt-out of document level validation.
+    ///
+    /// @note
+    ///   On servers >= 3.2, the server applies validation by default. On servers < 3.2, this option
+    ///   is ignored.
+    ///
+    /// @param bypass_document_validation
+    ///   Whether or not to bypass document validation
+    ///
+    update& bypass_document_validation(bool bypass_document_validation);
+
+    ///
+    /// Gets the current value of the bypass_document_validation option.
+    ///
+    /// @return The optional value of the bypass_document_validation option.
+    ///
+    const stdx::optional<bool>& bypass_document_validation() const;
+
     ///
     /// Sets the upsert option.
     ///
@@ -52,26 +71,6 @@ class MONGOCXX_API update {
     const stdx::optional<bool>& upsert() const;
 
     ///
-    /// Sets the bypass_document_validation option.
-    /// If true, allows the write to opt-out of document level validation.
-    ///
-    /// @note
-    ///   On servers >= 3.2, the server applies validation by default. On servers < 3.2, this option
-    ///   is ignored.
-    ///
-    /// @param bypass_document_validation
-    ///   Whether or not to bypass document validation
-    ///
-    update& bypass_document_validation(bool bypass_document_validation);
-
-    ///
-    /// Gets the current value of the bypass_document_validation option.
-    ///
-    /// @return The optional value of the bypass_document_validation option.
-    ///
-    const stdx::optional<bool>& bypass_document_validation() const;
-
-    ///
     /// Sets the write_concern for this operation.
     ///
     /// @param wc
@@ -92,8 +91,8 @@ class MONGOCXX_API update {
     const stdx::optional<class write_concern>& write_concern() const;
 
    private:
-    stdx::optional<bool> _upsert;
     stdx::optional<bool> _bypass_document_validation;
+    stdx::optional<bool> _upsert;
     stdx::optional<class write_concern> _write_concern;
 };
 

--- a/src/mongocxx/test/CMakeLists.txt
+++ b/src/mongocxx/test/CMakeLists.txt
@@ -28,7 +28,10 @@ set(mongocxx_test_sources
     hint.cpp
     model/update_many.cpp
     options/aggregate.cpp
+    options/count.cpp
     options/create_collection.cpp
+    options/delete.cpp
+    options/distinct.cpp
     options/find.cpp
     options/find_one_and_delete.cpp
     options/find_one_and_replace.cpp

--- a/src/mongocxx/test/options/count.cpp
+++ b/src/mongocxx/test/options/count.cpp
@@ -17,20 +17,23 @@
 #include "catch.hpp"
 #include "helpers.hpp"
 
+#include <bsoncxx/builder/stream/document.hpp>
 #include <mongocxx/instance.hpp>
-#include <mongocxx/options/aggregate.hpp>
+#include <mongocxx/options/count.hpp>
 
+using namespace bsoncxx::builder::stream;
 using namespace mongocxx;
 
-TEST_CASE("aggregate", "[aggregate][option]") {
+TEST_CASE("count", "[count][option]") {
     instance::current();
 
-    options::aggregate agg;
+    options::count cnt;
 
-    CHECK_OPTIONAL_ARGUMENT(agg, allow_disk_use, true);
-    CHECK_OPTIONAL_ARGUMENT(agg, batch_size, 500);
-    CHECK_OPTIONAL_ARGUMENT(agg, bypass_document_validation, true);
-    CHECK_OPTIONAL_ARGUMENT(agg, max_time, std::chrono::milliseconds{1000});
-    CHECK_OPTIONAL_ARGUMENT_WITHOUT_EQUALITY(agg, read_preference, read_preference{});
-    CHECK_OPTIONAL_ARGUMENT(agg, use_cursor, true);
+    auto hint = bsoncxx::document::view_or_value{document{} << "_id" << 1 << finalize};
+
+    CHECK_OPTIONAL_ARGUMENT(cnt, hint, hint);
+    CHECK_OPTIONAL_ARGUMENT(cnt, limit, 3);
+    CHECK_OPTIONAL_ARGUMENT(cnt, max_time, std::chrono::milliseconds{1000});
+    CHECK_OPTIONAL_ARGUMENT_WITHOUT_EQUALITY(cnt, read_preference, read_preference{});
+    CHECK_OPTIONAL_ARGUMENT(cnt, skip, 3);
 }

--- a/src/mongocxx/test/options/delete.cpp
+++ b/src/mongocxx/test/options/delete.cpp
@@ -18,19 +18,14 @@
 #include "helpers.hpp"
 
 #include <mongocxx/instance.hpp>
-#include <mongocxx/options/aggregate.hpp>
+#include <mongocxx/options/delete.hpp>
 
 using namespace mongocxx;
 
-TEST_CASE("aggregate", "[aggregate][option]") {
+TEST_CASE("delete_options", "[delete][option]") {
     instance::current();
 
-    options::aggregate agg;
+    options::delete_options del;
 
-    CHECK_OPTIONAL_ARGUMENT(agg, allow_disk_use, true);
-    CHECK_OPTIONAL_ARGUMENT(agg, batch_size, 500);
-    CHECK_OPTIONAL_ARGUMENT(agg, bypass_document_validation, true);
-    CHECK_OPTIONAL_ARGUMENT(agg, max_time, std::chrono::milliseconds{1000});
-    CHECK_OPTIONAL_ARGUMENT_WITHOUT_EQUALITY(agg, read_preference, read_preference{});
-    CHECK_OPTIONAL_ARGUMENT(agg, use_cursor, true);
+    CHECK_OPTIONAL_ARGUMENT_WITHOUT_EQUALITY(del, write_concern, write_concern{});
 }

--- a/src/mongocxx/test/options/distinct.cpp
+++ b/src/mongocxx/test/options/distinct.cpp
@@ -18,19 +18,15 @@
 #include "helpers.hpp"
 
 #include <mongocxx/instance.hpp>
-#include <mongocxx/options/aggregate.hpp>
+#include <mongocxx/options/distinct.hpp>
 
 using namespace mongocxx;
 
-TEST_CASE("aggregate", "[aggregate][option]") {
+TEST_CASE("distinct", "[distinct][option]") {
     instance::current();
 
-    options::aggregate agg;
+    options::distinct dist;
 
-    CHECK_OPTIONAL_ARGUMENT(agg, allow_disk_use, true);
-    CHECK_OPTIONAL_ARGUMENT(agg, batch_size, 500);
-    CHECK_OPTIONAL_ARGUMENT(agg, bypass_document_validation, true);
-    CHECK_OPTIONAL_ARGUMENT(agg, max_time, std::chrono::milliseconds{1000});
-    CHECK_OPTIONAL_ARGUMENT_WITHOUT_EQUALITY(agg, read_preference, read_preference{});
-    CHECK_OPTIONAL_ARGUMENT(agg, use_cursor, true);
+    CHECK_OPTIONAL_ARGUMENT(dist, max_time, std::chrono::milliseconds{1000});
+    CHECK_OPTIONAL_ARGUMENT_WITHOUT_EQUALITY(dist, read_preference, read_preference{});
 }

--- a/src/mongocxx/test/options/find.cpp
+++ b/src/mongocxx/test/options/find.cpp
@@ -17,16 +17,23 @@
 #include "catch.hpp"
 #include "helpers.hpp"
 
+#include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/find.hpp>
 
+using namespace bsoncxx::builder::stream;
 using namespace mongocxx;
 
 TEST_CASE("find", "[find][option]") {
     instance::current();
 
     options::find find_opts{};
+
+    auto modifiers = document{} << "$comment"
+                                << "comment" << finalize;
+    auto projection = document{} << "_id" << false << finalize;
+    auto sort = document{} << "x" << -1 << finalize;
 
     CHECK_OPTIONAL_ARGUMENT(find_opts, allow_partial_results, true);
     CHECK_OPTIONAL_ARGUMENT(find_opts, batch_size, 3);
@@ -35,11 +42,10 @@ TEST_CASE("find", "[find][option]") {
     CHECK_OPTIONAL_ARGUMENT(find_opts, limit, 3);
     CHECK_OPTIONAL_ARGUMENT(find_opts, max_await_time, std::chrono::milliseconds{300});
     CHECK_OPTIONAL_ARGUMENT(find_opts, max_time, std::chrono::milliseconds{300});
+    CHECK_OPTIONAL_ARGUMENT(find_opts, modifiers, modifiers.view());
     CHECK_OPTIONAL_ARGUMENT(find_opts, no_cursor_timeout, true);
-    CHECK_OPTIONAL_ARGUMENT(find_opts, skip, 3);
-
+    CHECK_OPTIONAL_ARGUMENT(find_opts, projection, projection.view());
     CHECK_OPTIONAL_ARGUMENT_WITHOUT_EQUALITY(find_opts, read_preference, read_preference{});
-    CHECK_OPTIONAL_ARGUMENT(find_opts, modifiers, bsoncxx::document::view{});
-    CHECK_OPTIONAL_ARGUMENT(find_opts, projection, bsoncxx::document::view{});
-    CHECK_OPTIONAL_ARGUMENT(find_opts, sort, bsoncxx::document::view{});
+    CHECK_OPTIONAL_ARGUMENT(find_opts, skip, 3);
+    CHECK_OPTIONAL_ARGUMENT(find_opts, sort, sort.view());
 }

--- a/src/mongocxx/test/options/find.cpp
+++ b/src/mongocxx/test/options/find.cpp
@@ -30,6 +30,8 @@ TEST_CASE("find", "[find][option]") {
 
     options::find find_opts{};
 
+    auto collation = document{} << "locale"
+                                << "en_US" << finalize;
     auto modifiers = document{} << "$comment"
                                 << "comment" << finalize;
     auto projection = document{} << "_id" << false << finalize;
@@ -37,6 +39,7 @@ TEST_CASE("find", "[find][option]") {
 
     CHECK_OPTIONAL_ARGUMENT(find_opts, allow_partial_results, true);
     CHECK_OPTIONAL_ARGUMENT(find_opts, batch_size, 3);
+    CHECK_OPTIONAL_ARGUMENT(find_opts, collation, collation.view());
     CHECK_OPTIONAL_ARGUMENT(find_opts, comment, "comment");
     CHECK_OPTIONAL_ARGUMENT(find_opts, cursor_type, cursor::type::k_non_tailable);
     CHECK_OPTIONAL_ARGUMENT(find_opts, limit, 3);

--- a/src/mongocxx/test/options/find_one_and_delete.cpp
+++ b/src/mongocxx/test/options/find_one_and_delete.cpp
@@ -30,10 +30,10 @@ TEST_CASE("find_one_and_delete", "[find_one_and_delete][option]") {
     options::find_one_and_delete opts{};
 
     std::chrono::milliseconds ms{400};
-    auto proj = document{} << "_id" << false << finalize;
+    auto projection = document{} << "_id" << false << finalize;
     auto sort = document{} << "x" << -1 << finalize;
 
     CHECK_OPTIONAL_ARGUMENT(opts, max_time, ms);
-    CHECK_OPTIONAL_ARGUMENT(opts, projection, proj.view());
+    CHECK_OPTIONAL_ARGUMENT(opts, projection, projection.view());
     CHECK_OPTIONAL_ARGUMENT(opts, sort, sort.view());
 }

--- a/src/mongocxx/test/options/find_one_and_replace.cpp
+++ b/src/mongocxx/test/options/find_one_and_replace.cpp
@@ -30,12 +30,12 @@ TEST_CASE("find_one_and_replace", "[find_one_and_replace][option]") {
     options::find_one_and_replace opts{};
 
     std::chrono::milliseconds ms{400};
-    auto proj = document{} << "_id" << false << finalize;
+    auto projection = document{} << "_id" << false << finalize;
     auto sort = document{} << "x" << -1 << finalize;
 
     CHECK_OPTIONAL_ARGUMENT(opts, bypass_document_validation, true);
     CHECK_OPTIONAL_ARGUMENT(opts, max_time, ms);
-    CHECK_OPTIONAL_ARGUMENT(opts, projection, proj.view());
+    CHECK_OPTIONAL_ARGUMENT(opts, projection, projection.view());
     CHECK_OPTIONAL_ARGUMENT(opts, return_document, options::return_document::k_before);
     CHECK_OPTIONAL_ARGUMENT(opts, sort, sort.view());
     CHECK_OPTIONAL_ARGUMENT(opts, upsert, true);

--- a/src/mongocxx/test/options/find_one_and_update.cpp
+++ b/src/mongocxx/test/options/find_one_and_update.cpp
@@ -30,12 +30,12 @@ TEST_CASE("find_one_and_update", "[find_one_and_update][option]") {
     options::find_one_and_update opts{};
 
     std::chrono::milliseconds ms{400};
-    auto proj = document{} << "_id" << false << finalize;
+    auto projection = document{} << "_id" << false << finalize;
     auto sort = document{} << "x" << -1 << finalize;
 
     CHECK_OPTIONAL_ARGUMENT(opts, bypass_document_validation, true);
     CHECK_OPTIONAL_ARGUMENT(opts, max_time, ms);
-    CHECK_OPTIONAL_ARGUMENT(opts, projection, proj.view());
+    CHECK_OPTIONAL_ARGUMENT(opts, projection, projection.view());
     CHECK_OPTIONAL_ARGUMENT(opts, return_document, options::return_document::k_before);
     CHECK_OPTIONAL_ARGUMENT(opts, sort, sort.view());
     CHECK_OPTIONAL_ARGUMENT(opts, upsert, true);

--- a/src/mongocxx/test/options/index.cpp
+++ b/src/mongocxx/test/options/index.cpp
@@ -15,20 +15,24 @@
 #include "catch.hpp"
 #include "helpers.hpp"
 
+#include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/index.hpp>
 #include <mongocxx/stdx.hpp>
 
+using namespace bsoncxx::builder::stream;
 using namespace mongocxx;
-using namespace mongocxx::options;
 
 TEST_CASE("index", "[index][option]") {
     instance::current();
 
     options::index idx;
-    std::unique_ptr<index::wiredtiger_storage_options> storage =
-        stdx::make_unique<index::wiredtiger_storage_options>();
+    std::unique_ptr<options::index::wiredtiger_storage_options> storage =
+        stdx::make_unique<options::index::wiredtiger_storage_options>();
+
+    auto partial_filter_expression = document{} << "x" << true << finalize;
+    auto weights = document{} << "a" << 100 << finalize;
 
     CHECK_OPTIONAL_ARGUMENT(idx, background, true);
     CHECK_OPTIONAL_ARGUMENT(idx, unique, true);
@@ -43,8 +47,8 @@ TEST_CASE("index", "[index][option]") {
     CHECK_OPTIONAL_ARGUMENT(idx, twod_location_min, 90.0);
     CHECK_OPTIONAL_ARGUMENT(idx, twod_location_max, 90.0);
     CHECK_OPTIONAL_ARGUMENT(idx, haystack_bucket_size, 90.0);
-    CHECK_OPTIONAL_ARGUMENT_WITHOUT_EQUALITY(idx, weights, bsoncxx::document::view{});
+    CHECK_OPTIONAL_ARGUMENT_WITHOUT_EQUALITY(idx, weights, weights.view());
     CHECK_OPTIONAL_ARGUMENT_WITHOUT_EQUALITY(idx, partial_filter_expression,
-                                             bsoncxx::document::view{});
+                                             partial_filter_expression.view());
     REQUIRE_NOTHROW(idx.storage_options(std::move(storage)));
 }

--- a/src/mongocxx/test/options/update.cpp
+++ b/src/mongocxx/test/options/update.cpp
@@ -25,7 +25,7 @@ TEST_CASE("update opts", "[update][option]") {
 
     options::update updt;
 
-    CHECK_OPTIONAL_ARGUMENT(updt, upsert, true);
     CHECK_OPTIONAL_ARGUMENT(updt, bypass_document_validation, true);
+    CHECK_OPTIONAL_ARGUMENT(updt, upsert, true);
     CHECK_OPTIONAL_ARGUMENT_WITHOUT_EQUALITY(updt, write_concern, write_concern{});
 }


### PR DESCRIPTION
On top of #535.  Supersedes https://github.com/jrassi/mongo-cxx-driver/pull/1.

@acmorrow, @xdg: PTAL.  Also, let me know also if you'd like me to use some other workflow for submitting reviews on top of work that hasn't been pushed yet (like stacking many commits in a single pull request, for example).