### PR TITLE
cmake: honor LIB_SUFFIX

### DIFF
--- a/src/bsoncxx/CMakeLists.txt
+++ b/src/bsoncxx/CMakeLists.txt
@@ -216,12 +216,12 @@ install(FILES
 install(TARGETS
     bsoncxx
     RUNTIME DESTINATION bin COMPONENT runtime
-    LIBRARY DESTINATION lib COMPONENT runtime
-    ARCHIVE DESTINATION lib COMPONENT dev
+    LIBRARY DESTINATION lib${LIB_SUFFIX} COMPONENT runtime
+    ARCHIVE DESTINATION lib${LIB_SUFFIX} COMPONENT dev
 )
 
 set(PACKAGE_INCLUDE_INSTALL_DIRS ${BSONCXX_HEADER_INSTALL_DIR})
-set(PACKAGE_LIBRARY_INSTALL_DIRS lib)
+set(PACKAGE_LIBRARY_INSTALL_DIRS lib${LIB_SUFFIX})
 set(PACKAGE_LIBRARIES bsoncxx)
 
 include(CMakePackageConfigHelpers)
@@ -234,7 +234,7 @@ endif()
 
 configure_package_config_file(
   cmake/${PKG}-config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/${PKG}-config.cmake
-  INSTALL_DESTINATION lib/cmake/${PKG}-${BSONCXX_VERSION}
+  INSTALL_DESTINATION lib${LIB_SUFFIX}/cmake/${PKG}-${BSONCXX_VERSION}
   PATH_VARS PACKAGE_INCLUDE_INSTALL_DIRS PACKAGE_LIBRARY_INSTALL_DIRS
 )
 
@@ -246,7 +246,7 @@ write_basic_package_version_file(
 
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/${PKG}-config.cmake ${CMAKE_CURRENT_BINARY_DIR}/${PKG}-config-version.cmake
-  DESTINATION lib/cmake/${PKG}-${BSONCXX_VERSION}
+  DESTINATION lib${LIB_SUFFIX}/cmake/${PKG}-${BSONCXX_VERSION}
 )
 
 add_subdirectory(test)

--- a/src/bsoncxx/config/CMakeLists.txt
+++ b/src/bsoncxx/config/CMakeLists.txt
@@ -43,7 +43,7 @@ if (BUILD_SHARED_LIBS)
 
     install(FILES
         "${CMAKE_CURRENT_BINARY_DIR}/libbsoncxx.pc"
-        DESTINATION lib/pkgconfig
+        DESTINATION lib${LIB_SUFFIX}/pkgconfig
         COMPONENT dev
     )
 else()
@@ -55,7 +55,7 @@ else()
 
     install(FILES
         "${CMAKE_CURRENT_BINARY_DIR}/libbsoncxx-static.pc"
-        DESTINATION lib/pkgconfig
+        DESTINATION lib${LIB_SUFFIX}/pkgconfig
         COMPONENT dev
     )
 endif()

--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -205,12 +205,12 @@ install(FILES
 install(TARGETS
     mongocxx
     RUNTIME DESTINATION bin COMPONENT runtime
-    LIBRARY DESTINATION lib COMPONENT runtime
-    ARCHIVE DESTINATION lib COMPONENT dev
+    LIBRARY DESTINATION lib${LIB_SUFFIX} COMPONENT runtime
+    ARCHIVE DESTINATION lib${LIB_SUFFIX} COMPONENT dev
 )
 
 set(PACKAGE_INCLUDE_INSTALL_DIRS ${MONGOCXX_HEADER_INSTALL_DIR})
-set(PACKAGE_LIBRARY_INSTALL_DIRS lib)
+set(PACKAGE_LIBRARY_INSTALL_DIRS lib${LIB_SUFFIX})
 set(PACKAGE_LIBRARIES mongocxx)
 
 include(CMakePackageConfigHelpers)
@@ -223,7 +223,7 @@ endif()
 
 configure_package_config_file(
   cmake/${PKG}-config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/${PKG}-config.cmake
-  INSTALL_DESTINATION lib/cmake/${PKG}-${MONGOCXX_VERSION}
+  INSTALL_DESTINATION lib${LIB_SUFFIX}/cmake/${PKG}-${MONGOCXX_VERSION}
   PATH_VARS PACKAGE_INCLUDE_INSTALL_DIRS PACKAGE_LIBRARY_INSTALL_DIRS
 )
 
@@ -235,7 +235,7 @@ write_basic_package_version_file(
 
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/${PKG}-config.cmake ${CMAKE_CURRENT_BINARY_DIR}/${PKG}-config-version.cmake
-  DESTINATION lib/cmake/${PKG}-${MONGOCXX_VERSION}
+  DESTINATION lib${LIB_SUFFIX}/cmake/${PKG}-${MONGOCXX_VERSION}
 )
 
 add_subdirectory(test)

--- a/src/mongocxx/config/CMakeLists.txt
+++ b/src/mongocxx/config/CMakeLists.txt
@@ -43,7 +43,7 @@ if (BUILD_SHARED_LIBS)
 
     install(FILES
         "${CMAKE_CURRENT_BINARY_DIR}/libmongocxx.pc"
-        DESTINATION lib/pkgconfig
+        DESTINATION lib${LIB_SUFFIX}/pkgconfig
         COMPONENT dev
     )
 else()
@@ -55,7 +55,7 @@ else()
 
     install(FILES
         "${CMAKE_CURRENT_BINARY_DIR}/libmongocxx-static.pc"
-        DESTINATION lib/pkgconfig
+        DESTINATION lib${LIB_SUFFIX}/pkgconfig
         COMPONENT dev
     )
 endif()


### PR DESCRIPTION
On some systems, e.g., Fedora, libraries are installed to /usr/lib64. A typical pattern is to honor a variable named LIB_SUFFIX. It is common and specified by default in the Fedora build system if necessary.

This patch extends the installation paths from "lib" to "lib${LIB_SUFFIX" in order to allow for proper packaging and installation.

The suffix can be set as "-DLIB_SUFFIX=64" and is ignored if not set.