### PR TITLE
CXX-1072 create_collection::to_document(): serialize _no_padding fix

### DIFF
--- a/src/mongocxx/options/create_collection.cpp
+++ b/src/mongocxx/options/create_collection.cpp
@@ -84,7 +84,7 @@ bsoncxx::document::value create_collection::to_document() const {
     }
 
     if (_no_padding) {
-        doc << "noPadding" << *_no_padding;
+        doc << "flags" << (*_no_padding ? 0x10 : 0x00);
     }
 
     if (_validation) {

--- a/src/mongocxx/test/options/create_collection.cpp
+++ b/src/mongocxx/test/options/create_collection.cpp
@@ -47,7 +47,7 @@ TEST_CASE("create_collection", "[create_collection]") {
         cc.capped(true);
         cc.size(256);
         cc.max(100);
-        cc.no_padding(false);
+        cc.no_padding(true);
 
         auto doc = cc.to_document();
         document::view doc_view{doc.view()};
@@ -74,11 +74,11 @@ TEST_CASE("create_collection", "[create_collection]") {
         REQUIRE(max.type() == type::k_int32);
         REQUIRE(max.get_int32() == 100);
 
-        // noPadding should be set to false
-        document::element padding{doc_view["noPadding"]};
+        // flags should be set to 0x10
+        document::element padding{doc_view["flags"]};
         REQUIRE(padding);
-        REQUIRE(padding.type() == type::k_bool);
-        REQUIRE(padding.get_bool() == false);
+        REQUIRE(padding.type() == type::k_int32);
+        REQUIRE(padding.get_int32() == 0x10);
 
         // storageEngine should not be set
         document::element engine{doc_view["storageEngine"]};


### PR DESCRIPTION
Previously, options::create_collection::_no_padding was always
serialized incorrectly.