### PR TITLE
CXX-1231 When patching include paths to use 'mnmlstc', avoid filename collisions

### DIFF
--- a/src/bsoncxx/third_party/CMakeLists.txt
+++ b/src/bsoncxx/third_party/CMakeLists.txt
@@ -33,7 +33,7 @@ if (BSONCXX_POLY_USE_MNMLSTC AND NOT BSONCXX_POLY_USE_SYSTEM_MNMLSTC)
         EP_mnmlstc_core
         fix-includes
         WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/${BSONCXX_HEADER_INSTALL_DIR}/bsoncxx/third_party/mnmlstc
-        COMMAND find . -type f | xargs perl -pi -e "s|#include <core|#include <bsoncxx/third_party/mnmlstc/core|g"
+        COMMAND find . -type f | xargs perl -pi.bak -e "s|#include <core|#include <bsoncxx/third_party/mnmlstc/core|g"
         DEPENDEES install
     )
 


### PR DESCRIPTION
By default, perl's "-i" option tells it to:
* Open the specified file.
* Unlink the file.
* Create a new file with the same name.
* Copy the old file to the new file, transforming it per the regex.

This is not valid on Windows because you can't have two files with the same name, even if one of them has been unlinked.

The quick fix is to tell Perl to instead create a backup file, so it moves the original file rather than unlinking it.