### PR TITLE
CXX-1460 Small fixups

### DIFF
--- a/src/bsoncxx/util/functor.hpp
+++ b/src/bsoncxx/util/functor.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <functional>
 #include <type_traits>
 
 #include <bsoncxx/config/prelude.hpp>

--- a/src/mongocxx/private/libbson.cpp
+++ b/src/mongocxx/private/libbson.cpp
@@ -40,14 +40,14 @@ scoped_bson_t::scoped_bson_t(bsoncxx::document::view_or_value doc)
 scoped_bson_t::scoped_bson_t(bsoncxx::stdx::optional<bsoncxx::document::view_or_value> doc)
     : _is_initialized{doc} {
     if (doc) {
-        _doc = doc;
+        _doc = std::move(doc);
         doc_to_bson_t(*_doc, &_bson);
     }
 }
 
 void scoped_bson_t::init_from_static(bsoncxx::document::view_or_value doc) {
     _is_initialized = true;
-    _doc = doc;
+    _doc = std::move(doc);
     doc_to_bson_t(*_doc, &_bson);
 }
 
@@ -55,7 +55,7 @@ void scoped_bson_t::init_from_static(
     bsoncxx::stdx::optional<bsoncxx::document::view_or_value> doc) {
     if (doc) {
         _is_initialized = true;
-        _doc = doc;
+        _doc = std::move(doc);
         doc_to_bson_t(*_doc, &_bson);
     }
 }


### PR DESCRIPTION
These two commits don't address the central issue of CXX-1460, which is that GCC thinks there is an ambiguity between the scoped_bson_t constructors in C++17 mode, but clang requires both overloads. I'm not sure which compiler is in the right, yet.

In the meantime, this adds a clearly missing header, and adds some missing calls to `std::move` that were observed while looking into the implementation of `scoped_bson_t`.