### PR TITLE
CXX-2063 options::encrypt::key_id() takes a bson_value::view_or_value

### DIFF
--- a/src/bsoncxx/CMakeLists.txt
+++ b/src/bsoncxx/CMakeLists.txt
@@ -277,6 +277,7 @@ set_local_dist (src_bsoncxx_DIST_local
    types/bson_value/value.hpp
    types/bson_value/view.cpp
    types/bson_value/view.hpp
+   types/bson_value/view_or_value.hpp
    util/functor.hpp
    validate.cpp
    validate.hpp

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -49,7 +49,7 @@ class BSONCXX_API value {
     ///
     /// Create an owning copy of a bson_value::view.
     ///
-    value(const view&);
+    explicit value(const view&);
 
     ///
     /// Get a view over the bson_value owned by this object.

--- a/src/bsoncxx/types/bson_value/view.cpp
+++ b/src/bsoncxx/types/bson_value/view.cpp
@@ -41,6 +41,8 @@ BSONCXX_INLINE_NAMESPACE_BEGIN
 namespace types {
 namespace bson_value {
 
+view::view() noexcept : view(nullptr) {}
+
 // Boost doesn't mark the copy constructor and copy-assignment operator of string_ref as noexcept
 // so we can't rely on automatic noexcept propagation. It really is though, so it is OK.
 #if !defined(BSONCXX_POLY_USE_BOOST)
@@ -122,11 +124,17 @@ view::view(const std::uint8_t* raw,
     _init((void*)value);
 }
 
-view::view(void* internal_value) {
+view::view(void* internal_value) noexcept {
     _init(internal_value);
 }
 
-void view::_init(void* internal_value) {
+void view::_init(void* internal_value) noexcept {
+    if (!internal_value) {
+        _type = bsoncxx::type::k_null;
+        _b_null = bsoncxx::types::b_null{};
+        return;
+    }
+
     bson_value_t* v = (bson_value_t*)(internal_value);
     _type = static_cast<bsoncxx::type>(v->value_type);
 

--- a/src/bsoncxx/types/bson_value/view.hpp
+++ b/src/bsoncxx/types/bson_value/view.hpp
@@ -61,6 +61,12 @@ class BSONCXX_API view {
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
 
+    ///
+    /// Default constructs a bson_value::view. The resulting view will be initialized
+    /// to point at a bson_value of type k_null.
+    ///
+    view() noexcept;
+
     view(const view&) noexcept;
     view& operator=(const view&) noexcept;
 
@@ -259,9 +265,9 @@ class BSONCXX_API view {
     friend class bson_value::value;
 
     view(const std::uint8_t* raw, std::uint32_t length, std::uint32_t offset, std::uint32_t keylen);
-    view(void* internal_value);
+    view(void* internal_value) noexcept;
 
-    void _init(void* internal_value);
+    void _init(void* internal_value) noexcept;
 
     void BSONCXX_PRIVATE destroy() noexcept;
 

--- a/src/bsoncxx/types/bson_value/view_or_value.hpp
+++ b/src/bsoncxx/types/bson_value/view_or_value.hpp
@@ -1,0 +1,35 @@
+// Copyright 2020 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/types/bson_value/value.hpp>
+#include <bsoncxx/types/bson_value/view.hpp>
+#include <bsoncxx/view_or_value.hpp>
+
+#include <bsoncxx/config/prelude.hpp>
+
+namespace bsoncxx {
+BSONCXX_INLINE_NAMESPACE_BEGIN
+namespace types {
+namespace bson_value {
+
+using view_or_value = bsoncxx::view_or_value<bson_value::view, bson_value::value>;
+
+}  // namespace bson_value
+}  // namespace types
+BSONCXX_INLINE_NAMESPACE_END
+}  // namespace bsoncxx
+
+#include <bsoncxx/config/postlude.hpp>

--- a/src/mongocxx/options/encrypt.hpp
+++ b/src/mongocxx/options/encrypt.hpp
@@ -18,6 +18,7 @@
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types.hpp>
+#include <bsoncxx/types/bson_value/view_or_value.hpp>
 #include <mongocxx/stdx.hpp>
 
 namespace mongocxx {
@@ -36,15 +37,19 @@ class MONGOCXX_API encrypt {
     /// Sets the key to use for this encryption operation. A key id can be used instead
     /// of a key alt name.
     ///
+    /// If a non-owning bson_value::view is passed in as the key_id, the object that owns
+    /// key_id's memory must outlive this object.
+    ///
     /// @param key_id
-    ///   The id of the key to use for encryption, as a UUID (BSON binary subtype 4).
+    ///   The id of the key to use for encryption, as a bson_value containing a
+    ///   UUID (BSON binary subtype 4).
     ///
     /// @return
     ///   A reference to this object to facilitate method chaining.
     ///
     /// @see https://docs.mongodb.com/manual/core/security-client-side-encryption/
     ///
-    encrypt& key_id(bsoncxx::types::b_binary key_id);
+    encrypt& key_id(bsoncxx::types::bson_value::view_or_value key_id);
 
     ///
     /// Sets a name by which to lookup a key from the key vault collection to use
@@ -103,12 +108,19 @@ class MONGOCXX_API encrypt {
     ///
     const stdx::optional<encryption_algorithm>& algorithm() const;
 
+    ///
+    /// Gets the key_id.
+    ///
+    /// @return
+    ///   An optional owning bson_value containing the key_id.
+    ///
+    const stdx::optional<bsoncxx::types::bson_value::view_or_value>& key_id() const;
+
    private:
     friend class mongocxx::client_encryption;
     MONGOCXX_PRIVATE void* convert() const;
 
-    bool _key_id_set;
-    bsoncxx::types::b_binary _key_id;
+    stdx::optional<bsoncxx::types::bson_value::view_or_value> _key_id;
     stdx::optional<std::string> _key_alt_name;
     stdx::optional<encryption_algorithm> _algorithm;
 };

--- a/src/mongocxx/test/client_side_encryption.cpp
+++ b/src/mongocxx/test/client_side_encryption.cpp
@@ -202,7 +202,7 @@ void run_datakey_and_double_encryption(Callable create_data_key,
 
     options::encrypt opts{};
     opts.algorithm(options::encrypt::encryption_algorithm::k_deterministic);
-    opts.key_id(datakey_id.view().get_binary());
+    opts.key_id(std::move(datakey_id));
 
     auto encrypted_val = client_encryption->encrypt(to_encrypt["v"].get_value(), opts);
 


### PR DESCRIPTION
- implement bson_value::view_or_value
- change options::encrypt::key_id() to take a bson_value::view_or_value

In our original discussion of this, we talked about changing this method to take a bson_value::value, to avoid creating tricky lifetime semantics.  However, most of our options that take documents take a document::view_or_value.  This allows the user to decide whether to give the options class ownership (by std::move-ing in a document::value) or to intentionally pass in a view and manage the lifetime themselves.  I think this is the most consistent and flexible approach for bson_value, too.