### PR TITLE
CXX-1447 Deprecate things the right way

### DIFF
--- a/src/bsoncxx/oid.cpp
+++ b/src/bsoncxx/oid.cpp
@@ -34,7 +34,11 @@ oid::oid() {
 
 const oid::init_tag_t oid::init_tag{};
 
-oid::oid(init_tag_t) : oid::oid() {}
+oid::oid(init_tag_t) : oid::oid(init_tag_deprecated) {}
+
+const oid::init_tag_t_deprecated oid::init_tag_deprecated{};
+
+oid::oid(init_tag_t_deprecated) : oid::oid() {}
 
 oid::oid(const bsoncxx::stdx::string_view& str) {
     if (!bson_oid_is_valid(str.data(), str.size())) {
@@ -63,6 +67,10 @@ std::string oid::to_string() const {
 }
 
 oid::operator bool() const {
+    return operator_bool_deprecated();
+}
+
+bool oid::operator_bool_deprecated() const {
     return true;
 }
 

--- a/src/bsoncxx/oid.hpp
+++ b/src/bsoncxx/oid.hpp
@@ -49,7 +49,7 @@ class BSONCXX_API oid {
     //
     // See https://connect.microsoft.com/VisualStudio/feedback/details/2092790
     //
-    static const init_tag_t init_tag;
+    BSONCXX_DEPRECATED static const init_tag_t init_tag;
 
     ///
     /// Constructs an oid and initializes it to a newly generated ObjectId.
@@ -61,6 +61,10 @@ class BSONCXX_API oid {
     ///   A bsoncxx::oid::init_tag used to dispatch this overload.
     ///
     BSONCXX_DEPRECATED explicit oid(init_tag_t tag);
+
+    struct init_tag_t_deprecated {};
+    static const init_tag_t_deprecated init_tag_deprecated;
+    explicit oid(init_tag_t_deprecated);
 
     ///
     /// Constructs an oid initializes it to the contents of the provided buffer.
@@ -118,6 +122,7 @@ class BSONCXX_API oid {
     /// @return True
     ///
     BSONCXX_DEPRECATED explicit operator bool() const;
+    bool operator_bool_deprecated() const;
 
     ///
     /// Extracts the timestamp portion of the underlying ObjectId.

--- a/src/mongocxx/client.cpp
+++ b/src/mongocxx/client.cpp
@@ -64,9 +64,13 @@ client::operator bool() const noexcept {
     return static_cast<bool>(_impl);
 }
 
-void client::read_concern(class read_concern rc) {
+void client::read_concern_deprecated(class read_concern rc) {
     auto client_t = _get_impl().client_t;
     libmongoc::client_set_read_concern(client_t, rc._impl->read_concern_t);
+}
+
+void client::read_concern(class read_concern rc) {
+    return read_concern_deprecated(std::move(rc));
 }
 
 class read_concern client::read_concern() const {
@@ -74,8 +78,12 @@ class read_concern client::read_concern() const {
     return {stdx::make_unique<read_concern::impl>(libmongoc::read_concern_copy(rc))};
 }
 
-void client::read_preference(class read_preference rp) {
+void client::read_preference_deprecated(class read_preference rp) {
     libmongoc::client_set_read_prefs(_get_impl().client_t, rp._impl->read_preference_t);
+}
+
+void client::read_preference(class read_preference rp) {
+    return read_preference_deprecated(std::move(rp));
 }
 
 class read_preference client::read_preference() const {
@@ -90,8 +98,12 @@ class uri client::uri() const {
     return connection_string;
 }
 
-void client::write_concern(class write_concern wc) {
+void client::write_concern_deprecated(class write_concern wc) {
     libmongoc::client_set_write_concern(_get_impl().client_t, wc._impl->write_concern_t);
+}
+
+void client::write_concern(class write_concern wc) {
+    return write_concern_deprecated(std::move(wc));
 }
 
 class write_concern client::write_concern() const {

--- a/src/mongocxx/client.hpp
+++ b/src/mongocxx/client.hpp
@@ -111,6 +111,7 @@ class MONGOCXX_API client {
     /// @see https://docs.mongodb.com/master/reference/read-concern/
     ///
     MONGOCXX_DEPRECATED void read_concern(class read_concern rc);
+    void read_concern_deprecated(class read_concern rc);
 
     ///
     /// Returns the current read concern for this client.
@@ -136,6 +137,7 @@ class MONGOCXX_API client {
     /// @see https://docs.mongodb.com/master/core/read-preference/
     ///
     MONGOCXX_DEPRECATED void read_preference(class read_preference rp);
+    void read_preference_deprecated(class read_preference rp);
 
     ///
     /// Returns the current read preference for this client.
@@ -168,6 +170,7 @@ class MONGOCXX_API client {
     ///   The new write concern
     ///
     MONGOCXX_DEPRECATED void write_concern(class write_concern wc);
+    void write_concern_deprecated(class write_concern wc);
 
     ///
     /// Returns the current write concern for this client.

--- a/src/mongocxx/database.cpp
+++ b/src/mongocxx/database.cpp
@@ -110,11 +110,16 @@ bsoncxx::document::value database::run_command(bsoncxx::document::view_or_value 
     return reply_bson.steal();
 }
 
-bsoncxx::document::value database::modify_collection(stdx::string_view name,
-                                                     const options::modify_collection& options) {
+bsoncxx::document::value database::modify_collection_deprecated(stdx::string_view name,
+                                                                const options::modify_collection& options) {
     auto doc = make_document(kvp("collMod", name), concatenate(options.to_document()));
 
     return run_command(doc.view());
+}
+
+bsoncxx::document::value database::modify_collection(stdx::string_view name,
+                                                     const options::modify_collection& options) {
+    return modify_collection_deprecated(name, options);
 }
 
 class collection database::create_collection(

--- a/src/mongocxx/database.hpp
+++ b/src/mongocxx/database.hpp
@@ -153,6 +153,10 @@ class MONGOCXX_API database {
         stdx::string_view name,
         const options::modify_collection& options = options::modify_collection());
 
+    bsoncxx::document::value modify_collection_deprecated(
+        stdx::string_view name,
+        const options::modify_collection& options = options::modify_collection());
+
     ///
     /// Drops the database and all its collections.
     ///

--- a/src/mongocxx/hint.cpp
+++ b/src/mongocxx/hint.cpp
@@ -41,7 +41,7 @@ bsoncxx::types::value hint::to_value() const {
     return bsoncxx::types::value{bsoncxx::types::b_utf8{*_index_string}};
 }
 
-bsoncxx::document::value hint::to_document() const {
+bsoncxx::document::value hint::to_document_deprecated() const {
     auto doc = bsoncxx::builder::basic::document{};
 
     if (_index_doc) {
@@ -51,6 +51,10 @@ bsoncxx::document::value hint::to_document() const {
     }
 
     return doc.extract();
+}
+
+bsoncxx::document::value hint::to_document() const {
+    return to_document_deprecated();
 }
 
 bool MONGOCXX_CALL operator==(const hint& index_hint, std::string index) {

--- a/src/mongocxx/hint.hpp
+++ b/src/mongocxx/hint.hpp
@@ -82,6 +82,7 @@ class MONGOCXX_API hint {
     /// @return Hint, as a document.
     ///
     MONGOCXX_DEPRECATED bsoncxx::document::value to_document() const;
+    bsoncxx::document::value to_document_deprecated() const;
 
     ///
     /// Returns a types::value representing this hint.
@@ -156,7 +157,7 @@ MONGOCXX_INLINE hint::operator bsoncxx::types::value() const {
 }
 
 MONGOCXX_INLINE hint::operator bsoncxx::document::value() const {
-    return to_document();
+    return to_document_deprecated();
 }
 
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/options/create_collection.cpp
+++ b/src/mongocxx/options/create_collection.cpp
@@ -28,9 +28,13 @@ namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 namespace options {
 
-create_collection& create_collection::auto_index_id(bool auto_index_id) {
+create_collection& create_collection::auto_index_id_deprecated(bool auto_index_id) {
     _auto_index_id = auto_index_id;
     return *this;
+}
+
+create_collection& create_collection::auto_index_id(bool auto_index_id) {
+    return auto_index_id_deprecated(auto_index_id);
 }
 
 create_collection& create_collection::capped(bool capped) {
@@ -101,7 +105,7 @@ const stdx::optional<class validation_criteria>& create_collection::validation_c
     return _validation;
 }
 
-bsoncxx::document::value create_collection::to_document() const {
+bsoncxx::document::value create_collection::to_document_deprecated() const {
     auto doc = bsoncxx::builder::basic::document{};
 
     if (_auto_index_id) {
@@ -133,10 +137,14 @@ bsoncxx::document::value create_collection::to_document() const {
     }
 
     if (_validation) {
-        doc.append(concatenate(_validation->to_document()));
+        doc.append(concatenate(_validation->to_document_deprecated()));
     }
 
     return doc.extract();
+}
+
+bsoncxx::document::value create_collection::to_document() const {
+    return to_document_deprecated();
 }
 
 bool MONGOCXX_CALL operator==(const create_collection& lhs, const create_collection& rhs) {

--- a/src/mongocxx/options/create_collection.hpp
+++ b/src/mongocxx/options/create_collection.hpp
@@ -47,6 +47,7 @@ class MONGOCXX_API create_collection {
     ///   method chaining.
     ///
     MONGOCXX_DEPRECATED create_collection& auto_index_id(bool auto_index_id);
+    create_collection& auto_index_id_deprecated(bool auto_index_id);
 
     ///
     /// Gets the current auto_index_id setting.
@@ -238,6 +239,7 @@ class MONGOCXX_API create_collection {
     /// @return Options, as a document.
     ///
     MONGOCXX_DEPRECATED bsoncxx::document::value to_document() const;
+    bsoncxx::document::value to_document_deprecated() const;
 
     ///
     /// @deprecated
@@ -263,7 +265,7 @@ class MONGOCXX_API create_collection {
 };
 
 MONGOCXX_INLINE create_collection::operator bsoncxx::document::value() const {
-    return to_document();
+    return to_document_deprecated();
 }
 
 }  // namespace options

--- a/src/mongocxx/options/create_view.cpp
+++ b/src/mongocxx/options/create_view.cpp
@@ -53,7 +53,7 @@ const stdx::optional<class write_concern>& create_view::write_concern() const {
     return _write_concern;
 }
 
-bsoncxx::document::value create_view::to_document() const {
+bsoncxx::document::value create_view::to_document_deprecated() const {
     auto doc = bsoncxx::builder::basic::document{};
 
     if (_collation) {
@@ -65,6 +65,10 @@ bsoncxx::document::value create_view::to_document() const {
     }
 
     return doc.extract();
+}
+
+bsoncxx::document::value create_view::to_document() const {
+    return to_document_deprecated();
 }
 
 bool MONGOCXX_CALL operator==(const create_view& lhs, const create_view& rhs) {

--- a/src/mongocxx/options/create_view.hpp
+++ b/src/mongocxx/options/create_view.hpp
@@ -115,6 +115,7 @@ class MONGOCXX_API create_view {
     /// @return Options, as a document.
     ///
     MONGOCXX_DEPRECATED bsoncxx::document::value to_document() const;
+    bsoncxx::document::value to_document_deprecated() const;
 
     ///
     /// @deprecated
@@ -133,7 +134,7 @@ class MONGOCXX_API create_view {
 };
 
 MONGOCXX_INLINE create_view::operator bsoncxx::document::value() const {
-    return to_document();
+    return to_document_deprecated();
 }
 
 }  // namespace options

--- a/src/mongocxx/options/find.cpp
+++ b/src/mongocxx/options/find.cpp
@@ -82,9 +82,13 @@ find& find::min(bsoncxx::document::view_or_value min) {
     return *this;
 }
 
-find& find::modifiers(bsoncxx::document::view_or_value modifiers) {
+find& find::modifiers_deprecated(bsoncxx::document::view_or_value modifiers) {
     _modifiers = std::move(modifiers);
     return *this;
+}
+
+find& find::modifiers(bsoncxx::document::view_or_value modifiers) {
+    return modifiers_deprecated(std::move(modifiers));
 }
 
 find& find::no_cursor_timeout(bool no_cursor_timeout) {
@@ -180,8 +184,12 @@ const stdx::optional<bsoncxx::document::view_or_value>& find::min() const {
     return _min;
 }
 
-const stdx::optional<bsoncxx::document::view_or_value>& find::modifiers() const {
+const stdx::optional<bsoncxx::document::view_or_value>& find::modifiers_deprecated() const {
     return _modifiers;
+}
+
+const stdx::optional<bsoncxx::document::view_or_value>& find::modifiers() const {
+    return modifiers_deprecated();
 }
 
 const stdx::optional<bool>& find::no_cursor_timeout() const {

--- a/src/mongocxx/options/find.hpp
+++ b/src/mongocxx/options/find.hpp
@@ -341,6 +341,7 @@ class MONGOCXX_API find {
     /// @see https://docs.mongodb.com/master/reference/operator/query-modifier/
     ///
     MONGOCXX_DEPRECATED find& modifiers(bsoncxx::document::view_or_value modifiers);
+    find& modifiers_deprecated(bsoncxx::document::view_or_value modifiers);
 
     ///
     /// Gets the current query modifiers.
@@ -353,6 +354,7 @@ class MONGOCXX_API find {
     ///   calling find::modifiers() with a document containing a "$snapshot" field.
     ///
     MONGOCXX_DEPRECATED const stdx::optional<bsoncxx::document::view_or_value>& modifiers() const;
+    const stdx::optional<bsoncxx::document::view_or_value>& modifiers_deprecated() const;
 
     ///
     /// Sets the cursor flag to prevent cursor from timing out server-side due to a period of

--- a/src/mongocxx/options/modify_collection.cpp
+++ b/src/mongocxx/options/modify_collection.cpp
@@ -60,9 +60,7 @@ bsoncxx::document::value modify_collection::to_document() const {
     }
 
     if (_validation) {
-        BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN;
-        doc.append(concatenate(_validation->to_document()));
-        BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END;
+        doc.append(concatenate(_validation->to_document_deprecated()));
     }
 
     return doc.extract();

--- a/src/mongocxx/options/private/rewriter.cpp
+++ b/src/mongocxx/options/private/rewriter.cpp
@@ -160,16 +160,14 @@ void convert_snapshot_modifier(find* options, bsoncxx::document::element ele) {
 
 }  // namespace
 
-BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
-
 find rewriter::rewrite_find_modifiers(const find& options) {
-    if (!options.modifiers()) {
+    if (!options.modifiers_deprecated()) {
         return options;
     }
 
     find converted_options{options};
 
-    for (auto&& ele : converted_options.modifiers()->view()) {
+    for (auto&& ele : converted_options.modifiers_deprecated()->view()) {
         if (ele.key() == stdx::string_view("$comment")) {
             convert_comment_modifier(&converted_options, ele);
         } else if (ele.key() == stdx::string_view("$explain")) {
@@ -205,8 +203,6 @@ find rewriter::rewrite_find_modifiers(const find& options) {
 
     return converted_options;
 }
-
-BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
 
 }  // namespace options
 MONGOCXX_INLINE_NAMESPACE_END

--- a/src/mongocxx/pipeline.cpp
+++ b/src/mongocxx/pipeline.cpp
@@ -209,8 +209,12 @@ pipeline& pipeline::unwind(std::string field_name) {
     return *this;
 }
 
-bsoncxx::document::view pipeline::view() const {
+bsoncxx::document::view pipeline::view_deprecated() const {
     return _impl->view();
+}
+
+bsoncxx::document::view pipeline::view() const {
+    return view_deprecated();
 }
 
 bsoncxx::array::view pipeline::view_array() const {

--- a/src/mongocxx/pipeline.hpp
+++ b/src/mongocxx/pipeline.hpp
@@ -451,6 +451,7 @@ class MONGOCXX_API pipeline {
     /// @deprecated The view_array() method should be used instead of this method.
     ///
     MONGOCXX_DEPRECATED bsoncxx::document::view view() const;
+    bsoncxx::document::view view_deprecated() const;
 
    private:
     friend class collection;

--- a/src/mongocxx/read_preference.cpp
+++ b/src/mongocxx/read_preference.cpp
@@ -48,11 +48,17 @@ read_preference::read_preference()
           libmongoc::conversions::read_mode_t_from_read_mode(read_mode::k_primary)))) {}
 
 read_preference::read_preference(read_mode mode)
+    : read_preference(mode, deprecated_tag{}) {}
+
+read_preference::read_preference(read_mode mode, deprecated_tag)
     : _impl(stdx::make_unique<impl>(
           libmongoc::read_prefs_new(libmongoc::conversions::read_mode_t_from_read_mode(mode)))) {}
 
 read_preference::read_preference(read_mode mode, bsoncxx::document::view_or_value tags)
-    : read_preference(mode) {
+    : read_preference(mode, std::move(tags), deprecated_tag{}) {}
+
+read_preference::read_preference(read_mode mode, bsoncxx::document::view_or_value tags, deprecated_tag)
+    : read_preference(mode, deprecated_tag{}) {
     read_preference::tags(std::move(tags));
 }
 

--- a/src/mongocxx/read_preference.hpp
+++ b/src/mongocxx/read_preference.hpp
@@ -99,6 +99,8 @@ class MONGOCXX_API read_preference {
     ///
     read_preference();
 
+    struct deprecated_tag{};
+
     ///
     /// Constructs a new read_preference.
     ///
@@ -108,6 +110,7 @@ class MONGOCXX_API read_preference {
     /// @deprecated The constructor with no arguments and the method mode() should be used.
     ///
     MONGOCXX_DEPRECATED read_preference(read_mode mode);
+    read_preference(read_mode mode, deprecated_tag);
 
     ///
     /// Constructs a new read_preference with tags.
@@ -122,6 +125,7 @@ class MONGOCXX_API read_preference {
     /// @deprecated The tags() method should be used instead.
     ///
     MONGOCXX_DEPRECATED read_preference(read_mode mode, bsoncxx::document::view_or_value tags);
+    read_preference(read_mode mode, bsoncxx::document::view_or_value tags, deprecated_tag);
 
     ///
     /// Copy constructs a read_preference.

--- a/src/mongocxx/test/client.cpp
+++ b/src/mongocxx/test/client.cpp
@@ -131,9 +131,7 @@ TEST_CASE("A client has a settable Read Concern", "[client]") {
             client_set_rc_called = true;
         });
 
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN;
-    mongo_client.read_concern(rc);
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END;
+    mongo_client.read_concern_deprecated(rc);
     REQUIRE(client_set_rc_called);
 }
 
@@ -161,9 +159,7 @@ TEST_CASE("A client's read preferences may be set and obtained", "[client]") {
     client_get_preference->interpose([&](const mongoc_client_t*) { return saved_preference.get(); })
         .forever();
 
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN;
-    mongo_client.read_preference(std::move(preference));
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END;
+    mongo_client.read_preference_deprecated(std::move(preference));
     REQUIRE(called_set);
 
     REQUIRE(read_preference::read_mode::k_secondary_preferred ==
@@ -193,9 +189,7 @@ TEST_CASE("A client's write concern may be set and obtained", "[client]") {
         return underlying_wc;
     });
 
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN;
-    mongo_client.write_concern(concern);
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END;
+    mongo_client.write_concern_deprecated(concern);
     REQUIRE(set_called);
 
     MOCK_CONCERN

--- a/src/mongocxx/test/database.cpp
+++ b/src/mongocxx/test/database.cpp
@@ -393,9 +393,7 @@ TEST_CASE("Database integration tests", "[database]") {
             options::modify_collection opts;
             opts.index(key_pattern.view(), std::chrono::seconds{2});
 
-            BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN;
-            database.modify_collection(collection_name, opts);
-            BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END;
+            database.modify_collection_deprecated(collection_name, opts);
 
             auto cursor = database[collection_name].list_indexes();
             for (auto&& index : cursor) {
@@ -426,9 +424,7 @@ TEST_CASE("Database integration tests", "[database]") {
 
             if (test_util::get_max_wire_version(mongo_client) >= 4) {
                 // The server supports document validation.
-                BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN;
-                REQUIRE_NOTHROW(database.modify_collection(collection_name, opts));
-                BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END;
+                REQUIRE_NOTHROW(database.modify_collection_deprecated(collection_name, opts));
 
                 auto cursor = database.list_collections();
                 for (auto&& coll : cursor) {
@@ -438,10 +434,8 @@ TEST_CASE("Database integration tests", "[database]") {
                 }
             } else {
                 // The server does not support document validation.
-                BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN;
-                REQUIRE_THROWS_AS(database.modify_collection(collection_name, opts),
+                REQUIRE_THROWS_AS(database.modify_collection_deprecated(collection_name, opts),
                                   operation_exception);
-                BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END;
             }
         }
     }
@@ -464,9 +458,7 @@ TEST_CASE("Database integration tests", "[database]") {
 
         read_concern rc{};
         rc.acknowledge_level(majority);
-        BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN;
-        mongo_client.read_concern(rc);
-        BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END;
+        mongo_client.read_concern_deprecated(rc);
 
         mongocxx::database rc_db = mongo_client[database_name];
 

--- a/src/mongocxx/test/hint.cpp
+++ b/src/mongocxx/test/hint.cpp
@@ -60,10 +60,8 @@ TEST_CASE("Hint", "[hint]") {
         }
 
         SECTION("Test for deprecated method to_document()") {
-            BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN;
             document::value filter =
-                make_document(kvp("a", 15), concatenate(index_hint.to_document()));
-            BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END;
+                make_document(kvp("a", 15), concatenate(index_hint.to_document_deprecated()));
             document::view view{filter.view()};
             document::element ele{view["$hint"]};
             REQUIRE(ele);
@@ -104,10 +102,8 @@ TEST_CASE("Hint", "[hint]") {
         }
 
         SECTION("Test for deprecated method to_document()") {
-            BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN;
             document::value filter =
-                make_document(kvp("a", 12), concatenate(index_hint.to_document()));
-            BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END;
+                make_document(kvp("a", 12), concatenate(index_hint.to_document_deprecated()));
             document::view view{filter.view()};
             document::element ele{view["$hint"]};
             REQUIRE(ele);

--- a/src/mongocxx/test/options/create_collection.cpp
+++ b/src/mongocxx/test/options/create_collection.cpp
@@ -103,9 +103,7 @@ TEST_CASE("create_collection can be exported to a document", "[create_collection
     cc.collation(collation_en_US.view());
     cc.no_padding(true);
 
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN;
-    auto doc = cc.to_document();
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END;
+    auto doc = cc.to_document_deprecated();
     document::view doc_view{doc.view()};
 
     // capped field is set to true

--- a/src/mongocxx/test/options/create_view.cpp
+++ b/src/mongocxx/test/options/create_view.cpp
@@ -82,9 +82,7 @@ TEST_CASE("create_view can be exported to a document", "[create_view]") {
     cv.collation(collation_en_US.view());
     cv.pipeline(std::move(pipeline{}.limit(1)));
 
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN;
-    auto doc = cv.to_document();
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END;
+    auto doc = cv.to_document_deprecated();
     document::view doc_view{doc.view()};
 
     // "collation" field is set correctly.

--- a/src/mongocxx/test/options/find.cpp
+++ b/src/mongocxx/test/options/find.cpp
@@ -53,9 +53,7 @@ TEST_CASE("find", "[find][option]") {
     CHECK_OPTIONAL_ARGUMENT(find_opts, max_scan, 3);
     CHECK_OPTIONAL_ARGUMENT(find_opts, max_time, std::chrono::milliseconds{300});
     CHECK_OPTIONAL_ARGUMENT(find_opts, min, min.view());
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN;
-    CHECK_OPTIONAL_ARGUMENT(find_opts, modifiers, modifiers.view());
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END;
+    CHECK_OPTIONAL_ARGUMENT(find_opts, modifiers_deprecated, modifiers.view());
     CHECK_OPTIONAL_ARGUMENT(find_opts, no_cursor_timeout, true);
     CHECK_OPTIONAL_ARGUMENT(find_opts, projection, projection.view());
     CHECK_OPTIONAL_ARGUMENT(find_opts, read_preference, read_preference{});

--- a/src/mongocxx/test/options/private/rewriter.cpp
+++ b/src/mongocxx/test/options/private/rewriter.cpp
@@ -28,22 +28,20 @@ namespace {
 using namespace bsoncxx::builder::basic;
 using namespace mongocxx;
 
-BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
-
 TEST_CASE("options::rewriter::rewrite_find_modifiers() with $comment", "[find][option]") {
     instance::current();
 
     SECTION("$comment with k_utf8 type is translated") {
         auto find_opts = options::rewriter::rewrite_find_modifiers(
-            options::find{}.modifiers(make_document(kvp("$comment", "test"))));
-        REQUIRE(!find_opts.modifiers());
+            options::find{}.modifiers_deprecated(make_document(kvp("$comment", "test"))));
+        REQUIRE(!find_opts.modifiers_deprecated());
         REQUIRE(find_opts.comment());
         REQUIRE(*find_opts.comment() == stdx::string_view("test"));
     }
 
     SECTION("$comment with other types is rejected") {
         REQUIRE_THROWS_AS(options::rewriter::rewrite_find_modifiers(
-                              options::find{}.modifiers(make_document(kvp("$comment", 1)))),
+                              options::find{}.modifiers_deprecated(make_document(kvp("$comment", 1)))),
                           logic_error);
     }
 }
@@ -53,7 +51,7 @@ TEST_CASE("options::rewriter::rewrite_find_modifiers() with $explain", "[find][o
 
     SECTION("$explain isn't supported") {
         REQUIRE_THROWS_AS(options::rewriter::rewrite_find_modifiers(
-                              options::find{}.modifiers(make_document(kvp("$explain", true)))),
+                              options::find{}.modifiers_deprecated(make_document(kvp("$explain", true)))),
                           logic_error);
     }
 }
@@ -64,23 +62,23 @@ TEST_CASE("options::rewriter::rewrite_find_modifiers() with $hint", "[find][opti
 
     SECTION("$hint with k_utf8 type is translated") {
         find_opts = options::rewriter::rewrite_find_modifiers(
-            options::find{}.modifiers(make_document(kvp("$hint", "index"))));
-        REQUIRE(!find_opts.modifiers());
+            options::find{}.modifiers_deprecated(make_document(kvp("$hint", "index"))));
+        REQUIRE(!find_opts.modifiers_deprecated());
         REQUIRE(find_opts.hint());
         REQUIRE(*find_opts.hint() == "index");
     }
 
     SECTION("$hint with k_document is translated") {
         find_opts = options::rewriter::rewrite_find_modifiers(
-            options::find{}.modifiers(make_document(kvp("$hint", make_document(kvp("a", 1))))));
-        REQUIRE(!find_opts.modifiers());
+            options::find{}.modifiers_deprecated(make_document(kvp("$hint", make_document(kvp("a", 1))))));
+        REQUIRE(!find_opts.modifiers_deprecated());
         REQUIRE(find_opts.hint());
         REQUIRE(*find_opts.hint() == make_document(kvp("a", 1)));
     }
 
     SECTION("$hint with other types is rejected") {
         REQUIRE_THROWS_AS(options::rewriter::rewrite_find_modifiers(
-                              options::find{}.modifiers(make_document(kvp("$hint", 1)))),
+                              options::find{}.modifiers_deprecated(make_document(kvp("$hint", 1)))),
                           logic_error);
     }
 }
@@ -90,15 +88,15 @@ TEST_CASE("options::rewriter::rewrite_find_modifiers() with $max", "[find][optio
 
     SECTION("$max with k_document type is translated") {
         auto find_opts = options::rewriter::rewrite_find_modifiers(
-            options::find{}.modifiers(make_document(kvp("$max", make_document(kvp("a", 1))))));
-        REQUIRE(!find_opts.modifiers());
+            options::find{}.modifiers_deprecated(make_document(kvp("$max", make_document(kvp("a", 1))))));
+        REQUIRE(!find_opts.modifiers_deprecated());
         REQUIRE(find_opts.max());
         REQUIRE(*find_opts.max() == make_document(kvp("a", 1)));
     }
 
     SECTION("$max with other types is rejected") {
         REQUIRE_THROWS_AS(options::rewriter::rewrite_find_modifiers(
-                              options::find{}.modifiers(make_document(kvp("$max", 1)))),
+                              options::find{}.modifiers_deprecated(make_document(kvp("$max", 1)))),
                           logic_error);
     }
 }
@@ -109,31 +107,31 @@ TEST_CASE("options::rewriter::rewrite_find_modifiers() with $maxScan", "[find][o
 
     SECTION("$maxScan with k_int32 type is translated") {
         find_opts = options::rewriter::rewrite_find_modifiers(
-            options::find{}.modifiers(make_document(kvp("$maxScan", 1))));
-        REQUIRE(!find_opts.modifiers());
+            options::find{}.modifiers_deprecated(make_document(kvp("$maxScan", 1))));
+        REQUIRE(!find_opts.modifiers_deprecated());
         REQUIRE(find_opts.max_scan());
         REQUIRE(*find_opts.max_scan() == 1);
     }
 
     SECTION("$maxScan with k_int64 type is translated") {
         find_opts = options::rewriter::rewrite_find_modifiers(
-            options::find{}.modifiers(make_document(kvp("$maxScan", std::int64_t{1}))));
-        REQUIRE(!find_opts.modifiers());
+            options::find{}.modifiers_deprecated(make_document(kvp("$maxScan", std::int64_t{1}))));
+        REQUIRE(!find_opts.modifiers_deprecated());
         REQUIRE(find_opts.max_scan());
         REQUIRE(*find_opts.max_scan() == 1);
     }
 
     SECTION("$maxScan with k_double type is translated") {
         find_opts = options::rewriter::rewrite_find_modifiers(
-            options::find{}.modifiers(make_document(kvp("$maxScan", 1.0))));
-        REQUIRE(!find_opts.modifiers());
+            options::find{}.modifiers_deprecated(make_document(kvp("$maxScan", 1.0))));
+        REQUIRE(!find_opts.modifiers_deprecated());
         REQUIRE(find_opts.max_scan());
         REQUIRE(*find_opts.max_scan() == 1);
     }
 
     SECTION("$maxScan with other types is rejected") {
         REQUIRE_THROWS_AS(options::rewriter::rewrite_find_modifiers(
-                              options::find{}.modifiers(make_document(kvp("$maxScan", "foo")))),
+                              options::find{}.modifiers_deprecated(make_document(kvp("$maxScan", "foo")))),
                           logic_error);
     }
 }
@@ -144,31 +142,31 @@ TEST_CASE("options::rewriter::rewrite_find_modifiers() with $maxTimeMS", "[find]
 
     SECTION("$maxTimeMS with k_int32 type is translated") {
         find_opts = options::rewriter::rewrite_find_modifiers(
-            options::find{}.modifiers(make_document(kvp("$maxTimeMS", 1))));
-        REQUIRE(!find_opts.modifiers());
+            options::find{}.modifiers_deprecated(make_document(kvp("$maxTimeMS", 1))));
+        REQUIRE(!find_opts.modifiers_deprecated());
         REQUIRE(find_opts.max_time());
         REQUIRE(find_opts.max_time()->count() == 1);
     }
 
     SECTION("$maxTimeMS with k_int64 type is translated") {
         find_opts = options::rewriter::rewrite_find_modifiers(
-            options::find{}.modifiers(make_document(kvp("$maxTimeMS", std::int64_t{1}))));
-        REQUIRE(!find_opts.modifiers());
+            options::find{}.modifiers_deprecated(make_document(kvp("$maxTimeMS", std::int64_t{1}))));
+        REQUIRE(!find_opts.modifiers_deprecated());
         REQUIRE(find_opts.max_time());
         REQUIRE(find_opts.max_time()->count() == 1);
     }
 
     SECTION("$maxTimeMS with k_double type is translated") {
         find_opts = options::rewriter::rewrite_find_modifiers(
-            options::find{}.modifiers(make_document(kvp("$maxTimeMS", 1.0))));
-        REQUIRE(!find_opts.modifiers());
+            options::find{}.modifiers_deprecated(make_document(kvp("$maxTimeMS", 1.0))));
+        REQUIRE(!find_opts.modifiers_deprecated());
         REQUIRE(find_opts.max_time());
         REQUIRE(find_opts.max_time()->count() == 1);
     }
 
     SECTION("$maxTimeMS with other types is rejected") {
         REQUIRE_THROWS_AS(options::rewriter::rewrite_find_modifiers(
-                              options::find{}.modifiers(make_document(kvp("$maxTimeMS", "foo")))),
+                              options::find{}.modifiers_deprecated(make_document(kvp("$maxTimeMS", "foo")))),
                           logic_error);
     }
 }
@@ -178,15 +176,15 @@ TEST_CASE("options::rewriter::rewrite_find_modifiers() with $min", "[find][optio
 
     SECTION("$min with k_document type is translated") {
         auto find_opts = options::rewriter::rewrite_find_modifiers(
-            options::find{}.modifiers(make_document(kvp("$min", make_document(kvp("a", 1))))));
-        REQUIRE(!find_opts.modifiers());
+            options::find{}.modifiers_deprecated(make_document(kvp("$min", make_document(kvp("a", 1))))));
+        REQUIRE(!find_opts.modifiers_deprecated());
         REQUIRE(find_opts.min());
         REQUIRE(*find_opts.min() == make_document(kvp("a", 1)));
     }
 
     SECTION("$min with other types is rejected") {
         REQUIRE_THROWS_AS(options::rewriter::rewrite_find_modifiers(
-                              options::find{}.modifiers(make_document(kvp("$min", 1)))),
+                              options::find{}.modifiers_deprecated(make_document(kvp("$min", 1)))),
                           logic_error);
     }
 }
@@ -196,15 +194,15 @@ TEST_CASE("options::rewriter::rewrite_find_modifiers() with $orderby", "[find][o
 
     SECTION("$orderby with k_document type is translated") {
         auto find_opts = options::rewriter::rewrite_find_modifiers(
-            options::find{}.modifiers(make_document(kvp("$orderby", make_document(kvp("a", 1))))));
-        REQUIRE(!find_opts.modifiers());
+            options::find{}.modifiers_deprecated(make_document(kvp("$orderby", make_document(kvp("a", 1))))));
+        REQUIRE(!find_opts.modifiers_deprecated());
         REQUIRE(find_opts.sort());
         REQUIRE(*find_opts.sort() == make_document(kvp("a", 1)));
     }
 
     SECTION("$orderby with other types is rejected") {
         REQUIRE_THROWS_AS(options::rewriter::rewrite_find_modifiers(
-                              options::find{}.modifiers(make_document(kvp("$orderby", 1)))),
+                              options::find{}.modifiers_deprecated(make_document(kvp("$orderby", 1)))),
                           logic_error);
     }
 }
@@ -213,7 +211,7 @@ TEST_CASE("options::rewriter::rewrite_find_modifiers() with $query", "[find][opt
     instance::current();
 
     SECTION("$query isn't supported") {
-        REQUIRE_THROWS_AS(options::rewriter::rewrite_find_modifiers(options::find{}.modifiers(
+        REQUIRE_THROWS_AS(options::rewriter::rewrite_find_modifiers(options::find{}.modifiers_deprecated(
                               make_document(kvp("$query", make_document(kvp("a", 1)))))),
                           logic_error);
     }
@@ -224,15 +222,15 @@ TEST_CASE("options::rewriter::rewrite_find_modifiers() with $returnKey", "[find]
 
     SECTION("$returnKey with k_bool type is translated") {
         auto find_opts = options::rewriter::rewrite_find_modifiers(
-            options::find{}.modifiers(make_document(kvp("$returnKey", true))));
-        REQUIRE(!find_opts.modifiers());
+            options::find{}.modifiers_deprecated(make_document(kvp("$returnKey", true))));
+        REQUIRE(!find_opts.modifiers_deprecated());
         REQUIRE(find_opts.return_key());
         REQUIRE(*find_opts.return_key() == true);
     }
 
     SECTION("$returnKey with other types is rejected") {
         REQUIRE_THROWS_AS(options::rewriter::rewrite_find_modifiers(
-                              options::find{}.modifiers(make_document(kvp("$returnKey", 1)))),
+                              options::find{}.modifiers_deprecated(make_document(kvp("$returnKey", 1)))),
                           logic_error);
     }
 }
@@ -242,15 +240,15 @@ TEST_CASE("options::rewriter::rewrite_find_modifiers() with $showDiskLoc", "[fin
 
     SECTION("$showDiskLoc with k_bool type is translated") {
         auto find_opts = options::rewriter::rewrite_find_modifiers(
-            options::find{}.modifiers(make_document(kvp("$showDiskLoc", true))));
-        REQUIRE(!find_opts.modifiers());
+            options::find{}.modifiers_deprecated(make_document(kvp("$showDiskLoc", true))));
+        REQUIRE(!find_opts.modifiers_deprecated());
         REQUIRE(find_opts.show_record_id());
         REQUIRE(*find_opts.show_record_id() == true);
     }
 
     SECTION("$showDiskLoc with other types is rejected") {
         REQUIRE_THROWS_AS(options::rewriter::rewrite_find_modifiers(
-                              options::find{}.modifiers(make_document(kvp("$showDiskLoc", 1)))),
+                              options::find{}.modifiers_deprecated(make_document(kvp("$showDiskLoc", 1)))),
                           logic_error);
     }
 }
@@ -260,15 +258,15 @@ TEST_CASE("options::rewriter::rewrite_find_modifiers() with $snapshot", "[find][
 
     SECTION("$snapshot with k_bool type is translated") {
         auto find_opts = options::rewriter::rewrite_find_modifiers(
-            options::find{}.modifiers(make_document(kvp("$snapshot", true))));
-        REQUIRE(!find_opts.modifiers());
+            options::find{}.modifiers_deprecated(make_document(kvp("$snapshot", true))));
+        REQUIRE(!find_opts.modifiers_deprecated());
         REQUIRE(find_opts.snapshot());
         REQUIRE(*find_opts.snapshot() == true);
     }
 
     SECTION("$snapshot with other types is rejected") {
         REQUIRE_THROWS_AS(options::rewriter::rewrite_find_modifiers(
-                              options::find{}.modifiers(make_document(kvp("$snapshot", 1)))),
+                              options::find{}.modifiers_deprecated(make_document(kvp("$snapshot", 1)))),
                           logic_error);
     }
 }

--- a/src/mongocxx/test/read_preference.cpp
+++ b/src/mongocxx/test/read_preference.cpp
@@ -73,9 +73,7 @@ TEST_CASE("Read preference", "[read_preference]") {
 TEST_CASE("Read preference can be constructed with another read_mode", "[read_preference]") {
     instance::current();
 
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN;
-    read_preference rp(read_preference::read_mode::k_secondary);
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END;
+    read_preference rp(read_preference::read_mode::k_secondary, read_preference::deprecated_tag{});
     REQUIRE(rp.mode() == read_preference::read_mode::k_secondary);
     REQUIRE_FALSE(rp.tags());
 }
@@ -84,9 +82,7 @@ TEST_CASE("Read preference can be constructed with a read_mode and tags", "[read
     instance::current();
     auto tags = make_document(kvp("tag_key", "tag_value"));
 
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN;
-    read_preference rp(read_preference::read_mode::k_secondary, tags.view());
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END;
+    read_preference rp(read_preference::read_mode::k_secondary, tags.view(), read_preference::deprecated_tag{});
     REQUIRE(rp.mode() == read_preference::read_mode::k_secondary);
     REQUIRE(rp.tags().value() == tags);
 }

--- a/src/mongocxx/test/validation_criteria.cpp
+++ b/src/mongocxx/test/validation_criteria.cpp
@@ -70,9 +70,7 @@ TEST_CASE("validation_criteria can be exported to a document", "[validation_crit
     criteria.action(validation_criteria::validation_action::k_warn);
     criteria.rule(doc.view());
 
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN;
-    auto criteria_doc = criteria.to_document();
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END;
+    auto criteria_doc = criteria.to_document_deprecated();
     auto criteria_view = criteria_doc.view();
 
     document::element ele;

--- a/src/mongocxx/validation_criteria.cpp
+++ b/src/mongocxx/validation_criteria.cpp
@@ -80,7 +80,7 @@ const stdx::optional<validation_criteria::validation_action>& validation_criteri
     return _action;
 }
 
-bsoncxx::document::value validation_criteria::to_document() const {
+bsoncxx::document::value validation_criteria::to_document_deprecated() const {
     bsoncxx::builder::basic::document doc;
 
     if (_rule) {
@@ -96,6 +96,10 @@ bsoncxx::document::value validation_criteria::to_document() const {
     }
 
     return doc.extract();
+}
+
+bsoncxx::document::value validation_criteria::to_document() const {
+    return to_document_deprecated();
 }
 
 MONGOCXX_API bool MONGOCXX_CALL operator==(const validation_criteria& lhs,

--- a/src/mongocxx/validation_criteria.hpp
+++ b/src/mongocxx/validation_criteria.hpp
@@ -127,6 +127,7 @@ class MONGOCXX_API validation_criteria {
     /// @return Validation criteria, as a document.
     ///
     MONGOCXX_DEPRECATED bsoncxx::document::value to_document() const;
+    bsoncxx::document::value to_document_deprecated() const;
 
     ///
     /// @deprecated
@@ -147,7 +148,7 @@ MONGOCXX_API bool MONGOCXX_CALL operator!=(const validation_criteria& lhs,
                                            const validation_criteria& rhs);
 
 MONGOCXX_INLINE validation_criteria::operator bsoncxx::document::value() const {
-    return to_document();
+    return to_document_deprecated();
 }
 
 MONGOCXX_INLINE_NAMESPACE_END


### PR DESCRIPTION
This re-structures the deprecations such that all deprecated functions and constructors have an associated `_deprecated` variant, or, for the case of constructors, a `deprecated` tag type. Then, the deprecated versions are implemented in terms of the non-deprecated one.

For us, this gives us an easy way to continue to call deprecated functions without warnings. It does the same thing for our users, except for them they are still clearly calling a deprecated function since the word deprecated is in the method, or on the line of code.