### PR TITLE
CXX-1553 Fix wrong call to b_timestamp ctor

### DIFF
--- a/src/bsoncxx/document/element.cpp
+++ b/src/bsoncxx/document/element.cpp
@@ -224,7 +224,7 @@ types::b_timestamp element::get_timestamp() const {
     uint32_t increment;
     bson_iter_timestamp(&iter, &timestamp, &increment);
 
-    return types::b_timestamp{timestamp, increment};
+    return types::b_timestamp{increment, timestamp};
 }
 
 types::b_minkey element::get_minkey() const {


### PR DESCRIPTION
In BSON document element class, the get_timestamp() accessor create a new b_timestamp object but with parameters timestamp and increment in the wrong order.