### PR TITLE
CXX-1199 Add a const qualifier to b_date conversion operator

### DIFF
--- a/src/bsoncxx/types.hpp
+++ b/src/bsoncxx/types.hpp
@@ -314,7 +314,7 @@ struct BSONCXX_API b_date {
     ///
     /// Conversion operator unwrapping a int64_t
     ///
-    BSONCXX_INLINE operator int64_t() {
+    BSONCXX_INLINE operator int64_t() const {
         return value.count();
     }
 


### PR DESCRIPTION
This allows implicit conversions from `const b_date` to int64_t types.