### PR TITLE
CXX-1875 add read/write concern tests

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -268,6 +268,7 @@ functions:
                   export TRANSACTIONS_TESTS_PATH="$(pwd)/../data/transactions"
                   export WITH_TRANSACTION_TESTS_PATH="$(pwd)/../data/with_transaction"
                   export RETRYABLE_READS_TESTS_PATH="$(pwd)/../data/retryable-reads"
+                  export READ_WRITE_CONCERN_OPERATION_TESTS_PATH="$(pwd)/../data/read-write-concern/operation"
 
                   # export environment variables for encryption tests (and redact them)
                   set +o xtrace
@@ -300,6 +301,7 @@ functions:
                       ${test_params} ./src/mongocxx/test/test_transactions_specs
                       ${test_params} ./src/mongocxx/test/test_logging
                       ${test_params} ./src/mongocxx/test/test_retryable_reads_specs
+                      ${test_params} ./src/mongocxx/test/test_read_write_concern_specs
 
 
                       # Some platforms like OS X don't support the /mode syntax to the -perm option

--- a/data/read-write-concern/operation/default-write-concern-2.6.json
+++ b/data/read-write-concern/operation/default-write-concern-2.6.json
@@ -1,0 +1,544 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "default_write_concern_coll",
+  "database_name": "default_write_concern_db",
+  "runOn": [
+    {
+      "minServerVersion": "2.6"
+    }
+  ],
+  "tests": [
+    {
+      "description": "DeleteOne omits default write concern",
+      "operations": [
+        {
+          "name": "deleteOne",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {}
+          },
+          "result": {
+            "deletedCount": 1
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "default_write_concern_coll",
+              "deletes": [
+                {
+                  "q": {},
+                  "limit": 1
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "DeleteMany omits default write concern",
+      "operations": [
+        {
+          "name": "deleteMany",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {}
+          },
+          "result": {
+            "deletedCount": 2
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "default_write_concern_coll",
+              "deletes": [
+                {
+                  "q": {},
+                  "limit": 0
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "BulkWrite with all models omits default write concern",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "ordered": true,
+            "requests": [
+              {
+                "name": "deleteMany",
+                "arguments": {
+                  "filter": {}
+                }
+              },
+              {
+                "name": "insertOne",
+                "arguments": {
+                  "document": {
+                    "_id": 1
+                  }
+                }
+              },
+              {
+                "name": "updateOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "$set": {
+                      "x": 1
+                    }
+                  }
+                }
+              },
+              {
+                "name": "insertOne",
+                "arguments": {
+                  "document": {
+                    "_id": 2
+                  }
+                }
+              },
+              {
+                "name": "replaceOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "x": 2
+                  }
+                }
+              },
+              {
+                "name": "insertOne",
+                "arguments": {
+                  "document": {
+                    "_id": 3
+                  }
+                }
+              },
+              {
+                "name": "updateMany",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "$set": {
+                      "x": 3
+                    }
+                  }
+                }
+              },
+              {
+                "name": "deleteOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 3
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "default_write_concern_coll",
+          "data": [
+            {
+              "_id": 1,
+              "x": 3
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      },
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "default_write_concern_coll",
+              "deletes": [
+                {
+                  "q": {},
+                  "limit": 0
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default_write_concern_coll",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "update": "default_write_concern_coll",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": {
+                    "$set": {
+                      "x": 1
+                    }
+                  }
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default_write_concern_coll",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "update": "default_write_concern_coll",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": {
+                    "x": 2
+                  }
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default_write_concern_coll",
+              "documents": [
+                {
+                  "_id": 3
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "update": "default_write_concern_coll",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": {
+                    "$set": {
+                      "x": 3
+                    }
+                  },
+                  "multi": true
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "default_write_concern_coll",
+              "deletes": [
+                {
+                  "q": {
+                    "_id": 3
+                  },
+                  "limit": 1
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "InsertOne and InsertMany omit default write concern",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "document": {
+              "_id": 3
+            }
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "documents": [
+              {
+                "_id": 4
+              },
+              {
+                "_id": 5
+              }
+            ]
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "default_write_concern_coll",
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            },
+            {
+              "_id": 5
+            }
+          ]
+        }
+      },
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default_write_concern_coll",
+              "documents": [
+                {
+                  "_id": 3
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default_write_concern_coll",
+              "documents": [
+                {
+                  "_id": 4
+                },
+                {
+                  "_id": 5
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "UpdateOne, UpdateMany, and ReplaceOne omit default write concern",
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "updateMany",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "update": {
+              "$set": {
+                "x": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "replaceOne",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "replacement": {
+              "x": 3
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "default_write_concern_coll",
+          "data": [
+            {
+              "_id": 1,
+              "x": 1
+            },
+            {
+              "_id": 2,
+              "x": 3
+            }
+          ]
+        }
+      },
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "default_write_concern_coll",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": {
+                    "$set": {
+                      "x": 1
+                    }
+                  }
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "update": "default_write_concern_coll",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 2
+                  },
+                  "u": {
+                    "$set": {
+                      "x": 2
+                    }
+                  },
+                  "multi": true
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "update": "default_write_concern_coll",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 2
+                  },
+                  "u": {
+                    "x": 3
+                  }
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/data/read-write-concern/operation/default-write-concern-2.6.yml
+++ b/data/read-write-concern/operation/default-write-concern-2.6.yml
@@ -1,0 +1,215 @@
+# Test that setting a default write concern does not add a write concern
+# to the command sent over the wire.
+# Test operations that require 2.6+ server.
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+collection_name: &collection_name default_write_concern_coll
+database_name: &database_name default_write_concern_db
+
+runOn:
+    - minServerVersion: "2.6"
+
+tests:
+  - description: DeleteOne omits default write concern
+    operations:
+      - name: deleteOne
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          filter: {}
+        result:
+          deletedCount: 1
+    expectations:
+      - command_started_event:
+          command:
+            delete: *collection_name
+            deletes:
+              - {q: {}, limit: 1}
+            writeConcern: null
+  - description: DeleteMany omits default write concern
+    operations:
+      - name: deleteMany
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          filter: {}
+        result:
+          deletedCount: 2
+    expectations:
+      - command_started_event:
+          command:
+            delete: *collection_name
+            deletes: [{q: {}, limit: 0}]
+            writeConcern: null
+  - description: BulkWrite with all models omits default write concern
+    operations:
+      - name: bulkWrite
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          ordered: true
+          requests:
+            - name: deleteMany
+              arguments:
+                filter: {}
+            - name: insertOne
+              arguments:
+                document: {_id: 1}
+            - name: updateOne
+              arguments:
+                filter: {_id: 1}
+                update: {$set: {x: 1}}
+            - name: insertOne
+              arguments:
+                document: {_id: 2}
+            - name: replaceOne
+              arguments:
+                filter: {_id: 1}
+                replacement: {x: 2}
+            - name: insertOne
+              arguments:
+                document: {_id: 3}
+            - name: updateMany
+              arguments:
+                filter: {_id: 1}
+                update: {$set: {x: 3}}
+            - name: deleteOne
+              arguments:
+                filter: {_id: 3}
+    outcome:
+      collection:
+        name: *collection_name
+        data:
+          - {_id: 1, x: 3}
+          - {_id: 2}
+    expectations:
+      - command_started_event:
+          command:
+            delete: *collection_name
+            deletes: [{q: {}, limit: 0}]
+            writeConcern: null
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - {_id: 1}
+            writeConcern: null
+      - command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              - {q: {_id: 1}, u: {$set: {x: 1}}}
+            writeConcern: null
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - {_id: 2}
+            writeConcern: null
+      - command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              - {q: {_id: 1}, u: {x: 2}}
+            writeConcern: null
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - {_id: 3}
+            writeConcern: null
+      - command_started_event:
+          command:
+            update: *collection_name
+            updates: 
+              - {q: {_id: 1}, u: {$set: {x: 3}}, multi: true}
+            writeConcern: null
+      - command_started_event:
+          command:
+            delete: *collection_name
+            deletes: [{q: {_id: 3}, limit: 1}]
+            writeConcern: null
+  - description: 'InsertOne and InsertMany omit default write concern'
+    operations:
+      - name: insertOne
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          document: {_id: 3}
+      - name: insertMany
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          documents:
+            - {_id: 4}
+            - {_id: 5}
+    outcome:
+      collection:
+        name: *collection_name
+        data:
+          - {_id: 1, x: 11}
+          - {_id: 2, x: 22}
+          - {_id: 3}
+          - {_id: 4}
+          - {_id: 5}
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - {_id: 3}
+            writeConcern: null
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - {_id: 4}
+              - {_id: 5}
+            writeConcern: null
+  - description: 'UpdateOne, UpdateMany, and ReplaceOne omit default write concern'
+    operations:
+      - name: updateOne
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          filter: {_id: 1}
+          update: {$set: {x: 1}}
+      - name: updateMany
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          filter: {_id: 2}
+          update: {$set: {x: 2}}
+      - name: replaceOne
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          filter: {_id: 2}
+          replacement: {x: 3}
+    outcome:
+      collection:
+        name: *collection_name
+        data:
+          - {_id: 1, x: 1}
+          - {_id: 2, x: 3}
+    expectations:
+      - command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              - {q: {_id: 1}, u: {$set: {x: 1}}}
+            writeConcern: null
+      - command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              - {q: {_id: 2}, u: {$set: {x: 2}}, multi: true}
+            writeConcern: null
+      - command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              - {q: {_id: 2}, u: {x: 3}}
+            writeConcern: null

--- a/data/read-write-concern/operation/default-write-concern-3.2.json
+++ b/data/read-write-concern/operation/default-write-concern-3.2.json
@@ -1,0 +1,125 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "default_write_concern_coll",
+  "database_name": "default_write_concern_db",
+  "runOn": [
+    {
+      "minServerVersion": "3.2"
+    }
+  ],
+  "tests": [
+    {
+      "description": "findAndModify operations omit default write concern",
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndReplace",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "replacement": {
+              "x": 2
+            }
+          }
+        },
+        {
+          "name": "findOneAndDelete",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {
+              "_id": 2
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "default_write_concern_coll",
+          "data": [
+            {
+              "_id": 1,
+              "x": 1
+            }
+          ]
+        }
+      },
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "default_write_concern_coll",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$set": {
+                  "x": 1
+                }
+              },
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "default_write_concern_coll",
+              "query": {
+                "_id": 2
+              },
+              "update": {
+                "x": 2
+              },
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "default_write_concern_coll",
+              "query": {
+                "_id": 2
+              },
+              "remove": true,
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/data/read-write-concern/operation/default-write-concern-3.2.yml
+++ b/data/read-write-concern/operation/default-write-concern-3.2.yml
@@ -1,0 +1,58 @@
+# Test that setting a default write concern does not add a write concern
+# to the command sent over the wire.
+# Test operations that require 3.2+ server, where findAndModify started
+# to accept a write concern.
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+collection_name: &collection_name default_write_concern_coll
+database_name: &database_name default_write_concern_db
+
+runOn:
+    - minServerVersion: "3.2"
+
+tests:
+  - description: 'findAndModify operations omit default write concern'
+    operations:
+      - name: findOneAndUpdate
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          filter: {_id: 1}
+          update: {$set: {x: 1}}
+      - name: findOneAndReplace
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          filter: {_id: 2}
+          replacement: {x: 2}
+      - name: findOneAndDelete
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          filter: {_id: 2}
+    outcome:
+      collection:
+        name: *collection_name
+        data:
+          - {_id: 1, x: 1}
+    expectations:
+      - command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: {_id: 1}
+            update: {$set: {x: 1}}
+            writeConcern: null
+      - command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: {_id: 2}
+            update: {x: 2}
+            writeConcern: null
+      - command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: {_id: 2}
+            remove: true
+            writeConcern: null

--- a/data/read-write-concern/operation/default-write-concern-3.4.json
+++ b/data/read-write-concern/operation/default-write-concern-3.4.json
@@ -1,0 +1,216 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "default_write_concern_coll",
+  "database_name": "default_write_concern_db",
+  "runOn": [
+    {
+      "minServerVersion": "3.4"
+    }
+  ],
+  "tests": [
+    {
+      "description": "Aggregate with $out omits default write concern",
+      "operations": [
+        {
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$out": "other_collection_name"
+              }
+            ]
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_collection_name",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      },
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "default_write_concern_coll",
+              "pipeline": [
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$out": "other_collection_name"
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "RunCommand with a write command omits default write concern (runCommand should never inherit write concern)",
+      "operations": [
+        {
+          "object": "database",
+          "databaseOptions": {
+            "writeConcern": {}
+          },
+          "name": "runCommand",
+          "command_name": "delete",
+          "arguments": {
+            "command": {
+              "delete": "default_write_concern_coll",
+              "deletes": [
+                {
+                  "q": {},
+                  "limit": 1
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "default_write_concern_coll",
+              "deletes": [
+                {
+                  "q": {},
+                  "limit": 1
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "CreateIndex and dropIndex omits default write concern",
+      "operations": [
+        {
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "name": "createIndex",
+          "arguments": {
+            "keys": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "name": "dropIndex",
+          "arguments": {
+            "name": "x_1"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "default_write_concern_coll",
+              "indexes": [
+                {
+                  "name": "x_1",
+                  "key": {
+                    "x": 1
+                  }
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "dropIndexes": "default_write_concern_coll",
+              "index": "x_1",
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "MapReduce omits default write concern",
+      "operations": [
+        {
+          "name": "mapReduce",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "map": {
+              "$code": "function inc() { return emit(0, this.x + 1) }"
+            },
+            "reduce": {
+              "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+            },
+            "out": {
+              "inline": 1
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "mapReduce": "default_write_concern_coll",
+              "map": {
+                "$code": "function inc() { return emit(0, this.x + 1) }"
+              },
+              "reduce": {
+                "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+              },
+              "out": {
+                "inline": 1
+              },
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/data/read-write-concern/operation/default-write-concern-3.4.yml
+++ b/data/read-write-concern/operation/default-write-concern-3.4.yml
@@ -1,0 +1,95 @@
+# Test that setting a default write concern does not add a write concern
+# to the command sent over the wire.
+# Test operations that require 3.4+ server, where all commands started
+# to accept a write concern.
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+collection_name: &collection_name default_write_concern_coll
+database_name: &database_name default_write_concern_db
+
+runOn:
+    - minServerVersion: "3.4"
+
+tests:
+  - description: Aggregate with $out omits default write concern
+    operations:
+      - object: collection
+        collectionOptions: {writeConcern: {}}
+        name: aggregate
+        arguments:
+          pipeline: &out_pipeline
+            - $match: {_id: {$gt: 1}}
+            - $out: &other_collection_name "other_collection_name"
+    outcome:
+      collection:
+        name: *other_collection_name
+        data:
+          - {_id: 2, x: 22}
+    expectations:
+      - command_started_event:
+          command:
+            aggregate: *collection_name
+            pipeline: *out_pipeline
+            writeConcern: null
+  - description: RunCommand with a write command omits default write concern (runCommand should never inherit write concern)
+    operations:
+      - object: database
+        databaseOptions: {writeConcern: {}}
+        name: runCommand
+        command_name: delete
+        arguments:
+          command:
+            delete: *collection_name
+            deletes:
+              - {q: {}, limit: 1}
+    expectations:
+      - command_started_event:
+          command:
+            delete: *collection_name
+            deletes:
+              - {q: {}, limit: 1}
+            writeConcern: null
+  - description: CreateIndex and dropIndex omits default write concern 
+    operations:
+      - object: collection
+        collectionOptions: {writeConcern: {}}
+        name: createIndex
+        arguments:
+          keys: {x: 1}
+      - object: collection
+        collectionOptions: {writeConcern: {}}
+        name: dropIndex
+        arguments:
+          name: x_1
+    expectations:
+      - command_started_event:
+          command:
+            createIndexes: *collection_name
+            indexes:
+              - name: x_1
+                key: {x: 1}
+            writeConcern: null
+      - command_started_event:
+          command:
+            dropIndexes: *collection_name
+            index: x_1
+            writeConcern: null
+  - description: MapReduce omits default write concern
+    operations:
+      - name: mapReduce
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          map: { $code: 'function inc() { return emit(0, this.x + 1) }' }
+          reduce: { $code: 'function sum(key, values) { return values.reduce((acc, x) => acc + x); }' }
+          out: { inline: 1 }
+    expectations:
+      - command_started_event:
+          command:
+            mapReduce: *collection_name
+            map: { $code: 'function inc() { return emit(0, this.x + 1) }' }
+            reduce: { $code: 'function sum(key, values) { return values.reduce((acc, x) => acc + x); }' }
+            out: { inline: 1 }
+            writeConcern: null

--- a/data/read-write-concern/operation/default-write-concern-4.2.json
+++ b/data/read-write-concern/operation/default-write-concern-4.2.json
@@ -1,0 +1,87 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "default_write_concern_coll",
+  "database_name": "default_write_concern_db",
+  "runOn": [
+    {
+      "minServerVersion": "4.2"
+    }
+  ],
+  "tests": [
+    {
+      "description": "Aggregate with $merge omits default write concern",
+      "operations": [
+        {
+          "object": "collection",
+          "databaseOptions": {
+            "writeConcern": {}
+          },
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$merge": {
+                  "into": "other_collection_name"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "default_write_concern_coll",
+              "pipeline": [
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$merge": {
+                    "into": "other_collection_name"
+                  }
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_collection_name",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/data/read-write-concern/operation/default-write-concern-4.2.yml
+++ b/data/read-write-concern/operation/default-write-concern-4.2.yml
@@ -1,0 +1,36 @@
+# Test that setting a default write concern does not add a write concern
+# to the command sent over the wire.
+# Test operations that require 4.2+ server.
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+collection_name: &collection_name default_write_concern_coll
+database_name: &database_name default_write_concern_db
+
+runOn:
+    - minServerVersion: "4.2"
+
+tests:
+  - description: Aggregate with $merge omits default write concern
+    operations:
+      - object: collection
+        databaseOptions: {writeConcern: {}}
+        collectionOptions: {writeConcern: {}}
+        name: aggregate
+        arguments:
+          pipeline: &merge_pipeline
+            - $match: {_id: {$gt: 1}}
+            - $merge: {into: &other_collection_name "other_collection_name" }
+    expectations:
+      - command_started_event:
+          command:
+            aggregate: *collection_name
+            pipeline: *merge_pipeline
+            # "null" fields will be checked for non-existence
+            writeConcern: null
+    outcome:
+      collection:
+        name: *other_collection_name
+        data:
+          - {_id: 2, x: 22}

--- a/data/read-write-concern/operation/test_files.txt
+++ b/data/read-write-concern/operation/test_files.txt
@@ -1,0 +1,4 @@
+default-write-concern-2.6.json
+default-write-concern-3.2.json
+default-write-concern-3.4.json
+default-write-concern-4.2.json

--- a/src/mongocxx/test/CMakeLists.txt
+++ b/src/mongocxx/test/CMakeLists.txt
@@ -146,6 +146,13 @@ add_executable(test_retryable_reads_specs
     ${spec_test_common}
 )
 
+add_executable(test_read_write_concern_specs
+    ${CMAKE_SOURCE_DIR}/src/mongocxx/test_util/client_helpers.cpp
+    ${THIRD_PARTY_SOURCE_DIR}/catch/main.cpp
+    spec/read_write_concern.cpp
+    ${spec_test_common}
+)
+
 target_link_libraries(test_driver mongocxx_mocked ${libmongoc_target})
 target_link_libraries(test_logging mongocxx_mocked ${libmongoc_target})
 target_link_libraries(test_instance mongocxx_mocked ${libmongoc_target})
@@ -156,6 +163,7 @@ target_link_libraries(test_command_monitoring_specs mongocxx_mocked ${libmongoc_
 target_link_libraries(test_change_stream_specs mongocxx_mocked ${libmongoc_target})
 target_link_libraries(test_transactions_specs mongocxx_mocked ${libmongoc_target})
 target_link_libraries(test_retryable_reads_specs mongocxx_mocked ${libmongoc_target})
+target_link_libraries(test_read_write_concern_specs mongocxx_mocked ${libmongoc_target})
 
 target_include_directories(test_driver PRIVATE ${libmongoc_include_directories})
 target_include_directories(test_logging PRIVATE ${libmongoc_include_directories})
@@ -166,6 +174,7 @@ target_include_directories(test_command_monitoring_specs PRIVATE ${libmongoc_inc
 target_include_directories(test_change_stream_specs PRIVATE ${libmongoc_include_directories})
 target_include_directories(test_transactions_specs PRIVATE ${libmongoc_include_directories})
 target_include_directories(test_retryable_reads_specs PRIVATE ${libmongoc_include_directories})
+target_include_directories(test_read_write_concern_specs PRIVATE ${libmongoc_include_directories})
 
 target_compile_definitions(test_driver PRIVATE ${libmongoc_definitions})
 target_compile_definitions(test_logging PRIVATE ${libmongoc_definitions})
@@ -185,6 +194,7 @@ add_test(command_monitoring_specs test_command_monitoring_specs)
 add_test(change_stream_specs test_change_stream_specs)
 add_test(transactions_specs test_transactions_specs)
 add_test(retryable_reads_spec test_retryable_reads_specs)
+add_test(read_write_concern_specs test_read_write_concern_specs)
 
 set_tests_properties(crud_specs PROPERTIES
     ENVIRONMENT "CRUD_TESTS_PATH=${CMAKE_SOURCE_DIR}/data/crud")
@@ -208,6 +218,9 @@ set_property(TEST transactions_specs
 
 set_tests_properties(retryable_reads_spec PROPERTIES
    ENVIRONMENT "RETRYABLE_READS_TESTS_PATH=${CMAKE_SOURCE_DIR}/data/retryable-reads")
+
+set_tests_properties(read_write_concern_specs PROPERTIES
+   ENVIRONMENT "READ_WRITE_CONCERN_OPERATION_TESTS_PATH=${CMAKE_SOURCE_DIR}/data/read-write-concern/operation")
 
 if (MONGOCXX_ENABLE_SLOW_TESTS)
   set_tests_properties(driver PROPERTIES
@@ -277,6 +290,7 @@ set_dist_list (src_mongocxx_test_DIST
    spec/monitoring.hh
    spec/operation.cpp
    spec/operation.hh
+   spec/read_write_concern.cpp
    spec/retryable-reads.cpp
    spec/transactions.cpp
    spec/util.cpp

--- a/src/mongocxx/test/sdam-monitoring.cpp
+++ b/src/mongocxx/test/sdam-monitoring.cpp
@@ -265,7 +265,6 @@ TEST_CASE("SDAM Monitoring", "[sdam_monitoring]") {
 TEST_CASE("Heartbeat failed event", "[sdam_monitoring]") {
     instance::current();
     options::apm apm_opts;
-    stdx::optional<oid> topology_id;
     bool failed_awaited_called = false;
     auto mock_failed_awaited = libmongoc::apm_server_heartbeat_failed_get_awaited.create_instance();
 

--- a/src/mongocxx/test/spec/operation.cpp
+++ b/src/mongocxx/test/spec/operation.cpp
@@ -873,17 +873,29 @@ void operation_runner::_set_collection_options(document::view operation) {
     document::view options = operation["collectionOptions"].get_document().value;
 
     if (options["writeConcern"]) {
-        document::view write_concern_options = options["writeConcern"].get_document().value;
-        int32_t w_option = write_concern_options["w"].get_int32().value;
         write_concern w;
-        w.nodes(w_option);
+        document::view write_concern_options = options["writeConcern"].get_document().value;
+
+        // Empty writeConcern document means use the default.
+        if (!write_concern_options.empty()) {
+            REQUIRE(write_concern_options["w"]);
+
+            int32_t w_option = write_concern_options["w"].get_int32().value;
+            w.nodes(w_option);
+        }
         _coll->write_concern(w);
     }
 
     if (options["readConcern"]) {
         document::view read_concern_options = options["readConcern"].get_document().value;
         read_concern rc;
-        rc.acknowledge_string(read_concern_options["level"].get_utf8().value);
+
+        // Empty readConcern document means use the default.
+        if (!read_concern_options.empty()) {
+            REQUIRE(read_concern_options["level"]);
+
+            rc.acknowledge_string(read_concern_options["level"].get_utf8().value);
+        }
         _coll->read_concern(rc);
     }
 }

--- a/src/mongocxx/test/spec/read_write_concern.cpp
+++ b/src/mongocxx/test/spec/read_write_concern.cpp
@@ -21,15 +21,10 @@ namespace {
 using namespace mongocxx;
 using namespace spec;
 
-TEST_CASE("Transactions spec automated tests", "[transactions_spec]") {
+TEST_CASE("Read / Write concern spec tests", "[read_write_concern_spec]") {
     instance::current();
 
-    /* Tests that use operations that the C++ driver does not have. */
-    std::set<std::string> unsupported_transaction_tests = {"count.json"};
-
-    run_tests_in_suite(
-        "TRANSACTIONS_TESTS_PATH", &run_transactions_tests_in_file, unsupported_transaction_tests);
-
-    run_tests_in_suite("WITH_TRANSACTION_TESTS_PATH", &run_transactions_tests_in_file);
+    // Reuse the transactions test runner.
+    run_tests_in_suite("READ_WRITE_CONCERN_OPERATION_TESTS_PATH", &run_transactions_tests_in_file);
 }
 }  // namespace

--- a/src/mongocxx/test/spec/util.cpp
+++ b/src/mongocxx/test/spec/util.cpp
@@ -13,17 +13,50 @@
 // limitations under the License.
 
 #include <fstream>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #include <mongocxx/test/spec/util.hh>
 
+#include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
+#include <bsoncxx/document/value.hpp>
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/exception/exception.hpp>
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/to_string.hpp>
 #include <bsoncxx/test_util/catch.hh>
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/cursor.hpp>
+#include <mongocxx/database.hpp>
 #include <mongocxx/exception/operation_exception.hpp>
-#include <mongocxx/test_util/client_helpers.hh>
-#include <third_party/catch/include/catch.hpp>
+#include <mongocxx/instance.hpp>
+#include <mongocxx/options/aggregate.hpp>
+#include <mongocxx/options/count.hpp>
+#include <mongocxx/options/delete.hpp>
+#include <mongocxx/options/distinct.hpp>
+#include <mongocxx/options/find.hpp>
+#include <mongocxx/options/find_one_and_delete.hpp>
+#include <mongocxx/options/find_one_and_replace.hpp>
+#include <mongocxx/options/find_one_and_update.hpp>
+#include <mongocxx/options/find_one_common_options.hpp>
+#include <mongocxx/options/update.hpp>
+#include <mongocxx/pipeline.hpp>
+#include <mongocxx/result/delete.hpp>
+#include <mongocxx/result/insert_many.hpp>
+#include <mongocxx/result/insert_one.hpp>
+#include <mongocxx/result/replace_one.hpp>
+#include <mongocxx/result/update.hpp>
+#include <mongocxx/test/spec/monitoring.hh>
+#include <mongocxx/test/spec/operation.hh>
 
 #include <mongocxx/config/private/prelude.hh>
 
@@ -31,9 +64,11 @@ namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 namespace spec {
 
-using namespace mongocxx;
 using namespace bsoncxx;
+using namespace mongocxx;
+using namespace spec;
 using bsoncxx::builder::basic::kvp;
+using bsoncxx::builder::basic::make_array;
 using bsoncxx::builder::basic::make_document;
 using bsoncxx::stdx::optional;
 using bsoncxx::stdx::string_view;
@@ -51,12 +86,34 @@ uint32_t error_code_from_name(string_view name) {
         return 112;
     } else if (name.compare("Interrupted") == 0) {
         return 11601;
+    } else if (name.compare("MaxTimeMSExpired") == 0) {
+        return 50;
+    } else if (name.compare("UnknownReplWriteConcern") == 0) {
+        return 79;
+    } else if (name.compare("UnsatisfiableWriteConcern") == 0) {
+        return 100;
+    } else if (name.compare("OperationNotSupportedInTransaction") == 0) {
+        return 263;
     }
 
     return 0;
 }
 
+/* Called with the entire test file and individual tests. */
 bool should_skip_spec_test(const client& client, document::view test) {
+    std::set<std::string> unsupported_tests = {
+        "CreateIndex and dropIndex omits default write concern",
+        "MapReduce omits default write concern"};
+
+    if (test["description"]) {
+        std::string description = std::string(test["description"].get_utf8().value);
+        if (unsupported_tests.find(description) != unsupported_tests.end()) {
+            UNSCOPED_INFO("Test skipped - " << description << "\n"
+                                            << "reason: unsupported in C++ driver");
+            return true;
+        }
+    }
+
     if (test["skipReason"]) {
         UNSCOPED_INFO("Test skipped - " << test["description"].get_utf8().value << "\n"
                                         << "reason: "
@@ -403,6 +460,318 @@ void run_tests_in_suite(std::string ev, test_runner cb, std::set<std::string> un
 void run_tests_in_suite(std::string ev, test_runner cb) {
     std::set<std::string> empty;
     run_tests_in_suite(ev, cb, empty);
+}
+
+void test_setup(document::view test, document::view test_spec) {
+    // Step 1. "clean up any open transactions from previous test failures"
+    client client{uri{}};
+    try {
+        client["admin"].run_command(make_document(kvp("killAllSessions", make_array())));
+    } catch (const operation_exception& e) {
+    }
+
+    // Steps 2 - 5, set up new collection
+    set_up_collection(client, test_spec);
+
+    // Step 6. "If failPoint is specified, its value is a configureFailPoint command"
+    configure_fail_point(client, test);
+}
+
+void parse_session_opts(document::view session_opts, options::client_session* out) {
+    options::transaction txn_opts;
+    if (session_opts["defaultTransactionOptions"]) {
+        auto rc = lookup_read_concern(session_opts["defaultTransactionOptions"].get_document());
+        if (rc) {
+            txn_opts.read_concern(*rc);
+        }
+
+        auto wc = lookup_write_concern(session_opts["defaultTransactionOptions"].get_document());
+        if (wc) {
+            txn_opts.write_concern(*wc);
+        }
+
+        auto rp = lookup_read_preference(session_opts["defaultTransactionOptions"].get_document());
+        if (rp) {
+            txn_opts.read_preference(*rp);
+        }
+    }
+
+    out->default_transaction_opts(txn_opts);
+}
+
+using bsoncxx::stdx::string_view;
+void run_transaction_operations(document::view test,
+                                client* client,
+                                string_view db_name,
+                                string_view coll_name,
+                                client_session* session0,
+                                client_session* session1,
+                                bool* fail_point_enabled,
+                                bool throw_on_error = false) {
+    auto operations = test["operations"].get_array().value;
+
+    REQUIRE(session0);
+    REQUIRE(session1);
+
+    for (auto&& op : operations) {
+        *fail_point_enabled =
+            *fail_point_enabled || op.get_document().value["arguments"]["failPoint"];
+        std::string error_msg;
+        optional<document::value> server_error;
+        optional<operation_exception> exception;
+        optional<document::value> actual_result;
+        std::error_code ec;
+        INFO("Operation: " << bsoncxx::to_json(op.get_document().value));
+
+        auto operation = op.get_document().value;
+
+        // Handle with_transaction separately.
+        if (operation["name"].get_utf8().value.compare("withTransaction") == 0) {
+            auto session = [&]() {
+                if (operation["object"].get_utf8().value.compare("session0") == 0) {
+                    return session0;
+                } else {
+                    return session1;
+                }
+            }();
+
+            auto with_txn_test_cb = [&](client_session*) {
+                // This will get called from client_session::with_transaction.
+                // Run the nested operation(s) inside here.
+                REQUIRE(operation["arguments"]);
+                REQUIRE(operation["arguments"]["callback"]);
+                auto callback = operation["arguments"]["callback"].get_document().value;
+                run_transaction_operations(callback,
+                                           client,
+                                           db_name,
+                                           coll_name,
+                                           session0,
+                                           session1,
+                                           fail_point_enabled,
+                                           true);
+            };
+
+            try {
+                session->with_transaction(with_txn_test_cb);
+            } catch (const operation_exception& e) {
+                error_msg = e.what();
+                server_error = e.raw_server_error();
+                exception = e;
+                ec = e.code();
+            }
+        } else {
+            try {
+                database db = client->database(db_name);
+                parse_database_options(operation, &db);
+                collection coll = db[coll_name];
+                parse_collection_options(operation, &coll);
+                operation_runner op_runner{&db, &coll, session0, session1, client};
+                actual_result = op_runner.run(operation);
+            } catch (const operation_exception& e) {
+                error_msg = e.what();
+                server_error = e.raw_server_error();
+                exception = e;
+                ec = e.code();
+            }
+        }
+
+        // "If the result document has an 'errorContains' field, verify that the method threw an
+        // exception or returned an error, and that the value of the 'errorContains' field
+        // matches the error string."
+        if (op["result"]["errorContains"]) {
+            REQUIRE(exception);
+            // Do a case insensitive check.
+            auto error_contains =
+                test_util::tolowercase(op["result"]["errorContains"].get_utf8().value);
+            REQUIRE(test_util::tolowercase(error_msg).find(error_contains) < error_msg.length());
+        }
+
+        // "If the result document has an 'errorCodeName' field, verify that the method threw a
+        // command failed exception or returned an error, and that the value of the
+        // 'errorCodeName' field matches the 'codeName' in the server error response."
+        if (op["result"]["errorCodeName"]) {
+            REQUIRE(exception);
+            REQUIRE(server_error);
+            uint32_t expected =
+                error_code_from_name(op["result"]["errorCodeName"].get_utf8().value);
+            REQUIRE(exception->code().value() == static_cast<int>(expected));
+        }
+
+        // "If the result document has an 'errorLabelsContain' field, [...] Verify that all of
+        // the error labels in 'errorLabelsContain' are present"
+        if (op["result"]["errorLabelsContain"]) {
+            REQUIRE(exception);
+            for (auto&& label_el : op["result"]["errorLabelsContain"].get_array().value) {
+                auto label = label_el.get_utf8().value;
+                if (!exception->has_error_label(label)) {
+                    FAIL("Expected exception to contain the label '" << label
+                                                                     << "' but it did not.\n");
+                }
+            }
+        }
+
+        // "If the result document has an 'errorLabelsOmit' field, [...] Verify that none of the
+        // error labels in 'errorLabelsOmit' are present."
+        if (op["result"]["errorLabelsOmit"]) {
+            REQUIRE(exception);
+            for (auto&& label_el : op["result"]["errorLabelsOmit"].get_array().value) {
+                auto label = label_el.get_utf8().value;
+                if (exception->has_error_label(label)) {
+                    FAIL("Expected exception to NOT contain the label '" << label
+                                                                         << "' but it did.\n");
+                }
+            }
+        }
+
+        // "If the operation returns a raw command response, eg from runCommand, then compare
+        // only the fields present in the expected result document. Otherwise, compare the
+        // method's return value to result using the same logic as the CRUD Spec Tests runner."
+        if (!exception && op["result"]) {
+            REQUIRE(actual_result);
+            REQUIRE(actual_result->view()["result"]);
+            INFO("actual result" << bsoncxx::to_json(actual_result->view()));
+            INFO("expected result" << bsoncxx::to_json(op.get_document().value));
+            REQUIRE(test_util::matches(actual_result->view()["result"].get_value(),
+                                       op["result"].get_value()));
+        }
+
+        // If we are running inside with_transaction, we need to rethrow what we caught.
+        if (throw_on_error && exception) {
+            throw operation_exception(ec, std::move(*server_error), error_msg);
+        }
+    }
+}
+
+void run_transactions_tests_in_file(const std::string& test_path) {
+    INFO("Test path: " << test_path);
+    auto test_spec = test_util::parse_test_file(test_path);
+    REQUIRE(test_spec);
+    auto test_spec_view = test_spec->view();
+    auto db_name = test_spec_view["database_name"].get_utf8().value;
+    auto coll_name = test_spec_view["collection_name"].get_utf8().value;
+    auto tests = test_spec_view["tests"].get_array().value;
+
+    /* we may not have a supported topology */
+    if (should_skip_spec_test(client{uri{}}, test_spec_view)) {
+        WARN("File skipped - " + test_path);
+        return;
+    }
+
+    for (auto&& test : tests) {
+        bool fail_point_enabled = (bool)test["failPoint"];
+        auto description = test["description"].get_utf8().value;
+        INFO("Test description: " << description);
+        if (should_skip_spec_test(client{uri{}}, test.get_document().value)) {
+            continue;
+        }
+
+        // Steps 1-6.
+        test_setup(test.get_document().value, test_spec_view);
+
+        // Step 7. "Create a new MongoClient client, with Command Monitoring listeners enabled."
+        options::client client_opts;
+        apm_checker apm_checker;
+        client_opts.apm_opts(apm_checker.get_apm_opts(true /* command_started_events_only */));
+        client client;
+        if (test["useMultipleMongoses"]) {
+            client = {uri{"mongodb://localhost:27017,localhost:27018"}, client_opts};
+        } else {
+            client = {get_uri(test.get_document().value), client_opts};
+        }
+
+        /* individual test may contain a skipReason */
+        if (should_skip_spec_test(client, test.get_document())) {
+            continue;
+        }
+
+        options::client_session session0_opts;
+        options::client_session session1_opts;
+
+        // Step 8: "Call client.startSession twice to create ClientSession objects"
+        if (test["sessionOptions"] && test["sessionOptions"]["session0"]) {
+            parse_session_opts(test["sessionOptions"]["session0"].get_document().value,
+                               &session0_opts);
+        }
+        if (test["sessionOptions"] && test["sessionOptions"]["session1"]) {
+            parse_session_opts(test["sessionOptions"]["session1"].get_document().value,
+                               &session1_opts);
+        }
+
+        document::value session_lsid0{{}};
+        document::value session_lsid1{{}};
+
+        // We wrap this section in its own scope as a way to control when the client_session
+        // objects created inside get destroyed. On destruction, client_sessions can send
+        // an abortTransaction that some of the spec tests look for.
+
+        {
+            client_session session0 = client.start_session(session0_opts);
+            client_session session1 = client.start_session(session1_opts);
+            session_lsid0.reset(session0.id());
+            session_lsid1.reset(session1.id());
+
+            // Step 9. Perform the operations.
+            apm_checker.clear();
+
+            run_transaction_operations(test.get_document().value,
+                                       &client,
+                                       db_name,
+                                       coll_name,
+                                       &session0,
+                                       &session1,
+                                       &fail_point_enabled);
+
+            // Step 10. "Call session0.endSession() and session1.endSession." (done in destructors).
+        }
+
+        // Step 11. Compare APM events.
+        test_util::match_visitor visitor = [&](
+            bsoncxx::stdx::string_view key,
+            bsoncxx::stdx::optional<bsoncxx::types::bson_value::view> main,
+            bsoncxx::types::bson_value::view pattern) {
+            if (key.compare("lsid") == 0) {
+                REQUIRE(pattern.type() == type::k_utf8);
+                REQUIRE(main);
+                REQUIRE(main->type() == type::k_document);
+                auto session_name = pattern.get_utf8().value;
+                if (session_name.compare("session0") == 0) {
+                    REQUIRE(test_util::matches(session_lsid0, main->get_document().value));
+                } else {
+                    REQUIRE(test_util::matches(session_lsid1, main->get_document().value));
+                }
+                return test_util::match_action::k_skip;
+            } else if (pattern.type() == type::k_null) {
+                if (main) {
+                    return test_util::match_action::k_not_equal;
+                }
+                return test_util::match_action::k_skip;
+            }
+            return test_util::match_action::k_skip;
+        };
+
+        if (test["expectations"]) {
+            apm_checker.compare(test["expectations"].get_array().value, false, visitor);
+        }
+
+        // Step 12. Disable the failpoint.
+        if (fail_point_enabled) {
+            disable_fail_point("mongodb://localhost:27017", client_opts);
+            if (test["useMultipleMongoses"]) {
+                disable_fail_point("mongodb://localhost:27018", client_opts);
+            }
+        }
+
+        // Step 13. Compare the collection outcomes
+        if (test["outcome"] && test["outcome"]["collection"]) {
+            auto outcome_coll_name = coll_name;
+            if (test["outcome"]["collection"]["name"]) {
+                outcome_coll_name = test["outcome"]["collection"]["name"].get_utf8().value;
+            }
+            auto coll = client[db_name][outcome_coll_name];
+            test_util::check_outcome_collection(&coll,
+                                                test["outcome"]["collection"].get_document().value);
+        }
+    }
 }
 
 }  // namespace spec

--- a/src/mongocxx/test/spec/util.hh
+++ b/src/mongocxx/test/spec/util.hh
@@ -100,6 +100,11 @@ using test_runner = std::function<void(const std::string& file)>;
 void run_tests_in_suite(std::string ev, test_runner cb, std::set<std::string> unsupported_tests);
 void run_tests_in_suite(std::string ev, test_runner cb);
 
+//
+// The transactions spec test runner, also used by other spec tests.
+//
+void run_transactions_tests_in_file(const std::string& test_path);
+
 }  // namespace spec
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx


### PR DESCRIPTION
- Reuse transaction spec runner for read/write concern integration tests.
- Allow empty read/write concern in spec tests.