### PR TITLE
CXX-1033 Re-enable decimal128 in libbson compilation for CI

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -80,7 +80,7 @@ functions:
                 # TODO: Update this to our real minimum for the C++11 driver 3.1 release, once known.
                 git checkout master
                 rm -rf /data/tmp/c-driver-install
-                ./autogen.sh --prefix="/data/tmp/c-driver-install" --enable-tests=no --enable-examples=no --with-libbson=bundled --disable-decimal-bid --disable-extra-align --enable-debug --enable-optimizations --disable-shm-counters --disable-static --disable-dependency-tracking --with-pic --disable-automatic-init-and-cleanup ${cdriver_configure_flags}
+                ./autogen.sh --prefix="/data/tmp/c-driver-install" --enable-tests=no --enable-examples=no --with-libbson=bundled --disable-extra-align --enable-debug --enable-optimizations --disable-shm-counters --disable-static --disable-dependency-tracking --with-pic --disable-automatic-init-and-cleanup ${cdriver_configure_flags}
                 make ${compile_concurrency}
                 make install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ install:
     # TODO: Update this to our real minimum for the C++11 driver 3.1 release, once known.
     - git checkout master
 
-    - ./autogen.sh --enable-tests=no --enable-examples=no --with-libbson=bundled --disable-decimal-bid; make; sudo make install
+    - ./autogen.sh --enable-tests=no --enable-examples=no --with-libbson=bundled; make; sudo make install
 
     - popd
 


### PR DESCRIPTION
libmongoc master has updated its libbson submodule to include
the fix that should allow us to remove `--disable-decimal-bid`.

