### PR TITLE
Skip FLE prose test on pre 4.2 servers

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -595,7 +595,7 @@ buildvariants:
     #######################################
     - matrix_name: "integration"
       matrix_spec: {os: "*", mongodb_version: "*"}
-      display_name: "${os} ${mongodb_version}"
+      display_name: "${os} (MongoDB ${mongodb_version})"
       tasks:
           - name: compile_and_test_with_shared_libs
       exclude_spec:
@@ -617,7 +617,7 @@ buildvariants:
     #         Linux Buildvariants         #
     #######################################
     - name: ubuntu1604-release
-      display_name: "Ubuntu 16.04 Release"
+      display_name: "Ubuntu 16.04 Release (MongoDB Latest)"
       expansions:
           build_type: "Release"
           tar_options: *linux_tar_options
@@ -635,7 +635,7 @@ buildvariants:
           - name: uninstall_check
 
     - name: ubuntu1604-debug-std-experimental
-      display_name: "Ubuntu 16.04 Debug (std::experimental)"
+      display_name: "Ubuntu 16.04 Debug (std::experimental) (MongoDB Latest)"
       expansions:
           build_type: "Debug"
           tar_options: *linux_tar_options
@@ -652,7 +652,7 @@ buildvariants:
           - name: compile_and_test_with_static_libs
 
     - name: ubuntu1604-debug-valgrind
-      display_name: "Valgrind Ubuntu 16.04 Debug"
+      display_name: "Valgrind Ubuntu 16.04 Debug (MongoDB Latest)"
       expansions:
           build_type: "Debug"
           tar_options: *linux_tar_options
@@ -669,7 +669,7 @@ buildvariants:
           - name: compile_and_test_with_static_libs
 
     - name: ubuntu1604-debug-asan
-      display_name: "ASAN Ubuntu 16.04 Debug"
+      display_name: "ASAN Ubuntu 16.04 Debug (MongoDB Latest)"
       expansions:
           build_type: "Debug"
           tar_options: *linux_tar_options
@@ -689,7 +689,7 @@ buildvariants:
           - name: compile_and_test_with_static_libs
 
     - name: ubuntu1604-debug-ubsan
-      display_name: "UBSAN Ubuntu 16.04 Debug"
+      display_name: "UBSAN Ubuntu 16.04 Debug (MongoDB Latest)"
       expansions:
           build_type: "Debug"
           tar_options: *linux_tar_options
@@ -712,7 +712,7 @@ buildvariants:
           - name: compile_and_test_with_static_libs
 
     - name: ubuntu1604-zseries
-      display_name: "s390x Ubuntu 16.04"
+      display_name: "s390x Ubuntu 16.04 (MongoDB Latest)"
       batchtime: 1440 # 1 day
       expansions:
           build_type: "Release"
@@ -727,7 +727,7 @@ buildvariants:
           - name: compile_and_test_with_static_libs
 
     - name: power8-ubuntu1604
-      display_name: "ppc64le Ubuntu 16.04"
+      display_name: "ppc64le Ubuntu 16.04 (MongoDB Latest)"
       batchtime: 1440 # 1 day
       expansions:
           build_type: "Release"
@@ -742,7 +742,7 @@ buildvariants:
           - name: compile_and_test_with_static_libs
 
     - name: arm-ubuntu1804
-      display_name: "arm64 Ubuntu 18.04"
+      display_name: "arm64 Ubuntu 18.04 (MongoDB Latest)"
       batchtime: 1440 # 1 day
       expansions:
           build_type: "Release"
@@ -760,7 +760,7 @@ buildvariants:
     #         Mac and Windows             #
     #######################################
     - name: macos-1014
-      display_name: "MacOS 10.14 Release (Boost)"
+      display_name: "MacOS 10.14 Release (Boost) (MongoDB Latest)"
       expansions:
           build_type: "Release"
           cdriver_configure_flags: *macos_cdriver_configure_flags
@@ -775,7 +775,7 @@ buildvariants:
           - name: compile_and_test_with_static_libs
 
     - name: windows-2k8-release
-      display_name: "Windows (VS 2015) Release"
+      display_name: "Windows (VS 2015) Release (MongoDB 4.2)"
       expansions:
           build_type: "Release"
           tar_options: *linux_tar_options
@@ -790,7 +790,7 @@ buildvariants:
           - name: uninstall_check_windows
 
     - name: windows-2k8-debug
-      display_name: "Windows (VS 2015) Debug Static"
+      display_name: "Windows (VS 2015) Debug Static (MongoDB 4.2)"
       expansions:
           build_type: "Debug"
           tar_options: *linux_tar_options
@@ -804,7 +804,7 @@ buildvariants:
           - name: compile_and_test_with_static_libs
 
     - name: windows-msvc2017-debug
-      display_name: "Windows (VS 2017) Debug"
+      display_name: "Windows (VS 2017) Debug (MongoDB Latest)"
       expansions:
           build_type: "Debug"
           tar_options: *linux_tar_options

--- a/src/mongocxx/test/client_side_encryption.cpp
+++ b/src/mongocxx/test/client_side_encryption.cpp
@@ -261,6 +261,12 @@ TEST_CASE("Datakey and double encryption", "[client_side_encryption]") {
         uri{}, std::move(client_opts)
     };
 
+    if (test_util::get_max_wire_version(setup_client) < 8) {
+        // Automatic encryption requires wire version 8.
+        WARN("Skipping - max wire version is < 8");
+        return;
+    }
+
     // 2. Drop keyvault.datakeys and db.coll
     _setup_drop_collections(setup_client);
 


### PR DESCRIPTION
The tasks on the `ppc64le Ubuntu 16.04 (MongoDB Latest)` variant appear to be failing due to other reasons.