### PR TITLE
fix allow_invalid_certificates documentation

### DIFF
--- a/src/mongocxx/options/ssl.hpp
+++ b/src/mongocxx/options/ssl.hpp
@@ -129,7 +129,7 @@ class MONGOCXX_API ssl {
     const stdx::optional<bsoncxx::string::view_or_value>& crl_file() const;
 
     ///
-    /// If false, the driver will not verify the server's CA file.
+    /// If true, the driver will not verify the server's CA file.
     ///
     /// @param allow_invalid_certificates
     ///   Whether or not to check the server's CA file.


### PR DESCRIPTION
```c++
    ///
    /// If false, the driver will not verify the server's CA file.
    ///
    /// @param allow_invalid_certificates
    ///   Whether or not to check the server's CA file.
    ///
    /// @return
    ///   A reference to the object on which this member function is being called.  This facilitates
    ///   method chaining.
    ///
    ssl& allow_invalid_certificates(bool allow_invalid_certificates);
```
Should be "If true, the driver will not verify the server's CA file."