### PR TITLE
fix compare key name error

### DIFF
--- a/src/bsoncxx/document/view.cpp
+++ b/src/bsoncxx/document/view.cpp
@@ -125,7 +125,7 @@ view::const_iterator view::find(stdx::string_view key) const {
 
     while (bson_iter_next(&iter)) {
         const char* ikey = bson_iter_key(&iter);
-        if (0 == strncmp(key.data(), ikey, key.size())) {
+        if (0 == strncmp(key.data(), ikey, key.size()) && strlen(ikey) == key.size()) {
             return const_iterator(element(iter.raw, iter.len, iter.off));
         }
     }


### PR DESCRIPTION
If a document has a "de" key and a "desc" key, when searching for the "de" key, it may match the "desc" key.
So compare the key length to make sure match the right key.