### PR TITLE
minor: fix typos in tutorial

### DIFF
--- a/docs/content/mongocxx-v3/tutorial.md
+++ b/docs/content/mongocxx-v3/tutorial.md
@@ -124,7 +124,7 @@ mongocxx::collection coll = db["test"];
 
 ### Create a Document
 
-To create a :term:`document` using the C++ driver, use one of the two
+To create a `document` using the C++ driver, use one of the two
 available builder interfaces:
 
 Stream builder: `bsoncxx::builder::stream`

--- a/docs/content/mongocxx-v3/tutorial.md
+++ b/docs/content/mongocxx-v3/tutorial.md
@@ -436,8 +436,8 @@ index type for each field:
 { "index1": "<type>", "index2": <type> }
 ```
 
-- For an ascending index type, specify 1 for <type>.
-- For a descending index type, specify -1 for <type>.
+- For an ascending index type, specify 1 for `<type>`.
+- For a descending index type, specify -1 for `<type>`.
 
 The following example creates an ascending index on the `i` field:
 


### PR DESCRIPTION
Hey team, this is just a few minor typos in the tutorial. I'm not familiar with the C++ driver contribution process, so please let me know if I should file a JIRA ticket/edit the commit messages/etc.

In addition: I'm not familiar with formatting, so I don't exactly know how to fix this, but it seems that`h5` doesn't seem to have styling on [the tutorial page](https://mongodb.github.io/mongo-cxx-driver/mongocxx-v3/tutorial/). For example, see the "Get A Single Document That Matches a Filter" section; it's formatted the same as plain text.