### PR TITLE
CXX-2048 Temporarily skip tests on PPC Ubuntu 16.04

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -725,8 +725,10 @@ buildvariants:
       run_on:
           - ubuntu1604-power8-build
       tasks:
-          - name: compile_and_test_with_shared_libs
-          - name: compile_and_test_with_static_libs
+          # Once BUILD-11375 is resolved, add upgrade to Ubuntu 18.04 and add tests back.
+          - name: compile_with_shared_libs
+          #- name: compile_and_test_with_shared_libs
+          #- name: compile_and_test_with_static_libs
 
     - name: arm-ubuntu1804
       display_name: "arm64 Ubuntu 18.04 (MongoDB Latest)"


### PR DESCRIPTION
MongoDB dropped support for MongoDB 4.2 in PowerPC Ubuntu 16.04:
https://docs.mongodb.com/manual/administration/production-notes/#ppc64le-mongodb-enterprise-edition

So the "latest" download for PowerPC Ubuntu 16.04 is actually a 4.1 development version. Based on the logs of [this task](https://evergreen.mongodb.com/task/cxx_driver_power8_ubuntu1604_compile_and_test_with_shared_libs_796c11cf072b2c5db23ce6492cb808bf4d6ff2c2_20_06_15_23_14_06): `db version v4.1.9-271-g501b707`

Client-Side Field Level Encryption is a 4.2 feature. I believe that version of mongocryptd is a development version that does not support the "isRemoteSchema" field, causing the:
```
mongocryptd error: BSON field 'insert.isRemoteSchema' is an unknown field.::
```

As a sidenote, this is an unreleased development version, not something users are downloading.

The full fix for CXX-2048 should be to upgrade to using PowerPC Ubuntu 18.04. I tried that but it seems the version of cmake that comes on the toolchain does not work. So the full fix depends on BUILD-11375.