### PR TITLE
Disable trivially_constructible test for atomic on MSVC++.

### DIFF
--- a/src/mongocxx/instance.cpp
+++ b/src/mongocxx/instance.cpp
@@ -75,7 +75,8 @@ typename std::aligned_storage<sizeof(instance), alignof(instance)>::type sentine
 std::atomic<instance*> current_instance{nullptr};
 static_assert(std::is_standard_layout<decltype(current_instance)>::value,
               "Must be standard layout");
-#if (!defined(__GNUC__) || (defined(__clang__) && !defined(__GLIBCXX__))) || (__GNUC__ >= 5)
+#if (!defined(_MSVC_STL_VERSION)) \
+    && ((!defined(__GNUC__) || (defined(__clang__) && !defined(__GLIBCXX__))) || (__GNUC__ >= 5))
 static_assert(std::is_trivially_constructible<decltype(current_instance)>::value,
               "Must be trivially constructible");
 #endif

--- a/src/mongocxx/instance.cpp
+++ b/src/mongocxx/instance.cpp
@@ -75,11 +75,6 @@ typename std::aligned_storage<sizeof(instance), alignof(instance)>::type sentine
 std::atomic<instance*> current_instance{nullptr};
 static_assert(std::is_standard_layout<decltype(current_instance)>::value,
               "Must be standard layout");
-#if (!defined(_MSVC_STL_VERSION)) \
-    && ((!defined(__GNUC__) || (defined(__clang__) && !defined(__GLIBCXX__))) || (__GNUC__ >= 5))
-static_assert(std::is_trivially_constructible<decltype(current_instance)>::value,
-              "Must be trivially constructible");
-#endif
 static_assert(std::is_trivially_destructible<decltype(current_instance)>::value,
               "Must be trivially destructible");
 


### PR DESCRIPTION
MSVC++ implements P0883 unconditionally, which changes the rules for std::atomic. It removes atomic's trivial constructor, and makes the default constructor value initialize the T.

Note that Mongo was not following the C++11 rules, because it used the atomic before calling atomic_init first. MSVC++ never implemented the C++11 rules and previously default initialized the T.

All versions of MSVC++ will provide constant initialization of the guarded value "current_instance". In old versions, atomic didn't implement P0883 due to bugs in the constexpr evaluator; in current versions the constexpr evaluator was fixed and atomic value initializes unconditionally. Therefore, this PR disables the check whenever MSVC++'s standard library is detected.

See https://github.com/microsoft/STL/issues/661 for further discussion.