### PR TITLE
CXX-1111 Remove std::iterator inheritance

### DIFF
--- a/src/bsoncxx/array/view.hpp
+++ b/src/bsoncxx/array/view.hpp
@@ -146,12 +146,17 @@ class BSONCXX_API view {
 /// This iterator type provides a const forward iterator interface to array
 /// view elements.
 ///
-class BSONCXX_API view::const_iterator : public std::iterator<std::forward_iterator_tag,
-                                                              element,
-                                                              std::ptrdiff_t,
-                                                              const element*,
-                                                              const element&> {
+class BSONCXX_API view::const_iterator {
    public:
+    ///
+    /// std::iterator_traits
+    ///
+    using value_type = element;
+    using reference = element&;
+    using pointer = element*;
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+
     const_iterator();
     explicit const_iterator(const element& element);
 

--- a/src/bsoncxx/document/view.hpp
+++ b/src/bsoncxx/document/view.hpp
@@ -150,12 +150,17 @@ class BSONCXX_API view {
 /// This iterator type provides a const forward iterator interface to document
 /// view elements.
 ///
-class BSONCXX_API view::const_iterator : public std::iterator<std::forward_iterator_tag,
-                                                              element,
-                                                              std::ptrdiff_t,
-                                                              const element*,
-                                                              const element&> {
+class BSONCXX_API view::const_iterator {
    public:
+    ///
+    /// std::iterator_traits
+    ///
+    using value_type = element;
+    using reference = element&;
+    using pointer = element*;
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+
     const_iterator();
     explicit const_iterator(const element& element);
 

--- a/src/mongocxx/cursor.hpp
+++ b/src/mongocxx/cursor.hpp
@@ -110,9 +110,17 @@ class MONGOCXX_API cursor {
 /// exhausted iterator so that it no longer compares equal to the
 /// end-iterator.
 ///
-class MONGOCXX_API cursor::iterator
-    : public std::iterator<std::input_iterator_tag, bsoncxx::document::view> {
+class MONGOCXX_API cursor::iterator {
    public:
+    ///
+    /// std::iterator_traits
+    ///
+    using value_type = bsoncxx::document::view;
+    using reference = bsoncxx::document::view&;
+    using pointer = bsoncxx::document::view*;
+    using iterator_category = std::input_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+
     ///
     /// Dereferences the view for the document currently being pointed to.
     ///


### PR DESCRIPTION
Directly specify std::iterator_traits fields in classes