### PR TITLE
CXX-971 (part 10) Add collation support for collection find/find_one

### DIFF
--- a/src/mongocxx/collection.cpp
+++ b/src/mongocxx/collection.cpp
@@ -203,6 +203,10 @@ bsoncxx::document::value build_find_options_document(const options::find& option
         options_builder << "batchSize" << *options.batch_size();
     }
 
+    if (options.collation()) {
+        options_builder << "collation" << *options.collation();
+    }
+
     if (options.comment()) {
         options_builder << "comment" << *options.comment();
     }


### PR DESCRIPTION
@xdg, PTAL.

Note that the existing collection integration tests do a weird mix of holding onto `bsoncxx::builder::stream::document` and `bsoncxx::document::value` local variables.  I've attempted to write new tests that are consistent with the existing tests (with the hope that we'll revisit integration testing in general within the next few months), but I'd be happy to make the new tests look somewhat different from the existing tests if you'd prefer.