### PR TITLE
Cmake boost include

### DIFF
--- a/cmake/BsoncxxUtil.cmake
+++ b/cmake/BsoncxxUtil.cmake
@@ -33,7 +33,7 @@ function(bsoncxx_add_library TARGET OUTPUT_NAME LINK_TYPE)
         ExternalProject_Get_Property(EP_mnmlstc_core source_dir)
         target_include_directories(${TARGET} PUBLIC ${source_dir}/include)
     elseif(BSONCXX_POLY_USE_BOOST)
-        target_include_directories(${TARGET} PUBLIC ${Boost_INCLUDE_DIRS})
+        target_link_libraries(${TARGET} PUBLIC Boost::boost)
     endif()
 
     target_include_directories(${TARGET} PRIVATE ${libbson_include_directories})

--- a/examples/projects/bsoncxx/cmake/shared/CMakeLists.txt
+++ b/examples/projects/bsoncxx/cmake/shared/CMakeLists.txt
@@ -42,9 +42,7 @@ add_executable(hello_bsoncxx ../../hello_bsoncxx.cpp)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     find_package(Boost 1.56.0 REQUIRED)
-    target_include_directories(hello_bsoncxx
-      PRIVATE ${Boost_INCLUDE_DIRS}
-    )
+    target_link_libraries(hello_bsoncxx PRIVATE Boost::boost)
 endif()
 
 target_include_directories(hello_bsoncxx

--- a/examples/projects/bsoncxx/cmake/static/CMakeLists.txt
+++ b/examples/projects/bsoncxx/cmake/static/CMakeLists.txt
@@ -42,9 +42,7 @@ add_executable(hello_bsoncxx ../../hello_bsoncxx.cpp)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     find_package(Boost 1.56.0 REQUIRED)
-    target_include_directories(hello_bsoncxx
-      PRIVATE ${Boost_INCLUDE_DIRS}
-    )
+    target_link_libraries(hello_bsoncxx PRIVATE Boost::boost)
 endif()
 
 target_include_directories(hello_bsoncxx

--- a/examples/projects/mongocxx/cmake/shared/CMakeLists.txt
+++ b/examples/projects/mongocxx/cmake/shared/CMakeLists.txt
@@ -42,9 +42,7 @@ add_executable(hello_mongocxx ../../hello_mongocxx.cpp)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     find_package(Boost 1.56.0 REQUIRED)
-    target_include_directories(hello_mongocxx
-      PRIVATE ${Boost_INCLUDE_DIRS}
-    )
+    target_link_libraries(hello_mongocxx PRIVATE Boost::boost)
 endif()
 
 target_include_directories(hello_mongocxx

--- a/examples/projects/mongocxx/cmake/static/CMakeLists.txt
+++ b/examples/projects/mongocxx/cmake/static/CMakeLists.txt
@@ -42,9 +42,7 @@ add_executable(hello_mongocxx ../../hello_mongocxx.cpp)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     find_package(Boost 1.56.0 REQUIRED)
-    target_include_directories(hello_mongocxx
-      PRIVATE ${Boost_INCLUDE_DIRS}
-    )
+    target_link_libraries(hello_mongocxx PRIVATE Boost::boost)
 endif()
 
 target_include_directories(hello_mongocxx


### PR DESCRIPTION
When trying to compile mongocxx driver against boost 1.71 I had to update boost linking. Note that using recent cmake (e.g 3.15) seems to fix the issue by introducing backward compatibility, but I think using Boost::boost is cleaner.