### PR TITLE
CXX-1062 read_concern::acknowledge_string("") sets level to default

### DIFF
--- a/src/mongocxx/read_concern.cpp
+++ b/src/mongocxx/read_concern.cpp
@@ -66,7 +66,9 @@ void read_concern::acknowledge_level(read_concern::level rc_level) {
 }
 
 void read_concern::acknowledge_string(stdx::string_view rc_string) {
-    libmongoc::read_concern_set_level(_impl->read_concern_t, rc_string.to_string().data());
+    // libmongoc uses a NULL level to mean "use the server's default read_concern."
+    libmongoc::read_concern_set_level(_impl->read_concern_t,
+                                      rc_string.empty() ? NULL : rc_string.to_string().data());
 }
 
 read_concern::level read_concern::acknowledge_level() const {

--- a/src/mongocxx/test/read_concern.cpp
+++ b/src/mongocxx/test/read_concern.cpp
@@ -63,6 +63,11 @@ TEST_CASE("read_concern level and string affect each other", "[read_concern]") {
         REQUIRE(rc.acknowledge_level() == read_concern::level::k_majority);
     }
 
+    SECTION("setting the string to the empty string changes the level to server default") {
+        rc.acknowledge_string("");
+        REQUIRE(rc.acknowledge_level() == read_concern::level::k_server_default);
+    }
+
     SECTION("setting the string to an unknown value changes the level to unknown") {
         rc.acknowledge_string("futureCompatible");
         REQUIRE(rc.acknowledge_level() == read_concern::level::k_unknown);


### PR DESCRIPTION
Fixes a bug where passing the empty string to
read_concern::acknowledge_string() would incorrectly set the read
concern level to read_concern::level::k_unknown, instead of the
correct value of read_concern::level::k_server_default.