### PR TITLE
CXX-1088 RHEL 5 Evergreen variant should use v3.2-latest server binary

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -10,7 +10,10 @@ variables:
     ## source variables
     source:
         linux_64_source: &linux_64_source https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-latest.tgz
-        rhel55_source: &rhel55_source http://downloads.mongodb.org/linux/mongodb-linux-x86_64-rhel55-latest.tgz
+        # Versions 3.4+ of the server no longer run RHEL 5.5, so we pin to v3.2-latest instead. In
+        # addition, the download tools on the RHEL 5 hosts don't support SNI, so we must use an
+        # http:// link.
+        rhel55_source: &rhel55_source http://downloads.mongodb.org/linux/mongodb-linux-x86_64-rhel55-v3.2-latest.tgz
         osx_source: &osx_source https://fastdl.mongodb.org/osx/mongodb-osx-x86_64-latest.tgz
         ubuntu_s390x_source: &ubuntu_s390x_source http://downloads.10gen.com/linux/mongodb-linux-s390x-enterprise-ubuntu1604-latest.tgz
         ubuntu_ppc64le_source: &ubuntu_ppc64le_source http://downloads.10gen.com/linux/mongodb-linux-ppc64le-enterprise-ubuntu1604-latest.tgz


### PR DESCRIPTION
The server no longer builds on RHEL 5, so the source server binary
link for the RHEL 5.5 Evergreen variant is out of date.