### PR TITLE
CXX-948 Support new readConcern level "linearizable"

### DIFF
--- a/src/mongocxx/read_concern.cpp
+++ b/src/mongocxx/read_concern.cpp
@@ -56,6 +56,10 @@ void read_concern::acknowledge_level(read_concern::level rc_level) {
             libmongoc::read_concern_set_level(_impl->read_concern_t,
                                               MONGOC_READ_CONCERN_LEVEL_MAJORITY);
             break;
+        case read_concern::level::k_linearizable:
+            libmongoc::read_concern_set_level(_impl->read_concern_t,
+                                              MONGOC_READ_CONCERN_LEVEL_LINEARIZABLE);
+            break;
         case read_concern::level::k_server_default:
             // libmongoc uses a NULL level to mean "use the server's default read_concern."
             libmongoc::read_concern_set_level(_impl->read_concern_t, NULL);
@@ -80,6 +84,8 @@ read_concern::level read_concern::acknowledge_level() const {
         return read_concern::level::k_local;
     } else if (strcmp(MONGOC_READ_CONCERN_LEVEL_MAJORITY, level) == 0) {
         return read_concern::level::k_majority;
+    } else if (strcmp(MONGOC_READ_CONCERN_LEVEL_LINEARIZABLE, level) == 0) {
+        return read_concern::level::k_linearizable;
     } else {
         return read_concern::level::k_unknown;
     }

--- a/src/mongocxx/read_concern.hpp
+++ b/src/mongocxx/read_concern.hpp
@@ -41,6 +41,12 @@ class uri;
 /// been written to a majority of nodes and thus cannot be rolled back. By default, MongoDB uses a
 /// readConcern of "local" which does not guarantee that the read data would not be rolled back.
 ///
+/// MongoDB 3.4 introduces a read concern level of "linearizable" to read data that has been written
+/// to a majority of nodes (i.e. cannot be rolled back) @b and is not stale. Linearizable read
+/// concern is available for all MongoDB supported storage engines and applies to read operations on
+/// a single document. Note that writes must be made with majority write concern in order for reads
+/// to be linearizable.
+///
 /// @see https://docs.mongodb.org/manual/reference/read-concern/
 ///
 class MONGOCXX_API read_concern {
@@ -53,6 +59,7 @@ class MONGOCXX_API read_concern {
     enum class level {
         k_local,
         k_majority,
+        k_linearizable,
         k_server_default,
         k_unknown,
     };
@@ -95,9 +102,11 @@ class MONGOCXX_API read_concern {
     /// Sets the read concern level.
     ///
     /// @param rc_level
-    ///   Either k_local, k_majority, or k_server_default.
+    ///   Either k_local, k_majority, k_linearizable, or k_server_default.
     ///
-    /// @throws std::invalid_argument if rc_level is not k_local, k_majority, or k_server_default.
+    /// @throws
+    ///   std::invalid_argument if rc_level is not k_local, k_majority, k_linearizable, or
+    ///   k_server_default.
     ///
     void acknowledge_level(level rc_level);
 
@@ -105,7 +114,7 @@ class MONGOCXX_API read_concern {
     /// Gets the current read concern level.
     ///
     /// If this was set with acknowledge_string to anything other than "local", "majority",
-    /// or an empty string, this will return k_unknown.
+    /// "linearizable", or an empty string, this will return k_unknown.
     ///
     /// @return The read concern level.
     ///
@@ -114,7 +123,7 @@ class MONGOCXX_API read_concern {
     ///
     /// Sets the read concern string.
     ///
-    /// One of "local", "majority", or "".
+    /// One of "local", "majority", "linearizable", or "".
     ///
     /// @param rc_string
     ///   The read concern string.
@@ -125,7 +134,7 @@ class MONGOCXX_API read_concern {
     /// Gets the current read concern string.
     ///
     /// If the read concern level was set with acknowledge_level, this will return either "local",
-    /// "majority", or an empty string for k_server_default.
+    /// "majority", "linearizable", or an empty string for k_server_default.
     ///
     /// @return The read concern string.
     ///

--- a/src/mongocxx/test/read_concern.cpp
+++ b/src/mongocxx/test/read_concern.cpp
@@ -22,56 +22,68 @@
 
 using namespace mongocxx;
 
-TEST_CASE("a default read_concern", "[read_concern]") {
+TEST_CASE("valid read concern settings", "[read_concern]") {
     instance::current();
 
     read_concern rc{};
 
-    SECTION("has level k_server_default") {
-        REQUIRE(rc.acknowledge_level() == read_concern::level::k_server_default);
+    read_concern::level level_setting;
+    stdx::string_view string_setting;
+
+    SECTION("default-constructed read_concern") {
+        level_setting = read_concern::level::k_server_default;
+        string_setting = stdx::string_view{""};
     }
 
-    SECTION("has an empty string") {
-        REQUIRE(rc.acknowledge_string() == stdx::string_view{""});
+    SECTION("can be assigned with acknowledge_level()") {
+        SECTION("local") {
+            level_setting = read_concern::level::k_local;
+            string_setting = stdx::string_view{"local"};
+        }
+
+        SECTION("majority") {
+            level_setting = read_concern::level::k_majority;
+            string_setting = stdx::string_view{"majority"};
+        }
+
+        SECTION("server default") {
+            level_setting = read_concern::level::k_server_default;
+            string_setting = stdx::string_view{""};
+        }
+
+        REQUIRE_NOTHROW(rc.acknowledge_level(level_setting));
     }
+
+    SECTION("can be assigned with acknowledge_string()") {
+        SECTION("local") {
+            level_setting = read_concern::level::k_local;
+            string_setting = stdx::string_view{"local"};
+        }
+
+        SECTION("majority") {
+            level_setting = read_concern::level::k_majority;
+            string_setting = stdx::string_view{"majority"};
+        }
+
+        SECTION("server default") {
+            level_setting = read_concern::level::k_server_default;
+            string_setting = stdx::string_view{""};
+        }
+
+        REQUIRE_NOTHROW(rc.acknowledge_string(string_setting));
+    }
+
+    REQUIRE(rc.acknowledge_level() == level_setting);
+    REQUIRE(rc.acknowledge_string() == string_setting);
 }
 
-TEST_CASE("read_concern fields may be set and retrieved", "[read_concern]") {
+TEST_CASE("setting the string to an unknown value changes the level to unknown", "[read_concern]") {
     instance::current();
 
     read_concern rc{};
 
-    REQUIRE_NOTHROW(rc.acknowledge_level(read_concern::level::k_majority));
-    REQUIRE(rc.acknowledge_level() == read_concern::level::k_majority);
-
-    REQUIRE_NOTHROW(rc.acknowledge_string(stdx::string_view{"local"}));
-    REQUIRE(rc.acknowledge_string() == stdx::string_view{"local"});
-}
-
-TEST_CASE("read_concern level and string affect each other", "[read_concern]") {
-    instance::current();
-
-    read_concern rc{};
-
-    SECTION("setting the level changes the string") {
-        rc.acknowledge_level(read_concern::level::k_local);
-        REQUIRE(rc.acknowledge_string() == stdx::string_view{"local"});
-    }
-
-    SECTION("setting the string changes the level") {
-        rc.acknowledge_string("majority");
-        REQUIRE(rc.acknowledge_level() == read_concern::level::k_majority);
-    }
-
-    SECTION("setting the string to the empty string changes the level to server default") {
-        rc.acknowledge_string("");
-        REQUIRE(rc.acknowledge_level() == read_concern::level::k_server_default);
-    }
-
-    SECTION("setting the string to an unknown value changes the level to unknown") {
-        rc.acknowledge_string("futureCompatible");
-        REQUIRE(rc.acknowledge_level() == read_concern::level::k_unknown);
-    }
+    rc.acknowledge_string("futureCompatible");
+    REQUIRE(rc.acknowledge_level() == read_concern::level::k_unknown);
 }
 
 TEST_CASE("read_concern throws when trying to set level to k_unknown", "[read_concern]") {

--- a/src/mongocxx/test/read_concern.cpp
+++ b/src/mongocxx/test/read_concern.cpp
@@ -46,6 +46,11 @@ TEST_CASE("valid read concern settings", "[read_concern]") {
             string_setting = stdx::string_view{"majority"};
         }
 
+        SECTION("linearizable") {
+            level_setting = read_concern::level::k_linearizable;
+            string_setting = stdx::string_view{"linearizable"};
+        }
+
         SECTION("server default") {
             level_setting = read_concern::level::k_server_default;
             string_setting = stdx::string_view{""};
@@ -63,6 +68,11 @@ TEST_CASE("valid read concern settings", "[read_concern]") {
         SECTION("majority") {
             level_setting = read_concern::level::k_majority;
             string_setting = stdx::string_view{"majority"};
+        }
+
+        SECTION("linearizable") {
+            level_setting = read_concern::level::k_linearizable;
+            string_setting = stdx::string_view{"linearizable"};
         }
 
         SECTION("server default") {


### PR DESCRIPTION
@acmorrow @xdg, PTAL.