### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,12 @@ endif()
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Force MS compiler to report correct version in __cplusplus define
+# to be able to compile without boost polyfill
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus")
+endif()
+
 # Include the required modules
 include(GenerateExportHeader)
 include(InstallRequiredSystemLibraries)


### PR DESCRIPTION
Cl compiler reports __cplusplus == 199711L for any /std option (https://developercommunity.visualstudio.com/content/problem/120156/-cplusplus-macro-still-defined-as-pre-c11-value.html). To report correct standard version /Zc:__cplusplus should be set, otherwise \src\bsoncxx\stdx\make_unique.hpp (at least) fails to compile, as it relies on version in __cplusplus.