### PR TITLE
CXX-971 (part 8) Add client helpers to test_util

### DIFF
--- a/src/mongocxx/exception/error_code.cpp
+++ b/src/mongocxx/exception/error_code.cpp
@@ -51,6 +51,8 @@ class error_category final : public std::error_category {
                 return "invalid attempt to set an unknown write concern level";
             case error_code::k_instance_already_exists:
                 return "cannot create more than one mongocxx::instance object";
+            case error_code::k_server_response_malformed:
+                return "the response from the server was malformed";
             default:
                 return "unknown mongocxx error";
         }

--- a/src/mongocxx/exception/error_code.hpp
+++ b/src/mongocxx/exception/error_code.hpp
@@ -33,6 +33,7 @@ enum class error_code : std::int32_t {
     k_ssl_not_supported,
     k_unknown_read_concern,
     k_unknown_write_concern,
+    k_server_response_malformed,
     // Add new constant string message to error_code.cpp as well!
 };
 

--- a/src/mongocxx/test/CMakeLists.txt
+++ b/src/mongocxx/test/CMakeLists.txt
@@ -62,6 +62,7 @@ set(mongocxx_test_sources
 )
 
 add_executable(test_driver
+    ${CMAKE_SOURCE_DIR}/src/mongocxx/test_util/client_helpers.cpp
     ${THIRD_PARTY_SOURCE_DIR}/catch/main.cpp
     ${mongocxx_test_sources}
 )

--- a/src/mongocxx/test_util/client_helpers.cpp
+++ b/src/mongocxx/test_util/client_helpers.cpp
@@ -1,0 +1,41 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/test_util/client_helpers.hh>
+
+#include <bsoncxx/builder/stream/document.hpp>
+#include <mongocxx/client.hpp>
+#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/exception/operation_exception.hpp>
+
+#include <mongocxx/config/private/prelude.hh>
+
+namespace mongocxx {
+MONGOCXX_INLINE_NAMESPACE_BEGIN
+namespace test_util {
+
+std::int32_t get_max_wire_version(const client& client) {
+    auto reply =
+        client["admin"].run_command(bsoncxx::builder::stream::document{}
+                                    << "isMaster" << 1 << bsoncxx::builder::stream::finalize);
+    auto max_wire_version = reply.view()["maxWireVersion"];
+    if (!max_wire_version || max_wire_version.type() != bsoncxx::type::k_int32) {
+        throw operation_exception{error_code::k_server_response_malformed};
+    }
+    return max_wire_version.get_int32().value;
+}
+
+}  // namespace test_util
+MONGOCXX_INLINE_NAMESPACE_END
+}  // namespace mongocxx

--- a/src/mongocxx/test_util/client_helpers.cpp
+++ b/src/mongocxx/test_util/client_helpers.cpp
@@ -30,7 +30,11 @@ std::int32_t get_max_wire_version(const client& client) {
         client["admin"].run_command(bsoncxx::builder::stream::document{}
                                     << "isMaster" << 1 << bsoncxx::builder::stream::finalize);
     auto max_wire_version = reply.view()["maxWireVersion"];
-    if (!max_wire_version || max_wire_version.type() != bsoncxx::type::k_int32) {
+    if (!max_wire_version) {
+        // If wire version is not available (i.e. server version too old), it is assumed to be zero.
+        return 0;
+    }
+    if (max_wire_version.type() != bsoncxx::type::k_int32) {
         throw operation_exception{error_code::k_server_response_malformed};
     }
     return max_wire_version.get_int32().value;

--- a/src/mongocxx/test_util/client_helpers.cpp
+++ b/src/mongocxx/test_util/client_helpers.cpp
@@ -40,6 +40,10 @@ std::int32_t get_max_wire_version(const client& client) {
     return max_wire_version.get_int32().value;
 }
 
+bool supports_collation(const client& client) {
+    return get_max_wire_version(client) >= 5;
+}
+
 }  // namespace test_util
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx

--- a/src/mongocxx/test_util/client_helpers.hh
+++ b/src/mongocxx/test_util/client_helpers.hh
@@ -1,0 +1,40 @@
+// Copyright 2016 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+#include <mongocxx/config/private/prelude.hh>
+
+namespace mongocxx {
+MONGOCXX_INLINE_NAMESPACE_BEGIN
+
+class client;
+
+namespace test_util {
+
+//
+// Determines the max wire version associated with the given client, by running the "isMaster"
+// command.
+//
+// Throws mongocxx::operation_exception if the operation fails, or the server reply is malformed.
+//
+std::int32_t get_max_wire_version(const client& client);
+
+}  // namespace test_util
+MONGOCXX_INLINE_NAMESPACE_END
+}  // namespace mongocxx
+
+#include <mongocxx/config/private/postlude.hh>

--- a/src/mongocxx/test_util/client_helpers.hh
+++ b/src/mongocxx/test_util/client_helpers.hh
@@ -33,6 +33,14 @@ namespace test_util {
 //
 std::int32_t get_max_wire_version(const client& client);
 
+//
+// Determines whether or not the given client supports the collation feature, by running the
+// "isMaster" command.
+//
+// Throws mongocxx::operation_exception if the operation fails, or the server reply is malformed.
+//
+bool supports_collation(const client& client);
+
 }  // namespace test_util
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx

--- a/src/mongocxx/test_util/mock.hh
+++ b/src/mongocxx/test_util/mock.hh
@@ -187,6 +187,6 @@ class mock<R (*)(Args...)> {
 
 }  // namespace test_util
 MONGOCXX_INLINE_NAMESPACE_END
-}  // namespace mongo
+}  // namespace mongocxx
 
 #include <mongocxx/config/private/postlude.hh>

--- a/src/mongocxx/test_util/mock.hh
+++ b/src/mongocxx/test_util/mock.hh
@@ -25,7 +25,10 @@
 #include <unordered_map>
 #include <vector>
 
+#include <mongocxx/config/private/prelude.hh>
+
 namespace mongocxx {
+MONGOCXX_INLINE_NAMESPACE_BEGIN
 namespace test_util {
 
 template <typename T>
@@ -183,4 +186,7 @@ class mock<R (*)(Args...)> {
 };
 
 }  // namespace test_util
+MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongo
+
+#include <mongocxx/config/private/postlude.hh>


### PR DESCRIPTION
@xdg, PTAL.

This is groundwork for the collation integration tests.