### PR TITLE
CXX-1817 Rename get_utf8() to get_string() to make it more user-friendly

### DIFF
--- a/docs/content/mongocxx-v3/tutorial.md
+++ b/docs/content/mongocxx-v3/tutorial.md
@@ -198,7 +198,7 @@ bsoncxx::document::element element = view["name"];
 if(element.type() != bsoncxx::type::k_utf8) {
   // Error
 }
-std::string name = element.get_utf8().value.to_string();
+std::string name = element.get_string().value.to_string();
 ```
 
 If the value in the `name` field is not a string and you do not

--- a/examples/bsoncxx/view_and_value.cpp
+++ b/examples/bsoncxx/view_and_value.cpp
@@ -81,7 +81,7 @@ int main(int, char**) {
                 array::view subarr{ele.get_array().value};
                 for (array::element ele : subarr) {
                     std::cout << "array element: "
-                              << bsoncxx::string::to_string(ele.get_utf8().value) << std::endl;
+                              << bsoncxx::string::to_string(ele.get_string().value) << std::endl;
                 }
                 break;
             }

--- a/examples/mongocxx/change_streams.cpp
+++ b/examples/mongocxx/change_streams.cpp
@@ -31,7 +31,7 @@ std::string get_server_version(const mongocxx::client& client) {
     server_status.append(bsoncxx::builder::basic::kvp("serverStatus", 1));
     bsoncxx::document::value output = client["test"].run_command(server_status.extract());
 
-    return bsoncxx::string::to_string(output.view()["version"].get_utf8().value);
+    return bsoncxx::string::to_string(output.view()["version"].get_string().value);
 }
 
 void watch_until(const mongocxx::client& client,

--- a/examples/mongocxx/get_values_from_documents.cpp
+++ b/examples/mongocxx/get_values_from_documents.cpp
@@ -76,7 +76,7 @@ void iterate_messagelist(const bsoncxx::document::element& ele) {
                     std::cout << "status: " << status.get_int32().value << std::endl;
                 }
                 if (msg && msg.type() == type::k_utf8) {
-                    std::cout << "msg: " << msg.get_utf8().value << std::endl;
+                    std::cout << "msg: " << msg.get_string().value << std::endl;
                 }
             } else {
                 std::cout << "Message is not a document" << std::endl;

--- a/examples/mongocxx/mongodb.com/aggregation_examples.cpp
+++ b/examples/mongocxx/mongodb.com/aggregation_examples.cpp
@@ -36,7 +36,7 @@ std::string get_server_version(const client& client) {
     server_status.append(bsoncxx::builder::basic::kvp("serverStatus", 1));
     bsoncxx::document::value output = client["test"].run_command(server_status.extract());
 
-    return bsoncxx::string::to_string(output.view()["version"].get_utf8().value);
+    return bsoncxx::string::to_string(output.view()["version"].get_string().value);
 }
 
 void aggregation_examples(const mongocxx::client& client, const mongocxx::database& db) {

--- a/examples/mongocxx/mongodb.com/documentation_examples.cpp
+++ b/examples/mongocxx/mongodb.com/documentation_examples.cpp
@@ -1036,11 +1036,11 @@ void update_examples(mongocxx::database db) {
         // End Example 52
 
         for (auto&& document : db["inventory"].find(make_document(kvp("item", "paper")))) {
-            if (document["size"].get_document().value["uom"].get_utf8().value !=
+            if (document["size"].get_document().value["uom"].get_string().value !=
                 bsoncxx::stdx::string_view{"cm"}) {
                 throw std::logic_error("error in example 52");
             }
-            if (document["status"].get_utf8().value != bsoncxx::stdx::string_view{"P"}) {
+            if (document["status"].get_string().value != bsoncxx::stdx::string_view{"P"}) {
                 throw std::logic_error("error in example 52");
             }
             check_has_field(document, "lastModified", 52);
@@ -1060,11 +1060,11 @@ void update_examples(mongocxx::database db) {
 
         for (auto&& document :
              db["inventory"].find(make_document(kvp("qty", make_document(kvp("$lt", 50)))))) {
-            if (document["size"].get_document().value["uom"].get_utf8().value !=
+            if (document["size"].get_document().value["uom"].get_string().value !=
                 bsoncxx::stdx::string_view{"in"}) {
                 throw std::logic_error("error in example 53");
             }
-            if (document["status"].get_utf8().value != bsoncxx::stdx::string_view{"P"}) {
+            if (document["status"].get_string().value != bsoncxx::stdx::string_view{"P"}) {
                 throw std::logic_error("error in example 53");
             }
             check_has_field(document, "lastModified", 53);

--- a/src/bsoncxx/array/element.hpp
+++ b/src/bsoncxx/array/element.hpp
@@ -43,6 +43,7 @@ class BSONCXX_API element : private document::element {
 
     using document::element::get_double;
     using document::element::get_utf8;
+    using document::element::get_string;
     using document::element::get_document;
     using document::element::get_array;
     using document::element::get_binary;

--- a/src/bsoncxx/builder/core.cpp
+++ b/src/bsoncxx/builder/core.cpp
@@ -647,15 +647,15 @@ core& core::concatenate(const bsoncxx::document::view& view) {
 
 core& core::append(const bsoncxx::types::bson_value::view& value) {
     switch (static_cast<int>(value.type())) {
-    // CXX-1817; deprecation warning suppressed for get_utf8()
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
+        // CXX-1817; deprecation warning suppressed for get_utf8()
+        BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
 #define BSONCXX_ENUM(type, val)     \
     case val:                       \
         append(value.get_##type()); \
         break;
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
+        BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
     }
 
     return *this;

--- a/src/bsoncxx/builder/core.cpp
+++ b/src/bsoncxx/builder/core.cpp
@@ -21,6 +21,7 @@
 #include <bsoncxx/private/itoa.hh>
 #include <bsoncxx/private/libbson.hh>
 #include <bsoncxx/private/stack.hh>
+#include <bsoncxx/private/suppress_deprecation_warnings.hh>
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/string/to_string.hpp>
@@ -646,12 +647,15 @@ core& core::concatenate(const bsoncxx::document::view& view) {
 
 core& core::append(const bsoncxx::types::bson_value::view& value) {
     switch (static_cast<int>(value.type())) {
+    // CXX-1817; deprecation warning suppressed for get_utf8()
+    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
 #define BSONCXX_ENUM(type, val)     \
     case val:                       \
         append(value.get_##type()); \
         break;
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
+    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
     }
 
     return *this;

--- a/src/bsoncxx/document/element.cpp
+++ b/src/bsoncxx/document/element.cpp
@@ -80,6 +80,8 @@ stdx::string_view element::key() const {
     return stdx::string_view{key};
 }
 
+// CXX-1817; deprecation warning suppressed for get_utf8()
+BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
 #define BSONCXX_ENUM(name, val)                                     \
     types::b_##name element::get_##name() const {                   \
         types::bson_value::view v{_raw, _length, _offset, _keylen}; \
@@ -87,6 +89,7 @@ stdx::string_view element::key() const {
     }
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
+BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
 
 types::b_utf8 element::get_string() const {
     types::bson_value::view v{_raw, _length, _offset, _keylen};
@@ -95,6 +98,7 @@ types::b_utf8 element::get_string() const {
 
 types::bson_value::view element::get_value() const {
     switch (static_cast<int>(type())) {
+        // CXX-1817; deprecation warning suppressed for get_utf8()
         BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
 #define BSONCXX_ENUM(type, val) \
     case val:                   \

--- a/src/bsoncxx/document/element.cpp
+++ b/src/bsoncxx/document/element.cpp
@@ -87,6 +87,10 @@ stdx::string_view element::key() const {
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
 
+types::b_utf8 element::get_string() const {
+    return element::get_utf8();
+}
+
 types::bson_value::view element::get_value() const {
     switch (static_cast<int>(type())) {
 #define BSONCXX_ENUM(type, val) \

--- a/src/bsoncxx/document/element.cpp
+++ b/src/bsoncxx/document/element.cpp
@@ -95,13 +95,13 @@ types::b_utf8 element::get_string() const {
 
 types::bson_value::view element::get_value() const {
     switch (static_cast<int>(type())) {
-BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
+        BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
 #define BSONCXX_ENUM(type, val) \
     case val:                   \
         return types::bson_value::view{get_##type()};
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
-BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
+        BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
     }
 
     BSONCXX_UNREACHABLE;

--- a/src/bsoncxx/document/element.cpp
+++ b/src/bsoncxx/document/element.cpp
@@ -21,6 +21,7 @@
 #include <bsoncxx/exception/exception.hpp>
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/private/libbson.hh>
+#include <bsoncxx/private/suppress_deprecation_warnings.hh>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
@@ -88,16 +89,19 @@ stdx::string_view element::key() const {
 #undef BSONCXX_ENUM
 
 types::b_utf8 element::get_string() const {
-    return element::get_utf8();
+    types::bson_value::view v{_raw, _length, _offset, _keylen};
+    return v.get_string();
 }
 
 types::bson_value::view element::get_value() const {
     switch (static_cast<int>(type())) {
+BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
 #define BSONCXX_ENUM(type, val) \
     case val:                   \
         return types::bson_value::view{get_##type()};
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
+BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
     }
 
     BSONCXX_UNREACHABLE;

--- a/src/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/document/element.hpp
@@ -147,11 +147,23 @@ class BSONCXX_API element {
     ///
     /// Getter for elements of the b_utf8 type.
     ///
+    /// @deprecated use document::element::get_string() instead.
+    ///
     /// @throws bsoncxx::exception if this element is not a b_utf8.
     ///
     /// @return the element's value.
     ///
-    types::b_utf8 get_utf8() const;
+    BSONCXX_DEPRECATED types::b_utf8 get_utf8() const;
+
+    ///
+    /// Getter for elements of the b_utf8, or string, type. This function acts as a
+    /// wrapper for get_utf8().
+    ///
+    /// @throws bsoncxx::exception if this element is not a b_utf8.
+    ///
+    /// @return the element's value.
+    ///
+    types::b_utf8 get_string() const;
 
     ///
     /// Getter for elements of the b_document type.

--- a/src/bsoncxx/test/bson_builder.cpp
+++ b/src/bsoncxx/test/bson_builder.cpp
@@ -813,7 +813,7 @@ TEST_CASE("core method chaining to build array works", "[bsoncxx::builder::core]
 
     REQUIRE(std::distance(array_view.begin(), array_view.end()) == 3);
     REQUIRE(array_view[0].type() == type::k_utf8);
-    REQUIRE(string::to_string(array_view[0].get_utf8().value) == "foo");
+    REQUIRE(string::to_string(array_view[0].get_string().value) == "foo");
     REQUIRE(array_view[1].type() == type::k_int32);
     REQUIRE(array_view[1].get_int32().value == 1);
     REQUIRE(array_view[2].type() == type::k_bool);
@@ -1198,7 +1198,7 @@ TEST_CASE("builder::basic::make_array works", "[bsoncxx::builder::basic::make_ar
 
     REQUIRE(std::distance(array_view.begin(), array_view.end()) == 3);
     REQUIRE(array_view[0].type() == type::k_utf8);
-    REQUIRE(string::to_string(array_view[0].get_utf8().value) == "foo");
+    REQUIRE(string::to_string(array_view[0].get_string().value) == "foo");
     REQUIRE(array_view[1].type() == type::k_int32);
     REQUIRE(array_view[1].get_int32().value == 1);
     REQUIRE(array_view[2].type() == type::k_bool);

--- a/src/bsoncxx/test/bson_get_values.cpp
+++ b/src/bsoncxx/test/bson_get_values.cpp
@@ -341,13 +341,4 @@ TEST_CASE("CXX-1880: array element should have key") {
     REQUIRE(val.view()[2].key() == stdx::string_view("2"));
 }
 
-TEST_CASE("get_string() should successfully return type b_utf8") {
-    auto test_string = "beepboop";
-    auto doc = make_document(kvp("test_string", test_string));
-    auto ele = doc.view()["test_string"];
-
-    REQUIRE(test_string == std::string(ele.get_string().value));
-    REQUIRE(ele.get_string() == ele.get_utf8());
-}
-
 }  // namespace

--- a/src/bsoncxx/test/bson_get_values.cpp
+++ b/src/bsoncxx/test/bson_get_values.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string>
 #include <utility>
 
 #include <bsoncxx/builder/basic/array.hpp>
@@ -338,6 +339,15 @@ TEST_CASE("CXX-1880: array element should have key") {
     REQUIRE(val.view()[0].key() == stdx::string_view("0"));
     REQUIRE(val.view()[1].key() == stdx::string_view("1"));
     REQUIRE(val.view()[2].key() == stdx::string_view("2"));
+}
+
+TEST_CASE("get_string() should successfully return type b_utf8") {
+    auto test_string = "beepboop";
+    auto doc = make_document(kvp("test_string", test_string));
+    auto ele = doc.view()["test_string"];
+
+    REQUIRE(test_string == std::string(ele.get_string().value));
+    REQUIRE(ele.get_string() == ele.get_utf8());
 }
 
 }  // namespace

--- a/src/bsoncxx/test/bson_types.cpp
+++ b/src/bsoncxx/test/bson_types.cpp
@@ -198,7 +198,7 @@ TEST_CASE("bson_value::view with b_double", "[bsoncxx::types::bson_value::view]"
 
 TEST_CASE("bson_value::view with b_utf8", "[bsoncxx::types::bson_value::view]") {
     b_utf8 utf8_val{"hello"};
-    REQUIRE(bson_value::view{utf8_val}.get_utf8() == utf8_val);
+    REQUIRE(bson_value::view{utf8_val}.get_string() == utf8_val);
 }
 
 TEST_CASE("bson_value::view with b_document", "[bsoncxx::types::bson_value::view]") {

--- a/src/bsoncxx/types/bson_value/view.cpp
+++ b/src/bsoncxx/types/bson_value/view.cpp
@@ -67,15 +67,15 @@ view::view() noexcept : view(nullptr) {}
 
 view::view(const view& rhs) noexcept {
     switch (static_cast<int>(rhs._type)) {
-    // CXX-1817; deprecation warning suppressed for get_utf8()
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
+        // CXX-1817; deprecation warning suppressed for get_utf8()
+        BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
 #define BSONCXX_ENUM(type, val)                      \
     case val:                                        \
         new (&_b_##type) b_##type(rhs.get_##type()); \
         break;
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
+        BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
     }
 
     _type = rhs._type;
@@ -89,15 +89,15 @@ view& view::operator=(const view& rhs) noexcept {
     destroy();
 
     switch (static_cast<int>(rhs._type)) {
-    // CXX-1817; deprecation warning suppressed for get_utf8()
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
+        // CXX-1817; deprecation warning suppressed for get_utf8()
+        BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
 #define BSONCXX_ENUM(type, val)                      \
     case val:                                        \
         new (&_b_##type) b_##type(rhs.get_##type()); \
         break;
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
+        BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
     }
 
     _type = rhs._type;
@@ -120,7 +120,7 @@ bsoncxx::type view::type() const {
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
 
-const b_utf8 & view::get_string() const {
+const b_utf8& view::get_string() const {
     return _b_utf8;
 }
 
@@ -168,14 +168,14 @@ bool operator==(const view& lhs, const view& rhs) {
     }
 
     switch (static_cast<int>(lhs.type())) {
-    // CXX-1817; deprecation warning suppressed for get_utf8()
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
+        // CXX-1817; deprecation warning suppressed for get_utf8()
+        BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
 #define BSONCXX_ENUM(type, val) \
     case val:                   \
         return lhs.get_##type() == rhs.get_##type();
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
+        BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
     }
 
     // Silence compiler warnings about failing to return a value.

--- a/src/bsoncxx/types/bson_value/view.cpp
+++ b/src/bsoncxx/types/bson_value/view.cpp
@@ -67,12 +67,15 @@ view::view() noexcept : view(nullptr) {}
 
 view::view(const view& rhs) noexcept {
     switch (static_cast<int>(rhs._type)) {
+    // CXX-1817; deprecation warning suppressed for get_utf8()
+    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
 #define BSONCXX_ENUM(type, val)                      \
     case val:                                        \
         new (&_b_##type) b_##type(rhs.get_##type()); \
         break;
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
+    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
     }
 
     _type = rhs._type;
@@ -86,12 +89,15 @@ view& view::operator=(const view& rhs) noexcept {
     destroy();
 
     switch (static_cast<int>(rhs._type)) {
+    // CXX-1817; deprecation warning suppressed for get_utf8()
+    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
 #define BSONCXX_ENUM(type, val)                      \
     case val:                                        \
         new (&_b_##type) b_##type(rhs.get_##type()); \
         break;
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
+    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
     }
 
     _type = rhs._type;
@@ -162,11 +168,14 @@ bool operator==(const view& lhs, const view& rhs) {
     }
 
     switch (static_cast<int>(lhs.type())) {
+    // CXX-1817; deprecation warning suppressed for get_utf8()
+    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
 #define BSONCXX_ENUM(type, val) \
     case val:                   \
         return lhs.get_##type() == rhs.get_##type();
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
+    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
     }
 
     // Silence compiler warnings about failing to return a value.

--- a/src/bsoncxx/types/bson_value/view.cpp
+++ b/src/bsoncxx/types/bson_value/view.cpp
@@ -21,6 +21,7 @@
 #include <bsoncxx/exception/exception.hpp>
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/private/libbson.hh>
+#include <bsoncxx/private/suppress_deprecation_warnings.hh>
 #include <bsoncxx/types/private/convert.hh>
 
 #include <bsoncxx/config/private/prelude.hh>
@@ -112,6 +113,10 @@ bsoncxx::type view::type() const {
     }
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
+
+const b_utf8 & view::get_string() const {
+    return _b_utf8;
+}
 
 view::view(const std::uint8_t* raw,
            std::uint32_t length,

--- a/src/bsoncxx/types/bson_value/view.hpp
+++ b/src/bsoncxx/types/bson_value/view.hpp
@@ -106,7 +106,7 @@ class BSONCXX_API view {
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.
     ///
-    const b_utf8& get_utf8() const;
+    BSONCXX_DEPRECATED const b_utf8& get_utf8() const;
 
     ///
     /// @return The underlying BSON UTF-8 string value.

--- a/src/bsoncxx/types/bson_value/view.hpp
+++ b/src/bsoncxx/types/bson_value/view.hpp
@@ -109,6 +109,14 @@ class BSONCXX_API view {
     const b_utf8& get_utf8() const;
 
     ///
+    /// @return The underlying BSON UTF-8 string value.
+    ///
+    /// @warning
+    ///   Calling the wrong get_<type> method will cause an exception to be thrown.
+    ///
+    const b_utf8& get_string() const;
+
+    ///
     /// @return The underlying BSON document value.
     ///
     /// @warning

--- a/src/bsoncxx/types/private/convert.hh
+++ b/src/bsoncxx/types/private/convert.hh
@@ -187,8 +187,8 @@ BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_array& arr, bson_
 //
 BSONCXX_INLINE void convert_to_libbson(bson_value_t* v, const class bson_value::view& bson_view) {
     switch (bson_view.type()) {
-    // CXX-1817; deprecation warning suppressed for get_utf8()
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
+        // CXX-1817; deprecation warning suppressed for get_utf8()
+        BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
 #define BSONCXX_ENUM(name, val)              \
     case bsoncxx::type::k_##name: {          \
         auto value = bson_view.get_##name(); \
@@ -197,7 +197,7 @@ BSONCXX_INLINE void convert_to_libbson(bson_value_t* v, const class bson_value::
     }
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
+        BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
         default:
             BSONCXX_UNREACHABLE;
     }

--- a/src/bsoncxx/types/private/convert.hh
+++ b/src/bsoncxx/types/private/convert.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <bsoncxx/private/libbson.hh>
+#include <bsoncxx/private/suppress_deprecation_warnings.hh>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
 #include <cstdlib>
@@ -186,6 +187,8 @@ BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_array& arr, bson_
 //
 BSONCXX_INLINE void convert_to_libbson(bson_value_t* v, const class bson_value::view& bson_view) {
     switch (bson_view.type()) {
+    // CXX-1817; deprecation warning suppressed for get_utf8()
+    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
 #define BSONCXX_ENUM(name, val)              \
     case bsoncxx::type::k_##name: {          \
         auto value = bson_view.get_##name(); \
@@ -194,6 +197,7 @@ BSONCXX_INLINE void convert_to_libbson(bson_value_t* v, const class bson_value::
     }
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
+    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
         default:
             BSONCXX_UNREACHABLE;
     }

--- a/src/mongocxx/index_view.cpp
+++ b/src/mongocxx/index_view.cpp
@@ -108,7 +108,8 @@ void index_view::drop_one(const client_session& session,
     bsoncxx::document::view opts_view = index_options.view();
 
     if (opts_view["name"]) {
-        drop_one(session, bsoncxx::string::to_string(opts_view["name"].get_string().value), options);
+        drop_one(
+            session, bsoncxx::string::to_string(opts_view["name"].get_string().value), options);
     } else {
         drop_one(session, _get_impl().get_index_name_from_keys(keys), options);
     }

--- a/src/mongocxx/index_view.cpp
+++ b/src/mongocxx/index_view.cpp
@@ -95,7 +95,7 @@ void index_view::drop_one(const bsoncxx::document::view_or_value& keys,
     bsoncxx::document::view opts_view = index_options.view();
 
     if (opts_view["name"]) {
-        drop_one(bsoncxx::string::to_string(opts_view["name"].get_utf8().value), options);
+        drop_one(bsoncxx::string::to_string(opts_view["name"].get_string().value), options);
     } else {
         drop_one(_get_impl().get_index_name_from_keys(keys), options);
     }
@@ -108,7 +108,7 @@ void index_view::drop_one(const client_session& session,
     bsoncxx::document::view opts_view = index_options.view();
 
     if (opts_view["name"]) {
-        drop_one(session, bsoncxx::string::to_string(opts_view["name"].get_utf8().value), options);
+        drop_one(session, bsoncxx::string::to_string(opts_view["name"].get_string().value), options);
     } else {
         drop_one(session, _get_impl().get_index_name_from_keys(keys), options);
     }

--- a/src/mongocxx/private/index_view.hh
+++ b/src/mongocxx/private/index_view.hh
@@ -79,14 +79,14 @@ class index_view::impl {
         bsoncxx::document::view result_view = result.view();
 
         if (result_view["note"] &&
-            bsoncxx::string::to_string(result_view["note"].get_utf8().value) ==
+            bsoncxx::string::to_string(result_view["note"].get_string().value) ==
                 "all indexes already exist") {
             return bsoncxx::stdx::nullopt;
         }
 
         if (auto name = model.options()["name"]) {
             return bsoncxx::stdx::make_optional(
-                bsoncxx::string::to_string(name.get_value().get_utf8().value));
+                bsoncxx::string::to_string(name.get_value().get_string().value));
         }
 
         return bsoncxx::stdx::make_optional(get_index_name_from_keys(model.keys()));

--- a/src/mongocxx/test/change_streams.cpp
+++ b/src/mongocxx/test/change_streams.cpp
@@ -320,7 +320,7 @@ TEST_CASE("Mock streams and error-handling") {
             REQUIRE(opts["batchSize"].get_int32() == batch_size);
             REQUIRE(opts["maxAwaitTimeMS"].get_int64() == 4);
             REQUIRE(opts["collation"].get_document().view() == collation);
-            REQUIRE(opts["fullDocument"].get_utf8().value ==
+            REQUIRE(opts["fullDocument"].get_string().value ==
                     bsoncxx::stdx::string_view{full_document});
             REQUIRE(opts["resumeAfter"].get_document().view() == resume_after);
         };
@@ -620,7 +620,7 @@ TEST_CASE("Watch a Collection", "[min36]") {
 
         SECTION("Can receive it") {
             auto it = *(x.begin());
-            REQUIRE(it["fullDocument"]["a"].get_utf8().value == stdx::string_view("b"));
+            REQUIRE(it["fullDocument"]["a"].get_string().value == stdx::string_view("b"));
         }
 
         SECTION("iterator equals itself") {
@@ -638,8 +638,8 @@ TEST_CASE("Watch a Collection", "[min36]") {
             auto it = x.begin();
             auto a = *it;
             auto b = *it;
-            REQUIRE(a["fullDocument"]["a"].get_utf8().value == stdx::string_view("b"));
-            REQUIRE(b["fullDocument"]["a"].get_utf8().value == stdx::string_view("b"));
+            REQUIRE(a["fullDocument"]["a"].get_string().value == stdx::string_view("b"));
+            REQUIRE(b["fullDocument"]["a"].get_string().value == stdx::string_view("b"));
         }
 
         SECTION("Calling .begin multiple times doesn't advance state") {

--- a/src/mongocxx/test/client.cpp
+++ b/src/mongocxx/test/client.cpp
@@ -364,14 +364,16 @@ TEST_CASE("integration tests for client metadata handshake feature") {
 
                 REQUIRE(metadata_view["application"]);
                 auto application = metadata_view["application"].get_document();
-                REQUIRE(application.view()["name"].get_string().value == stdx::string_view(app_name));
+                REQUIRE(application.view()["name"].get_string().value ==
+                        stdx::string_view(app_name));
 
                 REQUIRE(metadata_view["driver"]);
                 auto driver = metadata_view["driver"].get_document();
                 auto driver_view = driver.view();
                 REQUIRE(driver_view["name"].get_string().value ==
                         stdx::string_view{"mongoc / mongocxx"});
-                auto version = bsoncxx::string::to_string(driver_view["version"].get_string().value);
+                auto version =
+                    bsoncxx::string::to_string(driver_view["version"].get_string().value);
                 REQUIRE(version.find(MONGOCXX_VERSION_STRING) != std::string::npos);
 
                 REQUIRE(metadata_view["os"]);

--- a/src/mongocxx/test/client.cpp
+++ b/src/mongocxx/test/client.cpp
@@ -348,7 +348,7 @@ TEST_CASE("integration tests for client metadata handshake feature") {
             auto op_view = it.get_document().view();
 
             if (!op_view["appName"] ||
-                op_view["appName"].get_utf8().value != stdx::string_view(app_name)) {
+                op_view["appName"].get_string().value != stdx::string_view(app_name)) {
                 continue;
             }
 
@@ -364,14 +364,14 @@ TEST_CASE("integration tests for client metadata handshake feature") {
 
                 REQUIRE(metadata_view["application"]);
                 auto application = metadata_view["application"].get_document();
-                REQUIRE(application.view()["name"].get_utf8().value == stdx::string_view(app_name));
+                REQUIRE(application.view()["name"].get_string().value == stdx::string_view(app_name));
 
                 REQUIRE(metadata_view["driver"]);
                 auto driver = metadata_view["driver"].get_document();
                 auto driver_view = driver.view();
-                REQUIRE(driver_view["name"].get_utf8().value ==
+                REQUIRE(driver_view["name"].get_string().value ==
                         stdx::string_view{"mongoc / mongocxx"});
-                auto version = bsoncxx::string::to_string(driver_view["version"].get_utf8().value);
+                auto version = bsoncxx::string::to_string(driver_view["version"].get_string().value);
                 REQUIRE(version.find(MONGOCXX_VERSION_STRING) != std::string::npos);
 
                 REQUIRE(metadata_view["os"]);

--- a/src/mongocxx/test/client_side_encryption.cpp
+++ b/src/mongocxx/test/client_side_encryption.cpp
@@ -215,7 +215,7 @@ void run_datakey_and_double_encryption(Callable create_data_key,
     // Expect that exactly one document is returned with the correct "masterKey.provider"
     std::size_t i = 0;
     for (auto&& doc : cursor) {
-        REQUIRE(doc["masterKey"]["provider"].get_utf8().value == provider);
+        REQUIRE(doc["masterKey"]["provider"].get_string().value == provider);
         i++;
     }
 
@@ -260,7 +260,7 @@ void run_datakey_and_double_encryption(Callable create_data_key,
     REQUIRE(res);
     auto decrypted_bson_val = res->view()["value"];
     REQUIRE(decrypted_bson_val.type() == bsoncxx::type::k_utf8);
-    REQUIRE(decrypted_bson_val.get_utf8().value == stdx::string_view{"hello there"});
+    REQUIRE(decrypted_bson_val.get_string().value == stdx::string_view{"hello there"});
 
     // 3. Call client_encryption.encrypt() with the value "hello there", the algorithm
     // AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic, and the key_alt_name of provider_altname
@@ -824,11 +824,11 @@ void _run_corpus_test(bool use_schema_map) {
         // allowed is a boolean indicating whether the encryption for the given parameters is
         // permitted.
         // value is the value to be tested.
-        auto kms = subdoc["kms"].get_utf8().value;
-        auto type = subdoc["type"].get_utf8().value;
-        auto algo = subdoc["algo"].get_utf8().value;
-        auto method = subdoc["method"].get_utf8().value;
-        auto identifier = subdoc["identifier"].get_utf8().value;
+        auto kms = subdoc["kms"].get_string().value;
+        auto type = subdoc["type"].get_string().value;
+        auto algo = subdoc["algo"].get_string().value;
+        auto method = subdoc["method"].get_string().value;
+        auto identifier = subdoc["identifier"].get_string().value;
         auto allowed = subdoc["allowed"].get_bool().value;
         auto to_encrypt = subdoc["value"].get_value();
 
@@ -938,7 +938,7 @@ void _run_corpus_test(bool use_schema_map) {
         auto subdoc_val = ele.get_document();
         auto subdoc = subdoc_val.view();
 
-        auto algo = subdoc["algo"].get_utf8().value;
+        auto algo = subdoc["algo"].get_string().value;
         auto allowed = subdoc["allowed"].get_bool().value;
         auto value = subdoc["value"].get_value();
 

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -2343,7 +2343,8 @@ TEST_CASE("create_index tests", "[collection]") {
         options.name(indexName);
 
         auto response = coll.create_index(index.view(), options);
-        REQUIRE(response.view()["name"].get_string().value == bsoncxx::stdx::string_view(indexName));
+        REQUIRE(response.view()["name"].get_string().value ==
+                bsoncxx::stdx::string_view(indexName));
 
         find_index_and_validate(coll, indexName);
 

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -208,7 +208,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
             REQUIRE(result);
             REQUIRE(result->result().inserted_count() == 1);
             REQUIRE(result->inserted_id().type() == bsoncxx::type::k_utf8);
-            REQUIRE(result->inserted_id().get_utf8().value == expected_id);
+            REQUIRE(result->inserted_id().get_string().value == expected_id);
         }
 
         SECTION("unacknowledged write concern returns disengaged optional", "[collection]") {
@@ -245,7 +245,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
             REQUIRE(result);
             REQUIRE(result->result().inserted_count() == 1);
             REQUIRE(result->inserted_id().type() == bsoncxx::type::k_utf8);
-            REQUIRE(result->inserted_id().get_utf8().value == expected_id);
+            REQUIRE(result->inserted_id().get_string().value == expected_id);
         }
     }
 
@@ -328,7 +328,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
             // Verify result->inserted_ids() is correct:
             auto id_map = result->inserted_ids();
             REQUIRE(id_map[0].type() == bsoncxx::type::k_utf8);
-            REQUIRE(id_map[0].get_utf8().value == stdx::string_view{"foo"});
+            REQUIRE(id_map[0].get_string().value == stdx::string_view{"foo"});
             REQUIRE(id_map[1].type() == bsoncxx::type::k_oid);
             auto second_inserted_doc = coll.find_one(make_document(kvp("x", 2)));
             REQUIRE(second_inserted_doc);
@@ -422,7 +422,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
             // Verify result->inserted_ids() is correct:
             auto id_map = result->inserted_ids();
             REQUIRE(id_map[0].type() == bsoncxx::type::k_utf8);
-            REQUIRE(id_map[0].get_utf8().value == stdx::string_view{"foo"});
+            REQUIRE(id_map[0].get_string().value == stdx::string_view{"foo"});
             REQUIRE(id_map[1].type() == bsoncxx::type::k_oid);
             auto second_inserted_doc = coll.find_one(make_document(kvp("x", 2)));
             REQUIRE(second_inserted_doc);
@@ -560,7 +560,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
 
         auto result = coll.find_one(bson.view());
         REQUIRE(result);
-        REQUIRE(result->view()["name"].get_utf8().value == stdx::string_view("Charlotte"));
+        REQUIRE(result->view()["name"].get_string().value == stdx::string_view("Charlotte"));
 
         // Try adding stages with append_stage(s) instead
         pipeline array_update;
@@ -584,8 +584,8 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
 
         result = coll.find_one(bson.view());
         REQUIRE(result);
-        REQUIRE(result->view()["lastname"].get_utf8().value == stdx::string_view("Krause"));
-        REQUIRE(result->view()["department"].get_utf8().value == stdx::string_view("VIS"));
+        REQUIRE(result->view()["lastname"].get_string().value == stdx::string_view("Krause"));
+        REQUIRE(result->view()["department"].get_string().value == stdx::string_view("VIS"));
         REQUIRE(result->view()["count"].get_int32().value == 1);
     }
 
@@ -1242,7 +1242,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
 
             auto doc = coll.find_one_and_replace(criteria.view(), replacement.view());
             REQUIRE(doc);
-            REQUIRE(doc->view()["x"].get_utf8().value == stdx::string_view{"foo"});
+            REQUIRE(doc->view()["x"].get_string().value == stdx::string_view{"foo"});
         }
 
         SECTION("with return replacement returns new") {
@@ -1258,7 +1258,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
             options.return_document(options::return_document::k_after);
             auto doc = coll.find_one_and_replace(criteria.view(), replacement.view(), options);
             REQUIRE(doc);
-            REQUIRE(doc->view()["x"].get_utf8().value == stdx::string_view{"bar"});
+            REQUIRE(doc->view()["x"].get_string().value == stdx::string_view{"bar"});
         }
 
         SECTION("with collation") {
@@ -1287,7 +1287,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
                 auto doc = coll.find_one_and_replace(
                     collation_criteria.view(), replacement.view(), options);
                 REQUIRE(doc);
-                REQUIRE(doc->view()["x"].get_utf8().value == stdx::string_view{"foo"});
+                REQUIRE(doc->view()["x"].get_string().value == stdx::string_view{"foo"});
             } else {
                 REQUIRE_THROWS_AS(coll.find_one_and_replace(
                                       collation_criteria.view(), replacement.view(), options),
@@ -1329,7 +1329,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
             REQUIRE_NOTHROW(
                 doc = coll.find_one_and_replace(criteria.view(), replacement.view(), options));
             REQUIRE(doc);
-            REQUIRE(doc->view()["x"].get_utf8().value == stdx::string_view{"bar"});
+            REQUIRE(doc->view()["x"].get_string().value == stdx::string_view{"bar"});
         }
     }
 
@@ -1351,7 +1351,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
 
             REQUIRE(doc);
 
-            REQUIRE(doc->view()["x"].get_utf8().value == stdx::string_view{"foo"});
+            REQUIRE(doc->view()["x"].get_string().value == stdx::string_view{"foo"});
         }
 
         SECTION("with return update returns new") {
@@ -1367,7 +1367,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
             options.return_document(options::return_document::k_after);
             auto doc = coll.find_one_and_update(criteria.view(), update.view(), options);
             REQUIRE(doc);
-            REQUIRE(doc->view()["x"].get_utf8().value == stdx::string_view{"bar"});
+            REQUIRE(doc->view()["x"].get_string().value == stdx::string_view{"bar"});
         }
 
         SECTION("with collation") {
@@ -1396,7 +1396,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
                 auto doc =
                     coll.find_one_and_update(collation_criteria.view(), update.view(), options);
                 REQUIRE(doc);
-                REQUIRE(doc->view()["x"].get_utf8().value == stdx::string_view{"foo"});
+                REQUIRE(doc->view()["x"].get_string().value == stdx::string_view{"foo"});
 
             } else {
                 REQUIRE_THROWS_AS(
@@ -1439,7 +1439,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
             REQUIRE_NOTHROW(doc =
                                 coll.find_one_and_update(criteria.view(), update.view(), options));
             REQUIRE(doc);
-            REQUIRE(doc->view()["x"].get_utf8().value == stdx::string_view{"bar"});
+            REQUIRE(doc->view()["x"].get_string().value == stdx::string_view{"bar"});
         }
     }
 
@@ -1460,7 +1460,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
 
             REQUIRE(doc);
 
-            REQUIRE(doc->view()["x"].get_utf8().value == stdx::string_view{"foo"});
+            REQUIRE(doc->view()["x"].get_string().value == stdx::string_view{"foo"});
             REQUIRE(coll.count_documents({}) == 1);
         }
 
@@ -1488,7 +1488,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
                 options.write_concern(default_wc);
                 auto doc = coll.find_one_and_delete(collation_criteria.view(), options);
                 REQUIRE(doc);
-                REQUIRE(doc->view()["x"].get_utf8().value == stdx::string_view{"foo"});
+                REQUIRE(doc->view()["x"].get_string().value == stdx::string_view{"foo"});
 
             } else {
                 REQUIRE_THROWS_AS(coll.find_one_and_delete(collation_criteria.view(), options),
@@ -2237,7 +2237,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
 
         std::vector<stdx::string_view> distinct_values;
         for (auto&& value : values_array) {
-            distinct_values.push_back(value.get_utf8().value);
+            distinct_values.push_back(value.get_string().value);
         }
 
         const auto assert_contains_one = [&](stdx::string_view val) {
@@ -2267,7 +2267,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
             auto result = *iter;
             auto values = result["values"].get_array().value;
             REQUIRE(std::distance(values.begin(), values.end()) == 1);
-            REQUIRE(values[0].get_utf8().value == stdx::string_view{"foo"});
+            REQUIRE(values[0].get_string().value == stdx::string_view{"foo"});
         } else {
             // The server does not support collation.
             REQUIRE_THROWS_AS(coll.distinct("x", predicate.view(), distinct_opts),
@@ -2313,7 +2313,7 @@ void find_index_and_validate(collection& coll,
         REQUIRE(name_ele);
         REQUIRE(name_ele.type() == bsoncxx::type::k_utf8);
 
-        if (name_ele.get_utf8().value != index_name) {
+        if (name_ele.get_string().value != index_name) {
             continue;
         }
 
@@ -2343,14 +2343,14 @@ TEST_CASE("create_index tests", "[collection]") {
         options.name(indexName);
 
         auto response = coll.create_index(index.view(), options);
-        REQUIRE(response.view()["name"].get_utf8().value == bsoncxx::stdx::string_view(indexName));
+        REQUIRE(response.view()["name"].get_string().value == bsoncxx::stdx::string_view(indexName));
 
         find_index_and_validate(coll, indexName);
 
         bsoncxx::document::value index2 = make_document(kvp("b", 1), kvp("c", -1));
 
         auto response2 = coll.create_index(index2.view(), options::index{});
-        REQUIRE(response2.view()["name"].get_utf8().value ==
+        REQUIRE(response2.view()["name"].get_string().value ==
                 bsoncxx::stdx::string_view{"b_1_c_-1"});
 
         find_index_and_validate(coll, "b_1_c_-1");
@@ -2374,7 +2374,7 @@ TEST_CASE("create_index tests", "[collection]") {
             auto locale_ele = index["collation"]["locale"];
             REQUIRE(locale_ele);
             REQUIRE(locale_ele.type() == type::k_utf8);
-            REQUIRE((locale_ele.get_utf8() == locale));
+            REQUIRE((locale_ele.get_string() == locale));
         };
 
         find_index_and_validate(coll, "a_1", validate);
@@ -2474,7 +2474,7 @@ TEST_CASE("create_index tests", "[collection]") {
             auto config_string_ele = index["storageEngine"]["wiredTiger"]["configString"];
             REQUIRE(config_string_ele);
             REQUIRE(config_string_ele.type() == type::k_utf8);
-            REQUIRE(config_string_ele.get_utf8() == types::b_utf8{"block_allocation=first"});
+            REQUIRE(config_string_ele.get_string() == types::b_utf8{"block_allocation=first"});
         };
 
         find_index_and_validate(coll, index_name, validate);
@@ -2504,7 +2504,7 @@ TEST_CASE("list_indexes", "[collection]") {
     std::int8_t found = 0;
 
     for (auto&& index : cursor) {
-        auto name = index["name"].get_utf8();
+        auto name = index["name"].get_string();
 
         for (auto&& expected : expected_names) {
             if (bsoncxx::stdx::string_view(expected) == name.value) {

--- a/src/mongocxx/test/collection_mocked.cpp
+++ b/src/mongocxx/test/collection_mocked.cpp
@@ -116,7 +116,7 @@ TEST_CASE("Collection", "[collection]") {
                 bsoncxx::document::view o(bson_get_data(options), options->len);
 
                 bsoncxx::stdx::string_view bar(
-                    p[0].get_document().value["$match"].get_document().value["foo"].get_utf8());
+                    p[0].get_document().value["$match"].get_document().value["foo"].get_string());
                 std::int32_t one(
                     p[1].get_document().value["$sort"].get_document().value["foo"].get_int32());
 
@@ -348,7 +348,7 @@ TEST_CASE("Collection", "[collection]") {
                         *expected_allow_partial_results);
             }
             if (expected_comment) {
-                REQUIRE(opts_view["comment"].get_utf8().value == *expected_comment);
+                REQUIRE(opts_view["comment"].get_string().value == *expected_comment);
             }
             if (expected_cursor_type) {
                 bsoncxx::document::element tailable = opts_view["tailable"];
@@ -369,7 +369,7 @@ TEST_CASE("Collection", "[collection]") {
                 }
             }
             if (expected_hint) {
-                REQUIRE(opts_view["hint"].get_utf8() == expected_hint->get_utf8());
+                REQUIRE(opts_view["hint"].get_string() == expected_hint->get_string());
             }
             if (expected_no_cursor_timeout) {
                 REQUIRE(opts_view["noCursorTimeout"].get_bool().value ==
@@ -598,7 +598,7 @@ TEST_CASE("Collection", "[collection]") {
                 }
 
                 if (expected_hint) {
-                    REQUIRE(options_view["hint"].get_utf8() == expected_hint->get_utf8());
+                    REQUIRE(options_view["hint"].get_string() == expected_hint->get_string());
                 } else {
                     REQUIRE(!options_view["hint"]);
                 }
@@ -723,7 +723,7 @@ TEST_CASE("Collection", "[collection]") {
                 }
 
                 if (expected_hint) {
-                    REQUIRE(options_view["hint"].get_utf8() == expected_hint->get_utf8());
+                    REQUIRE(options_view["hint"].get_string() == expected_hint->get_string());
                 } else {
                     REQUIRE(!options_view["hint"]);
                 }
@@ -806,7 +806,7 @@ TEST_CASE("Collection", "[collection]") {
                 }
 
                 if (expected_hint) {
-                    REQUIRE(options_view["hint"].get_utf8() == expected_hint->get_utf8());
+                    REQUIRE(options_view["hint"].get_string() == expected_hint->get_string());
                 } else {
                     REQUIRE(!options_view["hint"]);
                 }
@@ -869,7 +869,7 @@ TEST_CASE("Collection", "[collection]") {
                 bsoncxx::document::view options_view{bson_get_data(options), options->len};
                 if (expected_hint) {
                     CAPTURE(to_json(options_view));
-                    REQUIRE(options_view["hint"].get_utf8() == expected_hint->get_utf8());
+                    REQUIRE(options_view["hint"].get_string() == expected_hint->get_string());
                 } else {
                     REQUIRE(!options_view["hint"]);
                 }
@@ -912,7 +912,7 @@ TEST_CASE("Collection", "[collection]") {
                 bsoncxx::document::view options_view{bson_get_data(options), options->len};
                 if (expected_hint) {
                     CAPTURE(to_json(options_view));
-                    REQUIRE(options_view["hint"].get_utf8() == expected_hint->get_utf8());
+                    REQUIRE(options_view["hint"].get_string() == expected_hint->get_string());
                 } else {
                     REQUIRE(!options_view["hint"]);
                 }

--- a/src/mongocxx/test/database.cpp
+++ b/src/mongocxx/test/database.cpp
@@ -44,7 +44,7 @@ bool check_for_collections(cursor cursor, std::set<std::string> expected_colls) 
     for (auto&& coll : cursor) {
         // Skip system collections which the MMAPv1 storage engine returns,
         // while WiredTiger does not.
-        auto name_string = bsoncxx::string::to_string(coll["name"].get_utf8().value);
+        auto name_string = bsoncxx::string::to_string(coll["name"].get_string().value);
         auto pos = name_string.find("system.");
         if (pos != std::string::npos && pos == 0) {
             continue;
@@ -358,8 +358,8 @@ TEST_CASE("Database integration tests", "[database]") {
             auto results = get_results(std::move(cursor));
 
             REQUIRE(results.size() == 2);
-            REQUIRE(results[0].view()["name"].get_utf8().value == stdx::string_view("Jane"));
-            REQUIRE(results[1].view()["name"].get_utf8().value == stdx::string_view("Jane"));
+            REQUIRE(results[0].view()["name"].get_string().value == stdx::string_view("Jane"));
+            REQUIRE(results[1].view()["name"].get_string().value == stdx::string_view("Jane"));
         }
     }
 

--- a/src/mongocxx/test/gridfs/bucket.cpp
+++ b/src/mongocxx/test/gridfs/bucket.cpp
@@ -61,7 +61,7 @@ void validate_gridfs_file(database db,
     REQUIRE(static_cast<std::size_t>(files_doc->view()["length"].get_int64().value) ==
             expected_contents.size());
     REQUIRE(files_doc->view()["chunkSize"].get_int32().value == expected_chunk_size);
-    REQUIRE(files_doc->view()["filename"].get_utf8().value ==
+    REQUIRE(files_doc->view()["filename"].get_string().value ==
             stdx::string_view(expected_file_name));
 
     // md5 is deprecated in GridFS, we don't include it:
@@ -119,7 +119,7 @@ void validate_gridfs_file(
     REQUIRE(files_doc->view()["_id"].get_oid() == id.get_oid());
     REQUIRE(files_doc->view()["length"].get_int64().value == expected_length);
     REQUIRE(files_doc->view()["chunkSize"].get_int32().value == expected_chunk_size);
-    REQUIRE(files_doc->view()["filename"].get_utf8().value ==
+    REQUIRE(files_doc->view()["filename"].get_string().value ==
             stdx::string_view(expected_file_name));
 
     std::size_t i = 0;

--- a/src/mongocxx/test/hint.cpp
+++ b/src/mongocxx/test/hint.cpp
@@ -41,7 +41,7 @@ TEST_CASE("Hint", "[hint]") {
         SECTION("Returns correct value from to_value") {
             types::bson_value::view val = index_hint.to_value();
             REQUIRE(val.type() == type::k_utf8);
-            REQUIRE(bsoncxx::string::to_string(val.get_utf8().value) == index_name);
+            REQUIRE(bsoncxx::string::to_string(val.get_string().value) == index_name);
         }
 
         SECTION("Compares equal to matching index name") {

--- a/src/mongocxx/test/index_view.cpp
+++ b/src/mongocxx/test/index_view.cpp
@@ -256,7 +256,7 @@ TEST_CASE("create_many", "[index_view]") {
         std::int8_t found = 0;
 
         for (auto&& index : indexes.list()) {
-            auto name = index["name"].get_utf8();
+            auto name = index["name"].get_string();
 
             for (auto expected : expected_names) {
                 if (stdx::string_view(expected) == name.value) {
@@ -458,7 +458,7 @@ TEST_CASE("index creation and deletion with different collation") {
         ++index_it;
         bsoncxx::document::view index = *index_it;
 
-        REQUIRE(bsoncxx::string::to_string(index["name"].get_utf8().value) == "custom_index_name");
+        REQUIRE(bsoncxx::string::to_string(index["name"].get_string().value) == "custom_index_name");
 
         coll.drop();
         db.drop();

--- a/src/mongocxx/test/index_view.cpp
+++ b/src/mongocxx/test/index_view.cpp
@@ -458,7 +458,8 @@ TEST_CASE("index creation and deletion with different collation") {
         ++index_it;
         bsoncxx::document::view index = *index_it;
 
-        REQUIRE(bsoncxx::string::to_string(index["name"].get_string().value) == "custom_index_name");
+        REQUIRE(bsoncxx::string::to_string(index["name"].get_string().value) ==
+                "custom_index_name");
 
         coll.drop();
         db.drop();

--- a/src/mongocxx/test/options/create_collection.cpp
+++ b/src/mongocxx/test/options/create_collection.cpp
@@ -134,7 +134,7 @@ TEST_CASE("create_collection can be exported to a document", "[create_collection
     document::element validationLevel{doc_view["validationLevel"]};
     REQUIRE(validationLevel);
     REQUIRE(validationLevel.type() == type::k_utf8);
-    REQUIRE(bsoncxx::string::to_string(validationLevel.get_utf8().value) == "strict");
+    REQUIRE(bsoncxx::string::to_string(validationLevel.get_string().value) == "strict");
 
     document::element validationAction{doc_view["validationAction"]};
     REQUIRE(!validationAction);

--- a/src/mongocxx/test/result/gridfs/upload.cpp
+++ b/src/mongocxx/test/result/gridfs/upload.cpp
@@ -57,7 +57,7 @@ TEST_CASE("result::gridfs::upload owns id", "[result::gridfs::upload]") {
 
     // Because result::gridfs::upload owns its id, we should still be able to correctly read new
     // value for the id.
-    REQUIRE(res.id().get_utf8().value == stdx::string_view(bar));
+    REQUIRE(res.id().get_string().value == stdx::string_view(bar));
 }
 
 TEST_CASE("result::gridfs::upload equals", "[result::gridfs::upload]") {

--- a/src/mongocxx/test/spec/change_stream.cpp
+++ b/src/mongocxx/test/spec/change_stream.cpp
@@ -40,7 +40,7 @@ using bsoncxx::builder::basic::make_array;
 using bsoncxx::builder::basic::make_document;
 
 bool should_skip(const array::element& test) {
-    if (test["description"].get_utf8().value.compare(
+    if (test["description"].get_string().value.compare(
             "Change Stream should error when an invalid aggregation stage is passed in") == 0) {
         UNSCOPED_INFO(
             "Skipping test with invalid pipeline stages. The C++ driver cannot test them.");
@@ -79,7 +79,7 @@ void run_change_stream_tests_in_file(const std::string& test_path) {
     // https://github.com/mongodb/specifications/tree/master/source/change-streams/tests#spec-test-runner
     for (auto&& test_el : tests) {
         auto test = test_el.get_document().value;
-        auto description = test["description"].get_utf8().value;
+        auto description = test["description"].get_string().value;
         SECTION(to_string(description)) {
             if (should_skip(test_el))
                 continue;
@@ -110,9 +110,9 @@ void run_change_stream_tests_in_file(const std::string& test_path) {
                     pipeline = build_pipeline(test["changeStreamPipeline"].get_array().value);
                 }
 
-                std::string db_name = to_string(test_spec["database_name"].get_utf8().value);
-                std::string coll_name = to_string(test_spec["collection_name"].get_utf8().value);
-                auto target = std::string(test["target"].get_utf8().value);
+                std::string db_name = to_string(test_spec["database_name"].get_string().value);
+                std::string coll_name = to_string(test_spec["collection_name"].get_string().value);
+                auto target = std::string(test["target"].get_string().value);
                 if (target == "collection") {
                     return client[db_name][coll_name].watch(pipeline, cs_opts);
                 } else if (target == "database") {
@@ -126,9 +126,9 @@ void run_change_stream_tests_in_file(const std::string& test_path) {
             // server."
             mongocxx::client global_client(uri{});
             for (auto&& operation : test["operations"].get_array().value) {
-                std::string operation_name = to_string(operation["name"].get_utf8().value);
-                auto dbname = to_string(operation["database"].get_utf8().value);
-                auto collname = to_string(operation["collection"].get_utf8().value);
+                std::string operation_name = to_string(operation["name"].get_string().value);
+                auto dbname = to_string(operation["database"].get_string().value);
+                auto collname = to_string(operation["collection"].get_string().value);
                 auto coll = global_client[dbname][collname];
                 operation_runner op_runner{&coll};
                 op_runner.run(operation.get_document().value);
@@ -169,7 +169,7 @@ void run_change_stream_tests_in_file(const std::string& test_path) {
             // Disable the failpoint.
             if (test["failPoint"]) {
                 disable_fail_point(client,
-                                   test["failPoint"]["configureFailPoint"].get_utf8().value);
+                                   test["failPoint"]["configureFailPoint"].get_string().value);
             }
 
             // Match captured APM events.

--- a/src/mongocxx/test/spec/client_side_encryption.cpp
+++ b/src/mongocxx/test/spec/client_side_encryption.cpp
@@ -60,7 +60,7 @@ void add_auto_encryption_opts(document::view test, options::client* client_opts)
 
         if (test_encrypt_opts["keyVaultNamespace"]) {
             auto ns_string =
-                string::to_string(test_encrypt_opts["keyVaultNamespace"].get_utf8().value);
+                string::to_string(test_encrypt_opts["keyVaultNamespace"].get_string().value);
             auto dot = ns_string.find(".");
             std::string db = ns_string.substr(0, dot);
             std::string coll = ns_string.substr(dot + 1);
@@ -135,8 +135,8 @@ void run_encryption_tests_in_file(const std::string& test_path) {
     REQUIRE(test_spec);
 
     auto test_spec_view = test_spec->view();
-    auto db_name = test_spec_view["database_name"].get_utf8().value;
-    auto coll_name = test_spec_view["collection_name"].get_utf8().value;
+    auto db_name = test_spec_view["database_name"].get_string().value;
+    auto coll_name = test_spec_view["collection_name"].get_string().value;
     auto tests = test_spec_view["tests"].get_array().value;
 
     /* we may not have a supported topology */
@@ -153,7 +153,7 @@ void run_encryption_tests_in_file(const std::string& test_path) {
     wc_majority.acknowledge_level(write_concern::level::k_majority);
 
     for (auto&& test : tests) {
-        auto description = test["description"].get_utf8().value;
+        auto description = test["description"].get_string().value;
         INFO("Test description: " << description);
         if (should_skip_spec_test(client{uri{}}, test.get_document().value)) {
             continue;
@@ -166,7 +166,7 @@ void run_encryption_tests_in_file(const std::string& test_path) {
 
         add_auto_encryption_opts(test.get_document().value, &client_opts);
 
-        if (strcmp(test["description"].get_utf8().value.data(),
+        if (strcmp(test["description"].get_string().value.data(),
                    "operation fails with maxWireVersion < 8") == 0) {
             // We cannot create a client with auto encryption enabled on 4.0,
             // and it fails in different ways on Windows and POSIX, so rather
@@ -175,7 +175,7 @@ void run_encryption_tests_in_file(const std::string& test_path) {
         }
 
         bool check_results_logging = false;
-        if (strcmp(test["description"].get_utf8().value.data(),
+        if (strcmp(test["description"].get_string().value.data(),
                    "Insert with deterministic encryption, then find it") == 0) {
             // CDRIVER-3566 Remove this once windows is debugged.
             check_results_logging = true;

--- a/src/mongocxx/test/spec/command_monitoring.cpp
+++ b/src/mongocxx/test/spec/command_monitoring.cpp
@@ -31,8 +31,8 @@ using namespace bsoncxx;
 using namespace mongocxx;
 
 void initialize_collection(document::view test_spec_view) {
-    std::string db_name = string::to_string(test_spec_view["database_name"].get_utf8().value);
-    std::string col_name = string::to_string(test_spec_view["collection_name"].get_utf8().value);
+    std::string db_name = string::to_string(test_spec_view["database_name"].get_string().value);
+    std::string col_name = string::to_string(test_spec_view["collection_name"].get_string().value);
 
     client temp_client{uri{}};
     collection temp_col = temp_client[db_name][col_name];
@@ -57,14 +57,14 @@ void run_command_monitoring_tests_in_file(std::string test_path) {
 
     document::view test_spec_view = test_spec->view();
 
-    std::string db_name = string::to_string(test_spec_view["database_name"].get_utf8().value);
-    std::string col_name = string::to_string(test_spec_view["collection_name"].get_utf8().value);
+    std::string db_name = string::to_string(test_spec_view["database_name"].get_string().value);
+    std::string col_name = string::to_string(test_spec_view["collection_name"].get_string().value);
 
     array::view tests = test_spec_view["tests"].get_array().value;
 
     for (auto&& test : tests) {
         initialize_collection(test_spec_view);
-        std::string description = string::to_string(test["description"].get_utf8().value);
+        std::string description = string::to_string(test["description"].get_string().value);
         INFO("Test description: " << description);
         array::view expectations = test["expectations"].get_array().value;
 
@@ -98,13 +98,13 @@ void run_command_monitoring_tests_in_file(std::string test_path) {
                 types::bson_value::view value{ele.get_value()};
 
                 if (field.compare("command_name") == 0) {
-                    REQUIRE(event.command_name() == value.get_utf8().value);
+                    REQUIRE(event.command_name() == value.get_string().value);
                 } else if (field.compare("command") == 0) {
                     document::view expected_command = value.get_document().value;
                     document::view command = event.command();
                     REQUIRE_BSON_MATCHES(command, expected_command);
                 } else if (field.compare("database_name") == 0) {
-                    REQUIRE(event.database_name() == value.get_utf8().value);
+                    REQUIRE(event.database_name() == value.get_string().value);
                 } else {
                     // Should not happen.
                     REQUIRE(false);
@@ -122,7 +122,7 @@ void run_command_monitoring_tests_in_file(std::string test_path) {
                 types::bson_value::view value{ele.get_value()};
 
                 if (field.compare("command_name") == 0) {
-                    REQUIRE(event.command_name() == value.get_utf8().value);
+                    REQUIRE(event.command_name() == value.get_string().value);
                 } else {
                     // Should not happen.
                     REQUIRE(false);
@@ -144,7 +144,7 @@ void run_command_monitoring_tests_in_file(std::string test_path) {
                 types::bson_value::view value{ele.get_value()};
 
                 if (field.compare("command_name") == 0) {
-                    REQUIRE(event.command_name() == value.get_utf8().value);
+                    REQUIRE(event.command_name() == value.get_string().value);
                 } else if (field.compare("reply") == 0) {
                     document::view expected_reply = value.get_document().value;
                     document::view reply = event.reply();
@@ -167,7 +167,7 @@ void run_command_monitoring_tests_in_file(std::string test_path) {
         collection coll = client[db_name][col_name];
 
         document::view operation = test["operation"].get_document().value;
-        std::string operation_name = string::to_string(operation["name"].get_utf8().value);
+        std::string operation_name = string::to_string(operation["name"].get_string().value);
         spec::operation_runner op_runner{&coll};
 
         try {

--- a/src/mongocxx/test/spec/crud.cpp
+++ b/src/mongocxx/test/spec/crud.cpp
@@ -59,9 +59,9 @@ void run_crud_tests_in_file(std::string test_path) {
     }
 
     for (auto&& test : test_spec_view["tests"].get_array().value) {
-        auto description = test["description"].get_utf8().value;
+        auto description = test["description"].get_string().value;
         SECTION(to_string(description)) {
-            if (is_unsupported(test["description"].get_utf8().value)) {
+            if (is_unsupported(test["description"].get_string().value)) {
                 continue;
             }
 
@@ -71,7 +71,7 @@ void run_crud_tests_in_file(std::string test_path) {
 
             auto get_value_or_default = [&](std::string key, std::string default_str) {
                 if (test_spec_view[key]) {
-                    return to_string(test_spec_view[key].get_utf8().value);
+                    return to_string(test_spec_view[key].get_string().value);
                 }
                 return default_str;
             };
@@ -91,7 +91,7 @@ void run_crud_tests_in_file(std::string test_path) {
             std::string outcome_collection_name = collection_name;
             if (test["outcome"] && test["outcome"]["collection"]["name"]) {
                 outcome_collection_name =
-                    to_string(test["outcome"]["collection"]["name"].get_utf8().value);
+                    to_string(test["outcome"]["collection"]["name"].get_string().value);
                 auto outcome_collection = database[outcome_collection_name];
                 initialize_collection(&outcome_collection, array::view{});
             }
@@ -165,7 +165,7 @@ void run_crud_tests_in_file(std::string test_path) {
 
             if (test["failPoint"]) {
                 disable_fail_point(client,
-                                   test["failPoint"]["configureFailPoint"].get_utf8().value);
+                                   test["failPoint"]["configureFailPoint"].get_string().value);
             }
         }
     }

--- a/src/mongocxx/test/spec/gridfs.cpp
+++ b/src/mongocxx/test/spec/gridfs.cpp
@@ -474,7 +474,8 @@ void run_gridfs_tests_in_file(std::string test_path, client* client) {
     gridfs::bucket bucket = db.gridfs_bucket();
 
     for (auto&& test : tests) {
-        std::string description = bsoncxx::string::to_string(test["description"].get_string().value);
+        std::string description =
+            bsoncxx::string::to_string(test["description"].get_string().value);
         INFO("Test description: " << description);
         initialize_collections(db, test_spec_view["data"].get_document().value);
 

--- a/src/mongocxx/test/spec/gridfs.cpp
+++ b/src/mongocxx/test/spec/gridfs.cpp
@@ -95,7 +95,7 @@ bsoncxx::stdx::optional<test_util::item_t> transform_hex(test_util::item_t pair,
     }
 
     std::basic_string<std::uint8_t> bytes =
-        test_util::convert_hex_string_to_bytes(data["$hex"].get_utf8().value);
+        test_util::convert_hex_string_to_bytes(data["$hex"].get_string().value);
     types::b_binary binary_data = {
         binary_sub_type::k_binary, static_cast<std::uint32_t>(bytes.size()), bytes.data()};
 
@@ -164,7 +164,7 @@ void compare_collections(database db) {
 
         REQUIRE(expected["filename"]);
         REQUIRE(actual["filename"]);
-        REQUIRE(expected["filename"].get_utf8().value == actual["filename"].get_utf8().value);
+        REQUIRE(expected["filename"].get_string().value == actual["filename"].get_string().value);
     }
 
     cursor expected_chunks_cursor = db["expected.chunks"].find({});
@@ -217,7 +217,7 @@ void test_download(database db,
     }
 
     if (assert_doc["error"]) {
-        bsoncxx::stdx::string_view error = assert_doc["error"].get_utf8().value;
+        bsoncxx::stdx::string_view error = assert_doc["error"].get_string().value;
 
         // If the GridFS file is not found, an error should be thrown when the download stream is
         // opened.
@@ -245,7 +245,7 @@ void test_download(database db,
     // The GridFS spec specifies the expected binary data in the form of { $hex: "<hexadecimal
     // string>" }, which needs to be converted to an array of bytes.
     REQUIRE(result["$hex"]);
-    std::string hex = bsoncxx::string::to_string(result["$hex"].get_utf8().value);
+    std::string hex = bsoncxx::string::to_string(result["$hex"].get_string().value);
     std::basic_string<std::uint8_t> expected = test_util::convert_hex_string_to_bytes(hex);
 
     REQUIRE(actual_size == expected.size());
@@ -277,7 +277,7 @@ void test_upload(database db,
     }
 
     REQUIRE(arguments["filename"]);
-    bsoncxx::stdx::string_view filename = arguments["filename"].get_utf8().value;
+    bsoncxx::stdx::string_view filename = arguments["filename"].get_string().value;
 
     gridfs::uploader uploader = bucket.open_upload_stream(filename, upload_options);
 
@@ -285,7 +285,7 @@ void test_upload(database db,
     document::view source = arguments["source"].get_document().value;
 
     REQUIRE(source["$hex"]);
-    std::string hex = bsoncxx::string::to_string(source["$hex"].get_utf8().value);
+    std::string hex = bsoncxx::string::to_string(source["$hex"].get_string().value);
     std::basic_string<std::uint8_t> source_bytes = test_util::convert_hex_string_to_bytes(hex);
 
     uploader.write(source_bytes.data(), source_bytes.size());
@@ -327,7 +327,7 @@ void test_upload(database db,
                     return convert_length_to_int64(pair, context);
                 }
 
-                std::string id_str = bsoncxx::string::to_string(value.get_utf8().value);
+                std::string id_str = bsoncxx::string::to_string(value.get_string().value);
 
                 if (id_str == "*actual") {
                     return bsoncxx::stdx::optional<test_util::item_t>{};
@@ -474,7 +474,7 @@ void run_gridfs_tests_in_file(std::string test_path, client* client) {
     gridfs::bucket bucket = db.gridfs_bucket();
 
     for (auto&& test : tests) {
-        std::string description = bsoncxx::string::to_string(test["description"].get_utf8().value);
+        std::string description = bsoncxx::string::to_string(test["description"].get_string().value);
         INFO("Test description: " << description);
         initialize_collections(db, test_spec_view["data"].get_document().value);
 
@@ -491,7 +491,7 @@ void run_gridfs_tests_in_file(std::string test_path, client* client) {
 
         REQUIRE(act["operation"]);
         auto test_runner =
-            gridfs_test_runners[bsoncxx::string::to_string(act["operation"].get_utf8().value)];
+            gridfs_test_runners[bsoncxx::string::to_string(act["operation"].get_string().value)];
         test_runner(db, bucket, act, assert_doc);
     }
 }

--- a/src/mongocxx/test/spec/operation.cpp
+++ b/src/mongocxx/test/spec/operation.cpp
@@ -1416,24 +1416,26 @@ document::value operation_runner::run(document::view operation) {
         client client{uri{}};
         auto cursor = client[_db->name()][_coll->name()].list_indexes();
 
-        REQUIRE(
-            cursor.end() ==
-            std::find_if(
-                cursor.begin(), cursor.end(), [operation](bsoncxx::v_noabi::document::view doc) {
-                    return (doc["name"].get_string() == operation["arguments"]["index"].get_string());
-                }));
+        REQUIRE(cursor.end() ==
+                std::find_if(cursor.begin(),
+                             cursor.end(),
+                             [operation](bsoncxx::v_noabi::document::view doc) {
+                                 return (doc["name"].get_string() ==
+                                         operation["arguments"]["index"].get_string());
+                             }));
 
         return empty_document;
     } else if (key.compare("assertIndexExists") == 0) {
         client client{uri{}};
         auto cursor = client[_db->name()][_coll->name()].list_indexes();
 
-        REQUIRE(
-            cursor.end() !=
-            std::find_if(
-                cursor.begin(), cursor.end(), [operation](bsoncxx::v_noabi::document::view doc) {
-                    return (doc["name"].get_string() == operation["arguments"]["index"].get_string());
-                }));
+        REQUIRE(cursor.end() !=
+                std::find_if(cursor.begin(),
+                             cursor.end(),
+                             [operation](bsoncxx::v_noabi::document::view doc) {
+                                 return (doc["name"].get_string() ==
+                                         operation["arguments"]["index"].get_string());
+                             }));
 
         return empty_document;
     } else {

--- a/src/mongocxx/test/spec/operation.cpp
+++ b/src/mongocxx/test/spec/operation.cpp
@@ -74,7 +74,7 @@ pipeline build_pipeline(array::view pipeline_docs) {
 bsoncxx::stdx::optional<read_concern> lookup_read_concern(document::view doc) {
     if (doc["readConcern"] && doc["readConcern"]["level"]) {
         read_concern rc;
-        rc.acknowledge_string(string::to_string(doc["readConcern"]["level"].get_utf8().value));
+        rc.acknowledge_string(string::to_string(doc["readConcern"]["level"].get_string().value));
         return rc;
     }
 
@@ -86,7 +86,7 @@ bsoncxx::stdx::optional<write_concern> lookup_write_concern(document::view doc) 
         write_concern wc;
         document::element w = doc["writeConcern"]["w"];
         if (w.type() == bsoncxx::type::k_utf8) {
-            std::string level = string::to_string(w.get_utf8().value);
+            std::string level = string::to_string(w.get_string().value);
             if (level.compare("majority") == 0) {
                 wc.acknowledge_level(write_concern::level::k_majority);
             } else if (level.compare("acknowledged") == 0) {
@@ -106,7 +106,7 @@ bsoncxx::stdx::optional<write_concern> lookup_write_concern(document::view doc) 
 bsoncxx::stdx::optional<read_preference> lookup_read_preference(document::view doc) {
     if (doc["readPreference"] && doc["readPreference"]["mode"]) {
         read_preference rp;
-        std::string mode = string::to_string(doc["readPreference"]["mode"].get_utf8().value);
+        std::string mode = string::to_string(doc["readPreference"]["mode"].get_string().value);
         if (mode.compare("Primary") == 0) {
             rp.mode(read_preference::read_mode::k_primary);
         } else if (mode.compare("PrimaryPreferred") == 0) {
@@ -136,7 +136,7 @@ client_session* operation_runner::_lookup_session(stdx::string_view key) {
 
 client_session* operation_runner::_lookup_session(document::view doc) {
     if (doc["session"]) {
-        stdx::string_view session_name = doc["session"].get_utf8().value;
+        stdx::string_view session_name = doc["session"].get_string().value;
         return _lookup_session(session_name);
     }
     return nullptr;
@@ -161,7 +161,7 @@ document::value operation_runner::_run_aggregate(document::view operation) {
     client_session* session = _lookup_session(operation["arguments"].get_document().value);
 
     if (operation["object"] &&
-        operation["object"].get_utf8().value == stdx::string_view{"database"}) {
+        operation["object"].get_string().value == stdx::string_view{"database"}) {
         REQUIRE(_db);
 
         // Run on the database
@@ -197,7 +197,7 @@ document::value operation_runner::_run_distinct(document::view operation) {
         filter = arguments["filter"].get_document().value;
     }
 
-    bsoncxx::stdx::string_view field_name = arguments["fieldName"].get_utf8().value;
+    bsoncxx::stdx::string_view field_name = arguments["fieldName"].get_string().value;
 
     options::distinct options{};
 
@@ -262,7 +262,7 @@ document::value operation_runner::_run_find(document::view operation) {
     if (arguments["modifiers"]) {
         document::view modifiers = arguments["modifiers"].get_document().value;
         if (modifiers["$comment"]) {
-            options.comment(modifiers["$comment"].get_utf8().value);
+            options.comment(modifiers["$comment"].get_string().value);
         }
 
         if (modifiers["$hint"]) {
@@ -320,7 +320,7 @@ document::value operation_runner::_run_delete_many(document::view operation) {
 
     if (arguments["hint"]) {
         if (arguments["hint"].type() == bsoncxx::v_noabi::type::k_utf8)
-            options.hint(hint{arguments["hint"].get_utf8().value});
+            options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
     }
@@ -357,7 +357,7 @@ document::value operation_runner::_run_delete_one(document::view operation) {
 
     if (arguments["hint"]) {
         if (arguments["hint"].type() == bsoncxx::v_noabi::type::k_utf8)
-            options.hint(hint{arguments["hint"].get_utf8().value});
+            options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
     }
@@ -394,14 +394,14 @@ document::value operation_runner::_run_find_one_and_delete(document::view operat
 
     if (arguments["hint"]) {
         if (arguments["hint"].type() == bsoncxx::v_noabi::type::k_utf8)
-            options.hint(hint{arguments["hint"].get_utf8().value});
+            options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
     }
 
     if (arguments["hint"]) {
         if (arguments["hint"].type() == bsoncxx::v_noabi::type::k_utf8)
-            options.hint(hint{arguments["hint"].get_utf8().value});
+            options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
     }
@@ -463,7 +463,7 @@ document::value operation_runner::_run_find_one_and_replace(document::view opera
 
     if (arguments["hint"]) {
         if (arguments["hint"].type() == bsoncxx::v_noabi::type::k_utf8)
-            options.hint(hint{arguments["hint"].get_utf8().value});
+            options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
     }
@@ -474,7 +474,7 @@ document::value operation_runner::_run_find_one_and_replace(document::view opera
 
     if (arguments["returnDocument"]) {
         std::string return_document =
-            bsoncxx::string::to_string(arguments["returnDocument"].get_utf8().value);
+            bsoncxx::string::to_string(arguments["returnDocument"].get_string().value);
 
         if (return_document == "After") {
             options.return_document(options::return_document::k_after);
@@ -523,7 +523,7 @@ document::value operation_runner::_run_find_one_and_update(document::view operat
 
     if (arguments["hint"]) {
         if (arguments["hint"].type() == bsoncxx::v_noabi::type::k_utf8)
-            options.hint(hint{arguments["hint"].get_utf8().value});
+            options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
     }
@@ -538,7 +538,7 @@ document::value operation_runner::_run_find_one_and_update(document::view operat
 
     if (arguments["returnDocument"]) {
         std::string return_document =
-            bsoncxx::string::to_string(arguments["returnDocument"].get_utf8().value);
+            bsoncxx::string::to_string(arguments["returnDocument"].get_string().value);
 
         if (return_document == "After") {
             options.return_document(options::return_document::k_after);
@@ -679,7 +679,7 @@ document::value operation_runner::_run_replace_one(document::view operation) {
 
     if (arguments["hint"]) {
         if (arguments["hint"].type() == bsoncxx::v_noabi::type::k_utf8)
-            options.hint(hint{arguments["hint"].get_utf8().value});
+            options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
     }
@@ -747,7 +747,7 @@ document::value operation_runner::_run_update_many(document::view operation) {
 
     if (arguments["hint"]) {
         if (arguments["hint"].type() == bsoncxx::v_noabi::type::k_utf8)
-            options.hint(hint{arguments["hint"].get_utf8().value});
+            options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
     }
@@ -839,7 +839,7 @@ document::value operation_runner::_run_update_one(document::view operation) {
 
     if (arguments["hint"]) {
         if (arguments["hint"].type() == bsoncxx::v_noabi::type::k_utf8)
-            options.hint(hint{arguments["hint"].get_utf8().value});
+            options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
     }
@@ -948,7 +948,7 @@ void operation_runner::_set_collection_options(document::view operation) {
         if (!read_concern_options.empty()) {
             REQUIRE(read_concern_options["level"]);
 
-            rc.acknowledge_string(read_concern_options["level"].get_utf8().value);
+            rc.acknowledge_string(read_concern_options["level"].get_string().value);
         }
         _coll->read_concern(rc);
     }
@@ -991,14 +991,14 @@ document::value operation_runner::_run_bulk_write(document::view operation) {
     for (auto&& request_element : requests) {
         auto request = request_element.get_document().value;
         auto request_arguments = request["arguments"].get_document().value;
-        auto operation_name = request["name"].get_utf8().value;
+        auto operation_name = request["name"].get_string().value;
 
         if (operation_name.compare("updateOne") == 0) {
             auto update_one = _build_update_model<model::update_one>(request_arguments);
 
             if (request_arguments["hint"]) {
                 if (request_arguments["hint"].type() == bsoncxx::v_noabi::type::k_utf8)
-                    update_one.hint(hint{request_arguments["hint"].get_utf8().value});
+                    update_one.hint(hint{request_arguments["hint"].get_string().value});
                 else
                     update_one.hint(hint{request_arguments["hint"].get_document().value});
             }
@@ -1021,7 +1021,7 @@ document::value operation_runner::_run_bulk_write(document::view operation) {
 
             if (request_arguments["hint"]) {
                 if (request_arguments["hint"].type() == bsoncxx::v_noabi::type::k_utf8)
-                    update_many.hint(hint{request_arguments["hint"].get_utf8().value});
+                    update_many.hint(hint{request_arguments["hint"].get_string().value});
                 else
                     update_many.hint(hint{request_arguments["hint"].get_document().value});
             }
@@ -1045,7 +1045,7 @@ document::value operation_runner::_run_bulk_write(document::view operation) {
             model::replace_one replace_one(filter, replacement);
             if (request_arguments["hint"]) {
                 if (request_arguments["hint"].type() == bsoncxx::v_noabi::type::k_utf8)
-                    replace_one.hint(hint{request_arguments["hint"].get_utf8().value});
+                    replace_one.hint(hint{request_arguments["hint"].get_string().value});
                 else
                     replace_one.hint(hint{request_arguments["hint"].get_document().value});
             }
@@ -1068,7 +1068,7 @@ document::value operation_runner::_run_bulk_write(document::view operation) {
             model::delete_one delete_one(filter);
             if (request_arguments["hint"]) {
                 if (request_arguments["hint"].type() == bsoncxx::v_noabi::type::k_utf8)
-                    delete_one.hint(hint{request_arguments["hint"].get_utf8().value});
+                    delete_one.hint(hint{request_arguments["hint"].get_string().value});
                 else
                     delete_one.hint(hint{request_arguments["hint"].get_document().value});
             }
@@ -1083,7 +1083,7 @@ document::value operation_runner::_run_bulk_write(document::view operation) {
             model::delete_many delete_many(filter);
             if (request_arguments["hint"]) {
                 if (request_arguments["hint"].type() == bsoncxx::v_noabi::type::k_utf8)
-                    delete_many.hint(hint{request_arguments["hint"].get_utf8().value});
+                    delete_many.hint(hint{request_arguments["hint"].get_string().value});
                 else
                     delete_many.hint(hint{request_arguments["hint"].get_document().value});
             }
@@ -1207,7 +1207,7 @@ document::value operation_runner::_run_start_transaction(bsoncxx::document::view
         }
     }
 
-    auto session = _lookup_session(operation["object"].get_utf8().value);
+    auto session = _lookup_session(operation["object"].get_string().value);
     REQUIRE(session);
     session->start_transaction(txn_opts);
 
@@ -1215,14 +1215,14 @@ document::value operation_runner::_run_start_transaction(bsoncxx::document::view
 }
 
 document::value operation_runner::_run_commit_transaction(bsoncxx::document::view operation) {
-    auto session = _lookup_session(operation["object"].get_utf8().value);
+    auto session = _lookup_session(operation["object"].get_string().value);
     REQUIRE(session);
     session->commit_transaction();
     return bsoncxx::builder::basic::make_document();
 }
 
 document::value operation_runner::_run_abort_transaction(bsoncxx::document::view operation) {
-    auto session = _lookup_session(operation["object"].get_utf8().value);
+    auto session = _lookup_session(operation["object"].get_string().value);
     REQUIRE(session);
     session->abort_transaction();
     return bsoncxx::builder::basic::make_document();
@@ -1266,7 +1266,7 @@ document::value operation_runner::_create_index(const document::view& operation)
     auto session = _lookup_session(arguments.get_document().value);
     REQUIRE(session);
 
-    auto name = arguments["name"].get_utf8().value;
+    auto name = arguments["name"].get_string().value;
     auto keys = arguments["keys"].get_document().value;
 
     bsoncxx::builder::basic::document opts;
@@ -1287,10 +1287,10 @@ document::value operation_runner::run(document::view operation) {
     using namespace bsoncxx::builder::basic;
     bsoncxx::document::value empty_document({});
 
-    stdx::string_view key = operation["name"].get_utf8().value;
+    stdx::string_view key = operation["name"].get_string().value;
     stdx::string_view object;
     if (operation["object"]) {
-        object = operation["object"].get_utf8().value;
+        object = operation["object"].get_string().value;
     }
 
     if (key.compare("aggregate") == 0) {
@@ -1361,13 +1361,13 @@ document::value operation_runner::run(document::view operation) {
         }
         return empty_document;
     } else if (key.compare("rename") == 0) {
-        _coll->rename(operation["arguments"]["to"].get_utf8().value);
+        _coll->rename(operation["arguments"]["to"].get_string().value);
         return empty_document;
     } else if (key.compare("drop") == 0) {
         _coll->drop();
         return empty_document;
     } else if (key.compare("dropCollection") == 0) {
-        auto collection_name = operation["arguments"]["collection"].get_utf8().value;
+        auto collection_name = operation["arguments"]["collection"].get_string().value;
         _db->collection(collection_name).drop();
         return empty_document;
     } else if (key.compare("listCollectionNames") == 0) {
@@ -1394,19 +1394,19 @@ document::value operation_runner::run(document::view operation) {
 
         return empty_document;
     } else if (key.compare("createCollection") == 0) {
-        auto collection_name = operation["arguments"]["collection"].get_utf8().value;
+        auto collection_name = operation["arguments"]["collection"].get_string().value;
         auto session = _lookup_session(operation["arguments"].get_document().value);
         REQUIRE(session);
 
         _db->create_collection(*session, collection_name);
         return empty_document;
     } else if (key.compare("assertCollectionNotExists") == 0) {
-        auto collection_name = operation["arguments"]["collection"].get_utf8().value;
+        auto collection_name = operation["arguments"]["collection"].get_string().value;
         client client{uri{}};
         REQUIRE_FALSE(client[_db->name()].has_collection(collection_name));
         return empty_document;
     } else if (key.compare("assertCollectionExists") == 0) {
-        auto collection_name = operation["arguments"]["collection"].get_utf8().value;
+        auto collection_name = operation["arguments"]["collection"].get_string().value;
         client client{uri{}};
         REQUIRE(client[_db->name()].has_collection(collection_name));
         return empty_document;
@@ -1420,7 +1420,7 @@ document::value operation_runner::run(document::view operation) {
             cursor.end() ==
             std::find_if(
                 cursor.begin(), cursor.end(), [operation](bsoncxx::v_noabi::document::view doc) {
-                    return (doc["name"].get_utf8() == operation["arguments"]["index"].get_utf8());
+                    return (doc["name"].get_string() == operation["arguments"]["index"].get_string());
                 }));
 
         return empty_document;
@@ -1432,7 +1432,7 @@ document::value operation_runner::run(document::view operation) {
             cursor.end() !=
             std::find_if(
                 cursor.begin(), cursor.end(), [operation](bsoncxx::v_noabi::document::view doc) {
-                    return (doc["name"].get_utf8() == operation["arguments"]["index"].get_utf8());
+                    return (doc["name"].get_string() == operation["arguments"]["index"].get_string());
                 }));
 
         return empty_document;

--- a/src/mongocxx/test/spec/retryable-reads.cpp
+++ b/src/mongocxx/test/spec/retryable-reads.cpp
@@ -48,14 +48,14 @@ void run_retryable_reads_tests_in_file(std::string test_path) {
             return;
         }
 
-        INFO("Test description: " << test["description"].get_utf8().value);
+        INFO("Test description: " << test["description"].get_string().value);
         if (should_skip_spec_test(client, test.get_document())) {
             continue;
         }
 
         auto get_value_or_default = [&](std::string key, std::string default_str) {
             if (test_spec_view[key]) {
-                return to_string(test_spec_view[key].get_utf8().value);
+                return to_string(test_spec_view[key].get_string().value);
             }
             return default_str;
         };
@@ -68,7 +68,7 @@ void run_retryable_reads_tests_in_file(std::string test_path) {
 
         /* SPEC: GridFS tests are denoted by when the YAML file contains 'bucket_name'. */
         if (test_spec_view["bucket_name"]) {
-            auto bucket_name = to_string(test_spec_view["bucket_name"].get_utf8().value);
+            auto bucket_name = to_string(test_spec_view["bucket_name"].get_string().value);
             auto data = test_spec_view["data"].get_document().value;
 
             auto files_collection_name = bucket_name + ".files";
@@ -113,7 +113,7 @@ void run_retryable_reads_tests_in_file(std::string test_path) {
         }
 
         if (test["failPoint"]) {
-            disable_fail_point(client, test["failPoint"]["configureFailPoint"].get_utf8().value);
+            disable_fail_point(client, test["failPoint"]["configureFailPoint"].get_string().value);
         }
     }
 }

--- a/src/mongocxx/test/spec/util.cpp
+++ b/src/mongocxx/test/spec/util.cpp
@@ -106,7 +106,7 @@ bool should_skip_spec_test(const client& client, document::view test) {
         "MapReduce omits default write concern"};
 
     if (test["description"]) {
-        std::string description = std::string(test["description"].get_utf8().value);
+        std::string description = std::string(test["description"].get_string().value);
         if (unsupported_tests.find(description) != unsupported_tests.end()) {
             UNSCOPED_INFO("Test skipped - " << description << "\n"
                                             << "reason: unsupported in C++ driver");
@@ -115,9 +115,9 @@ bool should_skip_spec_test(const client& client, document::view test) {
     }
 
     if (test["skipReason"]) {
-        UNSCOPED_INFO("Test skipped - " << test["description"].get_utf8().value << "\n"
+        UNSCOPED_INFO("Test skipped - " << test["description"].get_string().value << "\n"
                                         << "reason: "
-                                        << test["skipReason"].get_utf8().value);
+                                        << test["skipReason"].get_string().value);
         return true;
     }
 
@@ -126,7 +126,7 @@ bool should_skip_spec_test(const client& client, document::view test) {
 
     if (test["ignore_if_server_version_greater_than"]) {
         std::string max_server_version = bsoncxx::string::to_string(
-            test["ignore_if_server_version_greater_than"].get_utf8().value);
+            test["ignore_if_server_version_greater_than"].get_string().value);
         if (test_util::compare_versions(server_version, max_server_version) > 0) {
             return true;
         }
@@ -137,7 +137,7 @@ bool should_skip_spec_test(const client& client, document::view test) {
             auto topologies = requirements["topology"].get_array().value;
             bool found = false;
             for (auto&& el : topologies) {
-                if (std::string(el.get_utf8().value) == topology) {
+                if (std::string(el.get_string().value) == topology) {
                     found = true;
                     break;
                 }
@@ -149,7 +149,7 @@ bool should_skip_spec_test(const client& client, document::view test) {
 
         if (requirements["minServerVersion"]) {
             auto min_server_version =
-                string::to_string(requirements["minServerVersion"].get_utf8().value);
+                string::to_string(requirements["minServerVersion"].get_string().value);
             if (test_util::compare_versions(server_version, min_server_version) < 0) {
                 return true;
             }
@@ -157,7 +157,7 @@ bool should_skip_spec_test(const client& client, document::view test) {
 
         if (requirements["maxServerVersion"]) {
             auto max_server_version =
-                string::to_string(requirements["maxServerVersion"].get_utf8().value);
+                string::to_string(requirements["maxServerVersion"].get_string().value);
             if (test_util::compare_versions(server_version, max_server_version) > 0) {
                 return true;
             }
@@ -217,10 +217,10 @@ void set_up_collection(const client& client,
     write_concern wc_majority;
     wc_majority.acknowledge_level(write_concern::level::k_majority);
 
-    auto db = client[test[database_name].get_utf8().value];
+    auto db = client[test[database_name].get_string().value];
     db.drop();
 
-    auto coll_name = test[collection_name].get_utf8().value;
+    auto coll_name = test[collection_name].get_string().value;
     auto coll = db[coll_name];
 
     coll.drop(wc_majority);
@@ -336,11 +336,11 @@ void run_operation_check_result(document::view op, make_op_runner_fn make_op_run
     // matches the error string."
     if (op["result"]["errorContains"]) {
         REQUIRE(exception);
-        INFO("expected error message " << op["result"]["errorContains"].get_utf8().value);
+        INFO("expected error message " << op["result"]["errorContains"].get_string().value);
         INFO("got error message" << error_msg);
         // Do a case insensitive check.
         auto error_contains =
-            test_util::tolowercase(op["result"]["errorContains"].get_utf8().value);
+            test_util::tolowercase(op["result"]["errorContains"].get_string().value);
         REQUIRE(test_util::tolowercase(error_msg).find(error_contains) < error_msg.length());
     } else {
         if (exception) {
@@ -354,7 +354,7 @@ void run_operation_check_result(document::view op, make_op_runner_fn make_op_run
     // 'errorCodeName' field matches the 'codeName' in the server error response."
     if (op["result"]["errorCodeName"]) {
         REQUIRE(op_exception);
-        uint32_t expected = error_code_from_name(op["result"]["errorCodeName"].get_utf8().value);
+        uint32_t expected = error_code_from_name(op["result"]["errorCodeName"].get_string().value);
         REQUIRE(op_exception->code().value() == static_cast<int>(expected));
     }
 
@@ -363,7 +363,7 @@ void run_operation_check_result(document::view op, make_op_runner_fn make_op_run
     if (op["result"]["errorLabelsContain"]) {
         REQUIRE(op_exception);
         for (auto&& label_el : op["result"]["errorLabelsContain"].get_array().value) {
-            auto label = label_el.get_utf8().value;
+            auto label = label_el.get_string().value;
             REQUIRE(op_exception->has_error_label(label));
         }
     }
@@ -373,7 +373,7 @@ void run_operation_check_result(document::view op, make_op_runner_fn make_op_run
     if (op["result"]["errorLabelsOmit"]) {
         REQUIRE(op_exception);
         for (auto&& label_el : op["result"]["errorLabelsOmit"].get_array().value) {
-            auto label = label_el.get_utf8().value;
+            auto label = label_el.get_string().value;
             REQUIRE(!op_exception->has_error_label(label));
         }
     }
@@ -412,13 +412,13 @@ uri get_uri(document::view test) {
         }
         if (test["clientOptions"]["readConcernLevel"]) {
             add_opt("readConcernLevel=" +
-                    std::string(test["clientOptions"]["readConcernLevel"].get_utf8().value));
+                    std::string(test["clientOptions"]["readConcernLevel"].get_string().value));
         }
         if (test["clientOptions"]["w"]) {
             if (test["clientOptions"]["w"].type() == type::k_int32) {
                 add_opt("w=" + std::to_string(test["clientOptions"]["w"].get_int32().value));
             } else {
-                add_opt("w=" + string::to_string(test["clientOptions"]["w"].get_utf8().value));
+                add_opt("w=" + string::to_string(test["clientOptions"]["w"].get_string().value));
             }
         }
         if (test["clientOptions"]["heartbeatFrequencyMS"]) {
@@ -428,7 +428,7 @@ uri get_uri(document::view test) {
         }
         if (test["clientOptions"]["readPreference"]) {
             add_opt("readPreference=" +
-                    string::to_string(test["clientOptions"]["readPreference"].get_utf8().value));
+                    string::to_string(test["clientOptions"]["readPreference"].get_string().value));
         }
     }
     return uri{uri_string};
@@ -528,9 +528,9 @@ void run_transaction_operations(document::view test,
         auto operation = op.get_document().value;
 
         // Handle with_transaction separately.
-        if (operation["name"].get_utf8().value.compare("withTransaction") == 0) {
+        if (operation["name"].get_string().value.compare("withTransaction") == 0) {
             auto session = [&]() {
-                if (operation["object"].get_utf8().value.compare("session0") == 0) {
+                if (operation["object"].get_string().value.compare("session0") == 0) {
                     return session0;
                 } else {
                     return session1;
@@ -584,7 +584,7 @@ void run_transaction_operations(document::view test,
             REQUIRE(exception);
             // Do a case insensitive check.
             auto error_contains =
-                test_util::tolowercase(op["result"]["errorContains"].get_utf8().value);
+                test_util::tolowercase(op["result"]["errorContains"].get_string().value);
             REQUIRE(test_util::tolowercase(error_msg).find(error_contains) < error_msg.length());
         }
 
@@ -595,7 +595,7 @@ void run_transaction_operations(document::view test,
             REQUIRE(exception);
             REQUIRE(server_error);
             uint32_t expected =
-                error_code_from_name(op["result"]["errorCodeName"].get_utf8().value);
+                error_code_from_name(op["result"]["errorCodeName"].get_string().value);
             REQUIRE(exception->code().value() == static_cast<int>(expected));
         }
 
@@ -604,7 +604,7 @@ void run_transaction_operations(document::view test,
         if (op["result"]["errorLabelsContain"]) {
             REQUIRE(exception);
             for (auto&& label_el : op["result"]["errorLabelsContain"].get_array().value) {
-                auto label = label_el.get_utf8().value;
+                auto label = label_el.get_string().value;
                 if (!exception->has_error_label(label)) {
                     FAIL("Expected exception to contain the label '" << label
                                                                      << "' but it did not.\n");
@@ -617,7 +617,7 @@ void run_transaction_operations(document::view test,
         if (op["result"]["errorLabelsOmit"]) {
             REQUIRE(exception);
             for (auto&& label_el : op["result"]["errorLabelsOmit"].get_array().value) {
-                auto label = label_el.get_utf8().value;
+                auto label = label_el.get_string().value;
                 if (exception->has_error_label(label)) {
                     FAIL("Expected exception to NOT contain the label '" << label
                                                                          << "' but it did.\n");
@@ -649,8 +649,8 @@ void run_transactions_tests_in_file(const std::string& test_path) {
     auto test_spec = test_util::parse_test_file(test_path);
     REQUIRE(test_spec);
     auto test_spec_view = test_spec->view();
-    auto db_name = test_spec_view["database_name"].get_utf8().value;
-    auto coll_name = test_spec_view["collection_name"].get_utf8().value;
+    auto db_name = test_spec_view["database_name"].get_string().value;
+    auto coll_name = test_spec_view["collection_name"].get_string().value;
     auto tests = test_spec_view["tests"].get_array().value;
 
     /* we may not have a supported topology */
@@ -661,7 +661,7 @@ void run_transactions_tests_in_file(const std::string& test_path) {
 
     for (auto&& test : tests) {
         bool fail_point_enabled = (bool)test["failPoint"];
-        auto description = test["description"].get_utf8().value;
+        auto description = test["description"].get_string().value;
         INFO("Test description: " << description);
         if (should_skip_spec_test(client{uri{}}, test.get_document().value)) {
             continue;
@@ -735,7 +735,7 @@ void run_transactions_tests_in_file(const std::string& test_path) {
                 REQUIRE(pattern.type() == type::k_utf8);
                 REQUIRE(main);
                 REQUIRE(main->type() == type::k_document);
-                auto session_name = pattern.get_utf8().value;
+                auto session_name = pattern.get_string().value;
                 if (session_name.compare("session0") == 0) {
                     REQUIRE(test_util::matches(session_lsid0, main->get_document().value));
                 } else {
@@ -767,7 +767,7 @@ void run_transactions_tests_in_file(const std::string& test_path) {
         if (test["outcome"] && test["outcome"]["collection"]) {
             auto outcome_coll_name = coll_name;
             if (test["outcome"]["collection"]["name"]) {
-                outcome_coll_name = test["outcome"]["collection"]["name"].get_utf8().value;
+                outcome_coll_name = test["outcome"]["collection"]["name"].get_string().value;
             }
             auto coll = client[db_name][outcome_coll_name];
             test_util::check_outcome_collection(&coll,

--- a/src/mongocxx/test/validation_criteria.cpp
+++ b/src/mongocxx/test/validation_criteria.cpp
@@ -78,12 +78,12 @@ TEST_CASE("validation_criteria can be exported to a document", "[validation_crit
     ele = criteria_view["validationLevel"];
     REQUIRE(ele);
     REQUIRE(ele.type() == type::k_utf8);
-    REQUIRE(bsoncxx::string::to_string(ele.get_utf8().value) == "strict");
+    REQUIRE(bsoncxx::string::to_string(ele.get_string().value) == "strict");
 
     ele = criteria_view["validationAction"];
     REQUIRE(ele);
     REQUIRE(ele.type() == type::k_utf8);
-    REQUIRE(bsoncxx::string::to_string(ele.get_utf8().value) == "warn");
+    REQUIRE(bsoncxx::string::to_string(ele.get_string().value) == "warn");
 
     ele = criteria_view["validator"];
     REQUIRE(ele);

--- a/src/mongocxx/test_util/client_helpers.cpp
+++ b/src/mongocxx/test_util/client_helpers.cpp
@@ -202,14 +202,14 @@ std::string get_server_version(const client& client) {
     server_status.append(bsoncxx::builder::basic::kvp("serverStatus", 1));
     bsoncxx::document::value output = client["test"].run_command(server_status.extract());
 
-    return bsoncxx::string::to_string(output.view()["version"].get_utf8().value);
+    return bsoncxx::string::to_string(output.view()["version"].get_string().value);
 }
 
 std::string replica_set_name(const client& client) {
     auto reply = client["admin"].run_command(make_document(kvp("isMaster", 1)));
     auto name = reply.view()["setName"];
     if (name) {
-        return bsoncxx::string::to_string(name.get_utf8().value);
+        return bsoncxx::string::to_string(name.get_string().value);
     }
 
     return "";
@@ -225,7 +225,7 @@ std::string get_topology(const client& client) {
     if (reply.view()["setName"]) {
         return "replicaset";
     } else if (reply.view()["msg"] &&
-               std::string(reply.view()["msg"].get_utf8().value) == "isdbgrid") {
+               std::string(reply.view()["msg"].get_string().value) == "isdbgrid") {
         return "sharded";
     } else {
         return "single";
@@ -276,7 +276,7 @@ bool is_numeric(types::bson_value::view value) {
 
 stdx::optional<type> is_type_operator(types::bson_value::view value) {
     if (value.type() == type::k_document && value.get_document().value["$$type"]) {
-        auto t = value.get_document().value["$$type"].get_utf8().value;
+        auto t = value.get_document().value["$$type"].get_string().value;
         if (t.compare("binData") == 0) {
             return {type::k_binary};
         } else if (t.compare("long") == 0) {
@@ -305,7 +305,7 @@ bool matches(types::bson_value::view main,
 
     if (main.type() == type::k_document) {
         // the value '42' acts as placeholders for "any value"
-        if (pattern.type() == type::k_utf8 && 0 == pattern.get_utf8().value.compare("42")) {
+        if (pattern.type() == type::k_utf8 && 0 == pattern.get_string().value.compare("42")) {
             return true;
         }
 


### PR DESCRIPTION
Most of the changes include switching most calls to `get_utf8()` with `get_string()`. 

There are instances where `BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN` (and its corresponding closing macro) were used on calls to `get_utf8()` (or `get_##name()`) in order to not trigger the deprecation warnings/errors on Evergreen.