### PR TITLE
CXX-2028 fix writeConcern population in find_and_modify

### DIFF
--- a/src/mongocxx/collection.cpp
+++ b/src/mongocxx/collection.cpp
@@ -113,7 +113,7 @@ mongocxx::stdx::optional<bsoncxx::document::value> find_and_modify(
         if (!options.write_concern()->is_acknowledged() && options.collation()) {
             throw mongocxx::logic_error{mongocxx::error_code::k_invalid_parameter};
         }
-        extra.append(concatenate(options.write_concern()->to_document()));
+        extra.append(kvp("writeConcern", options.write_concern()->to_document()));
     }
 
     if (session_t) {


### PR DESCRIPTION
Mongo C++ Driver doesn’t populate the _writeConcern_ doc properly while sending a _find_one_and_update_ request to the mongo server. This was silently happening up until mongo 4.2 introduced stricter checks on the received payload. After which, a failure is seen.

This commit fixes _find_and_modify_ to populate _writeConcern_ in accordance with: https://docs.mongodb.com/manual/reference/method/db.collection.findAndModify/

More details: https://jira.mongodb.org/browse/CXX-2028