### PR TITLE
CXX-2042 Add 4.4 tasks to evergreen

### DIFF
--- a/.evergreen/compile.sh
+++ b/.evergreen/compile.sh
@@ -30,6 +30,7 @@ fi
 
 case "$OS" in
    darwin|linux)
+      GENERATOR=${GENERATOR:-"Unix Makefiles"}
       CMAKE_BUILD_OPTS="-j $CONCURRENCY"
       CMAKE_EXAMPLES_TARGET=examples
       if [ "$RUN_DISTCHECK" ]; then
@@ -38,6 +39,7 @@ case "$OS" in
       ;;
 
    cygwin*)
+      GENERATOR=${GENERATOR:-"Visual Studio 14 2015 Win64"}
       CMAKE_BUILD_OPTS="/maxcpucount:$CONCURRENCY"
       CMAKE_EXAMPLES_TARGET=examples/examples
       ;;
@@ -51,7 +53,7 @@ esac
 . .evergreen/find_cmake.sh
 
 cd build
-"$CMAKE" "-DCMAKE_BUILD_TYPE=${BUILD_TYPE}" -DCMAKE_VERBOSE_MAKEFILE=ON -DMONGOCXX_ENABLE_SLOW_TESTS=ON -DENABLE_UNINSTALL=ON "$@" ..
+"$CMAKE" -G "$GENERATOR" "-DCMAKE_BUILD_TYPE=${BUILD_TYPE}" -DCMAKE_VERBOSE_MAKEFILE=ON -DMONGOCXX_ENABLE_SLOW_TESTS=ON -DENABLE_UNINSTALL=ON "$@" ..
 "$CMAKE" --build . --config $BUILD_TYPE -- $CMAKE_BUILD_OPTS
 "$CMAKE" --build . --config $BUILD_TYPE --target install
 "$CMAKE" --build . --config $BUILD_TYPE --target $CMAKE_EXAMPLES_TARGET

--- a/.mci.yml
+++ b/.mci.yml
@@ -9,6 +9,7 @@ variables:
 
     mongodb_version:
         version_latest: &version_latest latest
+        version_44: &version_44 4.4
         version_42: &version_42 4.2
         version_40: &version_40 4.0
 
@@ -29,12 +30,16 @@ variables:
         macos_cmake_flags: &macos_cmake_flags -DCMAKE_C_FLAGS="-Wall -Wextra -Wno-attributes -Werror -Wno-missing-field-initializers" -DCMAKE_CXX_FLAGS="-stdlib=libc++ -Wall -Wextra -Wconversion -Wnarrowing -pedantic -Werror"
         asan_cmake_flags: &asan_cmake_flags -DCMAKE_C_FLAGS="-Wall -Wextra -Wno-attributes -Werror -Wno-missing-field-initializers" -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -DCMAKE_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=0 -fsanitize=address -O1 -g -fno-omit-frame-pointer -Wall -Wextra -Wconversion -Wnarrowing -pedantic -Werror"
         ubsan_cmake_flags: &ubsan_cmake_flags -DCMAKE_C_FLAGS="-Wall -Wextra -Wno-attributes -Werror -Wno-missing-field-initializers" -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -DCMAKE_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=0 -fsanitize=undefined -fsanitize-blacklist=$(pwd)/etc/ubsan.blacklist -fno-sanitize-recover=undefined -O1 -g -fno-omit-frame-pointer -Wall -Wextra -Wconversion -Wnarrowing -pedantic -Werror"
-        msvc2015_cmake_flags: &msvc2015_cmake_flags -G "Visual Studio 14 2015 Win64" -DBOOST_ROOT=c:/local/boost_1_60_0
+        msvc2015_cmake_flags: &msvc2015_cmake_flags -DBOOST_ROOT=c:/local/boost_1_60_0
+        msvc2015_generator: &msvc2015_generator Visual Studio 14 2015 Win64
         # The VS option /Zc:__cplusplus is necessary to build with VS2017's
         # native C++17 support. __cplusplus should indicate the standard of C++
         # the compiler supports. VS2017 erroneously reports it as 199711L
         # (instead of 201703L) without this option.
-        msvc2017_cmake_flags: &msvc2017_cmake_flags -G "Visual Studio 15 2017 Win64" -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS="/Zc:__cplusplus"
+        # The VS option /EHsc is necessary to opt into C++ standard exception unwinding.
+        # Without this option, some destructors may not be called in tests (CXX-2054).
+        msvc2017_cmake_flags: &msvc2017_cmake_flags -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS="/Zc:__cplusplus /EHsc"
+        msvc2017_generator: &msvc2017_generator Visual Studio 15 2017 Win64
 
     example_projects_cc:
         asan_cc_path: &asan_cc_path /usr/bin/clang
@@ -167,7 +172,7 @@ functions:
                     if [ "Windows_NT" == "$OS" ]; then
                         PREFIX=$(cygpath -m "$PREFIX")
                     fi
-                    export GENERATOR="${cdriver_cmake_generator}"
+                    export GENERATOR="${generator}"
                     ./.evergreen/install_c_driver.sh ${mongoc_version|master}
 
     "lint":
@@ -217,6 +222,8 @@ functions:
                       ./Scripts/pip install GitPython
                   fi
                   cd ..
+
+                  export GENERATOR="${generator}"
 
                   .evergreen/compile.sh -DCMAKE_PREFIX_PATH="$MONGOC_PREFIX" ${cmake_flags} ${poly_flags} $ADDL_OPTS -DCMAKE_INSTALL_PREFIX=install
 
@@ -271,7 +278,6 @@ functions:
                   set -o xtrace
 
                   if [ "Windows_NT" == "$OS" ]; then
-                      CRUD_TESTS_PATH=$(cygpath -m $CRUD_TESTS_PATH)
                       CTEST_OUTPUT_ON_FAILURE=1 MSBuild.exe /p:Configuration=${build_type} RUN_TESTS.vcxproj
                       CTEST_OUTPUT_ON_FAILURE=1 MSBuild.exe /p:Configuration=${build_type} examples/run-examples.vcxproj
                   else
@@ -543,14 +549,16 @@ axes:
             run_on:
                 - ubuntu1604-build
           - id: "windows-2k8"
-            display_name: "Windows (VS 2015) Debug"
+            display_name: "Windows (VS 2017) Debug"
             variables:
-                extra_path: *msvc2015_extra_path
-                cmake_flags: *msvc2015_cmake_flags
+                extra_path: *msvc2017_extra_path
+                cmake_flags: *msvc2017_cmake_flags
                 build_type: "Debug"
                 tar_options: *linux_tar_options # Same for Windows and Linux
+                generator: *msvc2017_generator
+                example_projects_cxx_standard: 17
             run_on:
-                - windows-64-vs2015-compile
+                - windows-64-vs2017-compile
 
     - id: mongodb_version
       display_name: "MongoDB Version"
@@ -559,6 +567,10 @@ axes:
             display_name: "Latest"
             variables:
                 mongodb_version: *version_latest
+          - id: "4.4"
+            display_name: "4.4"
+            variables:
+                mongodb_version: *version_44
           - id: "4.2"
             display_name: "4.2"
             variables:
@@ -582,20 +594,12 @@ buildvariants:
       display_name: "${os} (MongoDB ${mongodb_version})"
       tasks:
           - name: compile_and_test_with_shared_libs
-      exclude_spec:
-        # Windows latest only runs on Windows 10. This is tested in the VS 2017 variant.
-        os: "windows-2k8"
-        mongodb_version: "latest"
 
     - matrix_name: "auth"
       matrix_spec: {os: "*", mongodb_version: "latest"}
       display_name: "${os} ${mongodb_version} Auth"
       tasks:
           - name: compile_and_test_auth_with_shared_libs
-      exclude_spec:
-        # Windows latest only runs on Windows 10. This is tested in the VS 2017 variant.
-        os: "windows-2k8"
-        mongodb_version: "latest"
 
     #######################################
     #         Linux Buildvariants         #
@@ -775,6 +779,7 @@ buildvariants:
           extra_path: *msvc2015_extra_path
           cmake_flags: *msvc2015_cmake_flags
           mongodb_version: *version_42
+          generator: *msvc2015_generator
       run_on:
           - windows-64-vs2015-compile
       tasks:
@@ -790,23 +795,24 @@ buildvariants:
           extra_path: *msvc2015_extra_path
           cmake_flags: *msvc2015_cmake_flags
           mongodb_version: *version_42
+          generator: *msvc2015_generator
       run_on:
           - windows-64-vs2015-compile
       tasks:
           # The debug shared lib is tested in the "integration tests" matrix
           - name: compile_and_test_with_static_libs
 
-    - name: windows-msvc2017-debug
-      display_name: "Windows (VS 2017) Debug (MongoDB Latest)"
+    - name: windows-msvc2015-debug
+      display_name: "Windows (VS 2015) Debug (MongoDB 4.2)"
       expansions:
           build_type: "Debug"
           tar_options: *linux_tar_options
-          extra_path: *msvc2017_extra_path
-          cdriver_cmake_generator: "Visual Studio 15 2017 Win64"
-          cmake_flags: *msvc2017_cmake_flags
-          mongodb_version: *version_latest
+          extra_path: *msvc2015_extra_path
+          cmake_flags: *msvc2015_cmake_flags
+          generator: *msvc2015_generator
+          mongodb_version: *version_42
       run_on:
-         - windows-64-vs2017-compile
+         - windows-64-vs2015-compile
       tasks:
          - name: compile_with_shared_libs
          - name: compile_and_test_auth_with_shared_libs

--- a/examples/projects/bsoncxx/cmake-deprecated/shared/CMakeLists.txt
+++ b/examples/projects/bsoncxx/cmake-deprecated/shared/CMakeLists.txt
@@ -40,7 +40,8 @@ find_package(libbsoncxx REQUIRED)
 
 add_executable(hello_bsoncxx ../../hello_bsoncxx.cpp)
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+# Visual Studio pre 2017 requires boost polyfill.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND CMAKE_CXX_STANDARD LESS 17)
     find_package(Boost 1.56.0 REQUIRED)
     target_link_libraries(hello_bsoncxx PRIVATE Boost::boost)
 endif()

--- a/examples/projects/bsoncxx/cmake-deprecated/shared/build.sh
+++ b/examples/projects/bsoncxx/cmake-deprecated/shared/build.sh
@@ -13,6 +13,11 @@ if [ -z "$MSVC" ]; then
     "$CMAKE" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
     make run VERBOSE=1
 else
-    "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
-    MSBuild.exe /p:Configuration="${BUILD_TYPE}" run.vcxproj
+    if [ "$CXX_STANDARD" = "17" ]; then
+        "$CMAKE" -G "Visual Studio 15 2017 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
+    else
+        # Boost is needed for pre-17 Windows polyfill.
+        "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
+    fi
+    "$CMAKE" --build . --target run --config "${BUILD_TYPE}"
 fi

--- a/examples/projects/bsoncxx/cmake-deprecated/static/CMakeLists.txt
+++ b/examples/projects/bsoncxx/cmake-deprecated/static/CMakeLists.txt
@@ -40,7 +40,8 @@ find_package(libbsoncxx-static REQUIRED)
 
 add_executable(hello_bsoncxx ../../hello_bsoncxx.cpp)
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+# Visual Studio pre 2017 requires boost polyfill.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND CMAKE_CXX_STANDARD LESS 17)
     find_package(Boost 1.56.0 REQUIRED)
     target_link_libraries(hello_bsoncxx PRIVATE Boost::boost)
 endif()

--- a/examples/projects/bsoncxx/cmake-deprecated/static/build.sh
+++ b/examples/projects/bsoncxx/cmake-deprecated/static/build.sh
@@ -13,6 +13,11 @@ if [ -z "$MSVC" ]; then
     "$CMAKE" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
     make run VERBOSE=1
 else
-    "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
-    MSBuild.exe /p:Configuration="${BUILD_TYPE}" run.vcxproj
+    if [ "$CXX_STANDARD" = "17" ]; then
+        "$CMAKE" -G "Visual Studio 15 2017 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
+    else
+        # Boost is needed for pre-17 Windows polyfill.
+        "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
+    fi
+    "$CMAKE" --build . --target run --config "${BUILD_TYPE}"
 fi

--- a/examples/projects/bsoncxx/cmake/shared/CMakeLists.txt
+++ b/examples/projects/bsoncxx/cmake/shared/CMakeLists.txt
@@ -40,7 +40,8 @@ find_package(bsoncxx REQUIRED)
 
 add_executable(hello_bsoncxx ../../hello_bsoncxx.cpp)
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+# Visual Studio pre 2017 requires boost polyfill.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND CXX_STANDARD LESS 17)
   find_package(Boost 1.56.0 REQUIRED)
   if (CMAKE_VERSION VERSION_LESS 3.15.0)
     target_include_directories(hello_bsoncxx PRIVATE ${Boost_INCLUDE_DIRS})

--- a/examples/projects/bsoncxx/cmake/shared/build.sh
+++ b/examples/projects/bsoncxx/cmake/shared/build.sh
@@ -13,6 +13,11 @@ if [ -z "$MSVC" ]; then
     "$CMAKE" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
     make run VERBOSE=1
 else
-    "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
-    MSBuild.exe /p:Configuration="${BUILD_TYPE}" run.vcxproj
+    if [ "$CXX_STANDARD" = "17" ]; then
+        "$CMAKE" -G "Visual Studio 15 2017 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
+    else
+        # Boost is needed for pre-17 Windows polyfill.
+        "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
+    fi
+    "$CMAKE" --build . --target run --config "${BUILD_TYPE}"
 fi

--- a/examples/projects/bsoncxx/cmake/static/CMakeLists.txt
+++ b/examples/projects/bsoncxx/cmake/static/CMakeLists.txt
@@ -40,7 +40,8 @@ find_package(bsoncxx REQUIRED)
 
 add_executable(hello_bsoncxx ../../hello_bsoncxx.cpp)
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+# Visual Studio pre 2017 requires boost polyfill.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND CXX_STANDARD LESS 17)
   find_package(Boost 1.56.0 REQUIRED)
   if (CMAKE_VERSION VERSION_LESS 3.15.0)
     target_include_directories(hello_bsoncxx PRIVATE ${Boost_INCLUDE_DIRS})

--- a/examples/projects/bsoncxx/cmake/static/build.sh
+++ b/examples/projects/bsoncxx/cmake/static/build.sh
@@ -13,6 +13,11 @@ if [ -z "$MSVC" ]; then
     "$CMAKE" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
     make run VERBOSE=1
 else
-    "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
-    MSBuild.exe /p:Configuration="${BUILD_TYPE}" run.vcxproj
+    if [ "$CXX_STANDARD" = "17" ]; then
+        "$CMAKE" -G "Visual Studio 15 2017 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
+    else
+        # Boost is needed for pre-17 Windows polyfill.
+        "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
+    fi
+    "$CMAKE" --build . --target run --config "${BUILD_TYPE}"
 fi

--- a/examples/projects/mongocxx/cmake-deprecated/shared/CMakeLists.txt
+++ b/examples/projects/mongocxx/cmake-deprecated/shared/CMakeLists.txt
@@ -40,7 +40,8 @@ find_package(libmongocxx REQUIRED)
 
 add_executable(hello_mongocxx ../../hello_mongocxx.cpp)
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+# Visual Studio pre 2017 requires boost polyfill.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND CMAKE_CXX_STANDARD LESS 17)
     find_package(Boost 1.56.0 REQUIRED)
     target_link_libraries(hello_mongocxx PRIVATE Boost::boost)
 endif()

--- a/examples/projects/mongocxx/cmake-deprecated/shared/build.sh
+++ b/examples/projects/mongocxx/cmake-deprecated/shared/build.sh
@@ -13,6 +13,11 @@ if [ -z "$MSVC" ]; then
     "$CMAKE" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
     make run VERBOSE=1
 else
-    "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
-    MSBuild.exe /p:Configuration="${BUILD_TYPE}" run.vcxproj
+    if [ "$CXX_STANDARD" = "17" ]; then
+        "$CMAKE" -G "Visual Studio 15 2017 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
+    else
+        # Boost is needed for pre-17 Windows polyfill.
+        "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
+    fi
+    "$CMAKE" --build . --target run --config "${BUILD_TYPE}"
 fi

--- a/examples/projects/mongocxx/cmake-deprecated/static/CMakeLists.txt
+++ b/examples/projects/mongocxx/cmake-deprecated/static/CMakeLists.txt
@@ -40,7 +40,8 @@ find_package(libmongocxx-static REQUIRED)
 
 add_executable(hello_mongocxx ../../hello_mongocxx.cpp)
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+# Visual Studio pre 2017 requires boost polyfill.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND CMAKE_CXX_STANDARD LESS 17)
     find_package(Boost 1.56.0 REQUIRED)
     target_link_libraries(hello_mongocxx PRIVATE Boost::boost)
 endif()

--- a/examples/projects/mongocxx/cmake-deprecated/static/build.sh
+++ b/examples/projects/mongocxx/cmake-deprecated/static/build.sh
@@ -13,6 +13,11 @@ if [ -z "$MSVC" ]; then
     "$CMAKE" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
     make run VERBOSE=1
 else
-    "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
-    MSBuild.exe /p:Configuration="${BUILD_TYPE}" run.vcxproj
+    if [ "$CXX_STANDARD" = "17" ]; then
+        "$CMAKE" -G "Visual Studio 15 2017 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
+    else
+        # Boost is needed for pre-17 Windows polyfill.
+        "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
+    fi
+    "$CMAKE" --build . --target run --config "${BUILD_TYPE}"
 fi

--- a/examples/projects/mongocxx/cmake/shared/CMakeLists.txt
+++ b/examples/projects/mongocxx/cmake/shared/CMakeLists.txt
@@ -40,7 +40,8 @@ find_package(mongocxx REQUIRED)
 
 add_executable(hello_mongocxx ../../hello_mongocxx.cpp)
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+# Visual Studio pre 2017 requires boost polyfill.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND CMAKE_CXX_STANDARD LESS 17)
   find_package(Boost 1.56.0 REQUIRED)
   if (CMAKE_VERSION VERSION_LESS 3.15.0)
     target_include_directories(hello_mongocxx PRIVATE ${Boost_INCLUDE_DIRS})

--- a/examples/projects/mongocxx/cmake/shared/build.sh
+++ b/examples/projects/mongocxx/cmake/shared/build.sh
@@ -13,6 +13,11 @@ if [ -z "$MSVC" ]; then
     "$CMAKE" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
     make run VERBOSE=1
 else
-    "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
-    MSBuild.exe /p:Configuration="${BUILD_TYPE}" run.vcxproj
+    if [ "$CXX_STANDARD" = "17" ]; then
+        "$CMAKE" -G "Visual Studio 15 2017 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
+    else
+        # Boost is needed for pre-17 Windows polyfill.
+        "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
+    fi
+    "$CMAKE" --build . --target run --config "${BUILD_TYPE}"
 fi

--- a/examples/projects/mongocxx/cmake/static/CMakeLists.txt
+++ b/examples/projects/mongocxx/cmake/static/CMakeLists.txt
@@ -46,7 +46,8 @@ endif()
 
 add_executable(hello_mongocxx ../../hello_mongocxx.cpp)
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+# Visual Studio pre 2017 requires boost polyfill.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND CMAKE_CXX_STANDARD LESS 17)
   find_package(Boost 1.56.0 REQUIRED)
   if (CMAKE_VERSION VERSION_LESS 3.15.0)
     target_include_directories(hello_mongocxx PRIVATE ${Boost_INCLUDE_DIRS})

--- a/examples/projects/mongocxx/cmake/static/build.sh
+++ b/examples/projects/mongocxx/cmake/static/build.sh
@@ -13,6 +13,11 @@ if [ -z "$MSVC" ]; then
     "$CMAKE" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
     make run VERBOSE=1
 else
-    "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
-    MSBuild.exe /p:Configuration="${BUILD_TYPE}" run.vcxproj
+    if [ "$CXX_STANDARD" = "17" ]; then
+        "$CMAKE" -G "Visual Studio 15 2017 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
+    else
+        # Boost is needed for pre-17 Windows polyfill.
+        "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
+    fi
+    "$CMAKE" --build . --target run --config "${BUILD_TYPE}"
 fi

--- a/src/mongocxx/test/spec/client_side_encryption.cpp
+++ b/src/mongocxx/test/spec/client_side_encryption.cpp
@@ -247,6 +247,8 @@ void run_encryption_tests_in_file(const std::string& test_path) {
 
 TEST_CASE("Client side encryption spec automated tests", "[client_side_encryption_spec]") {
     instance::current();
+    /* Tests that use operations that the C++ driver does not have. */
+    std::set<std::string> unsupported_tests = {"count.json", "unsupportedCommand.json"};
 
     char* encryption_tests_path = std::getenv("ENCRYPTION_TESTS_PATH");
     REQUIRE(encryption_tests_path);
@@ -265,6 +267,11 @@ TEST_CASE("Client side encryption spec automated tests", "[client_side_encryptio
 
     std::string test_file;
     while (std::getline(test_files, test_file)) {
+        if (std::find(unsupported_tests.begin(), unsupported_tests.end(), test_file) !=
+            unsupported_tests.end()) {
+            WARN("skipping " << test_file << " due to unsupported operation");
+            continue;
+        }
         run_encryption_tests_in_file(path + "/" + test_file);
     }
 }

--- a/src/mongocxx/test/spec/util.cpp
+++ b/src/mongocxx/test/spec/util.cpp
@@ -273,6 +273,8 @@ void run_operation_check_result(document::view op, make_op_runner_fn make_op_run
     // matches the error string."
     if (op["result"]["errorContains"]) {
         REQUIRE(exception);
+        INFO("expected error message " << op["result"]["errorContains"].get_utf8().value);
+        INFO("got error message" << error_msg);
         // Do a case insensitive check.
         auto error_contains =
             test_util::tolowercase(op["result"]["errorContains"].get_utf8().value);

--- a/src/mongocxx/test_util/client_helpers.cpp
+++ b/src/mongocxx/test_util/client_helpers.cpp
@@ -382,7 +382,7 @@ std::string tolowercase(stdx::string_view view) {
     std::string out;
     out.reserve(view.size());
     for (size_t i = 0; i < view.length(); i++) {
-        out[i] = static_cast<char>(::tolower(view[i]));
+        out += static_cast<char>(::tolower(view[i]));
     }
     return out;
 }


### PR DESCRIPTION
- Upgrade Windows in matrix tasks to run "latest" and "4.4" as part of
matrix.
- Fix a test helper for lowercasing error messages.
- Skip FLE tests we cannot run on unsupported operations.
- Build on VS 2017 with /EHsc to prevent tests from failing due to
destructors not being called when exceptions are thrown. (CXX-2054)