### PR TITLE
Stream include added to documentation

### DIFF
--- a/docs/content/mongocxx-v3/tutorial.md
+++ b/docs/content/mongocxx-v3/tutorial.md
@@ -25,6 +25,7 @@ title = "Tutorial for mongocxx"
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/uri.hpp>
 #include <mongocxx/instance.hpp>
+#include <bsoncxx/builder/stream/document.hpp>
 
 using bsoncxx::builder::stream::close_array;
 using bsoncxx::builder::stream::close_document;


### PR DESCRIPTION
By default, when the `#include <bsoncxx/json.hpp>` is included, the default method to create a document is `bsoncxx::builder::basic` and not `bsoncxx::builder::stream`, even if we set the namespaces, as the documentation show:

```cpp
using bsoncxx::builder::stream::close_array;

using bsoncxx::builder::stream::close_document;

using bsoncxx::builder::stream::document;

using bsoncxx::builder::stream::finalize;

using bsoncxx::builder::stream::open_array;

using bsoncxx::builder::stream::open_document;
```

In this case, a [error](https://jira.mongodb.org/browse/CXX-1786) is issued.

To solve this question its necessary to  `#include <bsoncxx/builder/stream/document.hpp>`, besides the 'helper' headers, if you're going to use them in your document:

```cpp
#include <bsoncxx/builder/stream/array.hpp>

#include <bsoncxx/builder/stream/helpers.hpp>

#include <bsoncxx/types.hpp>
```

As this [example](https://github.com/mongodb/mongo-cxx-driver/blob/eccd8b0a525f72d85d6153085e299c291d02acec/examples/bsoncxx/builder_stream.cpp) show. Besides this, I recommend that details about what each include does, being added to the documentation.

I have tested this in Mint 19.1 - XFCE, Mongo C 1.13 and Mongo CXX 3.14 (the Mongo instance in a Docker container).