### PR TITLE
CXX-1346: fixing more __imp_bson and __imp_mongoc linker errors

### DIFF
--- a/src/bsoncxx/CMakeLists.txt
+++ b/src/bsoncxx/CMakeLists.txt
@@ -105,6 +105,7 @@ add_library(bsoncxx_static STATIC
 )
 
 target_compile_definitions(bsoncxx_static PUBLIC BSONCXX_STATIC)
+target_compile_definitions(bsoncxx_static PUBLIC BSON_STATIC)
 
 set_target_properties(bsoncxx_static PROPERTIES
     OUTPUT_NAME bsoncxx

--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -111,6 +111,8 @@ add_library(mongocxx_static STATIC
 )
 
 target_compile_definitions(mongocxx_static PUBLIC MONGOCXX_STATIC)
+target_compile_definitions(mongocxx_static PUBLIC BSON_STATIC)
+target_compile_definitions(mongocxx_static PUBLIC MONGOC_STATIC)
 
 set_target_properties(mongocxx_static PROPERTIES
     OUTPUT_NAME mongocxx

--- a/src/mongocxx/test_util/mock.hh
+++ b/src/mongocxx/test_util/mock.hh
@@ -25,6 +25,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <assert.h>
 #include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {


### PR DESCRIPTION
1. was still getting __imp_bson and __imp_mongoc linker errors when linking applications statically,
BSON_STATIC and MONGOC_STATIC must be added to the static version flags of the cxx static libs for them to be usable for static linking. The CDRIVER-2054 fix adresses the issue for apps linking statically against the c libs. The CXX version is one such apps so needs that for completeness :)

2. missing header added to mock.hh for "assert" to fix compile error on Visual Studio 2015

tested using the hello world example on the CXX driver Installing page. Now runs without any dependencies when linked statically as described