### PR TITLE
update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # MongoDB C++ Driver 
-[![Evergreen Build Status](https://evergreen.mongodb.com/static/img/favicon.ico)](https://evergreen.mongodb.com/waterfall/cxx-driver)[![Travis Build Status](https://travis-ci.org/mongodb/mongo-cxx-driver.svg?branch=master)](https://travis-ci.org/mongodb/mongo-cxx-driver)
+[![Evergreen Build Status](https://img.shields.io/badge/build-evergreen-brightgreen)](https://evergreen.mongodb.com/waterfall/cxx-driver)
+[![Travis Build Status](https://travis-ci.org/mongodb/mongo-cxx-driver.svg?branch=master)](https://travis-ci.org/mongodb/mongo-cxx-driver)
 [![codecov](https://codecov.io/gh/mongodb/mongo-cxx-driver/branch/master/graph/badge.svg)](https://codecov.io/gh/mongodb/mongo-cxx-driver)
+[![Documentation](https://img.shields.io/badge/docs-doxygen-blue.svg)](http://mongocxx.org/api/mongocxx-v3/)
 
 Welcome to the MongoDB C++ Driver!
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # MongoDB C++ Driver 
-[![Evergreen Build Status](https://img.shields.io/badge/build-evergreen-brightgreen)](https://evergreen.mongodb.com/waterfall/cxx-driver)
 [![Travis Build Status](https://travis-ci.org/mongodb/mongo-cxx-driver.svg?branch=master)](https://travis-ci.org/mongodb/mongo-cxx-driver)
+[![Evergreen Build Status](https://img.shields.io/badge/build-evergreen-brightgreen)](https://evergreen.mongodb.com/waterfall/cxx-driver)
 [![codecov](https://codecov.io/gh/mongodb/mongo-cxx-driver/branch/master/graph/badge.svg)](https://codecov.io/gh/mongodb/mongo-cxx-driver)
 [![Documentation](https://img.shields.io/badge/docs-doxygen-blue.svg)](http://mongocxx.org/api/mongocxx-v3/)
 [![Documentation](https://img.shields.io/badge/docs-mongocxx-green.svg)](http://mongocxx.org/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/mongodb/mongo-cxx-driver/blob/master/LICENSE)
 
 Welcome to the MongoDB C++ Driver!
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Travis Build Status](https://travis-ci.org/mongodb/mongo-cxx-driver.svg?branch=master)](https://travis-ci.org/mongodb/mongo-cxx-driver)
 [![codecov](https://codecov.io/gh/mongodb/mongo-cxx-driver/branch/master/graph/badge.svg)](https://codecov.io/gh/mongodb/mongo-cxx-driver)
 [![Documentation](https://img.shields.io/badge/docs-doxygen-blue.svg)](http://mongocxx.org/api/mongocxx-v3/)
+[![Documentation](https://img.shields.io/badge/docs-mongocxx-green.svg)](http://mongocxx.org/)
 
 Welcome to the MongoDB C++ Driver!
 


### PR DESCRIPTION
It isn't clear which links link to Doxygen or mongocxx.org. So, I added badges that link to our Doxygen and mongocxx pages. I also made the link to our evergreen build a badge so it's more uniform with the others. It didn't look clickable and the icon isn't as well know as we might like. 