### PR TITLE
(Debian packaging) remove archive generation workaround

### DIFF
--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -19,8 +19,6 @@ prebuild = bash -c "
     # Create upstream tarball from reference, exclude items that do not belong
     pushd $GBP_GIT_DIR/.. &&
     ls -1 &&
-    # TODO: remove this line and the next after the first time the change is pushed
-    echo '/.* !export-ignore' >$GBP_GIT_DIR/info/attributes &&
     git archive --format=tar --prefix=mongo-cxx-driver-\${upstream_version}/ \${archive_ref} | tar -f - --delete mongo-cxx-driver-\${upstream_version}/debian \$js_filter_files | gzip > $GBP_BUILD_DIR/../mongo-cxx-driver_\${upstream_version}.orig.tar.gz &&
     popd &&
     rm -rf \$js_rm_files"


### PR DESCRIPTION
This removes the one-line workaround we needed for the first waterfall build of the `debian-package-build` task.  It is now absolute.

Patch build: https://spruce.mongodb.com/version/5f0852bcd1fe076124055e41/tasks

(Note that the patch build title mentions CXX-1739, but the `debian-package-build` task in that build reflects the change in this PR.)