### PR TITLE
CXX-2041 fix travis compile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ compiler:
     - clang
 
 env:
-    global:
-        - MONGO_REPO="[ arch=amd64 ] http://repo.mongodb.com/apt/ubuntu"
-        - REPO_TYPE="trusty/mongodb-enterprise/3.4 multiverse"
-        - SOURCES_LOC="/etc/apt/sources.list.d/mongodb-enterprise.list"
-        - KEY_SERVER="hkp://keyserver.ubuntu.com:80"
 
     matrix:
         - CONFIG=Release
@@ -24,10 +19,6 @@ before_install:
     - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     - sudo add-apt-repository -y 'deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.6 main'
     - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
-
-    # MongoDB Enterprise Edition, latest stable version
-    - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6
-    - echo "deb ${MONGO_REPO} ${REPO_TYPE}" | sudo tee ${SOURCES_LOC}
 
     # Update all the repositories
     - sudo apt-get update -qq
@@ -45,13 +36,15 @@ install:
     # CMake
     - sudo apt-get install -qq cmake
 
-    # Blow away any prior mongodb state so we don't have prior db state that
-    # that doesn't have the right featureCompatibilityVersion
-    - sudo dpkg --purge mongodb-org
-    - sudo rm -rf /var/lib/mongodb
-
-    # Install MongoDB Enterprise
-    - sudo apt-get install mongodb-enterprise-server
+    # Install and start mongod.
+    - sudo apt-get install -qq libsnmp30
+    - curl --retry 8 http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-ubuntu1404-latest.tgz --max-time 300 --output mongodb-binaries.tgz
+    - tar -xf mongodb-binaries.tgz
+    - rm mongodb-binaries.tgz
+    - mv mongodb* mongodb
+    - ./mongodb/bin/mongod --version
+    - mkdir ./mongodb/data
+    - ./mongodb/bin/mongod  --dbpath ./mongodb/data --logpath ./mongodb/logs --fork --setParameter enableTestCommands=1
 
     # Install Mongo C Driver
     - pushd mongo-c-driver
@@ -66,9 +59,6 @@ install:
     - sudo make install
 
     - popd
-
-    # Start up the server. We don't care to terminate it, since we are in an ephemeral VM.
-    - sudo service mongod start
 
 before_script:
     - $CC --version
@@ -87,8 +77,7 @@ script:
     - ./src/bsoncxx/test/test_bson
 
     # Run mongocxx tests with catch
-    # TODO(CXX-1548) Remove filter once Travis runs mongo >= 3.6.
-    - ./src/mongocxx/test/test_driver '~[min36]'
+    - ./src/mongocxx/test/test_driver
 
     # Run mongocxx instance tests with catch
     - ./src/mongocxx/test/test_instance

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -186,8 +186,8 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
         bson_value::value value = elem.get_owning_value();
 
         SECTION("can create new views") {
-            bson_value::view view{value};
-            bson_value::view new_view{value};
+            bson_value::view view(value);
+            bson_value::view new_view(value);
             REQUIRE(view == new_view);
         }
 

--- a/src/bsoncxx/types/private/convert.hh
+++ b/src/bsoncxx/types/private/convert.hh
@@ -17,6 +17,7 @@
 #include <bsoncxx/private/libbson.hh>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
+#include <cstdlib>
 
 #include <bsoncxx/config/private/prelude.hh>
 

--- a/src/mongocxx/client.hpp
+++ b/src/mongocxx/client.hpp
@@ -386,8 +386,6 @@ class MONGOCXX_API client {
     friend class pool;
     friend class client_session;
     friend class options::auto_encryption;
-
-    friend class options::auto_encryption;
     friend class options::client_encryption;
 
     MONGOCXX_PRIVATE explicit client(void* implementation);

--- a/src/mongocxx/options/encrypt.hpp
+++ b/src/mongocxx/options/encrypt.hpp
@@ -47,14 +47,6 @@ class MONGOCXX_API encrypt {
     encrypt& key_id(bsoncxx::types::b_binary key_id);
 
     ///
-    /// Gets the current key id.
-    ///
-    /// @return
-    ///   An optional key id, as a UUID (BSON binary subtype 4).
-    ///
-    const stdx::optional<bsoncxx::types::b_binary>& key_id() const;
-
-    ///
     /// Sets a name by which to lookup a key from the key vault collection to use
     /// for this encryption operation. A key alt name can be used instead of a key id.
     ///
@@ -115,7 +107,8 @@ class MONGOCXX_API encrypt {
     friend class mongocxx::client_encryption;
     MONGOCXX_PRIVATE void* convert() const;
 
-    stdx::optional<bsoncxx::types::b_binary> _key_id;
+    bool _key_id_set;
+    bsoncxx::types::b_binary _key_id;
     stdx::optional<std::string> _key_alt_name;
     stdx::optional<encryption_algorithm> _algorithm;
 };

--- a/src/mongocxx/test/client_session.cpp
+++ b/src/mongocxx/test/client_session.cpp
@@ -541,7 +541,7 @@ TEST_CASE("lsid", "[session]") {
         std::vector<bsoncxx::document::view> docs{doc.view()};
 
         auto insert_vector = [&s, &collection, &docs](bool use_session) {
-            return use_session ? collection.insert_many(s, docs) : collection.insert_many(docs);
+            use_session ? collection.insert_many(s, docs) : collection.insert_many(docs);
         };
 
         test.test_method_with_session(insert_vector, s);

--- a/src/mongocxx/test/client_side_encryption.cpp
+++ b/src/mongocxx/test/client_side_encryption.cpp
@@ -228,7 +228,7 @@ void run_datakey_and_double_encryption(Callable create_data_key,
     // AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic, and the key_alt_name of provider_altname
     options::encrypt opts2{};
     opts2.algorithm(options::encrypt::encryption_algorithm::k_deterministic);
-    std::string altname{provider};
+    std::string altname(provider);
     altname += "_altname";
     opts2.key_alt_name(altname);
 

--- a/src/mongocxx/test/client_side_encryption.cpp
+++ b/src/mongocxx/test/client_side_encryption.cpp
@@ -261,6 +261,10 @@ TEST_CASE("Datakey and double encryption", "[client_side_encryption]") {
         uri{}, std::move(client_opts)
     };
 
+    if (!mongocxx::test_util::should_run_client_side_encryption_test()) {
+        return;
+    }
+
     if (test_util::get_max_wire_version(setup_client) < 8) {
         // Automatic encryption requires wire version 8.
         WARN("Skipping - max wire version is < 8");

--- a/src/mongocxx/test/spec/client_side_encryption.cpp
+++ b/src/mongocxx/test/spec/client_side_encryption.cpp
@@ -248,13 +248,12 @@ void run_encryption_tests_in_file(const std::string& test_path) {
 TEST_CASE("Client side encryption spec automated tests", "[client_side_encryption_spec]") {
     instance::current();
 
-#ifndef MONGOC_ENABLE_CLIENT_SIDE_ENCRYPTION
-    WARN("linked libmongoc does not support client side encryption - skipping tests");
-    return;
-#endif
-
     char* encryption_tests_path = std::getenv("ENCRYPTION_TESTS_PATH");
     REQUIRE(encryption_tests_path);
+
+    if (!mongocxx::test_util::should_run_client_side_encryption_test()) {
+        return;
+    }
 
     std::string path{encryption_tests_path};
     if (path.back() == '/') {

--- a/src/mongocxx/test_util/client_helpers.cpp
+++ b/src/mongocxx/test_util/client_helpers.cpp
@@ -438,6 +438,27 @@ bool server_has_sessions(const client& conn) {
     return false;
 }
 
+bool should_run_client_side_encryption_test(void) {
+#ifndef MONGOC_ENABLE_CLIENT_SIDE_ENCRYPTION
+    WARN("linked libmongoc does not support client side encryption - skipping tests");
+    return false;
+#endif
+
+    auto access_key = std::getenv("MONGOCXX_TEST_AWS_SECRET_ACCESS_KEY");
+    auto key_id = std::getenv("MONGOCXX_TEST_AWS_ACCESS_KEY_ID");
+
+    if (!access_key || !key_id) {
+        WARN(
+            "Skipping tests. Please set environment variables to enable client side encryption "
+            "tests:\n"
+            "\tMONGOCXX_TEST_AWS_SECRET_ACCESS_KEY\n"
+            "\tMONGOCXX_TEST_AWS_ACCESS_KEY_ID\n\n");
+        return false;
+    }
+
+    return true;
+}
+
 }  // namespace test_util
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx

--- a/src/mongocxx/test_util/client_helpers.hh
+++ b/src/mongocxx/test_util/client_helpers.hh
@@ -189,6 +189,8 @@ void check_outcome_collection(mongocxx::collection* coll, bsoncxx::document::vie
 //
 bool server_has_sessions(const client& conn);
 
+bool should_run_client_side_encryption_test(void);
+
 }  // namespace test_util
 
 MONGOCXX_INLINE_NAMESPACE_END


### PR DESCRIPTION
- Remove non-essential getter with optional b_binary, which gives
an error with MNMLSTC and clang 3.6
- Remove redundant friend declaration
- Add explicit static casts for constructing a bson_value::view from
bson_value::value and std::string from string_view
- Fix session lambda to have a void return