### PR TITLE
Provide correct SOVERSION

### DIFF
--- a/cmake/BsoncxxUtil.cmake
+++ b/cmake/BsoncxxUtil.cmake
@@ -20,7 +20,7 @@ function(bsoncxx_add_library TARGET OUTPUT_NAME LINK_TYPE)
         set_target_properties(${TARGET} PROPERTIES
             CXX_VISIBILITY_PRESET hidden
             VISIBILITY_INLINES_HIDDEN ON
-            SOVERSION ${BSONCXX_ABI_VERSION}
+            SOVERSION ${BSONCXX_VERSION_NO_EXTRA}
         )
     endif()
 

--- a/cmake/MongocxxUtil.cmake
+++ b/cmake/MongocxxUtil.cmake
@@ -20,7 +20,7 @@ function(mongocxx_add_library TARGET OUTPUT_NAME LINK_TYPE)
         set_target_properties (${TARGET} PROPERTIES
             CXX_VISIBILITY_PRESET hidden
             VISIBILITY_INLINES_HIDDEN ON
-            SOVERSION ${MONGOCXX_ABI_VERSION}
+            SOVERSION ${MONGOCXX_VERSION_NO_EXTRA}
         )
     endif()
 


### PR DESCRIPTION
Currently some odd named libraries are being created: `/usr/lib/libmongocxx.so._noabi` which is causing issues with the Alpine Linux packaging system and its SO dependency tracing, and likely other distros. By using the numeric ABI 0.0.0 as SOVERSION this SO file disappears.