### PR TITLE
CXX-971 (part 15) Add collation integration tests for create_collection() and create_view()

### DIFF
--- a/src/mongocxx/test/database.cpp
+++ b/src/mongocxx/test/database.cpp
@@ -287,16 +287,14 @@ TEST_CASE("Database integration tests", "[database]") {
     stdx::string_view collection_name{"collection"};
 
     SECTION("A database may create a collection via create_collection") {
-        SECTION("without any options") {
-            database[collection_name].drop();
+        database[collection_name].drop();
 
+        SECTION("without any options") {
             collection obtained_collection = database.create_collection(collection_name);
             REQUIRE(obtained_collection.name() == collection_name);
         }
 
         SECTION("with options") {
-            database[collection_name].drop();
-
             options::create_collection opts;
             opts.capped(true);
             opts.size(256);
@@ -308,17 +306,14 @@ TEST_CASE("Database integration tests", "[database]") {
         }
 
         SECTION("but raises exception when collection already exists") {
-            database[collection_name].drop();
-
             database.create_collection(collection_name);
 
             REQUIRE_THROWS(database.create_collection(collection_name));
         }
-
-        database[collection_name].drop();
     }
 
     SECTION("A collection may be modified via modify_collection") {
+        database[collection_name].drop();
         database.create_collection(collection_name);
 
         auto rule = document{} << "email" << open_document << "$exists"

--- a/src/mongocxx/test/database.cpp
+++ b/src/mongocxx/test/database.cpp
@@ -413,5 +413,20 @@ TEST_CASE("Database integration tests", "[database]") {
                 REQUIRE(view.count(bsoncxx::document::view{}) == 0);
             }
         }
+
+        SECTION("View creation with collation") {
+            options::create_view opts;
+            opts.collation(case_insensitive_collation.view());
+
+            if (test_util::supports_collation(mongo_client)) {
+                collection obtained_view = database.create_view(view_name, collection_name, opts);
+                REQUIRE(obtained_view.find_one(document{} << "x"
+                                                          << "FOO" << finalize));
+            } else {
+                // The server doesn't support collation.
+                REQUIRE_THROWS_AS(database.create_view(view_name, collection_name, opts),
+                                  operation_exception);
+            }
+        }
     }
 }


### PR DESCRIPTION
@xdg, PTAL.

Note that this change purely adds integration test coverage for `database::create_collection()` and `database::create_view()`.  Collation support for these methods was already added in #548 and #564 (respectively), due to the `to_document()` design of these options classes.