### PR TITLE
Fix build with libcxx

### DIFF
--- a/src/mongocxx/options/auto_encryption.hpp
+++ b/src/mongocxx/options/auto_encryption.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <string>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>

--- a/src/mongocxx/options/client_encryption.hpp
+++ b/src/mongocxx/options/client_encryption.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <string>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>


### PR DESCRIPTION
Fixes error "implicit instantiation of undefined template 'std::string'"
requested in mongocxx/options/auto_encryption.hpp:256:29:
    stdx::optional<ns_pair> _key_vault_namespace;

and likewise in client_encryption.hpp.