### PR TITLE
Missing header

### DIFF
--- a/docs/content/mongocxx-v3/tutorial.md
+++ b/docs/content/mongocxx-v3/tutorial.md
@@ -24,6 +24,7 @@ title = "Tutorial for mongocxx"
 #include <mongocxx/client.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/uri.hpp>
+#include <mongocxx/instance.hpp>
 
 using bsoncxx::builder::stream::close_array;
 using bsoncxx::builder::stream::close_document;


### PR DESCRIPTION
The header `<mongocxx/instance.hpp>` is missing on [Mongo CXX 3.0](http://mongocxx.org/mongocxx-v3/tutorial/) driver example, when the example is compiled a **core dump** error is issued. To fix, the `#include <mongocxx/instance.hpp>` was added to the example. The file / class its on */usr/local/include/mongocxx/v_noabi/mongocxx/instance.hpp*.