### PR TITLE
CXX-2062 + CXX-1953 (Insert test data with wc:majority + Fix session tests)

### DIFF
--- a/src/mongocxx/test/client_session.cpp
+++ b/src/mongocxx/test/client_session.cpp
@@ -129,6 +129,9 @@ TEST_CASE("session", "[session]") {
         auto a_id = value(session_a->id());
         auto b_id = value(session_b->id());
 
+        c["db"].run_command(*session_a, make_document(kvp("ping", 1)));
+        c["db"].run_command(*session_b, make_document(kvp("ping", 1)));
+
         // End session A, then session B.
         session_a = nullptr;
         session_b = nullptr;

--- a/src/mongocxx/test/spec/util.cpp
+++ b/src/mongocxx/test/spec/util.cpp
@@ -205,7 +205,13 @@ void initialize_collection(collection* coll, array::view initial_data) {
     }
 
     if (documents_to_insert.size() > 0) {
-        coll->insert_many(documents_to_insert);
+        write_concern wc_majority;
+        wc_majority.acknowledge_level(write_concern::level::k_majority);
+
+        options::insert insert_opts;
+        insert_opts.write_concern(wc_majority);
+
+        coll->insert_many(documents_to_insert, insert_opts);
     }
 }
 


### PR DESCRIPTION
[CXX-2062](https://jira.mongodb.org/browse/CXX-2062) is a fix to a flaky test failure from the test runner not using majority write concern to insert the initial data.
[CXX-1953](https://jira.mongodb.org/browse/CXX-1953) is a new (consistent) test failure due to a change in libmongoc's session pool behavior from [CDRIVER-3322](https://jira.mongodb.org/browse/CDRIVER-3322)