### PR TITLE
Minor refactoring

### DIFF
--- a/src/bsoncxx/builder/core.cpp
+++ b/src/bsoncxx/builder/core.cpp
@@ -47,17 +47,12 @@ class core::impl {
     }
 
     ~impl() {
-        while (!_stack.empty()) {
-            _stack.pop_back();
-        }
-
+        _stack.clear();
         bson_destroy(&_root);
     }
 
     void reinit() {
-        while (!_stack.empty()) {
-            _stack.pop_back();
-        }
+        _stack.clear();
 
         bson_reinit(&_root);
 

--- a/src/bsoncxx/document/element.cpp
+++ b/src/bsoncxx/document/element.cpp
@@ -27,7 +27,7 @@
 
 #include <bsoncxx/config/private/prelude.hh>
 
-#define CITER                \
+#define BSONCXX_CITER        \
     bson_iter_t iter;        \
     iter.raw = _raw;         \
     iter.len = _length;      \
@@ -78,7 +78,7 @@ bsoncxx::type element::type() const {
         throw bsoncxx::exception{error_code::k_unset_element};
     }
 
-    CITER;
+    BSONCXX_CITER;
     return static_cast<bsoncxx::type>(bson_iter_type(&iter));
 }
 
@@ -87,7 +87,7 @@ stdx::string_view element::key() const {
         throw bsoncxx::exception{error_code::k_unset_element};
     }
 
-    CITER;
+    BSONCXX_CITER;
 
     const char* key = bson_iter_key(&iter);
 
@@ -97,7 +97,7 @@ stdx::string_view element::key() const {
 types::b_binary element::get_binary() const {
     BSONCXX_TYPE_CHECK(k_binary);
 
-    CITER;
+    BSONCXX_CITER;
 
     bson_subtype_t type;
     std::uint32_t len;
@@ -111,7 +111,7 @@ types::b_binary element::get_binary() const {
 types::b_utf8 element::get_utf8() const {
     BSONCXX_TYPE_CHECK(k_utf8);
 
-    CITER;
+    BSONCXX_CITER;
 
     uint32_t len;
     const char* val = bson_iter_utf8(&iter, &len);
@@ -121,17 +121,17 @@ types::b_utf8 element::get_utf8() const {
 
 types::b_double element::get_double() const {
     BSONCXX_TYPE_CHECK(k_double);
-    CITER;
+    BSONCXX_CITER;
     return types::b_double{bson_iter_double(&iter)};
 }
 types::b_int32 element::get_int32() const {
     BSONCXX_TYPE_CHECK(k_int32);
-    CITER;
+    BSONCXX_CITER;
     return types::b_int32{bson_iter_int32(&iter)};
 }
 types::b_int64 element::get_int64() const {
     BSONCXX_TYPE_CHECK(k_int64);
-    CITER;
+    BSONCXX_CITER;
     return types::b_int64{bson_iter_int64(&iter)};
 }
 types::b_undefined element::get_undefined() const {
@@ -140,7 +140,7 @@ types::b_undefined element::get_undefined() const {
 }
 types::b_oid element::get_oid() const {
     BSONCXX_TYPE_CHECK(k_oid);
-    CITER;
+    BSONCXX_CITER;
 
     const bson_oid_t* boid = bson_iter_oid(&iter);
     oid v(reinterpret_cast<const char*>(boid->bytes), sizeof(boid->bytes));
@@ -149,7 +149,7 @@ types::b_oid element::get_oid() const {
 }
 types::b_decimal128 element::get_decimal128() const {
     BSONCXX_TYPE_CHECK(k_decimal128);
-    CITER;
+    BSONCXX_CITER;
 
     bson_decimal128_t d128;
     bson_iter_decimal128(&iter, &d128);
@@ -159,12 +159,12 @@ types::b_decimal128 element::get_decimal128() const {
 
 types::b_bool element::get_bool() const {
     BSONCXX_TYPE_CHECK(k_bool);
-    CITER;
+    BSONCXX_CITER;
     return types::b_bool{bson_iter_bool(&iter)};
 }
 types::b_date element::get_date() const {
     BSONCXX_TYPE_CHECK(k_date);
-    CITER;
+    BSONCXX_CITER;
     return types::b_date{std::chrono::milliseconds{bson_iter_date_time(&iter)}};
 }
 types::b_null element::get_null() const {
@@ -174,7 +174,7 @@ types::b_null element::get_null() const {
 
 types::b_regex element::get_regex() const {
     BSONCXX_TYPE_CHECK(k_regex);
-    CITER;
+    BSONCXX_CITER;
 
     const char* options;
     const char* regex = bson_iter_regex(&iter, &options);
@@ -184,7 +184,7 @@ types::b_regex element::get_regex() const {
 
 types::b_dbpointer element::get_dbpointer() const {
     BSONCXX_TYPE_CHECK(k_dbpointer);
-    CITER;
+    BSONCXX_CITER;
 
     uint32_t collection_len;
     const char* collection;
@@ -198,7 +198,7 @@ types::b_dbpointer element::get_dbpointer() const {
 
 types::b_code element::get_code() const {
     BSONCXX_TYPE_CHECK(k_code);
-    CITER;
+    BSONCXX_CITER;
 
     uint32_t len;
     const char* code = bson_iter_code(&iter, &len);
@@ -208,7 +208,7 @@ types::b_code element::get_code() const {
 
 types::b_symbol element::get_symbol() const {
     BSONCXX_TYPE_CHECK(k_symbol);
-    CITER;
+    BSONCXX_CITER;
 
     uint32_t len;
     const char* symbol = bson_iter_symbol(&iter, &len);
@@ -218,7 +218,7 @@ types::b_symbol element::get_symbol() const {
 
 types::b_codewscope element::get_codewscope() const {
     BSONCXX_TYPE_CHECK(k_codewscope);
-    CITER;
+    BSONCXX_CITER;
 
     uint32_t code_len;
     const uint8_t* scope_ptr;
@@ -231,7 +231,7 @@ types::b_codewscope element::get_codewscope() const {
 
 types::b_timestamp element::get_timestamp() const {
     BSONCXX_TYPE_CHECK(k_timestamp);
-    CITER;
+    BSONCXX_CITER;
 
     uint32_t timestamp;
     uint32_t increment;
@@ -251,7 +251,7 @@ types::b_maxkey element::get_maxkey() const {
 
 types::b_document element::get_document() const {
     BSONCXX_TYPE_CHECK(k_document);
-    CITER;
+    BSONCXX_CITER;
 
     const std::uint8_t* buf;
     std::uint32_t len;
@@ -263,7 +263,7 @@ types::b_document element::get_document() const {
 
 types::b_array element::get_array() const {
     BSONCXX_TYPE_CHECK(k_array);
-    CITER;
+    BSONCXX_CITER;
 
     const std::uint8_t* buf;
     std::uint32_t len;

--- a/src/bsoncxx/private/stack.hh
+++ b/src/bsoncxx/private/stack.hh
@@ -30,13 +30,17 @@ class stack {
     }
 
     ~stack() {
-        while (!empty()) {
-            pop_back();
-        }
+        clear();
 
         while (!_buckets.empty()) {
             operator delete(_buckets.back());
             _buckets.pop_back();
+        }
+    }
+
+    void clear() {
+        while (!empty()) {
+            pop_back();
         }
     }
 

--- a/src/bsoncxx/test/bson_get_values.cpp
+++ b/src/bsoncxx/test/bson_get_values.cpp
@@ -177,7 +177,7 @@ TEST_CASE("[] can reach into mixed nested arrays and documents", "[bsoncxx]") {
 TEST_CASE("[] with large nesting levels", "[bsoncxx]") {
     using namespace builder::stream;
 
-    std::int32_t nesting_level;
+    std::int32_t nesting_level = 0;
 
     SECTION("no nesting") {
         nesting_level = 0;

--- a/src/mongocxx/test/read_concern.cpp
+++ b/src/mongocxx/test/read_concern.cpp
@@ -27,8 +27,8 @@ TEST_CASE("valid read concern settings", "[read_concern]") {
 
     read_concern rc{};
 
-    read_concern::level level_setting;
-    stdx::string_view string_setting;
+    read_concern::level level_setting = read_concern::level::k_server_default;
+    stdx::string_view string_setting{""};
 
     SECTION("default-constructed read_concern") {
         level_setting = read_concern::level::k_server_default;


### PR DESCRIPTION
Initially I intended to remove the explicit clearing of the stack in the builder::core _impl destructor, but when I did that the tests had a memory corruption.

I am not sure why this is, possibly a double free maybe? (Maybe the stack needs to be cleared before bson_destroy?)