### PR TITLE
CXX-1173 support integration via CMake add_subdirectory()

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -557,6 +557,28 @@ tasks:
             export INSTALL_VERSION=${mongocxx_version_finder_sh}
             cmd.exe /c .\\.evergreen\\uninstall_check_windows.cmd
 
+    - name: build_example_with_add_subdirectory
+      commands:
+      - func: "setup"
+      - func: "start_mongod"
+      - command: shell.exec
+        type: test
+        params:
+          working_dir: "mongo-cxx-driver"
+          shell: bash
+          script: |-
+            set -o errexit
+            set -o xtrace
+            . .evergreen/find_cmake.sh
+            cd examples/add_subdirectory
+            [ -d mongo-c-driver ] || git clone --depth 1 https://github.com/mongodb/mongo-c-driver
+            rsync -aq --exclude='examples/add_subdirectory' $(readlink -f ../..) .
+            [ -d build ] || mkdir build
+            cd build
+            $CMAKE -DCMAKE_VERBOSE_MAKEFILE=ON ..
+            $CMAKE --build . -- -j 8
+            ./hello_mongocxx
+
     - name: debian-package-build
       commands:
       - func: "setup"
@@ -698,6 +720,9 @@ buildvariants:
           - name: compile_and_test_with_shared_libs
           - name: compile_and_test_with_static_libs
           - name: compile_and_test_with_shared_libs_replica_set
+          - name: build_example_with_add_subdirectory
+            distros:
+            - ubuntu1804-build
           - name: uninstall_check
 
     - name: ubuntu1604-debug-std-experimental

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,18 +334,23 @@ add_custom_command (OUTPUT ${DIST_FILE}
       ${ALL_DIST} ${dist_generated_depends}
 )
 
-add_custom_target (dist DEPENDS ${DIST_FILE})
+if(NOT (TARGET bson_shared OR TARGET mongoc_shared))
+   # If these targets exist, then libbson/libmongoc have already been included
+   # as a project sub-directory; the 'dist' and 'distcheck' targets here would
+   # collide with those declared in the mongo-c-driver project
+   add_custom_target (dist DEPENDS ${DIST_FILE})
 
-add_custom_target (distcheck DEPENDS dist
-   COMMAND ${CMAKE_COMMAND}
-      -D CMAKE_MODULE_PATH=${PROJECT_SOURCE_DIR}/cmake/make_dist
-      -D CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
-      -D PACKAGE_PREFIX=${PACKAGE_PREFIX}
-      -D CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-      -P ${PROJECT_SOURCE_DIR}/cmake/make_dist/MakeDistCheck.cmake
-)
+   add_custom_target (distcheck DEPENDS dist
+      COMMAND ${CMAKE_COMMAND}
+         -D CMAKE_MODULE_PATH=${PROJECT_SOURCE_DIR}/cmake/make_dist
+         -D CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
+         -D PACKAGE_PREFIX=${PACKAGE_PREFIX}
+         -D CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+         -P ${PROJECT_SOURCE_DIR}/cmake/make_dist/MakeDistCheck.cmake
+   )
+endif()
 
-if(ENABLE_UNINSTALL)
+if(ENABLE_UNINSTALL AND NOT (TARGET bson_shared OR TARGET mongoc_shared))
     if(WIN32)
         set(UNINSTALL_PROG "uninstall.cmd")
     else()

--- a/cmake/BsoncxxUtil.cmake
+++ b/cmake/BsoncxxUtil.cmake
@@ -31,7 +31,12 @@ function(bsoncxx_add_library TARGET OUTPUT_NAME LINK_TYPE)
     if(BSONCXX_POLY_USE_MNMLSTC AND NOT BSONCXX_POLY_USE_SYSTEM_MNMLSTC)
         add_dependencies(${TARGET} EP_mnmlstc_core)
         ExternalProject_Get_Property(EP_mnmlstc_core source_dir)
-        target_include_directories(${TARGET} PUBLIC $<BUILD_INTERFACE:${source_dir}/include>)
+        target_include_directories(
+            ${TARGET}
+            PUBLIC
+                $<BUILD_INTERFACE:${source_dir}/include>
+                $<BUILD_INTERFACE:${CMAKE_INSTALL_PREFIX}/${BSONCXX_HEADER_INSTALL_DIR}>
+        )
       elseif(BSONCXX_POLY_USE_BOOST)
 	if (CMAKE_VERSION VERSION_LESS 3.15.0)
 	  target_include_directories(${TARGET} PUBLIC ${Boost_INCLUDE_DIRS})
@@ -42,6 +47,12 @@ function(bsoncxx_add_library TARGET OUTPUT_NAME LINK_TYPE)
 
     target_link_libraries(${TARGET} PRIVATE ${libbson_target})
     target_include_directories(${TARGET} PRIVATE ${libbson_include_directories})
+    target_include_directories(
+        ${TARGET}
+        PUBLIC
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/..>
+            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/..>
+    )
     target_compile_definitions(${TARGET} PRIVATE ${libbson_definitions})
 
     generate_export_header(${TARGET}

--- a/cmake/MongocxxUtil.cmake
+++ b/cmake/MongocxxUtil.cmake
@@ -30,6 +30,13 @@ function(mongocxx_add_library TARGET OUTPUT_NAME LINK_TYPE)
 
     target_link_libraries(${TARGET} PRIVATE ${libmongoc_target})
     target_include_directories(${TARGET} PRIVATE ${libmongoc_include_directories})
+    target_include_directories(
+        ${TARGET}
+        PUBLIC
+            $<BUILD_INTERFACE:${source_dir}/include>
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/..>
+            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/..>
+    )
     target_compile_definitions(${TARGET} PRIVATE ${libmongoc_definitions})
 
     generate_export_header(${TARGET}

--- a/examples/add_subdirectory/.gitignore
+++ b/examples/add_subdirectory/.gitignore
@@ -1,0 +1,3 @@
+build
+mongo-c-driver
+mongo-cxx-driver

--- a/examples/add_subdirectory/CMakeLists.txt
+++ b/examples/add_subdirectory/CMakeLists.txt
@@ -1,0 +1,58 @@
+# Copyright 2020 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Demonstrates how to use the CMake 'add_subdirectory' mechanism to locate and
+# build against the libmongoc and libmongocxx shared libraries.
+
+cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+
+if(POLICY CMP0025)
+    cmake_policy(SET CMP0025 NEW)
+endif()
+
+project(HELLO_WORLD LANGUAGES C CXX)
+
+# Enforce the C++ standard, and disable extensions.
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11)
+endif()
+
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(BUILD_SHARED_AND_STATIC_LIBS ON CACHE BOOL "" FORCE)
+set(ENABLE_TESTS OFF CACHE BOOL "" FORCE)
+add_subdirectory(mongo-c-driver)
+add_subdirectory(mongo-cxx-driver)
+
+add_executable(hello_mongocxx hello_mongocxx.cpp)
+
+# Visual Studio pre 2017 requires boost polyfill.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND CMAKE_CXX_STANDARD LESS 17)
+  find_package(Boost 1.56.0 REQUIRED)
+  if (CMAKE_VERSION VERSION_LESS 3.15.0)
+    target_include_directories(hello_mongocxx PRIVATE ${Boost_INCLUDE_DIRS})
+  else()
+    target_link_libraries(hello_mongocxx PRIVATE Boost::boost)
+  endif()
+endif()
+
+target_link_libraries(hello_mongocxx
+  PRIVATE mongocxx_static
+)
+
+add_custom_target(run
+    COMMAND hello_mongocxx
+    DEPENDS hello_mongocxx
+    WORKING_DIRECTORY ${CMAKE_PROJECT_DIR}
+)

--- a/examples/add_subdirectory/hello_mongocxx.cpp
+++ b/examples/add_subdirectory/hello_mongocxx.cpp
@@ -1,0 +1,47 @@
+// Copyright 2020 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdlib>
+#include <iostream>
+
+#include <bsoncxx/builder/basic/document.hpp>
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/instance.hpp>
+#include <mongocxx/uri.hpp>
+
+int main(int argc, char* argv[]) {
+    using bsoncxx::builder::basic::kvp;
+    using bsoncxx::builder::basic::make_document;
+
+    // The mongocxx::instance constructor and destructor initialize and shut down the driver,
+    // respectively. Therefore, a mongocxx::instance must be created before using the driver and
+    // must remain alive for as long as the driver is in use.
+    mongocxx::instance inst;
+
+    try {
+        const auto uri = mongocxx::uri{(argc >= 2) ? argv[1] : mongocxx::uri::k_default_uri};
+
+        auto client = mongocxx::client{uri};
+        auto admin = client["admin"];
+        auto result = admin.run_command(make_document(kvp("isMaster", 1)));
+        std::cout << bsoncxx::to_json(result) << std::endl;
+
+        return EXIT_SUCCESS;
+    } catch (const std::exception& xcp) {
+        std::cout << "connection failed: " << xcp.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+}

--- a/src/bsoncxx/CMakeLists.txt
+++ b/src/bsoncxx/CMakeLists.txt
@@ -78,39 +78,55 @@ set(LIBBSON_REQUIRED_ABI_VERSION 1.0)
 
 set(bsoncxx_pkg_dep "")
 
-# Attempt to find libbson by new package name (without lib).
-find_package(bson-${LIBBSON_REQUIRED_ABI_VERSION} ${LIBBSON_REQUIRED_VERSION} QUIET)
+if(TARGET bson_shared OR TARGET bson_static)
+  # If these targets exist, then libbson has already been included as a project
+  # sub-directory
+  message ("found libbson targets declared in current build scope; version not checked")
 
-if(bson-${LIBBSON_REQUIRED_ABI_VERSION}_FOUND)
-  message ("found libbson version ${bson-${LIBBSON_REQUIRED_ABI_VERSION}_VERSION}")
   if(NOT BSONCXX_LINK_WITH_STATIC_MONGOC)
-    set(libbson_target mongo::bson_shared)
+    set(libbson_target bson_shared)
   else()
-    set(libbson_target mongo::bson_static)
+    set(libbson_target bson_static)
   endif()
 
   if(BSONCXX_BUILD_STATIC)
     set(bsoncxx_pkg_dep "find_dependency(bson-1.0 REQUIRED)")
   endif()
 else()
-  # Require package of old libbson name (with lib).
-  if(NOT BSONCXX_LINK_WITH_STATIC_MONGOC)
-    find_package(libbson-${LIBBSON_REQUIRED_ABI_VERSION} ${LIBBSON_REQUIRED_VERSION} REQUIRED)
-    message ("found libbson version ${BSON_VERSION}")
-    set(libbson_target ${BSON_LIBRARIES})
-    set(libbson_include_directories ${BSON_INCLUDE_DIRS})
-    set(libbson_definitions ${BSON_DEFINITIONS})
+  # Attempt to find libbson by new package name (without lib).
+  find_package(bson-${LIBBSON_REQUIRED_ABI_VERSION} ${LIBBSON_REQUIRED_VERSION} QUIET)
+
+  if(bson-${LIBBSON_REQUIRED_ABI_VERSION}_FOUND)
+    message ("found libbson version ${bson-${LIBBSON_REQUIRED_ABI_VERSION}_VERSION}")
+    if(NOT BSONCXX_LINK_WITH_STATIC_MONGOC)
+      set(libbson_target mongo::bson_shared)
+    else()
+      set(libbson_target mongo::bson_static)
+    endif()
+
     if(BSONCXX_BUILD_STATIC)
-      set(bsoncxx_pkg_dep "find_dependency(libbson-1.0 REQUIRED)")
+      set(bsoncxx_pkg_dep "find_dependency(bson-1.0 REQUIRED)")
     endif()
   else()
-    find_package(libbson-static-${LIBBSON_REQUIRED_ABI_VERSION} ${LIBBSON_REQUIRED_VERSION} REQUIRED)
-    message ("found libbson version ${BSON_STATIC_VERSION}")
-    set(libbson_target ${BSON_STATIC_LIBRARIES})
-    set(libbson_include_directories ${BSON_STATIC_INCLUDE_DIRS})
-    set(libbson_definitions ${BSON_STATIC_DEFINITIONS})
-    if(BSONCXX_BUILD_STATIC)
-      set(bsoncxx_pkg_dep "find_dependency(libbson-static-1.0 REQUIRED)")
+    # Require package of old libbson name (with lib).
+    if(NOT BSONCXX_LINK_WITH_STATIC_MONGOC)
+      find_package(libbson-${LIBBSON_REQUIRED_ABI_VERSION} ${LIBBSON_REQUIRED_VERSION} REQUIRED)
+      message ("found libbson version ${BSON_VERSION}")
+      set(libbson_target ${BSON_LIBRARIES})
+      set(libbson_include_directories ${BSON_INCLUDE_DIRS})
+      set(libbson_definitions ${BSON_DEFINITIONS})
+      if(BSONCXX_BUILD_STATIC)
+        set(bsoncxx_pkg_dep "find_dependency(libbson-1.0 REQUIRED)")
+      endif()
+    else()
+      find_package(libbson-static-${LIBBSON_REQUIRED_ABI_VERSION} ${LIBBSON_REQUIRED_VERSION} REQUIRED)
+      message ("found libbson version ${BSON_STATIC_VERSION}")
+      set(libbson_target ${BSON_STATIC_LIBRARIES})
+      set(libbson_include_directories ${BSON_STATIC_INCLUDE_DIRS})
+      set(libbson_definitions ${BSON_STATIC_DEFINITIONS})
+      if(BSONCXX_BUILD_STATIC)
+        set(bsoncxx_pkg_dep "find_dependency(libbson-static-1.0 REQUIRED)")
+      endif()
     endif()
   endif()
 endif()
@@ -136,11 +152,6 @@ set(bsoncxx_sources
     types/bson_value/value.cpp
     types/bson_value/view.cpp
     validate.cpp
-)
-
-include_directories(
-    ${CMAKE_SOURCE_DIR}/src
-    ${CMAKE_BINARY_DIR}/src
 )
 
 if(BSONCXX_POLY_USE_BOOST)

--- a/src/bsoncxx/test/CMakeLists.txt
+++ b/src/bsoncxx/test/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 include_directories(
-    ${CMAKE_SOURCE_DIR}/src/third_party/catch/include
+    ${MONGO_CXX_DRIVER_SOURCE_DIR}/src/third_party/catch/include
 )
 
 file (GLOB src_bsoncxx_test_DIST_cpps RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)

--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -34,39 +34,55 @@ set(LIBMONGOC_REQUIRED_ABI_VERSION 1.0)
 
 set(mongocxx_pkg_dep "")
 
-# Attempt to find libmongoc by new package name (without lib).
-find_package(mongoc-${LIBMONGOC_REQUIRED_ABI_VERSION} ${LIBMONGOC_REQUIRED_VERSION} QUIET)
+if(TARGET mongoc_shared OR TARGET mongoc_static)
+  # If these targets exist, then libmongoc has already been included as a project
+  # sub-directory
+  message ("found libmongoc targets declared in current build scope; version not checked")
 
-if(mongoc-${LIBMONGOC_REQUIRED_ABI_VERSION}_FOUND)
-  message ("found libmongoc version ${mongoc-${LIBMONGOC_REQUIRED_ABI_VERSION}_VERSION}")
   if(NOT MONGOCXX_LINK_WITH_STATIC_MONGOC)
-    set(libmongoc_target mongo::mongoc_shared)
+    set(libmongoc_target mongoc_shared)
   else()
-    set(libmongoc_target mongo::mongoc_static)
+    set(libmongoc_target mongoc_static)
   endif()
 
   if(MONGOCXX_BUILD_STATIC)
     set(mongocxx_pkg_dep "find_dependency(mongoc-1.0 REQUIRED)")
   endif()
 else()
-  # Require package of old libmongoc name (with lib).
-  if(NOT MONGOCXX_LINK_WITH_STATIC_MONGOC)
-    find_package(libmongoc-${LIBMONGOC_REQUIRED_ABI_VERSION} ${LIBMONGOC_REQUIRED_VERSION} REQUIRED)
-    message ("found libmongoc version ${MONGOC_VERSION}")
-    set(libmongoc_target ${MONGOC_LIBRARIES})
-    set(libmongoc_include_directories ${MONGOC_INCLUDE_DIRS})
-    set(libmongoc_definitions ${MONGOC_DEFINITIONS})
+  # Attempt to find libmongoc by new package name (without lib).
+  find_package(mongoc-${LIBMONGOC_REQUIRED_ABI_VERSION} ${LIBMONGOC_REQUIRED_VERSION} QUIET)
+
+  if(mongoc-${LIBMONGOC_REQUIRED_ABI_VERSION}_FOUND)
+    message ("found libmongoc version ${mongoc-${LIBMONGOC_REQUIRED_ABI_VERSION}_VERSION}")
+    if(NOT MONGOCXX_LINK_WITH_STATIC_MONGOC)
+      set(libmongoc_target mongo::mongoc_shared)
+    else()
+      set(libmongoc_target mongo::mongoc_static)
+    endif()
+
     if(MONGOCXX_BUILD_STATIC)
-      set(mongocxx_pkg_dep "find_dependency(libmongoc-1.0 REQUIRED)")
+      set(mongocxx_pkg_dep "find_dependency(mongoc-1.0 REQUIRED)")
     endif()
   else()
-    find_package(libmongoc-static-${LIBMONGOC_REQUIRED_ABI_VERSION} ${LIBMONGOC_REQUIRED_VERSION} REQUIRED)
-    message ("found libmongoc version ${MONGOC_STATIC_VERSION}")
-    set(libmongoc_target ${MONGOC_STATIC_LIBRARIES})
-    set(libmongoc_include_directories ${MONGOC_STATIC_INCLUDE_DIRS})
-    set(libmongoc_definitions ${MONGOC_STATIC_DEFINITIONS})
-    if(MONGOCXX_BUILD_STATIC)
-      set(mongocxx_pkg_dep "find_dependency(libmongoc-static-1.0 REQUIRED)")
+    # Require package of old libmongoc name (with lib).
+    if(NOT MONGOCXX_LINK_WITH_STATIC_MONGOC)
+      find_package(libmongoc-${LIBMONGOC_REQUIRED_ABI_VERSION} ${LIBMONGOC_REQUIRED_VERSION} REQUIRED)
+      message ("found libmongoc version ${MONGOC_VERSION}")
+      set(libmongoc_target ${MONGOC_LIBRARIES})
+      set(libmongoc_include_directories ${MONGOC_INCLUDE_DIRS})
+      set(libmongoc_definitions ${MONGOC_DEFINITIONS})
+      if(MONGOCXX_BUILD_STATIC)
+        set(mongocxx_pkg_dep "find_dependency(libmongoc-1.0 REQUIRED)")
+      endif()
+    else()
+      find_package(libmongoc-static-${LIBMONGOC_REQUIRED_ABI_VERSION} ${LIBMONGOC_REQUIRED_VERSION} REQUIRED)
+      message ("found libmongoc version ${MONGOC_STATIC_VERSION}")
+      set(libmongoc_target ${MONGOC_STATIC_LIBRARIES})
+      set(libmongoc_include_directories ${MONGOC_STATIC_INCLUDE_DIRS})
+      set(libmongoc_definitions ${MONGOC_STATIC_DEFINITIONS})
+      if(MONGOCXX_BUILD_STATIC)
+        set(mongocxx_pkg_dep "find_dependency(libmongoc-static-1.0 REQUIRED)")
+      endif()
     endif()
   endif()
 endif()
@@ -160,11 +176,6 @@ set(mongocxx_sources
     uri.cpp
     validation_criteria.cpp
     write_concern.cpp
-)
-
-include_directories(
-    ${CMAKE_SOURCE_DIR}/src
-    ${CMAKE_BINARY_DIR}/src
 )
 
 # We define both the normal libraries and the testing-only library.  The testing-only

--- a/src/mongocxx/test/CMakeLists.txt
+++ b/src/mongocxx/test/CMakeLists.txt
@@ -82,7 +82,7 @@ set(spec_test_common
     spec/util.cpp)
 
 add_executable(test_driver
-    ${CMAKE_SOURCE_DIR}/src/mongocxx/test_util/client_helpers.cpp
+    ${PROJECT_SOURCE_DIR}/test_util/client_helpers.cpp
     ${THIRD_PARTY_SOURCE_DIR}/catch/main.cpp
     ${test_driver_sources}
 )
@@ -98,56 +98,56 @@ add_executable(test_instance
 )
 
 add_executable(test_crud_specs
-    ${CMAKE_SOURCE_DIR}/src/mongocxx/test_util/client_helpers.cpp
+    ${PROJECT_SOURCE_DIR}/test_util/client_helpers.cpp
     ${THIRD_PARTY_SOURCE_DIR}/catch/main.cpp
     spec/crud.cpp
     ${spec_test_common}
 )
 
 add_executable(test_change_stream_specs
-    ${CMAKE_SOURCE_DIR}/src/mongocxx/test_util/client_helpers.cpp
+    ${PROJECT_SOURCE_DIR}/test_util/client_helpers.cpp
     ${THIRD_PARTY_SOURCE_DIR}/catch/main.cpp
     spec/change_stream.cpp
     ${spec_test_common}
 )
 
 add_executable(test_gridfs_specs
-    ${CMAKE_SOURCE_DIR}/src/mongocxx/test_util/client_helpers.cpp
+    ${PROJECT_SOURCE_DIR}/test_util/client_helpers.cpp
     ${THIRD_PARTY_SOURCE_DIR}/catch/main.cpp
     spec/gridfs.cpp
     ${spec_test_common}
 )
 
 add_executable(test_client_side_encryption_specs
-  ${CMAKE_SOURCE_DIR}/src/mongocxx/test_util/client_helpers.cpp
+  ${PROJECT_SOURCE_DIR}/test_util/client_helpers.cpp
   ${THIRD_PARTY_SOURCE_DIR}/catch/main.cpp
   spec/client_side_encryption.cpp
   ${spec_test_common}
 )
 
 add_executable(test_command_monitoring_specs
-    ${CMAKE_SOURCE_DIR}/src/mongocxx/test_util/client_helpers.cpp
+    ${PROJECT_SOURCE_DIR}/test_util/client_helpers.cpp
     ${THIRD_PARTY_SOURCE_DIR}/catch/main.cpp
     spec/command_monitoring.cpp
     ${spec_test_common}
 )
 
 add_executable(test_transactions_specs
-    ${CMAKE_SOURCE_DIR}/src/mongocxx/test_util/client_helpers.cpp
+    ${PROJECT_SOURCE_DIR}/test_util/client_helpers.cpp
     ${THIRD_PARTY_SOURCE_DIR}/catch/main.cpp
     spec/transactions.cpp
     ${spec_test_common}
 )
 
 add_executable(test_retryable_reads_specs
-    ${CMAKE_SOURCE_DIR}/src/mongocxx/test_util/client_helpers.cpp
+    ${PROJECT_SOURCE_DIR}/test_util/client_helpers.cpp
     ${THIRD_PARTY_SOURCE_DIR}/catch/main.cpp
     spec/retryable-reads.cpp
     ${spec_test_common}
 )
 
 add_executable(test_read_write_concern_specs
-    ${CMAKE_SOURCE_DIR}/src/mongocxx/test_util/client_helpers.cpp
+    ${PROJECT_SOURCE_DIR}/test_util/client_helpers.cpp
     ${THIRD_PARTY_SOURCE_DIR}/catch/main.cpp
     spec/read_write_concern.cpp
     ${spec_test_common}
@@ -197,33 +197,33 @@ add_test(retryable_reads_spec test_retryable_reads_specs)
 add_test(read_write_concern_specs test_read_write_concern_specs)
 
 set_tests_properties(crud_specs PROPERTIES
-    ENVIRONMENT "CRUD_TESTS_PATH=${CMAKE_SOURCE_DIR}/data/crud")
+    ENVIRONMENT "CRUD_TESTS_PATH=${PROJECT_SOURCE_DIR}/../../data/crud")
 
 set_tests_properties(gridfs_specs PROPERTIES
-    ENVIRONMENT "GRIDFS_TESTS_PATH=${CMAKE_SOURCE_DIR}/data/gridfs")
+    ENVIRONMENT "GRIDFS_TESTS_PATH=${PROJECT_SOURCE_DIR}/../../data/gridfs")
 
 set_tests_properties(client_side_encryption_specs PROPERTIES
-    ENVIRONMENT "ENCRYPTION_TESTS_PATH=${CMAKE_SOURCE_DIR}/data/client_side_encryption")
+    ENVIRONMENT "ENCRYPTION_TESTS_PATH=${PROJECT_SOURCE_DIR}/../../data/client_side_encryption")
 
 set_tests_properties(driver PROPERTIES
-    ENVIRONMENT "ENCRYPTION_TESTS_PATH=${CMAKE_SOURCE_DIR}/data/client_side_encryption")
+    ENVIRONMENT "ENCRYPTION_TESTS_PATH=${PROJECT_SOURCE_DIR}/../../data/client_side_encryption")
   
 set_tests_properties(command_monitoring_specs PROPERTIES
-    ENVIRONMENT "COMMAND_MONITORING_TESTS_PATH=${CMAKE_SOURCE_DIR}/data/command-monitoring")
+    ENVIRONMENT "COMMAND_MONITORING_TESTS_PATH=${PROJECT_SOURCE_DIR}/../../data/command-monitoring")
 
 set_tests_properties(change_stream_specs PROPERTIES
-    ENVIRONMENT "CHANGE_STREAM_TESTS_PATH=${CMAKE_SOURCE_DIR}/data/change_stream")
+    ENVIRONMENT "CHANGE_STREAM_TESTS_PATH=${PROJECT_SOURCE_DIR}/../../data/change_stream")
 
 set_tests_properties(transactions_specs PROPERTIES
-  ENVIRONMENT "TRANSACTIONS_TESTS_PATH=${CMAKE_SOURCE_DIR}/data/transactions")
+  ENVIRONMENT "TRANSACTIONS_TESTS_PATH=${PROJECT_SOURCE_DIR}/../../data/transactions")
 set_property(TEST transactions_specs
-  APPEND PROPERTY ENVIRONMENT "WITH_TRANSACTION_TESTS_PATH=${CMAKE_SOURCE_DIR}/data/with_transaction")
+  APPEND PROPERTY ENVIRONMENT "WITH_TRANSACTION_TESTS_PATH=${PROJECT_SOURCE_DIR}/../../data/with_transaction")
 
 set_tests_properties(retryable_reads_spec PROPERTIES
-   ENVIRONMENT "RETRYABLE_READS_TESTS_PATH=${CMAKE_SOURCE_DIR}/data/retryable-reads")
+   ENVIRONMENT "RETRYABLE_READS_TESTS_PATH=${PROJECT_SOURCE_DIR}/../../data/retryable-reads")
 
 set_tests_properties(read_write_concern_specs PROPERTIES
-   ENVIRONMENT "READ_WRITE_CONCERN_OPERATION_TESTS_PATH=${CMAKE_SOURCE_DIR}/data/read-write-concern/operation")
+   ENVIRONMENT "READ_WRITE_CONCERN_OPERATION_TESTS_PATH=${PROJECT_SOURCE_DIR}/../../data/read-write-concern/operation")
 
 if (MONGOCXX_ENABLE_SLOW_TESTS)
   set_tests_properties(driver PROPERTIES


### PR DESCRIPTION
Full patch build: https://spruce.mongodb.com/version/5f2ddb44a4cf47286d24b5d0/tasks

Note that the failures are not related to the changes in this PR.  Also, the new task of interest is called {{build_example_with_add_subdirectory}}.