### PR TITLE
CXX-1045 collection::count() serializes options::count::hint incorrectly

### DIFF
--- a/src/mongocxx/collection.cpp
+++ b/src/mongocxx/collection.cpp
@@ -216,7 +216,7 @@ cursor collection::find(view_or_value filter, const options::find& options) {
     }
 
     if (options.hint()) {
-        filter_builder << builder::stream::concatenate(options.hint()->to_document());
+        filter_builder << "$hint" << options.hint()->to_value();
     }
 
     if (options.comment()) {
@@ -601,7 +601,7 @@ std::int64_t collection::count(view_or_value filter, const options::count& optio
     }
 
     if (options.hint()) {
-        cmd_opts_builder << concatenate(options.hint()->to_document());
+        cmd_opts_builder << "$hint" << options.hint()->to_value();
     }
 
     scoped_bson_t cmd_opts_bson{cmd_opts_builder.view()};

--- a/src/mongocxx/collection.cpp
+++ b/src/mongocxx/collection.cpp
@@ -601,7 +601,7 @@ std::int64_t collection::count(view_or_value filter, const options::count& optio
     }
 
     if (options.hint()) {
-        cmd_opts_builder << "$hint" << options.hint()->to_value();
+        cmd_opts_builder << "hint" << options.hint()->to_value();
     }
 
     scoped_bson_t cmd_opts_bson{cmd_opts_builder.view()};

--- a/src/mongocxx/hint.cpp
+++ b/src/mongocxx/hint.cpp
@@ -27,6 +27,14 @@ hint::hint(bsoncxx::document::view_or_value index) : _index_doc(std::move(index)
 hint::hint(bsoncxx::string::view_or_value index) : _index_string(std::move(index)) {
 }
 
+bsoncxx::types::value hint::to_value() const {
+    if (_index_doc) {
+        return bsoncxx::types::value{bsoncxx::types::b_document{_index_doc->view()}};
+    }
+
+    return bsoncxx::types::value{bsoncxx::types::b_utf8{*_index_string}};
+}
+
 bsoncxx::document::value hint::to_document() const {
     auto doc = bsoncxx::builder::stream::document{};
 

--- a/src/mongocxx/hint.hpp
+++ b/src/mongocxx/hint.hpp
@@ -21,6 +21,7 @@
 #include <bsoncxx/builder/stream/key_context.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
+#include <bsoncxx/types/value.hpp>
 #include <mongocxx/stdx.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -68,7 +69,18 @@ class MONGOCXX_API hint {
     ///
 
     ///
+    /// Returns a types::value representing this hint.
+    ///
+    /// @return Hint, as a types::value. The caller must ensure that the returned object not outlive
+    /// the hint object that it was created from.
+    ///
+    bsoncxx::types::value to_value() const;
+
+    ///
     /// Return a bson document representing this hint.
+    ///
+    /// @deprecated
+    ///   This method has been deprecated in favor of to_value().
     ///
     /// @return Hint, as a document.
     ///
@@ -76,6 +88,14 @@ class MONGOCXX_API hint {
 
     ///
     /// @todo document this method
+    ///
+    MONGOCXX_INLINE operator bsoncxx::types::value() const;
+
+    ///
+    /// @todo document this method
+    ///
+    /// @deprecated
+    ///   This method has been deprecated in favor of operator bsoncxx::types::value().
     ///
     MONGOCXX_INLINE operator bsoncxx::document::value() const;
 
@@ -132,6 +152,10 @@ MONGOCXX_API bool MONGOCXX_CALL operator!=(bsoncxx::document::view index, const 
 ///
 /// @}
 ///
+
+MONGOCXX_INLINE hint::operator bsoncxx::types::value() const {
+    return to_value();
+}
 
 MONGOCXX_INLINE hint::operator bsoncxx::document::value() const {
     return to_document();

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -24,6 +24,7 @@
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/exception/logic_error.hpp>
+#include <mongocxx/exception/operation_exception.hpp>
 #include <mongocxx/insert_many_builder.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/pipeline.hpp>
@@ -252,6 +253,17 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
 
         REQUIRE(coll.count(doc_view) == 3);
         REQUIRE(coll.count({}) == 4);
+    }
+
+    SECTION("count with hint", "[collection]") {
+        options::count count_opts;
+        count_opts.hint(hint{"index_doesnt_exist"});
+
+        auto doc = document{} << "x" << 1 << finalize;
+        coll.insert_one(doc.view());
+
+        REQUIRE_THROWS_AS(coll.count({document{} << "x" << 1 << finalize}, count_opts),
+                          operation_exception);
     }
 
     SECTION("document replacement", "[collection]") {

--- a/src/mongocxx/test/collection_mocked.cpp
+++ b/src/mongocxx/test/collection_mocked.cpp
@@ -241,10 +241,9 @@ TEST_CASE("Collection", "[collection]") {
             opts.hint(index_hint);
 
             // set our expected_opts so we check against that
-            bsoncxx::document::value doc =
-                bsoncxx::builder::stream::document{}
-                << bsoncxx::builder::stream::concatenate(index_hint.to_document())
-                << bsoncxx::builder::stream::finalize;
+            bsoncxx::document::value doc = bsoncxx::builder::stream::document{}
+                                           << "$hint" << index_hint.to_value()
+                                           << bsoncxx::builder::stream::finalize;
             libbson::scoped_bson_t cmd_opts{std::move(doc)};
             expected_opts = cmd_opts.bson();
 
@@ -380,7 +379,7 @@ TEST_CASE("Collection", "[collection]") {
         auto find_doc = builder::stream::document{} << "a" << 1 << builder::stream::finalize;
         auto doc = find_doc.view();
         mongocxx::stdx::optional<bsoncxx::document::view> expected_sort{};
-        mongocxx::stdx::optional<bsoncxx::document::view> expected_hint{};
+        mongocxx::stdx::optional<bsoncxx::types::value> expected_hint{};
         mongocxx::stdx::optional<bsoncxx::stdx::string_view> expected_comment{};
         int expected_flags = 0;
 
@@ -402,8 +401,7 @@ TEST_CASE("Collection", "[collection]") {
                 REQUIRE(query_view["$orderby"].get_document() == *expected_sort);
             }
             if (expected_hint) {
-                REQUIRE(query_view["$hint"].get_utf8() ==
-                        expected_hint->operator[]("$hint").get_utf8());
+                REQUIRE(query_view["$hint"].get_utf8() == expected_hint->get_utf8());
             }
             if (expected_comment) {
                 REQUIRE(query_view["$comment"].get_utf8().value == *expected_comment);
@@ -426,8 +424,7 @@ TEST_CASE("Collection", "[collection]") {
             opts.hint(index_hint);
 
             // set our expected_hint so we check against that
-            bsoncxx::document::value hint_doc = index_hint.to_document();
-            expected_hint = hint_doc.view();
+            expected_hint = index_hint.to_value();
 
             REQUIRE_NOTHROW(mongo_coll.find(doc, opts));
         }

--- a/src/mongocxx/test/collection_mocked.cpp
+++ b/src/mongocxx/test/collection_mocked.cpp
@@ -242,7 +242,7 @@ TEST_CASE("Collection", "[collection]") {
 
             // set our expected_opts so we check against that
             bsoncxx::document::value doc = bsoncxx::builder::stream::document{}
-                                           << "$hint" << index_hint.to_value()
+                                           << "hint" << index_hint.to_value()
                                            << bsoncxx::builder::stream::finalize;
             libbson::scoped_bson_t cmd_opts{std::move(doc)};
             expected_opts = cmd_opts.bson();

--- a/src/mongocxx/test/hint.cpp
+++ b/src/mongocxx/test/hint.cpp
@@ -32,16 +32,10 @@ TEST_CASE("Hint", "[hint]") {
         std::string index_name = "a_1";
         hint index_hint{index_name};
 
-        SECTION("Can be applied to a query") {
-            document::value filter = builder::stream::document{}
-                                     << "a" << 15
-                                     << builder::stream::concatenate(index_hint.to_document())
-                                     << builder::stream::finalize;
-            document::view view{filter.view()};
-            document::element ele{view["$hint"]};
-            REQUIRE(ele);
-            REQUIRE(ele.type() == type::k_utf8);
-            REQUIRE(ele.get_utf8().value.to_string() == index_name);
+        SECTION("Returns correct value from to_value") {
+            types::value val = index_hint.to_value();
+            REQUIRE(val.type() == type::k_utf8);
+            REQUIRE(val.get_utf8().value.to_string() == index_name);
         }
 
         SECTION("Compares equal to matching index name") {
@@ -58,6 +52,19 @@ TEST_CASE("Hint", "[hint]") {
             auto index_doc = builder::stream::document{} << "a" << 1 << builder::stream::finalize;
             REQUIRE(index_hint != index_doc);
         }
+
+        SECTION("Test for deprecated method to_document()") {
+            document::value filter = builder::stream::document{}
+                                     << "a" << 15
+                                     << builder::stream::concatenate(index_hint.to_document())
+                                     << builder::stream::finalize;
+            document::view view{filter.view()};
+            document::element ele{view["$hint"]};
+            REQUIRE(ele);
+            REQUIRE(ele.type() == type::k_utf8);
+
+            REQUIRE(ele.get_utf8().value.to_string() == index_name);
+        }
     }
 
     SECTION("Can be constructed with index document value") {
@@ -66,16 +73,10 @@ TEST_CASE("Hint", "[hint]") {
 
         hint index_hint{std::move(index_doc)};
 
-        SECTION("Can be applied to a query") {
-            document::value filter = builder::stream::document{}
-                                     << "a" << 12
-                                     << builder::stream::concatenate(index_hint.to_document())
-                                     << builder::stream::finalize;
-            document::view view{filter.view()};
-            document::element ele{view["$hint"]};
-            REQUIRE(ele);
-            REQUIRE(ele.type() == type::k_document);
-            REQUIRE(ele.get_document().value == index_copy);
+        SECTION("Returns correct value from to_value") {
+            types::value val = index_hint.to_value();
+            REQUIRE(val.type() == type::k_document);
+            REQUIRE(val.get_document().value == index_copy);
         }
 
         SECTION("Compares equal to matching index doc view or value") {
@@ -95,6 +96,18 @@ TEST_CASE("Hint", "[hint]") {
         SECTION("Does not equal index string") {
             REQUIRE(index_hint != "totoro_1");
             REQUIRE("a" != index_hint);
+        }
+
+        SECTION("Test for deprecated method to_document()") {
+            document::value filter = builder::stream::document{}
+                                     << "a" << 12
+                                     << builder::stream::concatenate(index_hint.to_document())
+                                     << builder::stream::finalize;
+            document::view view{filter.view()};
+            document::element ele{view["$hint"]};
+            REQUIRE(ele);
+            REQUIRE(ele.type() == type::k_document);
+            REQUIRE(ele.get_document().value == index_copy);
         }
     }
 


### PR DESCRIPTION
First included commit is an ABI-breaking/API-breaking small refactor.  Second commit is the bugfix itself.

@acmorrow @xdg, PTAL.