### PR TITLE
CXX-999 Support read-only views

### DIFF
--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -63,6 +63,7 @@ set(mongocxx_sources
     options/client.cpp
     options/count.cpp
     options/create_collection.cpp
+    options/create_view.cpp
     options/delete.cpp
     options/distinct.cpp
     options/find.cpp

--- a/src/mongocxx/collection.cpp
+++ b/src/mongocxx/collection.cpp
@@ -318,7 +318,7 @@ stdx::optional<bsoncxx::document::value> collection::find_one(view_or_value filt
 cursor collection::aggregate(const pipeline& pipeline, const options::aggregate& options) {
     using namespace bsoncxx::builder::stream;
 
-    scoped_bson_t stages(pipeline._impl->view());
+    scoped_bson_t stages(bsoncxx::document::view(pipeline._impl->view_array()));
 
     bsoncxx::builder::stream::document b;
 

--- a/src/mongocxx/database.cpp
+++ b/src/mongocxx/database.cpp
@@ -118,12 +118,27 @@ class collection database::create_collection(bsoncxx::string::view_or_value name
     libbson::scoped_bson_t opts_bson{options.to_document()};
     auto result = libmongoc::database_create_collection(
         _get_impl().database_t, name.terminated().data(), opts_bson.bson(), &error);
-
     if (!result) {
         throw_exception<operation_exception>(error);
     }
 
-    return mongocxx::collection(*this, static_cast<void*>(result));
+    return mongocxx::collection(*this, result);
+}
+
+class collection database::create_view(bsoncxx::string::view_or_value name,
+                                       bsoncxx::string::view_or_value view_on,
+                                       const options::create_view& options) {
+    bson_error_t error;
+
+    libbson::scoped_bson_t opts_bson{document{} << "viewOn" << view_on
+                                                << concatenate(options.to_document()) << finalize};
+    auto result = libmongoc::database_create_collection(
+        _get_impl().database_t, name.terminated().data(), opts_bson.bson(), &error);
+    if (!result) {
+        throw_exception<operation_exception>(error);
+    }
+
+    return mongocxx::collection(*this, result);
 }
 
 void database::drop() {

--- a/src/mongocxx/database.hpp
+++ b/src/mongocxx/database.hpp
@@ -22,6 +22,7 @@
 #include <mongocxx/collection.hpp>
 #include <mongocxx/options/modify_collection.hpp>
 #include <mongocxx/options/create_collection.hpp>
+#include <mongocxx/options/create_view.hpp>
 #include <mongocxx/write_concern.hpp>
 #include <mongocxx/read_preference.hpp>
 
@@ -105,6 +106,24 @@ class MONGOCXX_API database {
     class collection create_collection(
         bsoncxx::string::view_or_value name,
         const options::create_collection& options = options::create_collection());
+
+    ///
+    /// Creates a non-materialized view in this database with the specified options.
+    /// Non-materialized views are represented by the @c collection objects, and support many of the
+    /// same read-only operations that regular collections do.
+    ///
+    /// @see https://docs.mongodb.com/master/release-notes/3.4/#views
+    ///
+    /// @param name the name of the view to be created.
+    /// @param view_on
+    ///   the name of the source view or collection in this database from which to create the view.
+    /// @param options the options for the new view.
+    ///
+    /// @throws mongocxx::operation_exception if the operation fails.
+    ///
+    class collection create_view(bsoncxx::string::view_or_value name,
+                                 bsoncxx::string::view_or_value view_on,
+                                 const options::create_view& options = options::create_view());
 
     ///
     /// Modify an existing collection.

--- a/src/mongocxx/options/create_view.cpp
+++ b/src/mongocxx/options/create_view.cpp
@@ -1,0 +1,43 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/options/create_view.hpp>
+
+#include <bsoncxx/builder/stream/document.hpp>
+#include <bsoncxx/types.hpp>
+
+#include <mongocxx/config/private/prelude.hh>
+
+namespace mongocxx {
+MONGOCXX_INLINE_NAMESPACE_BEGIN
+namespace options {
+
+create_view& create_view::pipeline(class pipeline pipeline) {
+    _pipeline = std::move(pipeline);
+    return *this;
+}
+
+bsoncxx::document::value create_view::to_document() const {
+    auto doc = bsoncxx::builder::stream::document{};
+
+    if (_pipeline) {
+        doc << "pipeline" << _pipeline->view_array();
+    }
+
+    return doc.extract();
+}
+
+}  // namespace options
+MONGOCXX_INLINE_NAMESPACE_END
+}  // namespace mongocxx

--- a/src/mongocxx/options/create_view.hpp
+++ b/src/mongocxx/options/create_view.hpp
@@ -1,0 +1,67 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/document/view_or_value.hpp>
+#include <bsoncxx/stdx/optional.hpp>
+#include <mongocxx/pipeline.hpp>
+#include <mongocxx/stdx.hpp>
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+MONGOCXX_INLINE_NAMESPACE_BEGIN
+namespace options {
+
+///
+/// Class representing the optional arguments to a view creation operation.
+///
+class MONGOCXX_API create_view {
+   public:
+    create_view() = default;
+
+    create_view(const create_view& other) = delete;
+    create_view& operator=(const create_view& other) = delete;
+
+    ///
+    /// Sets the pipeline that will be used to compute this view.
+    ///
+    /// @param pipeline
+    ///   Pipeline that will be used to compute the view.
+    ///
+    create_view& pipeline(pipeline pipeline);
+
+    ///
+    /// Return a bson document representing the options set on this object.
+    ///
+    /// @return Options, as a document.
+    ///
+    bsoncxx::document::value to_document() const;
+
+    MONGOCXX_INLINE operator bsoncxx::document::value() const;
+
+   private:
+    stdx::optional<class pipeline> _pipeline;
+};
+
+MONGOCXX_INLINE create_view::operator bsoncxx::document::value() const {
+    return to_document();
+}
+
+}  // namespace options
+MONGOCXX_INLINE_NAMESPACE_END
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/pipeline.cpp
+++ b/src/mongocxx/pipeline.cpp
@@ -95,5 +95,9 @@ bsoncxx::document::view pipeline::view() const {
     return _impl->view();
 }
 
+bsoncxx::array::view pipeline::view_array() const {
+    return _impl->view_array();
+}
+
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx

--- a/src/mongocxx/pipeline.hpp
+++ b/src/mongocxx/pipeline.hpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <memory>
 
+#include <bsoncxx/array/view.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 
@@ -174,9 +175,16 @@ class MONGOCXX_API pipeline {
     pipeline& unwind(std::string field_name);
 
     ///
+    /// @return A view of the underlying BSON array this pipeline represents.
+    ///
+    bsoncxx::array::view view_array() const;
+
+    ///
     /// @return A view of the underlying BSON document this pipeline represents.
     ///
-    bsoncxx::document::view view() const;
+    /// @deprecated The view_array() method should be used instead of this method.
+    ///
+    MONGOCXX_DEPRECATED bsoncxx::document::view view() const;
 
    private:
     friend class collection;

--- a/src/mongocxx/private/pipeline.hh
+++ b/src/mongocxx/private/pipeline.hh
@@ -29,6 +29,13 @@ class pipeline::impl {
         return _builder;
     }
 
+    bsoncxx::array::view view_array() {
+        return _builder.view();
+    }
+
+    ///
+    /// view() is deprecated. Use view_array() instead.
+    ///
     bsoncxx::document::view view() {
         return _builder.view();
     }

--- a/src/mongocxx/test/CMakeLists.txt
+++ b/src/mongocxx/test/CMakeLists.txt
@@ -35,6 +35,7 @@ set(mongocxx_test_sources
     options/aggregate.cpp
     options/count.cpp
     options/create_collection.cpp
+    options/create_view.cpp
     options/delete.cpp
     options/distinct.cpp
     options/find.cpp

--- a/src/mongocxx/test/options/create_view.cpp
+++ b/src/mongocxx/test/options/create_view.cpp
@@ -1,0 +1,44 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "catch.hpp"
+
+#include <bsoncxx/document/value.hpp>
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/types.hpp>
+#include <bsoncxx/types/value.hpp>
+#include <mongocxx/instance.hpp>
+#include <mongocxx/options/create_view.hpp>
+
+using namespace bsoncxx;
+using namespace mongocxx;
+
+TEST_CASE("create_view", "[create_view]") {
+    instance::current();
+
+    options::create_view cv;
+
+    SECTION("Can be exported to a document") {
+        cv.pipeline(std::move(pipeline{}.limit(1)));
+
+        auto doc = cv.to_document();
+        document::view doc_view{doc.view()};
+
+        // pipeline field is set correctly
+        document::element pipeline_ele{doc_view["pipeline"]};
+        REQUIRE(pipeline_ele);
+        REQUIRE(pipeline_ele.type() == type::k_array);
+        REQUIRE(pipeline_ele.get_array().value == pipeline{}.limit(1).view_array());
+    }
+}


### PR DESCRIPTION
@acmorrow @xdg, PTAL.

I modeled the design of database::create_view() off of the approach taken for [JAVA-2286](https://jira.mongodb.org/browse/JAVA-2286).  Note that I couldn't find record of any other driver having a collMod helper, so I just went ahead and added the view-related options to options::modify_collection() (though I also filed [CXX-1058](https://jira.mongodb.org/browse/CXX-1058) to have us consider deprecating database::modify_collection() outright).

Follow-up work:
- Collation support for views will be addressed in [CXX-971](https://jira.mongodb.org/browse/CXX-971).
- Updating the 3.3 development series documentation link will be addressed in [CXX-1061](https://jira.mongodb.org/browse/CXX-1061).