### PR TITLE
CXX-1855 add tutorial and example for client-side encryption

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -317,6 +317,9 @@ functions:
                       EXAMPLES=$(find examples -type f | sort | perl -nlwe 'print if -x')
                       for test in $EXAMPLES; do
                         case "$test" in
+                          *encryption*)
+                            echo "Skipping client side encryption example"
+                            ;;
                           *change_stream*)
                             echo "TODO CXX-1201, enable for servers that support change streams"
                             ;;

--- a/docs/content/mongocxx-v3/client-side-encryption.md
+++ b/docs/content/mongocxx-v3/client-side-encryption.md
@@ -48,7 +48,7 @@ auto_encrypt_opts.extra_options({mongocryptd_options.view()});
 
 ### Automatic Client-Side Field Level Encryption
 
-Automatic client-side field level encryption is enabled by creating a `mongocxx::client` with the `auto_encryption_opts` option set to an instance of 'mongocxx::options::auto_encryption`. The following examples show how to set up automatic client-side field level encryption using the `mongocxx::client_encryption` class to create a new encryption data key.
+Automatic Client-Side Field Level Encryption is enabled by creating a `mongocxx::client` with the `auto_encryption_opts` option set to an instance of 'mongocxx::options::auto_encryption`. The following examples show how to set up automatic client-side field level encryption using the `mongocxx::client_encryption` class to create a new encryption data key.
 
 {{% note %}}
 Automatic client-side field level encryption requires MongoDB 4.2 enterprise or a MongoDB 4.2 Atlas cluster. The community version of the server supports automatic decryption as well as explicit client-side field level encryption.
@@ -138,7 +138,6 @@ class client client_encrypted {uri{}, std::move(client_opts)};
 ```
 
 Please see  [`examples/mongocxx/explicit_encryption_auto_decryption.cpp`](https://github.com/mongodb/mongo-cxx-driver/blob/master/examples/mongocxx/explicit_encryption_auto_decryption.cpp) for an example of using explicit encryption with automatic decryption.
-
 
 
 

--- a/docs/content/mongocxx-v3/client-side-encryption.md
+++ b/docs/content/mongocxx-v3/client-side-encryption.md
@@ -71,7 +71,7 @@ JSON Schemas supplied in the `schema_map` only apply to configuring automatic cl
 //         "bsonType" : "object",
 //         "properties" : {
 //            "encryptedFieldName" : {
-//               "encryptField" : {
+//               "encrypt" : {
 //                  "keyId" : [ <datakey as UUID> ],
 //                  "bsonType" : "string",
 //                  "algorithm" : <algorithm>
@@ -138,7 +138,6 @@ class client client_encrypted {uri{}, std::move(client_opts)};
 ```
 
 Please see  [`examples/mongocxx/explicit_encryption_auto_decryption.cpp`](https://github.com/mongodb/mongo-cxx-driver/blob/master/examples/mongocxx/explicit_encryption_auto_decryption.cpp) for an example of using explicit encryption with automatic decryption.
-
 
 
 

--- a/docs/content/mongocxx-v3/client-side-encryption.md
+++ b/docs/content/mongocxx-v3/client-side-encryption.md
@@ -71,7 +71,11 @@ JSON Schemas supplied in the `schema_map` only apply to configuring automatic cl
 //         "bsonType" : "object",
 //         "properties" : {
 //            "encryptedFieldName" : {
+<<<<<<< HEAD
 //               "encrypt" : {
+=======
+//               "encryptField" : {
+>>>>>>> CXX-1855 add tutorial and example for client-side encryption
 //                  "keyId" : [ <datakey as UUID> ],
 //                  "bsonType" : "string",
 //                  "algorithm" : <algorithm>
@@ -141,3 +145,8 @@ Please see  [`examples/mongocxx/explicit_encryption_auto_decryption.cpp`](https:
 
 
 
+<<<<<<< HEAD
+=======
+
+
+>>>>>>> CXX-1855 add tutorial and example for client-side encryption

--- a/docs/content/mongocxx-v3/client-side-encryption.md
+++ b/docs/content/mongocxx-v3/client-side-encryption.md
@@ -1,0 +1,145 @@
++++
+title = "Client-Side Field Level Encryption with mongocxx"
+[menu.main]
+  identifier = 'mongocxx-cse'
+  weight = 11
+  parent='mongocxx3'
++++
+
+## Client-Side Field Level Encryption
+
+New in MongoDB 4.2 [Client-Side Field Level Encryption (CSFLE)](https://docs.mongodb.com/drivers/use-cases/client-side-field-level-encryption-guide) allows administrators and developers to encrypt specific data fields in addition to other MongoDB encryption features.
+
+With CSFLE, developers can encrypt fields client side without any server-side configuration or directives. Client-Side Field Level Encryption supports workloads where applications must guarantee that unauthorized parties, including server administrators, cannot read the encrypted data.
+
+For an overview of CSFLE, please read [the official MongoDB documentation in the manual](https://docs.mongodb.com/manual/core/security-client-side-encryption/).
+
+## Installation
+
+### libmongocrypt
+
+Client-Side Field Level Encryption relies on a C library called `libmongocrypt` to do the heavy lifting encryption work. This dependency is managed by the C driver.  As long as the C driver installation is 1.16.0 or higher, and has been compiled with Client-Side Field Level Encryption support, this dependency should be managed internally.  See the C driver's [Using Client-Side Field Level Encryption](http://mongoc.org/libmongoc/current/using_client_side_encryption.html) for more information.
+
+### mongocryptd
+
+Automatic CSFLE relies upon a new binary called `mongocryptd` running as a daemon while the driver operates.  This binary is only available with MongoDB Enterprise.
+
+`mongocryptd` can either be started separately from the driver, or left to spawn automatically when encryption is used.
+
+To run mongocryptd separately, pass the `mongocryptdBypassSpawn` flag to the client's auto encryption options:
+
+```c++
+auto mongocryptd_options = make_document(kvp("mongocryptdBypassSpawn", true));
+
+options::auto_encryption auto_encrypt_opts{};
+auto_encrypt_opts.extra_options({mongocryptd_options.view()});
+```
+
+If the mongocryptd binary is on the current path, the driver will be able to spawn it without any custom flags.  However, if the mongocryptd binary is on a different path, set the path with the `mongocryptdSpawnPath` option:
+
+```c++
+auto mongocryptd_options = make_document(kvp("mongocryptdSpawnPath", "path/to/mongocryptd"));
+
+options::auto_encryption auto_encrypt_opts{};
+auto_encrypt_opts.extra_options({mongocryptd_options.view()});
+```
+
+## Examples
+
+### Automatic Client-Side Field Level Encryption
+
+Automatic client-side field level encryption is enabled by creating a `mongocxx::client` with the `auto_encryption_opts` option set to an instance of 'mongocxx::options::auto_encryption`. The following examples show how to set up automatic client-side field level encryption using the `mongocxx::client_encryption` class to create a new encryption data key.
+
+{{% note %}}
+Automatic client-side field level encryption requires MongoDB 4.2 enterprise or a MongoDB 4.2 Atlas cluster. The community version of the server supports automatic decryption as well as explicit client-side field level encryption.
+{{% /note %}}
+
+### Providing Local Automatic Encryption Rules
+
+The following example shows how to specify automatic encryption rules via the schema_map option. The automatic encryption rules are expressed using a [strict subset of the JSON Schema syntax](https://docs.mongodb.com/manual/reference/security-client-side-automatic-json-schema/).
+
+Supplying a `schema_map` provides more security than relying on JSON Schemas obtained from the server. It protects against a malicious server advertising a false JSON Schema, which could trick the client into sending unencrypted data that should be encrypted.
+
+JSON Schemas supplied in the `schema_map` only apply to configuring automatic client-side field level encryption. Other validation rules in the JSON schema will not be enforced by the driver and will result in an error.
+
+```c++
+//
+// The schema map has the following form:
+//
+//   {
+//      "test.coll" : {
+//         "bsonType" : "object",
+//         "properties" : {
+//            "encryptedFieldName" : {
+//               "encryptField" : {
+//                  "keyId" : [ <datakey as UUID> ],
+//                  "bsonType" : "string",
+//                  "algorithm" : <algorithm>
+//               }
+//            }
+//         }
+//      }
+//   }
+//
+```
+
+Please see [`examples/mongocxx/automatic_client_side_field_level_encryption.cpp`](https://github.com/mongodb/mongo-cxx-driver/blob/master/examples/mongocxx/automatic_client_side_field_level_encryption.cpp) for a full example of how to set a json schema for automatic encryption.
+
+### Server-Side Field Level Encryption Enforcement
+
+The MongoDB 4.2 server supports using schema validation to enforce encryption of specific fields in a collection. This schema validation will prevent an application from inserting unencrypted values for any fields marked with the `"encrypt"` JSON schema keyword.
+
+It is possible to set up automatic client-side field level encryption using the `mongocxx::client_encryption` to create a new encryption data key and create a collection with the [Automatic Encryption JSON Schema Syntax](https://docs.mongodb.com/manual/reference/security-client-side-automatic-json-schema/).
+
+```c++
+// Please see the linked example below for full json_schema construction.
+bsoncxx::document::value json_schema{};
+
+// Create the collection with the encryption JSON Schema.
+auto cmd = document{} << "create"
+                      << "coll"
+                      << "validator" << open_document
+		      << "$jsonSchema" << json_schema.view()
+                      << close_document << finalize;
+
+db.run_command(cmd.view());
+```
+
+Please see [`examples/mongocxx/server_side_field_level_encryption_enforcement.cpp`](https://github.com/mongodb/mongo-cxx-driver/blob/master/examples/mongocxx/server_side_field_level_encryption_enforcement.cpp) for a full example of setting encryption enforcement on the server.
+
+### Explicit Encryption
+
+Explicit encryption is a MongoDB community feature and does not use the `mongocryptd` process. Explicit encryption is provided by the `mongocxx::client_encryption` class.
+
+```c++
+// Explicitly encrypt a BSON value.
+auto to_encrypt = bsoncxx::types::bson_value::make_value("secret message");
+auto encrypted_message = client_encryption.encrypt(to_encrypt, encrypt_opts);
+
+// Explicitly decrypt a BSON value.
+auto decrypted_message = client_encryption.decrypt(encrypted_message);
+```
+
+Please see [`examples/mongocxx/explicit_encryption.cpp`](https://github.com/mongodb/mongo-cxx-driver/blob/master/examples/mongocxx/explicit_encryption.cpp) for a full example of using explicit encryption and decryption.
+
+### Explicit Encryption with Automatic Decryption
+
+Although automatic encryption requires MongoDB 4.2 enterprise or a MongoDB 4.2 Atlas cluster, automatic decryption is supported for all users. To configure automatic decryption without automatic encryption, set `bypass_auto_encryption=True` in the `options::auto_encryption` class.
+
+```c++
+options::auto_encryption auto_encrypt_opts{};
+auto_encrypt_opts.bypass_auto_encryption(true);
+// Please see full example for complete options construction.
+
+// Create a client with automatic decryption enabled, but automatic encryption bypassed.
+options::client client_opts{};
+client_opts.auto_encryption_opts(std::move(auto_encrypt_opts));
+class client client_encrypted {uri{}, std::move(client_opts)};
+```
+
+Please see  [`examples/mongocxx/explicit_encryption_auto_decryption.cpp`](https://github.com/mongodb/mongo-cxx-driver/blob/master/examples/mongocxx/explicit_encryption_auto_decryption.cpp) for an example of using explicit encryption with automatic decryption.
+
+
+
+
+

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -50,7 +50,7 @@ foreach(EXAMPLE ${MONGOCXX_EXAMPLE_EXECUTABLES})
         continue()
     endif()
 
-    # Don't run the FLCSE examples as part of the suite; needs mongocryptd running.
+    # Don't run the CSFLE examples as part of the suite; needs mongocryptd running.
     if (${EXAMPLE} MATCHES "encryption")
         continue()
     endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -50,6 +50,11 @@ foreach(EXAMPLE ${MONGOCXX_EXAMPLE_EXECUTABLES})
         continue()
     endif()
 
+    # Don't run the FLCSE examples as part of the suite; needs mongocryptd running.
+    if (${EXAMPLE} MATCHES "encryption")
+        continue()
+    endif()
+
     add_custom_command(TARGET run-examples POST_BUILD COMMAND ${EXAMPLE})
 endforeach(EXAMPLE)
 

--- a/examples/mongocxx/CMakeLists.txt
+++ b/examples/mongocxx/CMakeLists.txt
@@ -19,6 +19,7 @@ include_directories(
 
 set(MONGOCXX_EXAMPLES
     aggregate.cpp
+    automatic_client_side_field_level_encryption.cpp
     bulk_write.cpp
     change_streams.cpp
     client_session.cpp
@@ -26,6 +27,8 @@ set(MONGOCXX_EXAMPLES
     create.cpp
     document_validation.cpp
     exception.cpp
+    explicit_encryption.cpp
+    explicit_encryption_auto_decryption.cpp
     get_values_from_documents.cpp
     gridfs.cpp
     index.cpp
@@ -39,6 +42,7 @@ set(MONGOCXX_EXAMPLES
     query_projection.cpp
     query.cpp
     remove.cpp
+    server_side_field_level_encryption_enforcement.cpp
     tailable_cursor.cpp
     update.cpp
     view_or_value_variant.cpp

--- a/examples/mongocxx/automatic_client_side_field_level_encryption.cpp
+++ b/examples/mongocxx/automatic_client_side_field_level_encryption.cpp
@@ -97,9 +97,8 @@ int main(int, char**) {
 
     // This must be the same master key that was used to create
     // the encryption key; here, we use a random key as a placeholder.
-    auto key_length = kKeyLength;
     char key_storage[kKeyLength];
-    std::generate_n(key_storage, key_length, std::rand);
+    std::generate_n(key_storage, kKeyLength, std::rand);
     bsoncxx::types::b_binary local_master_key{
         bsoncxx::binary_sub_type::k_binary, kKeyLength, (const uint8_t*)&key_storage};
 

--- a/examples/mongocxx/automatic_client_side_field_level_encryption.cpp
+++ b/examples/mongocxx/automatic_client_side_field_level_encryption.cpp
@@ -45,6 +45,8 @@ using bsoncxx::types::bson_value::make_value;
 
 using namespace mongocxx;
 
+const int kKeyLength = 96;
+
 using ns_pair = std::pair<std::string, std::string>;
 void create_json_schema_file(bsoncxx::document::view_or_value kms_providers,
                              ns_pair key_vault_ns,
@@ -95,11 +97,11 @@ int main(int, char**) {
 
     // This must be the same master key that was used to create
     // the encryption key; here, we use a random key as a placeholder.
-    auto key_length = 96;
-    char key_storage[96];
+    auto key_length = kKeyLength;
+    char key_storage[kKeyLength];
     std::generate_n(key_storage, key_length, std::rand);
     bsoncxx::types::b_binary local_master_key{
-        bsoncxx::binary_sub_type::k_binary, 96, (const uint8_t*)&key_storage};
+        bsoncxx::binary_sub_type::k_binary, kKeyLength, (const uint8_t*)&key_storage};
 
     auto kms_providers = document{} << "local" << open_document << "key" << local_master_key
                                     << close_document << finalize;

--- a/examples/mongocxx/automatic_client_side_field_level_encryption.cpp
+++ b/examples/mongocxx/automatic_client_side_field_level_encryption.cpp
@@ -1,0 +1,159 @@
+// Copyright 2020-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <random>
+
+#include <bsoncxx/builder/basic/document.hpp>
+#include <bsoncxx/builder/basic/kvp.hpp>
+#include <bsoncxx/builder/stream/document.hpp>
+#include <bsoncxx/builder/stream/helpers.hpp>
+#include <bsoncxx/json.hpp>
+#include <bsoncxx/types/bson_value/make_value.hpp>
+#include <mongocxx/client.hpp>
+#include <mongocxx/client_encryption.hpp>
+#include <mongocxx/instance.hpp>
+#include <mongocxx/options/auto_encryption.hpp>
+#include <mongocxx/options/client.hpp>
+#include <mongocxx/options/data_key.hpp>
+#include <mongocxx/options/encrypt.hpp>
+
+using bsoncxx::builder::basic::make_document;
+using bsoncxx::builder::basic::kvp;
+
+using bsoncxx::builder::stream::document;
+using bsoncxx::builder::stream::open_array;
+using bsoncxx::builder::stream::close_array;
+using bsoncxx::builder::stream::open_document;
+using bsoncxx::builder::stream::close_document;
+using bsoncxx::builder::stream::finalize;
+
+using bsoncxx::types::bson_value::make_value;
+
+using namespace mongocxx;
+
+using ns_pair = std::pair<std::string, std::string>;
+void create_json_schema_file(bsoncxx::document::view_or_value kms_providers,
+                             ns_pair key_vault_ns,
+                             class client* key_vault_client) {
+    options::client_encryption client_encryption_opts{};
+    client_encryption_opts.key_vault_namespace(std::move(key_vault_ns));
+    client_encryption_opts.kms_providers(kms_providers);
+    client_encryption_opts.key_vault_client(key_vault_client);
+
+    class client_encryption client_encryption {
+        std::move(client_encryption_opts)
+    };
+
+    // Create a new data key and json schema for the encryptedField.
+    auto data_key_id = client_encryption.create_data_key("local");
+
+    // Create a new json schema for the encryptedField.
+    auto json_schema = document{} << "properties" << open_document << "encryptedField"
+                                  << open_document << "encrypt" << open_document << "keyId"
+                                  << open_array << data_key_id << close_array << "bsonType"
+                                  << "string"
+                                  << "algorithm"
+                                  << "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic" << close_document
+                                  << close_document << close_document << "bsonType"
+                                  << "object" << finalize;
+
+    // Write to a file.
+    std::ofstream schema_file;
+    schema_file.open("jsonSchema.json");
+    schema_file << bsoncxx::to_json(json_schema);
+    schema_file.close();
+}
+
+bsoncxx::document::value doc_from_file(std::string path) {
+    std::ifstream file{path};
+    if (!file) {
+        throw std::runtime_error("could not open file");
+    }
+
+    std::string file_contents((std::istreambuf_iterator<char>(file)),
+                              std::istreambuf_iterator<char>());
+
+    return bsoncxx::from_json(file_contents);
+}
+
+int main(int, char**) {
+    instance inst{};
+
+    // This must be the same master key that was used to create
+    // the encryption key; here, we use a random key as a placeholder.
+    auto key_length = 96;
+    char key_storage[96];
+    std::generate_n(key_storage, key_length, std::rand);
+    bsoncxx::types::b_binary local_master_key{
+        bsoncxx::binary_sub_type::k_binary, 96, (const uint8_t*)&key_storage};
+
+    auto kms_providers = document{} << "local" << open_document << "key" << local_master_key
+                                    << close_document << finalize;
+
+    // The MongoClient used to access the key vault.
+    class client key_vault_client {
+        uri {}
+    };
+    auto key_vault = key_vault_client["keyvault"]["datakeys"];
+
+    // Ensure that two data keys cannot share the same keyAltName by adding
+    // a unique index on this field.
+    key_vault.drop();
+
+    mongocxx::options::index index_options{};
+    index_options.unique(true);
+    auto expression = document{} << "keyAltNames" << open_document << "$exists" << true
+                                 << close_document << finalize;
+    index_options.partial_filter_expression(expression.view());
+    key_vault.create_index(make_document(kvp("keyAltNames", 1)), index_options);
+
+    create_json_schema_file(kms_providers.view(), {"keyvault", "datakeys"}, &key_vault_client);
+
+    // Load the JSON Schema and construct the local schema_map option.
+    auto json_schema = doc_from_file("jsonSchema.json");
+    auto schema_map = make_document(kvp("test.coll", json_schema.view()));
+
+    options::auto_encryption auto_encrypt_opts{};
+    auto_encrypt_opts.kms_providers(kms_providers.view());
+    auto_encrypt_opts.key_vault_namespace({"keyvault", "datakeys"});
+    auto_encrypt_opts.schema_map({schema_map.view()});
+
+    options::client client_opts;
+    client_opts.auto_encryption_opts(std::move(auto_encrypt_opts));
+    class client client {
+        uri{}, std::move(client_opts)
+    };
+
+    auto coll = client["test"]["coll"];
+
+    // Clear old data
+    coll.drop();
+
+    coll.insert_one(make_document(kvp("encryptedField", "123456789")));
+
+    auto res = coll.find_one({});
+    std::cout << "\nDocument retrieved with auto-encrypted client:\n"
+              << bsoncxx::to_json(*res) << std::endl;
+
+    class client unencrypted_client {
+        uri {}
+    };
+    auto unencrypted_coll = unencrypted_client["test"]["coll"];
+    auto res2 = unencrypted_coll.find_one({});
+    std::cout << "\nDocument retrieved with unencrypted client:\n"
+              << bsoncxx::to_json(*res2) << std::endl;
+}

--- a/examples/mongocxx/explicit_encryption.cpp
+++ b/examples/mongocxx/explicit_encryption.cpp
@@ -42,16 +42,17 @@ using bsoncxx::types::bson_value::make_value;
 
 using namespace mongocxx;
 
+const int kKeyLength = 96;
+
 int main(int, char**) {
     instance inst{};
 
     // This must be the same master key that was used to create
     // the encryption key; here, we use a random key as a placeholder.
-    auto key_length = 96;
-    char key_storage[96];
-    std::generate_n(key_storage, key_length, std::rand);
+    char key_storage[kKeyLength];
+    std::generate_n(key_storage, kKeyLength, std::rand);
     bsoncxx::types::b_binary local_master_key{
-        bsoncxx::binary_sub_type::k_binary, 96, (const uint8_t*)&key_storage};
+        bsoncxx::binary_sub_type::k_binary, kKeyLength, (const uint8_t*)&key_storage};
 
     auto kms_providers = document{} << "local" << open_document << "key" << local_master_key
                                     << close_document << finalize;
@@ -107,6 +108,6 @@ int main(int, char**) {
     // Explicitly decrypt the field:
     auto encrypted_message_retrieved = res->view()["encryptedField"].get_value();
     auto decrypted_message = client_encryption.decrypt(encrypted_message_retrieved);
-    std::cout << "Explicitly decrypted message: " << decrypted_message.view().get_utf8().value
+    std::cout << "Explicitly decrypted message: " << decrypted_message.view().get_string().value
               << std::endl;
 }

--- a/examples/mongocxx/explicit_encryption.cpp
+++ b/examples/mongocxx/explicit_encryption.cpp
@@ -1,0 +1,112 @@
+// Copyright 2020-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <iostream>
+#include <random>
+
+#include <bsoncxx/builder/basic/document.hpp>
+#include <bsoncxx/builder/basic/kvp.hpp>
+#include <bsoncxx/builder/stream/document.hpp>
+#include <bsoncxx/builder/stream/helpers.hpp>
+#include <bsoncxx/json.hpp>
+#include <bsoncxx/types/bson_value/make_value.hpp>
+#include <mongocxx/client.hpp>
+#include <mongocxx/client_encryption.hpp>
+#include <mongocxx/instance.hpp>
+#include <mongocxx/options/auto_encryption.hpp>
+#include <mongocxx/options/client.hpp>
+#include <mongocxx/options/data_key.hpp>
+#include <mongocxx/options/encrypt.hpp>
+
+using bsoncxx::builder::basic::make_document;
+using bsoncxx::builder::basic::kvp;
+
+using bsoncxx::builder::stream::document;
+using bsoncxx::builder::stream::open_document;
+using bsoncxx::builder::stream::close_document;
+using bsoncxx::builder::stream::finalize;
+
+using bsoncxx::types::bson_value::make_value;
+
+using namespace mongocxx;
+
+int main(int, char**) {
+    instance inst{};
+
+    // This must be the same master key that was used to create
+    // the encryption key; here, we use a random key as a placeholder.
+    auto key_length = 96;
+    char key_storage[96];
+    std::generate_n(key_storage, key_length, std::rand);
+    bsoncxx::types::b_binary local_master_key{
+        bsoncxx::binary_sub_type::k_binary, 96, (const uint8_t*)&key_storage};
+
+    auto kms_providers = document{} << "local" << open_document << "key" << local_master_key
+                                    << close_document << finalize;
+
+    // Create an unencrypted mongocxx::client.
+    class client client {
+        uri {}
+    };
+    auto coll = client["test"]["coll"];
+
+    // Clear old data.
+    coll.drop();
+
+    // Set up the key vault for this example.
+    auto key_vault = client["keyvault"]["datakeys"];
+
+    // Ensure that two data keys cannot share the same keyAltName by adding
+    // a unique index on this field.
+    key_vault.drop();
+
+    mongocxx::options::index index_options{};
+    index_options.unique(true);
+    auto expression = document{} << "keyAltNames" << open_document << "$exists" << true
+                                 << close_document << finalize;
+    index_options.partial_filter_expression(expression.view());
+    key_vault.create_index(make_document(kvp("keyAltNames", 1)), index_options);
+
+    // Set up our client_encryption
+    options::client_encryption client_encryption_opts{};
+    client_encryption_opts.key_vault_namespace({"keyvault", "datakeys"});
+    client_encryption_opts.kms_providers(kms_providers.view());
+    client_encryption_opts.key_vault_client(&client);
+
+    class client_encryption client_encryption(std::move(client_encryption_opts));
+
+    // Create a new data key for the encryptedField.
+    auto data_key_id = client_encryption.create_data_key("local");
+
+    // Explicitly encrypt a field:
+    options::encrypt encrypt_opts{};
+    encrypt_opts.key_id(data_key_id.view());
+    encrypt_opts.algorithm(options::encrypt::encryption_algorithm::k_deterministic);
+
+    auto to_encrypt = make_value("secret message");
+    auto encrypted_message = client_encryption.encrypt(to_encrypt, encrypt_opts);
+
+    coll.insert_one(make_document(kvp("encryptedField", encrypted_message)));
+
+    // Automatically decrypts any encrypted fields.
+    auto res = coll.find_one({});
+    std::cout << "Explicitly encrypted document: " << bsoncxx::to_json(*res) << std::endl;
+
+    // Explicitly decrypt the field:
+    auto encrypted_message_retrieved = res->view()["encryptedField"].get_value();
+    auto decrypted_message = client_encryption.decrypt(encrypted_message_retrieved);
+    std::cout << "Explicitly decrypted message: " << decrypted_message.view().get_utf8().value
+              << std::endl;
+}

--- a/examples/mongocxx/explicit_encryption_auto_decryption.cpp
+++ b/examples/mongocxx/explicit_encryption_auto_decryption.cpp
@@ -42,16 +42,17 @@ using bsoncxx::types::bson_value::make_value;
 
 using namespace mongocxx;
 
+const int kKeyLength = 96;
+
 int main(int, char**) {
     instance inst{};
 
     // This must be the same master key that was used to create
     // the encryption key; here, we use a random key as a placeholder.
-    auto key_length = 96;
-    char key_storage[96];
-    std::generate_n(key_storage, key_length, std::rand);
+    char key_storage[kKeyLength];
+    std::generate_n(key_storage, kKeyLength, std::rand);
     bsoncxx::types::b_binary local_master_key{
-        bsoncxx::binary_sub_type::k_binary, 96, (const uint8_t*)&key_storage};
+        bsoncxx::binary_sub_type::k_binary, kKeyLength, (const uint8_t*)&key_storage};
 
     auto kms_providers = document{} << "local" << open_document << "key" << local_master_key
                                     << close_document << finalize;

--- a/examples/mongocxx/explicit_encryption_auto_decryption.cpp
+++ b/examples/mongocxx/explicit_encryption_auto_decryption.cpp
@@ -1,0 +1,123 @@
+// Copyright 2020-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <iostream>
+#include <random>
+
+#include <bsoncxx/builder/basic/document.hpp>
+#include <bsoncxx/builder/basic/kvp.hpp>
+#include <bsoncxx/builder/stream/document.hpp>
+#include <bsoncxx/builder/stream/helpers.hpp>
+#include <bsoncxx/json.hpp>
+#include <bsoncxx/types/bson_value/make_value.hpp>
+#include <mongocxx/client.hpp>
+#include <mongocxx/client_encryption.hpp>
+#include <mongocxx/instance.hpp>
+#include <mongocxx/options/auto_encryption.hpp>
+#include <mongocxx/options/client.hpp>
+#include <mongocxx/options/data_key.hpp>
+#include <mongocxx/options/encrypt.hpp>
+
+using bsoncxx::builder::basic::make_document;
+using bsoncxx::builder::basic::kvp;
+
+using bsoncxx::builder::stream::document;
+using bsoncxx::builder::stream::open_document;
+using bsoncxx::builder::stream::close_document;
+using bsoncxx::builder::stream::finalize;
+
+using bsoncxx::types::bson_value::make_value;
+
+using namespace mongocxx;
+
+int main(int, char**) {
+    instance inst{};
+
+    // This must be the same master key that was used to create
+    // the encryption key; here, we use a random key as a placeholder.
+    auto key_length = 96;
+    char key_storage[96];
+    std::generate_n(key_storage, key_length, std::rand);
+    bsoncxx::types::b_binary local_master_key{
+        bsoncxx::binary_sub_type::k_binary, 96, (const uint8_t*)&key_storage};
+
+    auto kms_providers = document{} << "local" << open_document << "key" << local_master_key
+                                    << close_document << finalize;
+
+    // Setting bypass_auto_encryption to "true" on the options::auto_encryption
+    // class will disable automatic encryption but keeps the automatic decryption
+    // behavior.  This will also disable spawning mongocryptd.
+    options::auto_encryption auto_encrypt_opts{};
+    auto_encrypt_opts.bypass_auto_encryption(true);
+    auto_encrypt_opts.kms_providers(kms_providers.view());
+    auto_encrypt_opts.key_vault_namespace({"keyvault", "datakeys"});
+
+    options::client client_opts{};
+    client_opts.auto_encryption_opts(std::move(auto_encrypt_opts));
+    class client client_encrypted {
+        uri{}, std::move(client_opts)
+    };
+
+    auto coll = client_encrypted["test"]["coll"];
+
+    // Clear old data.
+    coll.drop();
+
+    // Set up the key vault for this example.
+    auto key_vault = client_encrypted["keyvault"]["datakeys"];
+
+    // Ensure that two data keys cannot share the same keyAltName by adding
+    // a unique index on this field.
+    key_vault.drop();
+
+    mongocxx::options::index index_options{};
+    index_options.unique(true);
+    auto expression = document{} << "keyAltNames" << open_document << "$exists" << true
+                                 << close_document << finalize;
+    index_options.partial_filter_expression(expression.view());
+    key_vault.create_index(make_document(kvp("keyAltNames", 1)), index_options);
+
+    class client unencrypted_client {
+        uri {}
+    };
+
+    // Set up our client_encryption
+    options::client_encryption client_encryption_opts{};
+    client_encryption_opts.key_vault_namespace({"keyvault", "datakeys"});
+    client_encryption_opts.kms_providers(kms_providers.view());
+    client_encryption_opts.key_vault_client(&unencrypted_client);
+
+    class client_encryption client_encryption(std::move(client_encryption_opts));
+
+    // Create a new data key for the encryptedField.
+    auto data_key_id = client_encryption.create_data_key("local");
+
+    // Explicitly encrypt a field:
+    options::encrypt encrypt_opts{};
+    encrypt_opts.key_id(data_key_id.view());
+    encrypt_opts.algorithm(options::encrypt::encryption_algorithm::k_deterministic);
+
+    auto to_encrypt = make_value("secret message");
+    auto encrypted_message = client_encryption.encrypt(to_encrypt, encrypt_opts);
+
+    coll.insert_one(make_document(kvp("encryptedField", encrypted_message)));
+
+    // Automatically decrypts any encrypted fields.
+    auto res = coll.find_one({});
+    std::cout << "Decrypted document: " << bsoncxx::to_json(*res) << std::endl;
+
+    res = unencrypted_client["test"]["coll"].find_one({});
+    std::cout << "Encrypted document: " << bsoncxx::to_json(*res) << std::endl;
+}

--- a/examples/mongocxx/server_side_field_level_encryption_enforcement.cpp
+++ b/examples/mongocxx/server_side_field_level_encryption_enforcement.cpp
@@ -1,0 +1,148 @@
+// Copyright 2020-present MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <iostream>
+#include <random>
+
+#include <bsoncxx/builder/basic/document.hpp>
+#include <bsoncxx/builder/basic/kvp.hpp>
+#include <bsoncxx/builder/stream/document.hpp>
+#include <bsoncxx/builder/stream/helpers.hpp>
+#include <bsoncxx/json.hpp>
+#include <bsoncxx/types/bson_value/make_value.hpp>
+#include <mongocxx/client.hpp>
+#include <mongocxx/client_encryption.hpp>
+#include <mongocxx/instance.hpp>
+#include <mongocxx/options/auto_encryption.hpp>
+#include <mongocxx/options/client.hpp>
+#include <mongocxx/options/data_key.hpp>
+#include <mongocxx/options/encrypt.hpp>
+
+using bsoncxx::builder::basic::make_document;
+using bsoncxx::builder::basic::kvp;
+
+using bsoncxx::builder::stream::document;
+using bsoncxx::builder::stream::open_array;
+using bsoncxx::builder::stream::close_array;
+using bsoncxx::builder::stream::open_document;
+using bsoncxx::builder::stream::close_document;
+using bsoncxx::builder::stream::finalize;
+
+using bsoncxx::types::bson_value::make_value;
+
+using namespace mongocxx;
+
+int main(int, char**) {
+    instance inst{};
+
+    // This must be the same master key that was used to create
+    // the encryption key; here, we use a random key as a placeholder.
+    auto key_length = 96;
+    char key_storage[96];
+    std::generate_n(key_storage, key_length, std::rand);
+    bsoncxx::types::b_binary local_master_key{
+        bsoncxx::binary_sub_type::k_binary, 96, (const uint8_t*)&key_storage};
+
+    auto kms_providers = document{} << "local" << open_document << "key" << local_master_key
+                                    << close_document << finalize;
+
+    class client key_vault_client {
+        uri {}
+    };
+    auto key_vault = key_vault_client["keyvault"]["datakeys"];
+
+    // Ensure that two data keys cannot share the same keyAltName by adding
+    // a unique index on this field.
+    key_vault.drop();
+
+    mongocxx::options::index index_options{};
+    index_options.unique(true);
+    auto expression = document{} << "keyAltNames" << open_document << "$exists" << true
+                                 << close_document << finalize;
+    index_options.partial_filter_expression(expression.view());
+    key_vault.create_index(make_document(kvp("keyAltNames", 1)), index_options);
+
+    // Set up our client_encryption
+    options::client_encryption client_encryption_opts{};
+    client_encryption_opts.key_vault_namespace({"keyvault", "datakeys"});
+    client_encryption_opts.kms_providers(kms_providers.view());
+    client_encryption_opts.key_vault_client(&key_vault_client);
+
+    class client_encryption client_encryption(std::move(client_encryption_opts));
+
+    // Create a new data key for the encryptedField.
+    auto data_key_id = client_encryption.create_data_key("local");
+
+    // Create a new json schema for the encryptedField.
+    auto json_schema = document{} << "properties" << open_document << "encryptedField"
+                                  << open_document << "encrypt" << open_document << "keyId"
+                                  << open_array << data_key_id << close_array << "bsonType"
+                                  << "string"
+                                  << "algorithm"
+                                  << "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic" << close_document
+                                  << close_document << close_document << "bsonType"
+                                  << "object" << finalize;
+
+    // Set up auto encryption opts.
+    options::auto_encryption auto_encrypt_opts{};
+    auto_encrypt_opts.kms_providers(kms_providers.view());
+    auto_encrypt_opts.key_vault_namespace({"keyvault", "datakeys"});
+
+    // Create a client with auto encryption enabled.
+    options::client client_opts{};
+    client_opts.auto_encryption_opts(std::move(auto_encrypt_opts));
+    class client client {
+        uri{}, std::move(client_opts)
+    };
+
+    auto db = client["test"];
+
+    {
+        // Clear old data.
+        auto coll = db["coll"];
+        coll.drop();
+    }
+
+    // Create the collection with the encryption JSON Schema.
+    auto cmd = document{} << "create"
+                          << "coll"
+                          << "validator" << open_document << "$jsonSchema" << json_schema.view()
+                          << close_document << finalize;
+    db.run_command(cmd.view());
+
+    auto coll = db["coll"];
+
+    auto to_insert = make_document(kvp("encryptedField", "123456789"));
+    coll.insert_one(to_insert.view());
+
+    auto res = coll.find_one({});
+
+    std::cout << "Decrypted document: " << bsoncxx::to_json(*res) << std::endl;
+
+    class client unencrypted_client {
+        uri {}
+    };
+    res = unencrypted_client["test"]["coll"].find_one({});
+
+    std::cout << "Encrypted document: " << bsoncxx::to_json(*res) << std::endl;
+
+    try {
+        // Inserting via the unencrypted client fails, because the server
+        // requires that the encryptedField actually be encrypted.
+        unencrypted_client["test"]["coll"].insert_one(to_insert.view());
+    } catch (const std::exception& e) {
+        std::cout << "Unencrypted insert failed: " << e.what() << std::endl;
+    }
+}

--- a/examples/mongocxx/server_side_field_level_encryption_enforcement.cpp
+++ b/examples/mongocxx/server_side_field_level_encryption_enforcement.cpp
@@ -44,16 +44,17 @@ using bsoncxx::types::bson_value::make_value;
 
 using namespace mongocxx;
 
+const int kKeyLength = 96;
+
 int main(int, char**) {
     instance inst{};
 
     // This must be the same master key that was used to create
     // the encryption key; here, we use a random key as a placeholder.
-    auto key_length = 96;
-    char key_storage[96];
-    std::generate_n(key_storage, key_length, std::rand);
+    char key_storage[kKeyLength];
+    std::generate_n(key_storage, kKeyLength, std::rand);
     bsoncxx::types::b_binary local_master_key{
-        bsoncxx::binary_sub_type::k_binary, 96, (const uint8_t*)&key_storage};
+        bsoncxx::binary_sub_type::k_binary, kKeyLength, (const uint8_t*)&key_storage};
 
     auto kms_providers = document{} << "local" << open_document << "key" << local_master_key
                                     << close_document << finalize;


### PR DESCRIPTION
Adds a new example file and a new documentation file.  The example does not get run on evergreen.  In order to run it on evergreen we would need to capture and use the MONGOCRYPTD_PATH environment variable, and since that's pretty specific to our use case I thought it would feel clunky in the example.