### PR TITLE
CXX-2093 fix rpm-package-build task

### DIFF
--- a/.evergreen/build_snapshot_rpm.sh
+++ b/.evergreen/build_snapshot_rpm.sh
@@ -41,7 +41,7 @@ done
 package=mongo-cxx-driver
 spec_file=../mongo-cxx-driver.spec
 spec_url=https://src.fedoraproject.org/rpms/mongo-cxx-driver/raw/master/f/mongo-cxx-driver.spec
-config=${MOCK_TARGET_CONFIG:=fedora-33-x86_64}
+config=${MOCK_TARGET_CONFIG:=fedora-32-x86_64}
 
 if [ ! -x /usr/bin/rpmbuild -o ! -x /usr/bin/rpmspec ]; then
   echo "Missing the rpmbuild or rpmspec utility from the rpm-build package"


### PR DESCRIPTION
Patch build: https://spruce.mongodb.com/version/5f4009a7562343484191a8d5/tasks

The persistent problem appears to be that updated Fedora 33 packages were signed with the newly created Fedora 34 archive key (which is not present in the Fedora 33 environment).  The discussion here is what provided the necessary clue: https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/358

Since we don't rely on always using the latest and greatest Fedora, the simple solution is to switch the mock build environment from Fedora 33 to Fedora 32.  That still more than meets our needs.