### PR TITLE
CXX-915 Add CMake examples for package search mechanisms

### DIFF
--- a/examples/cmake/FindPkgConfig/CMakeLists.txt
+++ b/examples/cmake/FindPkgConfig/CMakeLists.txt
@@ -1,0 +1,54 @@
+# Copyright 2016 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Demonstrates how to use the CMake 'FindPkgConfig' mechanism to locate
+# and build against libmongocxx and libbsoncxx.
+
+cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+
+if(POLICY CMP0025)
+  cmake_policy(SET CMP0025 NEW)
+endif()
+
+project(MONGO_CXX_DRIVER LANGUAGES CXX)
+
+# Enforce the C++ standard, and disable extensions
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11)
+endif()
+
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(PkgConfig QUIET)
+
+# NOTE: For this to work, the PKG_CONFIG_PATH variable (man pkg-config) must be set to point to the
+# 'lib/pkgconfig' subdirectory of the directory used as the argument to CMAKE_INSTALL_PREFIX when
+# building libmongocxx and libbsoncxx.
+pkg_search_module(BSONCXX REQUIRED libbsoncxx)
+pkg_search_module(MONGOCXX REQUIRED libmongocxx)
+
+link_directories(
+  ${MONGOCXX_LIBRARY_DIRS}
+  ${BSONCXX_LIBRARY_DIRS}
+)
+
+add_executable(hello_mongocxx hello_mongocxx.cpp)
+
+target_include_directories(hello_mongocxx
+  PRIVATE ${MONGOCXX_INCLUDE_DIRS}
+  PRIVATE ${BSONCXX_INCLUDE_DIRS}
+)
+target_link_libraries(hello_mongocxx
+  PRIVATE ${MONGOCXX_LIBRARIES} ${BSONCXX_LIBRARIES}
+)

--- a/examples/cmake/FindPkgConfig/hello_mongocxx.cpp
+++ b/examples/cmake/FindPkgConfig/hello_mongocxx.cpp
@@ -1,0 +1,50 @@
+// Copyright 2015 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include <bsoncxx/builder/stream/document.hpp>
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/instance.hpp>
+#include <mongocxx/uri.hpp>
+
+int main(int argc, char* argv[]) {
+    using bsoncxx::builder::stream::document;
+
+    mongocxx::instance inst;
+
+    try {
+        const auto uri = mongocxx::uri{(argc >= 2) ? argv[1] : mongocxx::uri::k_default_uri};
+
+        auto client = mongocxx::client{uri};
+
+        auto admin = client["admin"];
+
+        document ismaster;
+        ismaster << "isMaster" << 1;
+
+        auto result = admin.run_command(ismaster.view());
+        std::cout << bsoncxx::to_json(result) << "\n";
+
+        return EXIT_SUCCESS;
+
+    } catch (const std::exception& xcp) {
+        std::cout << "connection failed: " << xcp.what() << "\n";
+        return EXIT_FAILURE;
+    }
+}

--- a/examples/cmake/find_package/CMakeLists.txt
+++ b/examples/cmake/find_package/CMakeLists.txt
@@ -1,0 +1,52 @@
+# Copyright 2016 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Demonstrates how to use the CMake 'find_package' mechanism to locate
+# and build against libmongocxx and libbsoncxx.
+
+cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+
+if(POLICY CMP0025)
+  cmake_policy(SET CMP0025 NEW)
+endif()
+
+project(MONGO_CXX_DRIVER LANGUAGES CXX)
+
+# Enforce the C++ standard, and disable extensions
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11)
+endif()
+
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# NOTE: For this to work, the CMAKE_PREFIX_PATH variable must be set to point to the directory that
+# was used as the argument to CMAKE_INSTALL_PREFIX when building libmongocxx and libbsoncxx.
+find_package(libbsoncxx)
+find_package(libmongocxx)
+
+link_directories(
+  ${LIBMONGOCXX_LIBRARY_DIRS}
+  ${LIBBSONCXX_LIBRARY_DIRS}
+)
+
+add_executable(hello_mongocxx hello_mongocxx.cpp)
+
+target_include_directories(hello_mongocxx
+  PRIVATE ${LIBMONGOCXX_INCLUDE_DIRS}
+  PRIVATE ${LIBBSONCXX_INCLUDE_DIRS}
+)
+
+target_link_libraries(hello_mongocxx
+  PRIVATE ${LIBMONGOCXX_LIBRARIES} ${LIBBSONCXX_LIBRARIES}
+)

--- a/examples/cmake/find_package/hello_mongocxx.cpp
+++ b/examples/cmake/find_package/hello_mongocxx.cpp
@@ -1,0 +1,50 @@
+// Copyright 2015 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include <bsoncxx/builder/stream/document.hpp>
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/instance.hpp>
+#include <mongocxx/uri.hpp>
+
+int main(int argc, char* argv[]) {
+    using bsoncxx::builder::stream::document;
+
+    mongocxx::instance inst;
+
+    try {
+        const auto uri = mongocxx::uri{(argc >= 2) ? argv[1] : mongocxx::uri::k_default_uri};
+
+        auto client = mongocxx::client{uri};
+
+        auto admin = client["admin"];
+
+        document ismaster;
+        ismaster << "isMaster" << 1;
+
+        auto result = admin.run_command(ismaster.view());
+        std::cout << bsoncxx::to_json(result) << "\n";
+
+        return EXIT_SUCCESS;
+
+    } catch (const std::exception& xcp) {
+        std::cout << "connection failed: " << xcp.what() << "\n";
+        return EXIT_FAILURE;
+    }
+}


### PR DESCRIPTION
This adds examples for how to find the mongocxx and bsoncxx libraries and link against them using the two primary CMake package search mechanisms:

https://cmake.org/cmake/help/v3.0/module/FindPkgConfig.html
https://cmake.org/cmake/help/v3.0/command/find_package.html

A follow up task should be to automatically run these in the CI loop so they don't go stale.