### PR TITLE
Allow libbsoncxx and libmongocxx library names to be changed externally

### DIFF
--- a/src/bsoncxx/CMakeLists.txt
+++ b/src/bsoncxx/CMakeLists.txt
@@ -24,7 +24,7 @@ option(BSONCXX_POLY_USE_SYSTEM_MNMLSTC "Obtain mnmlstc/core from system" OFF)
 option(BSONCXX_POLY_USE_BOOST "Use boost for stdx polyfills" OFF)
 option(BSONCXX_POLY_USE_STD "Use C++17 std library for stdx polyfills" OFF)
 
-set (BSONCXX_OUTPUT_BASENAME "bsoncxx" CACHE STRING "Output bsoncxx library base name")
+set(BSONCXX_OUTPUT_BASENAME "bsoncxx" CACHE STRING "Output bsoncxx library base name")
 
 # Count how many polyfill options are true-ish
 set(BSONCXX_POLY_OPTIONS_SET 0)

--- a/src/bsoncxx/CMakeLists.txt
+++ b/src/bsoncxx/CMakeLists.txt
@@ -24,6 +24,8 @@ option(BSONCXX_POLY_USE_SYSTEM_MNMLSTC "Obtain mnmlstc/core from system" OFF)
 option(BSONCXX_POLY_USE_BOOST "Use boost for stdx polyfills" OFF)
 option(BSONCXX_POLY_USE_STD "Use C++17 std library for stdx polyfills" OFF)
 
+set (BSONCXX_OUTPUT_BASENAME "bsoncxx" CACHE STRING "Output bsoncxx library base name")
+
 # Count how many polyfill options are true-ish
 set(BSONCXX_POLY_OPTIONS_SET 0)
 foreach (BSONCXX_POLY_OPTION  ${BSONCXX_POLY_USE_MNMLSTC} ${BSONCXX_POLY_USE_STD_EXPERIMENTAL} ${BSONCXX_POLY_USE_BOOST} ${BSONCXX_POLY_USE_STD})
@@ -120,11 +122,11 @@ endif()
 include(BsoncxxUtil)
 
 if(BSONCXX_BUILD_SHARED)
-    bsoncxx_add_library(bsoncxx_shared "bsoncxx" SHARED)
+    bsoncxx_add_library(bsoncxx_shared "${BSONCXX_OUTPUT_BASENAME}" SHARED)
 endif()
 
 if(BSONCXX_BUILD_STATIC)
-    bsoncxx_add_library(bsoncxx_static "bsoncxx-static" STATIC)
+    bsoncxx_add_library(bsoncxx_static "${BSONCXX_OUTPUT_BASENAME}-static" STATIC)
 endif()
 
 if(BSONCXX_BUILD_SHARED)

--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -21,7 +21,7 @@ set(MONGOCXX_ABI_VERSION _noabi)
 option(MONGOCXX_ENABLE_SSL "Enable SSL - if the underlying C driver offers it" ON)
 option(MONGOCXX_ENABLE_SLOW_TESTS "Run slow tests when invoking the the test target" OFF)
 
-set (MONGOCXX_OUTPUT_BASENAME "mongocxx" CACHE STRING "Output mongocxx library base name")
+set(MONGOCXX_OUTPUT_BASENAME "mongocxx" CACHE STRING "Output mongocxx library base name")
 
 set(MONGOCXX_VERSION_NO_EXTRA ${MONGOCXX_VERSION_MAJOR}.${MONGOCXX_VERSION_MINOR}.${MONGOCXX_VERSION_PATCH})
 set(MONGOCXX_VERSION ${MONGOCXX_VERSION_NO_EXTRA}${MONGOCXX_VERSION_EXTRA})

--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -21,6 +21,8 @@ set(MONGOCXX_ABI_VERSION _noabi)
 option(MONGOCXX_ENABLE_SSL "Enable SSL - if the underlying C driver offers it" ON)
 option(MONGOCXX_ENABLE_SLOW_TESTS "Run slow tests when invoking the the test target" OFF)
 
+set (MONGOCXX_OUTPUT_BASENAME "mongocxx" CACHE STRING "Output mongocxx library base name")
+
 set(MONGOCXX_VERSION_NO_EXTRA ${MONGOCXX_VERSION_MAJOR}.${MONGOCXX_VERSION_MINOR}.${MONGOCXX_VERSION_PATCH})
 set(MONGOCXX_VERSION ${MONGOCXX_VERSION_NO_EXTRA}${MONGOCXX_VERSION_EXTRA})
 message ("mongocxx version: ${MONGOCXX_VERSION}")
@@ -138,12 +140,12 @@ include_directories(
 include(MongocxxUtil)
 
 if(MONGOCXX_BUILD_SHARED)
-    mongocxx_add_library(mongocxx_shared "mongocxx" SHARED)
+    mongocxx_add_library(mongocxx_shared "${MONGOCXX_OUTPUT_BASENAME}" SHARED)
     target_link_libraries(mongocxx_shared PUBLIC bsoncxx_shared)
 endif()
 
 if(MONGOCXX_BUILD_STATIC)
-    mongocxx_add_library(mongocxx_static "mongocxx-static" STATIC)
+    mongocxx_add_library(mongocxx_static "${MONGOCXX_OUTPUT_BASENAME}-static" STATIC)
     target_link_libraries(mongocxx_static PUBLIC bsoncxx_static)
 endif()
 


### PR DESCRIPTION
Similarly to https://github.com/mongodb/mongo-c-driver/pull/588:
Internally we rename the libraries we integrate as to avoid interference with the library versions already available on the target systems by giving them a prefix.
This PR allows users to specify, for example:
```
-DBSONCXX_OUTPUT_BASENAME:STRING=MYORG_bsoncxx
-DMONGOCXX_OUTPUT_BASENAME:STRING=MYORG_mongocxx
```
I used `BASENAME` as the flavor and/or version are appended later.

Alternatively, it would be also fine for us to add a prefix variable like `OUTPUT_NAME_PREFIX` or so but I was unable to find a good name that cannot be confused the target `PREFIX` property (e.g. `lib`)