### PR TITLE
CXX-1068 Fix incomplete iterator API

### DIFF
--- a/src/bsoncxx/document/view.cpp
+++ b/src/bsoncxx/document/view.cpp
@@ -148,7 +148,15 @@ view::const_iterator view::cend() const {
     return const_iterator();
 }
 
-view::iterator view::begin() const {
+view::const_iterator view::begin() const {
+    return cbegin();
+}
+
+view::const_iterator view::end() const {
+    return const_iterator();
+}
+
+view::iterator view::begin() {
     bson_t b;
     bson_iter_t iter;
 
@@ -161,7 +169,7 @@ view::iterator view::begin() const {
     return iterator(element{iter.raw, iter.len, iter.off});
 }
 
-view::iterator view::end() const {
+view::iterator view::end() {
     return iterator();
 }
 
@@ -170,14 +178,14 @@ view::iterator view::find(stdx::string_view key) const {
     bson_iter_t iter;
 
     if (!bson_init_static(&b, _data, _length)) {
-        return end();
+        return const_cast<view*>(this)->end();
     }
 
     if (bson_iter_init_find(&iter, &b, key.to_string().data())) {
         return iterator(element(iter.raw, iter.len, iter.off));
     }
 
-    return end();
+    return const_cast<view*>(this)->end();
 }
 
 element view::operator[](stdx::string_view key) const {

--- a/src/bsoncxx/document/view.hpp
+++ b/src/bsoncxx/document/view.hpp
@@ -63,14 +63,24 @@ class BSONCXX_API view {
     const_iterator cend() const;
 
     ///
+    /// @returns A const_iterator to the first element of the document.
+    ///
+    const_iterator begin() const;
+
+    ///
+    /// @returns A const_iterator to the past-the-end element of the document.
+    ///
+    const_iterator end() const;
+
+    ///
     /// @returns An iterator to the first element of the document.
     ///
-    iterator begin() const;
+    iterator begin();
 
     ///
     /// @returns An iterator to the past-the-end element of the document.
     ///
-    iterator end() const;
+    iterator end();
 
     ///
     /// Finds the first element of the document with the provided key. If there is


### PR DESCRIPTION
When I use bsoncxx::document::view inside Google tests (https://github.com/google/googletest) I faced with this error:

`error: conversion from ‘bsoncxx::v_noabi::document::view::iterator’ to non-scalar type ‘bsoncxx::v_noabi::document::view::const_iterator’ requested
   for (typename C::const_iterator it = container.begin();`

I opened Google's code and found this code:
###### 

// Used to print an STL-style container when the user doesn't define
// a PrintTo() for it.
template <typename C>
void DefaultPrintTo(IsContainer, false_type, const C& container, ::std::ostream\* os) {
  // ...
  for (typename C::const_iterator it = container.begin();  it != container.end(); ++it, ++count) {
###### 

STL-style containers return const_iterator using methods begin/end for const objects, but your implementation returns non const iterators for const objects. 

I fixed this problem in my commit.
