### PR TITLE
CXX-2067 Expose bson_value::value type constructors

### DIFF
--- a/src/bsoncxx/exception/error_code.cpp
+++ b/src/bsoncxx/exception/error_code.cpp
@@ -72,8 +72,8 @@ class error_category_impl final : public std::error_category {
                 return "tried to complete appending an array, but overflowed";
             case error_code::k_cannot_end_appending_document:
                 return "tried to complete appending an document, but overflowed";
-            case error_code::k_invalid_type:
-                return "invalid type identifier";
+            case error_code::k_invalid_bson_type_id:
+                return "invalid BSON type identifier";
 #define BSONCXX_ENUM(name, value)            \
     case error_code::k_cannot_append_##name: \
         return {"unable to append " #name};

--- a/src/bsoncxx/exception/error_code.cpp
+++ b/src/bsoncxx/exception/error_code.cpp
@@ -72,6 +72,8 @@ class error_category_impl final : public std::error_category {
                 return "tried to complete appending an array, but overflowed";
             case error_code::k_cannot_end_appending_document:
                 return "tried to complete appending an document, but overflowed";
+            case error_code::k_invalid_type:
+                return "invalid type identifier";
 #define BSONCXX_ENUM(name, value)            \
     case error_code::k_cannot_append_##name: \
         return {"unable to append " #name};

--- a/src/bsoncxx/exception/error_code.hpp
+++ b/src/bsoncxx/exception/error_code.hpp
@@ -88,6 +88,9 @@ enum class error_code : std::int32_t {
     /// Invalid binary subtype.
     k_invalid_binary_subtype,
 
+    /// Invalid type.
+    k_invalid_type,
+
 /// A value failed to append.
 #define BSONCXX_ENUM(name, value) k_cannot_append_##name,
 #include <bsoncxx/enums/type.hpp>

--- a/src/bsoncxx/exception/error_code.hpp
+++ b/src/bsoncxx/exception/error_code.hpp
@@ -89,7 +89,7 @@ enum class error_code : std::int32_t {
     k_invalid_binary_subtype,
 
     /// Invalid type.
-    k_invalid_type,
+    k_invalid_bson_type_id,
 
 /// A value failed to append.
 #define BSONCXX_ENUM(name, value) k_cannot_append_##name,

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -21,7 +21,6 @@
 #include <bsoncxx/types/bson_value/make_value.hpp>
 #include <bsoncxx/types/bson_value/value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
-#include <iostream>
 #include <vector>
 
 namespace {
@@ -58,16 +57,7 @@ void coverting_construction_test(T actual, U expected) {
 }  // namespace
 
 TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
-    auto doc_value = make_document(kvp("hello", "world"));
-    auto doc2_value = make_document(kvp("a", 1));
-
-    auto doc = doc_value.view();
-    auto doc2 = doc2_value.view();
-
-    auto elem = doc["hello"];
-    auto elem2 = doc2["a"];
-
-    SECTION("can be constructed from a bson_value::view") {
+    SECTION("can be constructed from") {
         SECTION("bool") {
             auto test_doc = bson_value::make_value(b_bool{true});
             value_construction_test(test_doc.view());
@@ -77,13 +67,15 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
         }
 
         SECTION("utf8") {
-            auto test_doc = bson_value::make_value("super duper");
+            std::string value = "super duper";
+
+            auto test_doc = bson_value::make_value(value);
             value_construction_test(test_doc.view());
 
-            coverting_construction_test("super duper", test_doc);
-            coverting_construction_test(b_utf8{"super duper"}, test_doc);
-            coverting_construction_test(stdx::string_view{"super duper"}, test_doc);
-            coverting_construction_test(std::string{"super duper"}, test_doc);
+            coverting_construction_test(value, test_doc);
+            coverting_construction_test(value.c_str(), test_doc);
+            coverting_construction_test(b_utf8{value}, test_doc);
+            coverting_construction_test(stdx::string_view{value}, test_doc);
 
             auto test_empty = bson_value::make_value("");
             value_construction_test(test_empty.view());
@@ -313,6 +305,15 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
     }
 
     SECTION("can be constructed by a document::element") {
+        auto doc_value = make_document(kvp("hello", "world"));
+        auto doc2_value = make_document(kvp("a", 1));
+
+        auto doc = doc_value.view();
+        auto doc2 = doc2_value.view();
+
+        auto elem = doc["hello"];
+        auto elem2 = doc2["a"];
+
         bson_value::value value = elem.get_owning_value();
 
         SECTION("can create new views") {

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -77,7 +77,7 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             coverting_construction_test(stdx::string_view{value}, test_doc);
 
             const char raw_data[]{'s', 'u', 'p', 'e', 'r', ' ', 'd', 'u', 'p', 'e', 'r'};
-            coverting_construction_test(raw_data, test_doc);
+            coverting_construction_test(stdx::string_view{raw_data, 11}, test_doc);
 
             auto test_empty = bson_value::make_value("");
             value_construction_test(test_empty.view());

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -257,11 +257,15 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             auto doc = make_document(kvp("a", 1));
             auto test_doc = bson_value::make_value(doc.view());
             value_construction_test(test_doc.view());
+
+            coverting_construction_test(b_document{doc.view()}, test_doc);
             coverting_construction_test(value(doc.view()), test_doc);
 
             // Empty document
             test_doc = bson_value::make_value(document::view{});
             value_construction_test(test_doc.view());
+
+            coverting_construction_test(value(b_document{}), test_doc);
             coverting_construction_test(value(document::view{}), test_doc);
         }
 

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -166,7 +166,7 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
         }
 
         SECTION("regex") {
-            /* options are sorted and any duplicate or invalid options are ignored */
+            /* options are sorted and any duplicate or invalid options are removed */
             auto test_doc = bson_value::make_value(b_regex{"amy", "imsx"});
             value_construction_test(test_doc.view());
 
@@ -176,7 +176,7 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             auto empty_regex = bson_value::make_value(b_regex{"", ""});
             value_construction_test(empty_regex.view());
 
-            coverting_construction_test(value(type::k_regex), empty_regex);
+            coverting_construction_test(b_regex{"", ""}, empty_regex);
             coverting_construction_test(value(type::k_regex, ""), empty_regex);
             coverting_construction_test(value(type::k_regex, "", ""), empty_regex);
         }
@@ -196,12 +196,12 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
         SECTION("code") {
             auto test_doc = bson_value::make_value(b_code{"look at me I'm some JS code"});
             value_construction_test(test_doc.view());
+            coverting_construction_test(b_code{"look at me I'm some JS code"}, test_doc);
             coverting_construction_test(value(type::k_code, "look at me I'm some JS code"),
                                         test_doc);
 
             auto empty_code = bson_value::make_value(b_code{""});
             value_construction_test(empty_code.view());
-            coverting_construction_test(value(type::k_code), empty_code);
             coverting_construction_test(value(type::k_code, ""), empty_code);
         }
 
@@ -210,12 +210,17 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             auto test_doc =
                 bson_value::make_value(b_codewscope{"it's me, Code with Scope", doc.view()});
             value_construction_test(test_doc.view());
+
+            coverting_construction_test(value(b_codewscope{"it's me, Code with Scope", doc.view()}),
+                                        test_doc);
             coverting_construction_test(
                 value(type::k_codewscope, "it's me, Code with Scope", doc.view()), test_doc);
 
             auto empty_doc = make_document(kvp("a", ""));
             auto empty_code = bson_value::make_value(b_codewscope{"", empty_doc.view()});
             value_construction_test(empty_code.view());
+
+            coverting_construction_test(value(b_codewscope{"", empty_doc.view()}), empty_code);
             coverting_construction_test(value(type::k_codewscope, "", empty_doc.view()),
                                         empty_code);
         }
@@ -223,13 +228,17 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
         SECTION("minkey") {
             auto test_doc = bson_value::make_value(b_minkey{});
             value_construction_test(test_doc.view());
+
             coverting_construction_test(value(type::k_minkey), test_doc);
+            coverting_construction_test(value(b_minkey{}), test_doc);
         }
 
         SECTION("maxkey") {
             auto test_doc = bson_value::make_value(b_maxkey{});
             value_construction_test(test_doc.view());
+
             coverting_construction_test(value(type::k_maxkey), test_doc);
+            coverting_construction_test(value(b_maxkey{}), test_doc);
         }
 
         SECTION("binary") {

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -123,12 +123,12 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
         }
 
         SECTION("oid") {
-            oid _id{"0123456789abcdefABCDEFFF"};
-            auto test_doc = bson_value::make_value(b_oid{_id});
+            oid id{"0123456789abcdefABCDEFFF"};
+            auto test_doc = bson_value::make_value(b_oid{id});
             value_construction_test(test_doc.view());
 
-            coverting_construction_test(_id, test_doc);
-            coverting_construction_test(b_oid{_id}, test_doc);
+            coverting_construction_test(id, test_doc);
+            coverting_construction_test(b_oid{id}, test_doc);
         }
 
         SECTION("decimal128") {
@@ -179,12 +179,14 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
         }
 
         SECTION("dbpointer") {
-            oid _id{"507f1f77bcf86cd799439011"};
-            auto test_doc = bson_value::make_value(b_dbpointer{"collection", oid{_id}});
+            oid id{"0123456789abcdefABCDEFFF"};
+            auto coll_name = "collection";
+
+            auto test_doc = bson_value::make_value(b_dbpointer{coll_name, id});
             value_construction_test(test_doc.view());
 
-            coverting_construction_test(b_dbpointer{"collection", oid{_id}}, test_doc);
-            REQUIRE(value(type::k_dbpointer, "collection", oid{_id}) == test_doc);
+            coverting_construction_test(b_dbpointer{coll_name, id}, test_doc);
+            REQUIRE(value(type::k_dbpointer, coll_name, id) == test_doc);
 
             auto empty_oid = oid{};
             auto empty_collection = bson_value::make_value(b_dbpointer{"", empty_oid});
@@ -195,10 +197,12 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
         }
 
         SECTION("code") {
-            auto test_doc = bson_value::make_value(b_code{"look at me I'm some JS code"});
+            auto code = "look at me I'm some JS code";
+            auto test_doc = bson_value::make_value(b_code{code});
             value_construction_test(test_doc.view());
-            coverting_construction_test(b_code{"look at me I'm some JS code"}, test_doc);
-            REQUIRE(value(type::k_code, "look at me I'm some JS code") == test_doc);
+
+            coverting_construction_test(b_code{code}, test_doc);
+            REQUIRE(value(type::k_code, code) == test_doc);
 
             auto empty_code = bson_value::make_value(b_code{""});
             value_construction_test(empty_code.view());
@@ -207,13 +211,12 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
 
         SECTION("codewscope") {
             auto doc = make_document(kvp("a", "b"));
-            auto test_doc =
-                bson_value::make_value(b_codewscope{"it's me, Code with Scope", doc.view()});
-            value_construction_test(test_doc.view());
+            auto code = "it's me, Code with Scope";
+            auto test_doc = bson_value::make_value(b_codewscope{code, doc.view()});
 
-            coverting_construction_test(b_codewscope{"it's me, Code with Scope", doc.view()},
-                                        test_doc);
-            REQUIRE(value(type::k_codewscope, "it's me, Code with Scope", doc.view()) == test_doc);
+            value_construction_test(test_doc.view());
+            coverting_construction_test(b_codewscope{code, doc.view()}, test_doc);
+            REQUIRE(value(type::k_codewscope, code, doc.view()) == test_doc);
 
             auto empty_doc = make_document(kvp("a", ""));
             auto empty_code = bson_value::make_value(b_codewscope{"", empty_doc.view()});

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -271,11 +271,14 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
         }
 
         SECTION("timestamp") {
-            auto test_doc = bson_value::make_value(b_timestamp{5, 4});
+            uint32_t inc = std::numeric_limits<uint32_t>::max();
+            uint32_t time = std::numeric_limits<uint32_t>::max() - 1;
+
+            auto test_doc = bson_value::make_value(b_timestamp{inc, time});
             value_construction_test(test_doc.view());
 
-            coverting_construction_test(b_timestamp{5, 4}, test_doc);
-            REQUIRE(value(type::k_timestamp, 5, 4) == test_doc);
+            coverting_construction_test(b_timestamp{inc, time}, test_doc);
+            REQUIRE(value(type::k_timestamp, inc, time) == test_doc);
         }
 
         SECTION("document") {

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -29,6 +29,7 @@ using bsoncxx::to_json;
 using bsoncxx::builder::basic::make_array;
 using bsoncxx::builder::basic::make_document;
 using bsoncxx::builder::basic::kvp;
+using bsoncxx::types::bson_value::value;
 
 using namespace bsoncxx::types;
 
@@ -66,11 +67,11 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
 
     SECTION("can be constructed from a bson_value::view") {
         SECTION("bool") {
-            auto test_doc = bson_value::make_value(types::b_bool{true});
+            auto test_doc = bson_value::make_value(b_bool{true});
             value_construction_test(test_doc.view());
 
             coverting_construction_test(true, test_doc);
-            coverting_construction_test(types::b_bool{true}, test_doc);
+            coverting_construction_test(b_bool{true}, test_doc);
         }
 
         SECTION("utf8") {
@@ -78,7 +79,7 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             value_construction_test(test_doc.view());
 
             coverting_construction_test("super duper", test_doc);
-            coverting_construction_test(types::b_utf8{"super duper"}, test_doc);
+            coverting_construction_test(b_utf8{"super duper"}, test_doc);
             coverting_construction_test(stdx::string_view{"super duper"}, test_doc);
             coverting_construction_test(std::string{"super duper"}, test_doc);
 
@@ -86,104 +87,127 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             value_construction_test(test_empty.view());
 
             coverting_construction_test("", test_empty);
-            coverting_construction_test(types::b_utf8{""}, test_empty);
+            coverting_construction_test(b_utf8{""}, test_empty);
 
             auto test_nulls = bson_value::make_value("a\0\0\0");
             value_construction_test(test_nulls.view());
 
             coverting_construction_test("a\0\0\0", test_nulls);
-            coverting_construction_test(types::b_utf8{"a\0\0\0"}, test_nulls);
+            coverting_construction_test(b_utf8{"a\0\0\0"}, test_nulls);
         }
 
         SECTION("double") {
-            auto test_doc = bson_value::make_value(types::b_double{12});
+            auto lower_bound = std::numeric_limits<double>::min();
+            auto test_doc = bson_value::make_value(b_double{lower_bound});
             value_construction_test(test_doc.view());
 
-            coverting_construction_test(12.0, test_doc);
-            coverting_construction_test(types::b_double{12}, test_doc);
+            coverting_construction_test(lower_bound, test_doc);
+            coverting_construction_test(b_double{lower_bound}, test_doc);
         }
 
         SECTION("int32") {
-            auto test_doc = bson_value::make_value(types::b_int32{42});
+            auto lower_bound = std::numeric_limits<int32_t>::min();
+            auto test_doc = bson_value::make_value(b_int32{lower_bound});
             value_construction_test(test_doc.view());
 
-            coverting_construction_test(42, test_doc);
-            coverting_construction_test(types::b_int32{42}, test_doc);
+            coverting_construction_test(lower_bound, test_doc);
+            coverting_construction_test(b_int32{lower_bound}, test_doc);
         }
 
         SECTION("int64") {
-            auto test_doc = bson_value::make_value(types::b_int64{72});
+            auto lower_bound = std::numeric_limits<int64_t>::min();
+            auto test_doc = bson_value::make_value(b_int64{lower_bound});
             value_construction_test(test_doc.view());
+
+            coverting_construction_test(lower_bound, test_doc);
+            coverting_construction_test(b_int64{lower_bound}, test_doc);
         }
 
         SECTION("undefined") {
-            auto test_doc = bson_value::make_value(types::b_undefined{});
+            auto test_doc = bson_value::make_value(b_undefined{});
             value_construction_test(test_doc.view());
+
+            coverting_construction_test(b_undefined{}, test_doc);
         }
 
         SECTION("oid") {
-            auto test_doc = bson_value::make_value(types::b_oid{});
+            oid _id{"507f1f77bcf86cd799439011"};
+            auto test_doc = bson_value::make_value(b_oid{_id});
             value_construction_test(test_doc.view());
+
+            coverting_construction_test(_id, test_doc);
+            coverting_construction_test(b_oid{_id}, test_doc);
         }
 
         SECTION("decimal128") {
-            auto test_doc = bson_value::make_value(types::b_decimal128{decimal128{4, 4}});
+            auto test_doc = bson_value::make_value(b_decimal128{decimal128{5, 4}});
             value_construction_test(test_doc.view());
+
+            coverting_construction_test(decimal128{5, 4}, test_doc);
+            coverting_construction_test(b_decimal128{decimal128{5, 4}}, test_doc);
         }
 
         SECTION("date") {
-            auto test_doc =
-                bson_value::make_value(types::b_date(std::chrono::milliseconds(123456789)));
+            auto test_doc = bson_value::make_value(b_date(std::chrono::milliseconds(123456789)));
             value_construction_test(test_doc.view());
+
+            coverting_construction_test(std::chrono::milliseconds(123456789), test_doc);
+            coverting_construction_test(b_date(std::chrono::milliseconds(123456789)), test_doc);
         }
 
         SECTION("null") {
-            auto test_doc = bson_value::make_value(types::b_null{});
+            auto test_doc = bson_value::make_value(b_null{});
             value_construction_test(test_doc.view());
+
+            coverting_construction_test(nullptr, test_doc);
+            coverting_construction_test(b_null{}, test_doc);
         }
 
         SECTION("regex") {
-            auto test_doc = bson_value::make_value(types::b_regex{"amy", "no options"});
+            auto test_doc = bson_value::make_value(b_regex{"amy", "no options"});
             value_construction_test(test_doc.view());
 
-            auto empty_regex = bson_value::make_value(types::b_regex{"", ""});
+            coverting_construction_test(b_regex{"amy", "no options"}, test_doc);
+            coverting_construction_test(value(type::k_regex, "amy", "no options"), test_doc);
+
+            auto empty_regex = bson_value::make_value(b_regex{"", ""});
             value_construction_test(empty_regex.view());
         }
 
         SECTION("dbpointer") {
-            auto test_doc = bson_value::make_value(types::b_dbpointer{"collection", oid{}});
+            auto test_doc = bson_value::make_value(b_dbpointer{"collection", oid{}});
             value_construction_test(test_doc.view());
 
-            auto empty_collection = bson_value::make_value(types::b_dbpointer{"", oid{}});
+            auto empty_collection = bson_value::make_value(b_dbpointer{"", oid{}});
             value_construction_test(empty_collection.view());
         }
 
         SECTION("code") {
-            auto test_doc = bson_value::make_value(types::b_code{"look at me I'm some JS code"});
+            auto test_doc = bson_value::make_value(b_code{"look at me I'm some JS code"});
             value_construction_test(test_doc.view());
 
-            auto empty_code = bson_value::make_value(types::b_code{""});
+            auto empty_code = bson_value::make_value(b_code{""});
             value_construction_test(empty_code.view());
         }
 
         SECTION("codewscope") {
             auto doc = make_document(kvp("a", "b"));
             auto test_doc =
-                bson_value::make_value(types::b_codewscope{"it's me, Code with Scope", doc.view()});
+                bson_value::make_value(b_codewscope{"it's me, Code with Scope", doc.view()});
             value_construction_test(test_doc.view());
 
             auto empty_doc = make_document(kvp("a", ""));
-            auto empty_code = bson_value::make_value(types::b_codewscope{"", empty_doc.view()});
+            auto empty_code = bson_value::make_value(b_codewscope{"", empty_doc.view()});
             value_construction_test(empty_code.view());
         }
 
         SECTION("minkey") {
-            auto test_doc = bson_value::make_value(types::b_minkey{});
+            auto test_doc = bson_value::make_value(b_minkey{});
             value_construction_test(test_doc.view());
         }
 
         SECTION("maxkey") {
-            auto test_doc = bson_value::make_value(types::b_maxkey{});
+            auto test_doc = bson_value::make_value(b_maxkey{});
             value_construction_test(test_doc.view());
         }
 

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -273,7 +273,16 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             auto arr = make_array(make_document(kvp("hi", 0)));
             auto test_doc = bson_value::make_value(arr.view());
             value_construction_test(test_doc.view());
-            // coverting_construction_test(value(test_doc.view()), test_doc);
+
+            coverting_construction_test(value(b_array{arr.view()}), test_doc);
+            coverting_construction_test(value(arr.view()), test_doc);
+
+            // Empty array
+            test_doc = bson_value::make_value(array::view{});
+            value_construction_test(test_doc.view());
+
+            coverting_construction_test(value(b_array{}), test_doc);
+            coverting_construction_test(value(array::view{}), test_doc);
         }
     }
 

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -247,9 +247,13 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
                 b_binary{binary_sub_type::k_binary, (uint32_t)bin.size(), bin.data()});
             value_construction_test(test_doc.view());
 
-            // coverting_construction_test(value(b_maxkey{}), test_doc);
-            // coverting_construction_test(value(bin), test_doc);
-            // TODO
+            coverting_construction_test(
+                value(b_binary{binary_sub_type::k_binary, (uint32_t)bin.size(), bin.data()}),
+                test_doc);
+            coverting_construction_test(value(bin), test_doc);
+
+            auto empty = bson_value::make_value(b_binary{});
+            coverting_construction_test(value(std::vector<unsigned char>{}), empty);
         }
 
         SECTION("symbol") {

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -78,6 +78,8 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
 
             coverting_construction_test("super duper", test_doc);
             coverting_construction_test(types::b_utf8{"super duper"}, test_doc);
+            coverting_construction_test(stdx::string_view{"super duper"}, test_doc);
+            coverting_construction_test(std::string{"super duper"}, test_doc);
 
             auto test_empty = bson_value::make_value("");
             value_construction_test(test_empty.view());

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -216,14 +216,14 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
 
             value_construction_test(test_doc.view());
             coverting_construction_test(b_codewscope{code, doc.view()}, test_doc);
-            REQUIRE(value(type::k_codewscope, code, doc.view()) == test_doc);
+            REQUIRE(value(code, doc.view()) == test_doc);
 
             auto empty_doc = make_document(kvp("a", ""));
             auto empty_code = bson_value::make_value(b_codewscope{"", empty_doc.view()});
             value_construction_test(empty_code.view());
 
             coverting_construction_test(b_codewscope{"", empty_doc.view()}, empty_code);
-            REQUIRE(value(type::k_codewscope, "", empty_doc.view()) == empty_code);
+            REQUIRE(value("", empty_doc.view()) == empty_code);
         }
 
         SECTION("minkey") {

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -123,7 +123,7 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
         }
 
         SECTION("oid") {
-            oid _id{"507f1f77bcf86cd799439011"};
+            oid _id{"0123456789abcdefABCDEFFF"};
             auto test_doc = bson_value::make_value(b_oid{_id});
             value_construction_test(test_doc.view());
 

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -132,12 +132,15 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
         }
 
         SECTION("decimal128") {
-            auto test_doc = bson_value::make_value(b_decimal128{decimal128{5, 4}});
+            uint64_t high = std::numeric_limits<uint64_t>::max();
+            uint64_t low = std::numeric_limits<uint64_t>::min();
+
+            auto test_doc = bson_value::make_value(b_decimal128{decimal128{high, low}});
             value_construction_test(test_doc.view());
 
-            coverting_construction_test(decimal128{5, 4}, test_doc);
-            coverting_construction_test(b_decimal128{decimal128{5, 4}}, test_doc);
-            REQUIRE(value(type::k_decimal128, 5, 4) == test_doc);
+            coverting_construction_test(decimal128{high, low}, test_doc);
+            coverting_construction_test(b_decimal128{decimal128{high, low}}, test_doc);
+            REQUIRE(value(type::k_decimal128, high, low) == test_doc);
         }
 
         SECTION("date") {

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
@@ -21,6 +22,7 @@
 #include <bsoncxx/types/bson_value/value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
 #include <iostream>
+#include <vector>
 
 namespace {
 using namespace bsoncxx;

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -172,10 +172,10 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             coverting_construction_test(b_regex{regex, options}, test_doc);
             REQUIRE(bson_value::value(regex, options) == test_doc);
 
-            auto empty_regex = bson_value::make_value(b_regex{"", ""});
+            auto empty_regex = bson_value::make_value(b_regex{""});
             value_construction_test(empty_regex.view());
 
-            coverting_construction_test(b_regex{"", ""}, empty_regex);
+            coverting_construction_test(b_regex{""}, empty_regex);
             REQUIRE(bson_value::value(type::k_regex, "") == empty_regex);
             REQUIRE(bson_value::value("", "") == empty_regex);
         }

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -164,19 +164,17 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
         }
 
         SECTION("regex") {
-            auto test_doc = bson_value::make_value(b_regex{"amy", "no options"});
+            /* options are sorted and any duplicate or invalid options are ignored */
+            auto test_doc = bson_value::make_value(b_regex{"amy", "imsx"});
             value_construction_test(test_doc.view());
 
-            // std::cout << "id: " << test_doc.view().get_regex().type_id << std::endl;
-            std::cout << "regex: " << test_doc.view().get_regex().regex << std::endl;
-            std::cout << "options: " << test_doc.view().get_regex().options << std::endl;
-
-            coverting_construction_test(b_regex{"amy", "no options"}, test_doc);
-            coverting_construction_test(
-                value(type::k_regex, std::string("amy"), std::string("no options")), test_doc);
+            coverting_construction_test(b_regex{"amy", "imsx"}, test_doc);
+            coverting_construction_test(value(type::k_regex, "amy", "imsx"), test_doc);
 
             auto empty_regex = bson_value::make_value(b_regex{"", ""});
             value_construction_test(empty_regex.view());
+
+            // coverting_construction_test(value(type::k_regex, ""), empty_regex);
         }
 
         SECTION("dbpointer") {

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -186,14 +186,14 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             value_construction_test(test_doc.view());
 
             coverting_construction_test(b_dbpointer{coll_name, id}, test_doc);
-            REQUIRE(value(type::k_dbpointer, coll_name, id) == test_doc);
+            REQUIRE(value(coll_name, id) == test_doc);
 
             auto empty_oid = oid{};
             auto empty_collection = bson_value::make_value(b_dbpointer{"", empty_oid});
             value_construction_test(empty_collection.view());
 
             coverting_construction_test(b_dbpointer{"", empty_oid}, empty_collection);
-            REQUIRE(value(type::k_dbpointer, "", empty_oid) == empty_collection);
+            REQUIRE(value("", empty_oid) == empty_collection);
         }
 
         SECTION("code") {

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -246,18 +246,19 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             auto doc = make_document(kvp("a", 1));
             auto test_doc = bson_value::make_value(doc.view());
             value_construction_test(test_doc.view());
-            coverting_construction_test(value(test_doc.view()), test_doc);
+            coverting_construction_test(value(doc.view()), test_doc);
 
             // Empty document
             test_doc = bson_value::make_value(document::view{});
             value_construction_test(test_doc.view());
-            coverting_construction_test(value(test_doc.view()), test_doc);
+            coverting_construction_test(value(document::view{}), test_doc);
         }
 
         SECTION("array") {
             auto arr = make_array(make_document(kvp("hi", 0)));
             auto test_doc = bson_value::make_value(arr.view());
             value_construction_test(test_doc.view());
+            // coverting_construction_test(value(test_doc.view()), test_doc);
         }
     }
 

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -130,6 +130,7 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             value_construction_test(test_doc.view());
 
             coverting_construction_test(b_undefined{}, test_doc);
+            REQUIRE(value(type::k_undefined) == test_doc);
         }
 
         SECTION("oid") {

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -304,12 +304,11 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             coverting_construction_test(b_array{arr.view()}, test_doc);
             coverting_construction_test(arr.view(), test_doc);
 
-            // Empty array
-            test_doc = bson_value::make_value(array::view{});
-            value_construction_test(test_doc.view());
+            auto empty_doc = bson_value::make_value(array::view{});
+            value_construction_test(empty_doc.view());
 
-            coverting_construction_test(b_array{}, test_doc);
-            coverting_construction_test(array::view{}, test_doc);
+            coverting_construction_test(b_array{}, empty_doc);
+            coverting_construction_test(array::view{}, empty_doc);
         }
     }
 

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -160,12 +160,15 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
         }
 
         SECTION("regex") {
+            auto regex = "amy";
             /* options are sorted and any duplicate or invalid options are removed */
-            auto test_doc = bson_value::make_value(b_regex{"amy", "imsx"});
+            auto options = "imsx";
+
+            auto test_doc = bson_value::make_value(b_regex{regex, options});
             value_construction_test(test_doc.view());
 
-            coverting_construction_test(b_regex{"amy", "imsx"}, test_doc);
-            REQUIRE(value(type::k_regex, "amy", "imsx") == test_doc);
+            coverting_construction_test(b_regex{regex, options}, test_doc);
+            REQUIRE(value(type::k_regex, regex, options) == test_doc);
 
             auto empty_regex = bson_value::make_value(b_regex{"", ""});
             value_construction_test(empty_regex.view());

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -174,7 +174,9 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             auto empty_regex = bson_value::make_value(b_regex{"", ""});
             value_construction_test(empty_regex.view());
 
-            // coverting_construction_test(value(type::k_regex, ""), empty_regex);
+            coverting_construction_test(value(type::k_regex), empty_regex);
+            coverting_construction_test(value(type::k_regex, ""), empty_regex);
+            coverting_construction_test(value(type::k_regex, "", ""), empty_regex);
         }
 
         SECTION("dbpointer") {

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -147,6 +147,7 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
 
             coverting_construction_test(decimal128{5, 4}, test_doc);
             coverting_construction_test(b_decimal128{decimal128{5, 4}}, test_doc);
+            REQUIRE(value(type::k_decimal128, 5, 4) == test_doc);
         }
 
         SECTION("date") {
@@ -171,38 +172,41 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             value_construction_test(test_doc.view());
 
             coverting_construction_test(b_regex{"amy", "imsx"}, test_doc);
-            coverting_construction_test(value(type::k_regex, "amy", "imsx"), test_doc);
+            REQUIRE(value(type::k_regex, "amy", "imsx") == test_doc);
 
             auto empty_regex = bson_value::make_value(b_regex{"", ""});
             value_construction_test(empty_regex.view());
 
             coverting_construction_test(b_regex{"", ""}, empty_regex);
-            coverting_construction_test(value(type::k_regex, ""), empty_regex);
-            coverting_construction_test(value(type::k_regex, "", ""), empty_regex);
+            REQUIRE(value(type::k_regex, "") == empty_regex);
+            REQUIRE(value(type::k_regex, "", "") == empty_regex);
         }
 
         SECTION("dbpointer") {
             oid _id{"507f1f77bcf86cd799439011"};
             auto test_doc = bson_value::make_value(b_dbpointer{"collection", oid{_id}});
             value_construction_test(test_doc.view());
-            coverting_construction_test(value(type::k_dbpointer, "collection", oid{_id}), test_doc);
+
+            coverting_construction_test(b_dbpointer{"collection", oid{_id}}, test_doc);
+            REQUIRE(value(type::k_dbpointer, "collection", oid{_id}) == test_doc);
 
             auto empty_oid = oid{};
             auto empty_collection = bson_value::make_value(b_dbpointer{"", empty_oid});
             value_construction_test(empty_collection.view());
-            coverting_construction_test(value(type::k_dbpointer, "", empty_oid), empty_collection);
+
+            coverting_construction_test(b_dbpointer{"", empty_oid}, empty_collection);
+            REQUIRE(value(type::k_dbpointer, "", empty_oid) == empty_collection);
         }
 
         SECTION("code") {
             auto test_doc = bson_value::make_value(b_code{"look at me I'm some JS code"});
             value_construction_test(test_doc.view());
             coverting_construction_test(b_code{"look at me I'm some JS code"}, test_doc);
-            coverting_construction_test(value(type::k_code, "look at me I'm some JS code"),
-                                        test_doc);
+            REQUIRE(value(type::k_code, "look at me I'm some JS code") == test_doc);
 
             auto empty_code = bson_value::make_value(b_code{""});
             value_construction_test(empty_code.view());
-            coverting_construction_test(value(type::k_code, ""), empty_code);
+            REQUIRE(value(type::k_code, "") == empty_code);
         }
 
         SECTION("codewscope") {
@@ -211,34 +215,32 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
                 bson_value::make_value(b_codewscope{"it's me, Code with Scope", doc.view()});
             value_construction_test(test_doc.view());
 
-            coverting_construction_test(value(b_codewscope{"it's me, Code with Scope", doc.view()}),
+            coverting_construction_test(b_codewscope{"it's me, Code with Scope", doc.view()},
                                         test_doc);
-            coverting_construction_test(
-                value(type::k_codewscope, "it's me, Code with Scope", doc.view()), test_doc);
+            REQUIRE(value(type::k_codewscope, "it's me, Code with Scope", doc.view()) == test_doc);
 
             auto empty_doc = make_document(kvp("a", ""));
             auto empty_code = bson_value::make_value(b_codewscope{"", empty_doc.view()});
             value_construction_test(empty_code.view());
 
-            coverting_construction_test(value(b_codewscope{"", empty_doc.view()}), empty_code);
-            coverting_construction_test(value(type::k_codewscope, "", empty_doc.view()),
-                                        empty_code);
+            coverting_construction_test(b_codewscope{"", empty_doc.view()}, empty_code);
+            REQUIRE(value(type::k_codewscope, "", empty_doc.view()) == empty_code);
         }
 
         SECTION("minkey") {
             auto test_doc = bson_value::make_value(b_minkey{});
             value_construction_test(test_doc.view());
 
-            coverting_construction_test(value(type::k_minkey), test_doc);
-            coverting_construction_test(value(b_minkey{}), test_doc);
+            coverting_construction_test(b_minkey{}, test_doc);
+            REQUIRE(value(type::k_minkey) == test_doc);
         }
 
         SECTION("maxkey") {
             auto test_doc = bson_value::make_value(b_maxkey{});
             value_construction_test(test_doc.view());
 
-            coverting_construction_test(value(type::k_maxkey), test_doc);
-            coverting_construction_test(value(b_maxkey{}), test_doc);
+            coverting_construction_test(b_maxkey{}, test_doc);
+            REQUIRE(value(type::k_maxkey) == test_doc);
         }
 
         SECTION("binary") {
@@ -247,28 +249,33 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
                 b_binary{binary_sub_type::k_binary, (uint32_t)bin.size(), bin.data()});
             value_construction_test(test_doc.view());
 
-            coverting_construction_test(
-                value(b_binary{binary_sub_type::k_binary, (uint32_t)bin.size(), bin.data()}),
-                test_doc);
-            coverting_construction_test(value(bin), test_doc);
+            REQUIRE(value(b_binary{binary_sub_type::k_binary, (uint32_t)bin.size(), bin.data()}) ==
+                    test_doc);
+            coverting_construction_test(bin, test_doc);
 
             auto empty = bson_value::make_value(b_binary{});
-            coverting_construction_test(value(std::vector<unsigned char>{}), empty);
+            coverting_construction_test(std::vector<unsigned char>{}, empty);
         }
 
         SECTION("symbol") {
             auto test_doc = bson_value::make_value(b_symbol{"some symbol"});
             value_construction_test(test_doc.view());
+
             coverting_construction_test(b_symbol{"some symbol"}, test_doc);
-            coverting_construction_test(value(type::k_symbol, "some symbol"), test_doc);
+            REQUIRE(value(type::k_symbol, "some symbol") == test_doc);
 
             auto empty_symbol = bson_value::make_value(b_symbol{""});
             value_construction_test(empty_symbol.view());
-            coverting_construction_test(value(type::k_symbol, ""), empty_symbol);
+
+            REQUIRE(value(type::k_symbol, "") == empty_symbol);
         }
 
         SECTION("timestamp") {
-            // TODO
+            auto test_doc = bson_value::make_value(b_timestamp{5, 4});
+            value_construction_test(test_doc.view());
+
+            coverting_construction_test(b_timestamp{5, 4}, test_doc);
+            REQUIRE(value(type::k_timestamp, 5, 4) == test_doc);
         }
 
         SECTION("document") {
@@ -277,14 +284,14 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             value_construction_test(test_doc.view());
 
             coverting_construction_test(b_document{doc.view()}, test_doc);
-            coverting_construction_test(value(doc.view()), test_doc);
+            REQUIRE(value(doc.view()) == test_doc);
 
             // Empty document
             test_doc = bson_value::make_value(document::view{});
             value_construction_test(test_doc.view());
 
-            coverting_construction_test(value(b_document{}), test_doc);
-            coverting_construction_test(value(document::view{}), test_doc);
+            coverting_construction_test(b_document{}, test_doc);
+            coverting_construction_test(document::view{}, test_doc);
         }
 
         SECTION("array") {
@@ -292,15 +299,15 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             auto test_doc = bson_value::make_value(arr.view());
             value_construction_test(test_doc.view());
 
-            coverting_construction_test(value(b_array{arr.view()}), test_doc);
-            coverting_construction_test(value(arr.view()), test_doc);
+            coverting_construction_test(b_array{arr.view()}, test_doc);
+            coverting_construction_test(arr.view(), test_doc);
 
             // Empty array
             test_doc = bson_value::make_value(array::view{});
             value_construction_test(test_doc.view());
 
-            coverting_construction_test(value(b_array{}), test_doc);
-            coverting_construction_test(value(array::view{}), test_doc);
+            coverting_construction_test(b_array{}, test_doc);
+            coverting_construction_test(array::view{}, test_doc);
         }
     }
 

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -242,6 +242,13 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
         }
 
         SECTION("binary") {
+            std::vector<uint8_t> bin{'d', 'e', 'a', 'd', 'b', 'e', 'e', 'f'};
+            auto test_doc = bson_value::make_value(
+                b_binary{binary_sub_type::k_binary, (uint32_t)bin.size(), bin.data()});
+            value_construction_test(test_doc.view());
+
+            // coverting_construction_test(value(b_maxkey{}), test_doc);
+            // coverting_construction_test(value(bin), test_doc);
             // TODO
         }
 

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -180,11 +180,15 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
         }
 
         SECTION("dbpointer") {
-            auto test_doc = bson_value::make_value(b_dbpointer{"collection", oid{}});
+            oid _id{"507f1f77bcf86cd799439011"};
+            auto test_doc = bson_value::make_value(b_dbpointer{"collection", oid{_id}});
             value_construction_test(test_doc.view());
+            coverting_construction_test(value(type::k_dbpointer, "collection", oid{_id}), test_doc);
 
-            auto empty_collection = bson_value::make_value(b_dbpointer{"", oid{}});
+            auto empty_oid = oid{};
+            auto empty_collection = bson_value::make_value(b_dbpointer{"", empty_oid});
             value_construction_test(empty_collection.view());
+            coverting_construction_test(value(type::k_dbpointer, "", empty_oid), empty_collection);
         }
 
         SECTION("code") {

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -208,10 +208,14 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             auto test_doc =
                 bson_value::make_value(b_codewscope{"it's me, Code with Scope", doc.view()});
             value_construction_test(test_doc.view());
+            coverting_construction_test(
+                value(type::k_codewscope, "it's me, Code with Scope", doc.view()), test_doc);
 
             auto empty_doc = make_document(kvp("a", ""));
             auto empty_code = bson_value::make_value(b_codewscope{"", empty_doc.view()});
             value_construction_test(empty_code.view());
+            coverting_construction_test(value(type::k_codewscope, "", empty_doc.view()),
+                                        empty_code);
         }
 
         SECTION("minkey") {

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -170,14 +170,14 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             value_construction_test(test_doc.view());
 
             coverting_construction_test(b_regex{regex, options}, test_doc);
-            REQUIRE(bson_value::value(type::k_regex, regex, options) == test_doc);
+            REQUIRE(bson_value::value(regex, options) == test_doc);
 
             auto empty_regex = bson_value::make_value(b_regex{"", ""});
             value_construction_test(empty_regex.view());
 
             coverting_construction_test(b_regex{"", ""}, empty_regex);
             REQUIRE(bson_value::value(type::k_regex, "") == empty_regex);
-            REQUIRE(bson_value::value(type::k_regex, "", "") == empty_regex);
+            REQUIRE(bson_value::value("", "") == empty_regex);
         }
 
         SECTION("dbpointer") {

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -30,7 +30,6 @@ using bsoncxx::to_json;
 using bsoncxx::builder::basic::make_array;
 using bsoncxx::builder::basic::make_document;
 using bsoncxx::builder::basic::kvp;
-using bsoncxx::types::bson_value::value;
 
 using namespace bsoncxx::types;
 
@@ -119,7 +118,7 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             value_construction_test(test_doc.view());
 
             coverting_construction_test(b_undefined{}, test_doc);
-            REQUIRE(value(type::k_undefined) == test_doc);
+            REQUIRE(bson_value::value(type::k_undefined) == test_doc);
         }
 
         SECTION("oid") {
@@ -140,7 +139,7 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
 
             coverting_construction_test(decimal128{high, low}, test_doc);
             coverting_construction_test(b_decimal128{decimal128{high, low}}, test_doc);
-            REQUIRE(value(type::k_decimal128, high, low) == test_doc);
+            REQUIRE(bson_value::value(type::k_decimal128, high, low) == test_doc);
         }
 
         SECTION("date") {
@@ -168,14 +167,14 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             value_construction_test(test_doc.view());
 
             coverting_construction_test(b_regex{regex, options}, test_doc);
-            REQUIRE(value(type::k_regex, regex, options) == test_doc);
+            REQUIRE(bson_value::value(type::k_regex, regex, options) == test_doc);
 
             auto empty_regex = bson_value::make_value(b_regex{"", ""});
             value_construction_test(empty_regex.view());
 
             coverting_construction_test(b_regex{"", ""}, empty_regex);
-            REQUIRE(value(type::k_regex, "") == empty_regex);
-            REQUIRE(value(type::k_regex, "", "") == empty_regex);
+            REQUIRE(bson_value::value(type::k_regex, "") == empty_regex);
+            REQUIRE(bson_value::value(type::k_regex, "", "") == empty_regex);
         }
 
         SECTION("dbpointer") {
@@ -186,14 +185,14 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             value_construction_test(test_doc.view());
 
             coverting_construction_test(b_dbpointer{coll_name, id}, test_doc);
-            REQUIRE(value(coll_name, id) == test_doc);
+            REQUIRE(bson_value::value(coll_name, id) == test_doc);
 
             auto empty_oid = oid{};
             auto empty_collection = bson_value::make_value(b_dbpointer{"", empty_oid});
             value_construction_test(empty_collection.view());
 
             coverting_construction_test(b_dbpointer{"", empty_oid}, empty_collection);
-            REQUIRE(value("", empty_oid) == empty_collection);
+            REQUIRE(bson_value::value("", empty_oid) == empty_collection);
         }
 
         SECTION("code") {
@@ -202,11 +201,11 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             value_construction_test(test_doc.view());
 
             coverting_construction_test(b_code{code}, test_doc);
-            REQUIRE(value(type::k_code, code) == test_doc);
+            REQUIRE(bson_value::value(type::k_code, code) == test_doc);
 
             auto empty_code = bson_value::make_value(b_code{""});
             value_construction_test(empty_code.view());
-            REQUIRE(value(type::k_code, "") == empty_code);
+            REQUIRE(bson_value::value(type::k_code, "") == empty_code);
         }
 
         SECTION("codewscope") {
@@ -216,14 +215,14 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
 
             value_construction_test(test_doc.view());
             coverting_construction_test(b_codewscope{code, doc.view()}, test_doc);
-            REQUIRE(value(code, doc.view()) == test_doc);
+            REQUIRE(bson_value::value(code, doc.view()) == test_doc);
 
             auto empty_doc = make_document(kvp("a", ""));
             auto empty_code = bson_value::make_value(b_codewscope{"", empty_doc.view()});
             value_construction_test(empty_code.view());
 
             coverting_construction_test(b_codewscope{"", empty_doc.view()}, empty_code);
-            REQUIRE(value("", empty_doc.view()) == empty_code);
+            REQUIRE(bson_value::value("", empty_doc.view()) == empty_code);
         }
 
         SECTION("minkey") {
@@ -231,7 +230,7 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             value_construction_test(test_doc.view());
 
             coverting_construction_test(b_minkey{}, test_doc);
-            REQUIRE(value(type::k_minkey) == test_doc);
+            REQUIRE(bson_value::value(type::k_minkey) == test_doc);
         }
 
         SECTION("maxkey") {
@@ -239,7 +238,7 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             value_construction_test(test_doc.view());
 
             coverting_construction_test(b_maxkey{}, test_doc);
-            REQUIRE(value(type::k_maxkey) == test_doc);
+            REQUIRE(bson_value::value(type::k_maxkey) == test_doc);
         }
 
         SECTION("binary") {
@@ -249,10 +248,11 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             value_construction_test(test_doc.view());
 
             coverting_construction_test(bin, test_doc);
-            REQUIRE(value(b_binary{binary_sub_type::k_binary, (uint32_t)bin.size(), bin.data()}) ==
+            REQUIRE(bson_value::value(b_binary{
+                        binary_sub_type::k_binary, (uint32_t)bin.size(), bin.data()}) == test_doc);
+            REQUIRE(bson_value::value(bin.data(), bin.size(), binary_sub_type::k_binary) ==
                     test_doc);
-            REQUIRE(value(bin.data(), bin.size(), binary_sub_type::k_binary) == test_doc);
-            REQUIRE(value(bin.data(), bin.size()) == test_doc);
+            REQUIRE(bson_value::value(bin.data(), bin.size()) == test_doc);
 
             auto empty = bson_value::make_value(b_binary{});
             coverting_construction_test(std::vector<unsigned char>{}, empty);
@@ -264,12 +264,12 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             value_construction_test(test_doc.view());
 
             coverting_construction_test(b_symbol{symbol}, test_doc);
-            REQUIRE(value(type::k_symbol, symbol) == test_doc);
+            REQUIRE(bson_value::value(type::k_symbol, symbol) == test_doc);
 
             auto empty_symbol = bson_value::make_value(b_symbol{""});
             value_construction_test(empty_symbol.view());
 
-            REQUIRE(value(type::k_symbol, "") == empty_symbol);
+            REQUIRE(bson_value::value(type::k_symbol, "") == empty_symbol);
         }
 
         SECTION("timestamp") {
@@ -280,7 +280,7 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             value_construction_test(test_doc.view());
 
             coverting_construction_test(b_timestamp{inc, time}, test_doc);
-            REQUIRE(value(type::k_timestamp, inc, time) == test_doc);
+            REQUIRE(bson_value::value(type::k_timestamp, inc, time) == test_doc);
         }
 
         SECTION("document") {
@@ -289,7 +289,7 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             value_construction_test(test_doc.view());
 
             coverting_construction_test(b_document{doc.view()}, test_doc);
-            REQUIRE(value(doc.view()) == test_doc);
+            REQUIRE(bson_value::value(doc.view()) == test_doc);
 
             auto empty_doc = bson_value::make_value(document::view{});
             value_construction_test(empty_doc.view());

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -20,6 +20,7 @@
 #include <bsoncxx/types/bson_value/make_value.hpp>
 #include <bsoncxx/types/bson_value/value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
+#include <iostream>
 
 namespace {
 using namespace bsoncxx;
@@ -80,18 +81,18 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             coverting_construction_test(types::b_utf8{"super duper"}, test_doc);
             coverting_construction_test(stdx::string_view{"super duper"}, test_doc);
             coverting_construction_test(std::string{"super duper"}, test_doc);
-
-            auto test_empty = bson_value::make_value("");
-            value_construction_test(test_empty.view());
-
-            coverting_construction_test("", test_empty);
-            coverting_construction_test(types::b_utf8{""}, test_empty);
-
-            auto test_nulls = bson_value::make_value("a\0\0\0");
-            value_construction_test(test_nulls.view());
-
-            coverting_construction_test("a\0\0\0", test_nulls);
-            coverting_construction_test(types::b_utf8{"a\0\0\0"}, test_nulls);
+            //
+            //            auto test_empty = bson_value::make_value("");
+            //            value_construction_test(test_empty.view());
+            //
+            //            coverting_construction_test("", test_empty);
+            //            coverting_construction_test(types::b_utf8{""}, test_empty);
+            //
+            //            auto test_nulls = bson_value::make_value("a\0\0\0");
+            //            value_construction_test(test_nulls.view());
+            //
+            //            coverting_construction_test("a\0\0\0", test_nulls);
+            //            coverting_construction_test(types::b_utf8{"a\0\0\0"}, test_nulls);
         }
 
         SECTION("double") {

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -76,6 +76,9 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             coverting_construction_test(b_utf8{value}, test_doc);
             coverting_construction_test(stdx::string_view{value}, test_doc);
 
+            const char raw_data[]{'s', 'u', 'p', 'e', 'r', ' ', 'd', 'u', 'p', 'e', 'r'};
+            coverting_construction_test(raw_data, test_doc);
+
             auto test_empty = bson_value::make_value("");
             value_construction_test(test_empty.view());
             coverting_construction_test("", test_empty);

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -167,8 +167,13 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             auto test_doc = bson_value::make_value(b_regex{"amy", "no options"});
             value_construction_test(test_doc.view());
 
+            // std::cout << "id: " << test_doc.view().get_regex().type_id << std::endl;
+            std::cout << "regex: " << test_doc.view().get_regex().regex << std::endl;
+            std::cout << "options: " << test_doc.view().get_regex().options << std::endl;
+
             coverting_construction_test(b_regex{"amy", "no options"}, test_doc);
-            coverting_construction_test(value(type::k_regex, "amy", "no options"), test_doc);
+            coverting_construction_test(
+                value(type::k_regex, std::string("amy"), std::string("no options")), test_doc);
 
             auto empty_regex = bson_value::make_value(b_regex{"", ""});
             value_construction_test(empty_regex.view());

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -194,9 +194,13 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
         SECTION("code") {
             auto test_doc = bson_value::make_value(b_code{"look at me I'm some JS code"});
             value_construction_test(test_doc.view());
+            coverting_construction_test(value(type::k_code, "look at me I'm some JS code"),
+                                        test_doc);
 
             auto empty_code = bson_value::make_value(b_code{""});
             value_construction_test(empty_code.view());
+            coverting_construction_test(value(type::k_code), empty_code);
+            coverting_construction_test(value(type::k_code, ""), empty_code);
         }
 
         SECTION("codewscope") {

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -79,15 +79,12 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
 
             auto test_empty = bson_value::make_value("");
             value_construction_test(test_empty.view());
-
             coverting_construction_test("", test_empty);
-            coverting_construction_test(b_utf8{""}, test_empty);
 
-            auto test_nulls = bson_value::make_value("a\0\0\0");
+            auto nulls = "a\0\0\0";
+            auto test_nulls = bson_value::make_value(nulls);
             value_construction_test(test_nulls.view());
-
-            coverting_construction_test("a\0\0\0", test_nulls);
-            coverting_construction_test(b_utf8{"a\0\0\0"}, test_nulls);
+            coverting_construction_test(nulls, test_nulls);
         }
 
         SECTION("double") {

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -248,20 +248,21 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
                 b_binary{binary_sub_type::k_binary, (uint32_t)bin.size(), bin.data()});
             value_construction_test(test_doc.view());
 
+            coverting_construction_test(bin, test_doc);
             REQUIRE(value(b_binary{binary_sub_type::k_binary, (uint32_t)bin.size(), bin.data()}) ==
                     test_doc);
-            coverting_construction_test(bin, test_doc);
 
             auto empty = bson_value::make_value(b_binary{});
             coverting_construction_test(std::vector<unsigned char>{}, empty);
         }
 
         SECTION("symbol") {
-            auto test_doc = bson_value::make_value(b_symbol{"some symbol"});
+            auto symbol = "some symbol";
+            auto test_doc = bson_value::make_value(b_symbol{symbol});
             value_construction_test(test_doc.view());
 
-            coverting_construction_test(b_symbol{"some symbol"}, test_doc);
-            REQUIRE(value(type::k_symbol, "some symbol") == test_doc);
+            coverting_construction_test(b_symbol{symbol}, test_doc);
+            REQUIRE(value(type::k_symbol, symbol) == test_doc);
 
             auto empty_symbol = bson_value::make_value(b_symbol{""});
             value_construction_test(empty_symbol.view());

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -251,6 +251,8 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             coverting_construction_test(bin, test_doc);
             REQUIRE(value(b_binary{binary_sub_type::k_binary, (uint32_t)bin.size(), bin.data()}) ==
                     test_doc);
+            REQUIRE(value(bin.data(), bin.size(), binary_sub_type::k_binary) == test_doc);
+            REQUIRE(value(bin.data(), bin.size()) == test_doc);
 
             auto empty = bson_value::make_value(b_binary{});
             coverting_construction_test(std::vector<unsigned char>{}, empty);

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -246,10 +246,12 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             auto doc = make_document(kvp("a", 1));
             auto test_doc = bson_value::make_value(doc.view());
             value_construction_test(test_doc.view());
+            coverting_construction_test(value(test_doc.view()), test_doc);
 
             // Empty document
             test_doc = bson_value::make_value(document::view{});
             value_construction_test(test_doc.view());
+            coverting_construction_test(value(test_doc.view()), test_doc);
         }
 
         SECTION("array") {

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -221,11 +221,13 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
         SECTION("minkey") {
             auto test_doc = bson_value::make_value(b_minkey{});
             value_construction_test(test_doc.view());
+            coverting_construction_test(value(type::k_minkey), test_doc);
         }
 
         SECTION("maxkey") {
             auto test_doc = bson_value::make_value(b_maxkey{});
             value_construction_test(test_doc.view());
+            coverting_construction_test(value(type::k_maxkey), test_doc);
         }
 
         SECTION("binary") {

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -257,7 +257,14 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
         }
 
         SECTION("symbol") {
-            // TODO
+            auto test_doc = bson_value::make_value(b_symbol{"some symbol"});
+            value_construction_test(test_doc.view());
+            coverting_construction_test(b_symbol{"some symbol"}, test_doc);
+            coverting_construction_test(value(type::k_symbol, "some symbol"), test_doc);
+
+            auto empty_symbol = bson_value::make_value(b_symbol{""});
+            value_construction_test(empty_symbol.view());
+            coverting_construction_test(value(type::k_symbol, ""), empty_symbol);
         }
 
         SECTION("timestamp") {

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -58,11 +58,11 @@ void coverting_construction_test(T actual, U expected) {
 TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
     SECTION("can be constructed from") {
         SECTION("bool") {
-            auto test_doc = bson_value::make_value(b_bool{true});
-            value_construction_test(test_doc.view());
+            auto test_value = bson_value::make_value(b_bool{true});
+            value_construction_test(test_value.view());
 
-            coverting_construction_test(true, test_doc);
-            coverting_construction_test(b_bool{true}, test_doc);
+            coverting_construction_test(true, test_value);
+            coverting_construction_test(b_bool{true}, test_value);
         }
 
         SECTION("utf8") {

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -289,12 +289,11 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             coverting_construction_test(b_document{doc.view()}, test_doc);
             REQUIRE(value(doc.view()) == test_doc);
 
-            // Empty document
-            test_doc = bson_value::make_value(document::view{});
-            value_construction_test(test_doc.view());
+            auto empty_doc = bson_value::make_value(document::view{});
+            value_construction_test(empty_doc.view());
 
-            coverting_construction_test(b_document{}, test_doc);
-            coverting_construction_test(document::view{}, test_doc);
+            coverting_construction_test(b_document{}, empty_doc);
+            coverting_construction_test(document::view{}, empty_doc);
         }
 
         SECTION("array") {

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -81,18 +81,18 @@ TEST_CASE("types::bson_value::value", "[bsoncxx::types::bson_value::value]") {
             coverting_construction_test(types::b_utf8{"super duper"}, test_doc);
             coverting_construction_test(stdx::string_view{"super duper"}, test_doc);
             coverting_construction_test(std::string{"super duper"}, test_doc);
-            //
-            //            auto test_empty = bson_value::make_value("");
-            //            value_construction_test(test_empty.view());
-            //
-            //            coverting_construction_test("", test_empty);
-            //            coverting_construction_test(types::b_utf8{""}, test_empty);
-            //
-            //            auto test_nulls = bson_value::make_value("a\0\0\0");
-            //            value_construction_test(test_nulls.view());
-            //
-            //            coverting_construction_test("a\0\0\0", test_nulls);
-            //            coverting_construction_test(types::b_utf8{"a\0\0\0"}, test_nulls);
+
+            auto test_empty = bson_value::make_value("");
+            value_construction_test(test_empty.view());
+
+            coverting_construction_test("", test_empty);
+            coverting_construction_test(types::b_utf8{""}, test_empty);
+
+            auto test_nulls = bson_value::make_value("a\0\0\0");
+            value_construction_test(test_nulls.view());
+
+            coverting_construction_test("a\0\0\0", test_nulls);
+            coverting_construction_test(types::b_utf8{"a\0\0\0"}, test_nulls);
         }
 
         SECTION("double") {

--- a/src/bsoncxx/types.hpp
+++ b/src/bsoncxx/types.hpp
@@ -218,7 +218,7 @@ struct BSONCXX_API b_binary {
 ///
 BSONCXX_INLINE bool operator==(const b_binary& lhs, const b_binary& rhs) {
     return lhs.sub_type == rhs.sub_type && lhs.size == rhs.size &&
-           (std::memcmp(lhs.bytes, rhs.bytes, lhs.size) == 0);
+           (!lhs.size || (std::memcmp(lhs.bytes, rhs.bytes, lhs.size) == 0));
 }
 
 ///

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -90,13 +90,17 @@ value::value(decimal128 v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value.v_decimal128.low = v.low();
 }
 
-value::value(const type id, stdx::string_view a, stdx::string_view b)
-    : _impl{stdx::make_unique<impl>()} {
+value::value(const type id, const char* a, const char* b)
+    : value(id, stdx::string_view{a}, stdx::string_view{b}) {}
+
+template <typename T1, typename T2>
+value::value(const type id, T1 a, T2 b) : _impl{stdx::make_unique<impl>()} {
     switch (id) {
         case type::k_regex:
             _impl->_value.value_type = BSON_TYPE_REGEX;
             // static_assert(std::is_convertible<T1, stdx::string_view>::value = true, "regex must
             // be string");
+            (void)a, (void)b;
             _impl->_value.value.v_regex.regex = make_copy_for_libbson(a);
             _impl->_value.value.v_regex.options = make_copy_for_libbson(b);
             //            else if (sizeof...(args) == 0)

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -28,10 +28,29 @@ BSONCXX_INLINE_NAMESPACE_BEGIN
 namespace types {
 namespace bson_value {
 
+value::value(b_array v) : value(v.value) {}
+value::value(b_binary v) : value(v.type_id, v.sub_type, v.size, v.bytes) {}
+value::value(b_bool v) : value(v.value) {}
+value::value(b_code v) : value(v.type_id, v) {}
+value::value(b_codewscope v) : value(type::k_codewscope, v.code, v.scope) {}
+value::value(b_date v) : value(v.value) {}
+value::value(b_dbpointer v) : value(v.type_id, v.collection, v.value) {}
+value::value(b_decimal128 v) : value(v.value) {}
+value::value(b_document v) : value(v.view()) {}
 value::value(b_double v) : value(v.value) {}
 value::value(b_int32 v) : value(v.value) {}
 value::value(b_int64 v) : value(v.value) {}
+value::value(b_maxkey) : value(type::k_maxkey) {}
+value::value(b_minkey) : value(type::k_minkey) {}
+value::value(b_null) : value(nullptr) {}
+value::value(b_oid v) : value(v.value) {}
+value::value(b_regex v) : value(v.type_id, std::string{v.regex}, std::string{v.options}) {}
+value::value(b_symbol v) : value(v.type_id, v) {}
+value::value(b_timestamp v) : value(v.type_id, v.increment, v.timestamp) {}
+value::value(b_undefined) : value(type::k_undefined) {}
 value::value(b_utf8 v) : value(v.value) {}
+
+value::value(decimal128 v) : value(type::k_decimal128, v.high(), v.low()) {}
 
 value::value(double v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_DOUBLE;
@@ -57,38 +76,24 @@ value::value(stdx::string_view v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value.v_utf8.len = (uint32_t)v.size();
 }
 
-// BSONCXX_ENUM(document, 0x03)
-// BSONCXX_ENUM(array, 0x04)
-// BSONCXX_ENUM(binary, 0x05)
-value::value(b_undefined) : _impl{stdx::make_unique<impl>()} {
-    _impl->_value.value_type = BSON_TYPE_UNDEFINED;
-}
-
-value::value(b_null) : value(nullptr) {}
 value::value(nullptr_t) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_NULL;
 }
 
-value::value(b_date v) : value(v.value) {}
 value::value(std::chrono::milliseconds v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_DATE_TIME;
     _impl->_value.value.v_datetime = v.count();
 }
 
-value::value(b_oid v) : value(v.value) {}
 value::value(oid v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_OID;
     std::memcpy(_impl->_value.value.v_oid.bytes, v.bytes(), v.k_oid_length);
 }
-value::value(b_bool v) : value(v.value) {}
 value::value(bool v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_BOOL;
     _impl->_value.value.v_bool = v;
 }
 
-value::value(b_timestamp v) : value(v.type_id, v.increment, v.timestamp) {}
-value::value(b_decimal128 v) : value(v.value) {}
-value::value(decimal128 v) : value(type::k_decimal128, v.high(), v.low()) {}
 value::value(const type id, uint64_t a, uint64_t b) : _impl{stdx::make_unique<impl>()} {
     if (id == type::k_decimal128) {
         _impl->_value.value_type = BSON_TYPE_DECIMAL128;
@@ -103,7 +108,6 @@ value::value(const type id, uint64_t a, uint64_t b) : _impl{stdx::make_unique<im
     }
 }
 
-value::value(b_dbpointer v) : value(v.type_id, v.collection, v.value) {}
 value::value(const type id, stdx::string_view a, oid b) : _impl{stdx::make_unique<impl>()} {
     if (id == type::k_dbpointer) {
         _impl->_value.value_type = BSON_TYPE_DBPOINTER;
@@ -115,7 +119,6 @@ value::value(const type id, stdx::string_view a, oid b) : _impl{stdx::make_uniqu
     }
 }
 
-value::value(b_codewscope v) : value(type::k_codewscope, v.code, v.scope) {}
 value::value(const type id, stdx::string_view a, bsoncxx::document::view_or_value b)
     : _impl{stdx::make_unique<impl>()} {
     if (id == type::k_codewscope) {
@@ -128,7 +131,6 @@ value::value(const type id, stdx::string_view a, bsoncxx::document::view_or_valu
             _impl->_value.value.v_codewscope.scope_data, b.view().data(), b.view().length());
     }
 }
-value::value(b_document v) : value(v.view()) {}
 value::value(bsoncxx::document::view v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_DOCUMENT;
     _impl->_value.value.v_doc.data_len = (uint32_t)v.length();
@@ -138,7 +140,6 @@ value::value(bsoncxx::document::view v) : _impl{stdx::make_unique<impl>()} {
 
 value::value(std::vector<unsigned char> v, binary_sub_type sub_type)
     : value(type::k_binary, sub_type, (uint32_t)v.size(), (uint8_t*)v.data()) {}
-value::value(b_binary v) : value(v.type_id, v.sub_type, v.size, v.bytes) {}
 value::value(const type id, const binary_sub_type sub_id, uint32_t size, const uint8_t* data)
     : _impl{stdx::make_unique<impl>()} {
     if (id != type::k_binary)
@@ -152,7 +153,6 @@ value::value(const type id, const binary_sub_type sub_id, uint32_t size, const u
     std::memcpy(_impl->_value.value.v_binary.data, data, size);
 }
 
-value::value(b_array v) : value(v.value) {}
 value::value(bsoncxx::array::view v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_ARRAY;
     _impl->_value.value.v_doc.data_len = (uint32_t)v.length();
@@ -160,20 +160,18 @@ value::value(bsoncxx::array::view v) : _impl{stdx::make_unique<impl>()} {
     std::memcpy(_impl->_value.value.v_doc.data, v.data(), v.length());
 }
 
-value::value(b_minkey) : value(type::k_minkey) {}
-value::value(b_maxkey) : value(type::k_maxkey) {}
 value::value(const type id) : _impl{stdx::make_unique<impl>()} {
     if (id == type::k_minkey) {
         _impl->_value.value_type = BSON_TYPE_MINKEY;
     } else if (id == type::k_maxkey) {
         _impl->_value.value_type = BSON_TYPE_MAXKEY;
+    } else if (id == type::k_undefined) {
+        _impl->_value.value_type = BSON_TYPE_UNDEFINED;
     } else {
-        throw std::logic_error{"Must be min/max key"};
+        throw std::logic_error{"Must be min/max key or undefined"};
     }
 }
 
-value::value(b_symbol v) : value(v.type_id, v) {}
-value::value(b_code v) : value(v.type_id, v) {}
 value::value(const type id, stdx::string_view a, stdx::string_view b)
     : _impl{stdx::make_unique<impl>()} {
     if (id == type::k_regex) {
@@ -192,8 +190,6 @@ value::value(const type id, stdx::string_view a, stdx::string_view b)
         throw std::logic_error{"Unknown type"};
     }
 }
-
-value::value(b_regex v) : value(v.type_id, std::string{v.regex}, std::string{v.options}) {}
 
 value::~value() = default;
 

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -157,9 +157,9 @@ value::value(stdx::string_view code, bsoncxx::document::view_or_value scope)
     _impl->_value.value.v_codewscope.code = make_copy_for_libbson(code);
     _impl->_value.value.v_codewscope.code_len = (uint32_t)code.length();
     _impl->_value.value.v_codewscope.scope_len = (uint32_t)scope.view().length();
-    _impl->_value.value.v_codewscope.scope_data = (uint8_t*)bson_malloc0(scope.view().length());
-    std::memcpy(
-        _impl->_value.value.v_codewscope.scope_data, scope.view().data(), scope.view().length());
+
+    bson_t* cpy = bson_new_from_data(scope.view().data(), scope.view().length());
+    _impl->_value.value.v_codewscope.scope_data = bson_destroy_with_steal(cpy, true, &cpy->len);
 }
 
 value::value(b_binary v) : value(v.bytes, v.size, v.sub_type) {}
@@ -178,16 +178,18 @@ value::value(b_document v) : value(v.view()) {}
 value::value(bsoncxx::document::view v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_DOCUMENT;
     _impl->_value.value.v_doc.data_len = (uint32_t)v.length();
-    _impl->_value.value.v_doc.data = (uint8_t*)bson_malloc0(v.length());
-    std::memcpy(_impl->_value.value.v_doc.data, v.data(), v.length());
+
+    bson_t* cpy = bson_new_from_data(v.data(), v.length());
+    _impl->_value.value.v_doc.data = bson_destroy_with_steal(cpy, true, &cpy->len);
 }
 
 value::value(b_array v) : value(v.value) {}
 value::value(bsoncxx::array::view v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_ARRAY;
     _impl->_value.value.v_doc.data_len = (uint32_t)v.length();
-    _impl->_value.value.v_doc.data = (uint8_t*)bson_malloc0(v.length());
-    std::memcpy(_impl->_value.value.v_doc.data, v.data(), v.length());
+
+    bson_t* cpy = bson_new_from_data(v.data(), v.length());
+    _impl->_value.value.v_doc.data = bson_destroy_with_steal(cpy, true, &cpy->len);
 }
 
 value::~value() = default;

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -29,29 +29,32 @@ namespace types {
 namespace bson_value {
 
 value::value(b_double v) : value(v.value) {}
+value::value(b_int32 v) : value(v.value) {}
+value::value(b_int64 v) : value(v.value) {}
+value::value(b_utf8 v) : value(v.value) {}
+
 value::value(double v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_DOUBLE;
     _impl->_value.value.v_double = v;
 }
 
-value::value(b_int32 v) : value(v.value) {}
 value::value(int32_t v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_INT32;
     _impl->_value.value.v_int32 = v;
 }
 
-value::value(b_int64 v) : value(v.value) {}
 value::value(int64_t v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_INT64;
     _impl->_value.value.v_int64 = v;
 }
 
 // TODO: enable_if T in T* decays to char
-value::value(const char* v) : value(b_utf8{v}) {}
-value::value(std::string v) : value(b_utf8{v}) {}
-value::value(stdx::string_view v) : value(b_utf8{v}) {}
-value::value(b_utf8 v) : _impl{stdx::make_unique<impl>()} {
-    convert_to_libbson(v, &_impl->_value);
+value::value(const char* v) : value(stdx::string_view{v}) {}
+value::value(std::string v) : value(stdx::string_view{v}) {}
+value::value(stdx::string_view v) : _impl{stdx::make_unique<impl>()} {
+    _impl->_value.value_type = BSON_TYPE_UTF8;
+    _impl->_value.value.v_utf8.str = make_copy_for_libbson(v);
+    _impl->_value.value.v_utf8.len = (uint32_t)v.size();
 }
 
 // BSONCXX_ENUM(document, 0x03)

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -98,6 +98,8 @@ value::value(const type id, stdx::string_view a, oid b) : _impl{stdx::make_uniqu
         std::memcpy(_impl->_value.value.v_dbpointer.oid.bytes, b.bytes(), b.k_oid_length);
     }
 }
+
+value::value(b_codewscope v) : value(type::k_codewscope, v.code, v.scope) {}
 value::value(const type id, stdx::string_view a, bsoncxx::document::view_or_value b)
     : _impl{stdx::make_unique<impl>()} {
     if (id == type::k_codewscope) {
@@ -116,6 +118,20 @@ value::value(bsoncxx::document::view_or_value v) : _impl{stdx::make_unique<impl>
     _impl->_value.value.v_doc.data = (uint8_t*)bson_malloc0(v.view().length());
     std::memcpy(_impl->_value.value.v_doc.data, v.view().data(), v.view().length());
 }
+
+value::value(b_minkey) : value(type::k_minkey) {}
+value::value(b_maxkey) : value(type::k_maxkey) {}
+value::value(const type id) : _impl{stdx::make_unique<impl>()} {
+    if (id == type::k_minkey) {
+        _impl->_value.value_type = BSON_TYPE_MINKEY;
+    } else if (id == type::k_maxkey) {
+        _impl->_value.value_type = BSON_TYPE_MAXKEY;
+    } else {
+        throw std::logic_error{"Must be min/max key"};
+    }
+}
+
+value::value(b_code v) : value(type::k_code, v) {}
 value::value(const type id, stdx::string_view a, stdx::string_view b)
     : _impl{stdx::make_unique<impl>()} {
     if (id == type::k_regex) {
@@ -126,10 +142,8 @@ value::value(const type id, stdx::string_view a, stdx::string_view b)
         _impl->_value.value_type = BSON_TYPE_CODE;
         _impl->_value.value.v_code.code = make_copy_for_libbson(a);
         _impl->_value.value.v_code.code_len = (uint32_t)a.length();
-    } else if (id == type::k_minkey) {
-        _impl->_value.value_type = BSON_TYPE_MINKEY;
-    } else if (id == type::k_maxkey) {
-        _impl->_value.value_type = BSON_TYPE_MAXKEY;
+    } else {
+        throw std::logic_error{"Unknown type"};
     }
 }
 

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -120,6 +120,22 @@ value::value(bsoncxx::document::view_or_value v) : _impl{stdx::make_unique<impl>
     std::memcpy(_impl->_value.value.v_doc.data, v.view().data(), v.view().length());
 }
 
+value::value(std::vector<unsigned char> v, binary_sub_type sub_type)
+    : value(type::k_binary, sub_type, (uint32_t)v.size(), (uint8_t*)v.data()) {}
+value::value(b_binary v) : value(v.type_id, v.sub_type, v.size, v.bytes) {}
+value::value(const type id, const binary_sub_type sub_id, uint32_t size, const uint8_t* data)
+    : _impl{stdx::make_unique<impl>()} {
+    if (id != type::k_binary)
+        throw std::logic_error{"Not binary"};
+
+    _impl->_value.value_type = BSON_TYPE_BINARY;
+
+    _impl->_value.value.v_binary.subtype = static_cast<bson_subtype_t>(sub_id);
+    _impl->_value.value.v_binary.data_len = size;
+    _impl->_value.value.v_binary.data = (uint8_t*)bson_malloc(size);
+    std::memcpy(_impl->_value.value.v_binary.data, data, size);
+}
+
 value::value(b_array v) : value(v.value) {}
 value::value(bsoncxx::array::view_or_value v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_ARRAY;

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -27,30 +27,9 @@ BSONCXX_INLINE_NAMESPACE_BEGIN
 namespace types {
 namespace bson_value {
 
-value::value(b_array v) : value(v.value) {}
-value::value(b_binary v) : value(v.type_id, v.sub_type, v.size, v.bytes) {}
-value::value(b_bool v) : value(v.value) {}
-value::value(b_code v) : value(v.type_id, v) {}
-value::value(b_codewscope v) : value(type::k_codewscope, v.code, v.scope) {}
-value::value(b_date v) : value(v.value) {}
-value::value(b_dbpointer v) : value(v.type_id, v.collection, v.value) {}
-value::value(b_decimal128 v) : value(v.value) {}
-value::value(b_document v) : value(v.view()) {}
-value::value(b_double v) : value(v.value) {}
-value::value(b_int32 v) : value(v.value) {}
-value::value(b_int64 v) : value(v.value) {}
 value::value(b_maxkey) : value(type::k_maxkey) {}
 value::value(b_minkey) : value(type::k_minkey) {}
-value::value(b_null) : value(nullptr) {}
-value::value(b_oid v) : value(v.value) {}
-value::value(b_regex v) : value(v.type_id, std::string{v.regex}, std::string{v.options}) {}
-value::value(b_symbol v) : value(v.type_id, v) {}
-value::value(b_timestamp v) : value(v.type_id, v.increment, v.timestamp) {}
 value::value(b_undefined) : value(type::k_undefined) {}
-value::value(b_utf8 v) : value(v.value) {}
-
-value::value(decimal128 v) : value(type::k_decimal128, v.high(), v.low()) {}
-
 value::value(const type id) : _impl{stdx::make_unique<impl>()} {
     if (id == type::k_minkey) {
         _impl->_value.value_type = BSON_TYPE_MINKEY;
@@ -63,16 +42,19 @@ value::value(const type id) : _impl{stdx::make_unique<impl>()} {
     }
 }
 
+value::value(b_double v) : value(v.value) {}
 value::value(double v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_DOUBLE;
     _impl->_value.value.v_double = v;
 }
 
+value::value(b_int32 v) : value(v.value) {}
 value::value(int32_t v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_INT32;
     _impl->_value.value.v_int32 = v;
 }
 
+value::value(b_int64 v) : value(v.value) {}
 value::value(int64_t v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_INT64;
     _impl->_value.value.v_int64 = v;
@@ -80,31 +62,39 @@ value::value(int64_t v) : _impl{stdx::make_unique<impl>()} {
 
 value::value(const char* v) : value(stdx::string_view{v}) {}
 value::value(std::string v) : value(stdx::string_view{v}) {}
+value::value(b_utf8 v) : value(v.value) {}
 value::value(stdx::string_view v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_UTF8;
     _impl->_value.value.v_utf8.str = make_copy_for_libbson(v);
     _impl->_value.value.v_utf8.len = (uint32_t)v.size();
 }
 
+value::value(b_null) : value(nullptr) {}
 value::value(std::nullptr_t) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_NULL;
 }
 
+value::value(b_date v) : value(v.value) {}
 value::value(std::chrono::milliseconds v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_DATE_TIME;
     _impl->_value.value.v_datetime = v.count();
 }
 
+value::value(b_oid v) : value(v.value) {}
 value::value(oid v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_OID;
     std::memcpy(_impl->_value.value.v_oid.bytes, v.bytes(), v.k_oid_length);
 }
 
+value::value(b_bool v) : value(v.value) {}
 value::value(bool v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_BOOL;
     _impl->_value.value.v_bool = v;
 }
 
+value::value(b_code v) : value(v.type_id, v) {}
+value::value(b_regex v) : value(v.type_id, std::string{v.regex}, std::string{v.options}) {}
+value::value(b_symbol v) : value(v.type_id, v) {}
 value::value(const type id, stdx::string_view a, stdx::string_view b)
     : _impl{stdx::make_unique<impl>()} {
     if (id == type::k_regex) {
@@ -124,6 +114,9 @@ value::value(const type id, stdx::string_view a, stdx::string_view b)
     }
 }
 
+value::value(b_decimal128 v) : value(v.value) {}
+value::value(decimal128 v) : value(type::k_decimal128, v.high(), v.low()) {}
+value::value(b_timestamp v) : value(v.type_id, v.increment, v.timestamp) {}
 value::value(type id, uint64_t a, uint64_t b) : _impl{stdx::make_unique<impl>()} {
     if (id == type::k_decimal128) {
         _impl->_value.value_type = BSON_TYPE_DECIMAL128;
@@ -138,6 +131,7 @@ value::value(type id, uint64_t a, uint64_t b) : _impl{stdx::make_unique<impl>()}
     }
 }
 
+value::value(b_dbpointer v) : value(v.type_id, v.collection, v.value) {}
 value::value(const type id, stdx::string_view a, oid b) : _impl{stdx::make_unique<impl>()} {
     if (id == type::k_dbpointer) {
         _impl->_value.value_type = BSON_TYPE_DBPOINTER;
@@ -149,6 +143,7 @@ value::value(const type id, stdx::string_view a, oid b) : _impl{stdx::make_uniqu
     }
 }
 
+value::value(b_codewscope v) : value(type::k_codewscope, v.code, v.scope) {}
 value::value(const type id, stdx::string_view a, bsoncxx::document::view_or_value b)
     : _impl{stdx::make_unique<impl>()} {
     if (id == type::k_codewscope) {
@@ -162,6 +157,7 @@ value::value(const type id, stdx::string_view a, bsoncxx::document::view_or_valu
     }
 }
 
+value::value(b_binary v) : value(v.type_id, v.sub_type, v.size, v.bytes) {}
 value::value(const type id, const binary_sub_type sub_id, uint32_t size, const uint8_t* data)
     : _impl{stdx::make_unique<impl>()} {
     if (id != type::k_binary)
@@ -175,6 +171,7 @@ value::value(const type id, const binary_sub_type sub_id, uint32_t size, const u
     std::memcpy(_impl->_value.value.v_binary.data, data, size);
 }
 
+value::value(b_document v) : value(v.view()) {}
 value::value(bsoncxx::document::view v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_DOCUMENT;
     _impl->_value.value.v_doc.data_len = (uint32_t)v.length();
@@ -182,6 +179,7 @@ value::value(bsoncxx::document::view v) : _impl{stdx::make_unique<impl>()} {
     std::memcpy(_impl->_value.value.v_doc.data, v.data(), v.length());
 }
 
+value::value(b_array v) : value(v.value) {}
 value::value(std::vector<unsigned char> v, binary_sub_type sub_type)
     : value(type::k_binary, sub_type, (uint32_t)v.size(), (uint8_t*)v.data()) {}
 value::value(bsoncxx::array::view v) : _impl{stdx::make_unique<impl>()} {

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -86,7 +86,7 @@ value::value(stdx::string_view v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value.v_utf8.len = (uint32_t)v.size();
 }
 
-value::value(nullptr_t) : _impl{stdx::make_unique<impl>()} {
+value::value(std::nullptr_t) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_NULL;
 }
 

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -85,26 +85,33 @@ value::value(b_minkey) : value(type::k_minkey) {}
 value::value(b_undefined) : value(type::k_undefined) {}
 value::value(const type id, stdx::string_view a, stdx::string_view b)
     : _impl{stdx::make_unique<impl>()} {
-    if (id == type::k_regex) {
-        _impl->_value.value_type = BSON_TYPE_REGEX;
-        _impl->_value.value.v_regex.regex = make_copy_for_libbson(a);
-        _impl->_value.value.v_regex.options = make_copy_for_libbson(b);
-    } else if (id == type::k_code) {
-        _impl->_value.value_type = BSON_TYPE_CODE;
-        _impl->_value.value.v_code.code = make_copy_for_libbson(a);
-        _impl->_value.value.v_code.code_len = (uint32_t)a.length();
-    } else if (id == type::k_symbol) {
-        _impl->_value.value_type = BSON_TYPE_SYMBOL;
-        _impl->_value.value.v_symbol.symbol = make_copy_for_libbson(a);
-        _impl->_value.value.v_symbol.len = (uint32_t)a.length();
-    } else if (id == type::k_minkey) {
-        _impl->_value.value_type = BSON_TYPE_MINKEY;
-    } else if (id == type::k_maxkey) {
-        _impl->_value.value_type = BSON_TYPE_MAXKEY;
-    } else if (id == type::k_undefined) {
-        _impl->_value.value_type = BSON_TYPE_UNDEFINED;
-    } else {
-        throw std::logic_error{"Unknown type"};
+    switch (id) {
+        case type::k_regex:
+            _impl->_value.value_type = BSON_TYPE_REGEX;
+            _impl->_value.value.v_regex.regex = make_copy_for_libbson(a);
+            _impl->_value.value.v_regex.options = make_copy_for_libbson(b);
+            break;
+        case type::k_code:
+            _impl->_value.value_type = BSON_TYPE_CODE;
+            _impl->_value.value.v_code.code = make_copy_for_libbson(a);
+            _impl->_value.value.v_code.code_len = (uint32_t)a.length();
+            break;
+        case type::k_symbol:
+            _impl->_value.value_type = BSON_TYPE_SYMBOL;
+            _impl->_value.value.v_symbol.symbol = make_copy_for_libbson(a);
+            _impl->_value.value.v_symbol.len = (uint32_t)a.length();
+            break;
+        case type::k_minkey:
+            _impl->_value.value_type = BSON_TYPE_MINKEY;
+            break;
+        case type::k_maxkey:
+            _impl->_value.value_type = BSON_TYPE_MAXKEY;
+            break;
+        case type::k_undefined:
+            _impl->_value.value_type = BSON_TYPE_UNDEFINED;
+            break;
+        default:
+            throw bsoncxx::exception(error_code::k_invalid_type);
     }
 }
 

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -125,16 +125,12 @@ value::value(type id, uint64_t a, uint64_t b) : _impl{stdx::make_unique<impl>()}
     }
 }
 
-value::value(b_dbpointer v) : value(v.type_id, v.collection, v.value) {}
-value::value(const type id, stdx::string_view a, oid b) : _impl{stdx::make_unique<impl>()} {
-    if (id == type::k_dbpointer) {
-        _impl->_value.value_type = BSON_TYPE_DBPOINTER;
-        _impl->_value.value.v_dbpointer.collection = make_copy_for_libbson(a);
-        _impl->_value.value.v_dbpointer.collection_len = (uint32_t)a.length();
-        std::memcpy(_impl->_value.value.v_dbpointer.oid.bytes, b.bytes(), b.k_oid_length);
-    } else {
-        throw std::logic_error{"Not dbpointer"};
-    }
+value::value(b_dbpointer v) : value(v.collection, v.value) {}
+value::value(stdx::string_view collection, oid value) : _impl{stdx::make_unique<impl>()} {
+    _impl->_value.value_type = BSON_TYPE_DBPOINTER;
+    _impl->_value.value.v_dbpointer.collection = make_copy_for_libbson(collection);
+    _impl->_value.value.v_dbpointer.collection_len = (uint32_t)collection.length();
+    std::memcpy(_impl->_value.value.v_dbpointer.oid.bytes, value.bytes(), value.k_oid_length);
 }
 
 value::value(b_codewscope v) : value(type::k_codewscope, v.code, v.scope) {}

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -101,7 +101,7 @@ value::value(stdx::string_view regex, stdx::string_view options)
     : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_REGEX;
     _impl->_value.value.v_regex.regex = make_copy_for_libbson(regex);
-    _impl->_value.value.v_regex.options = make_copy_for_libbson(options);
+    _impl->_value.value.v_regex.options = options.empty() ? NULL : make_copy_for_libbson(options);
 }
 
 value::value(b_code v) : value(v.type_id, v) {}

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -77,12 +77,28 @@ value::value(bool v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value.v_bool = v;
 }
 
-value::value(b_code v) : value(v.type_id, v) {}
-value::value(b_regex v) : value(v.type_id, v.regex, v.options) {}
-value::value(b_symbol v) : value(v.type_id, v) {}
 value::value(b_maxkey) : value(type::k_maxkey) {}
 value::value(b_minkey) : value(type::k_minkey) {}
 value::value(b_undefined) : value(type::k_undefined) {}
+value::value(const type id) : _impl{stdx::make_unique<impl>()} {
+    switch (id) {
+        case type::k_minkey:
+            _impl->_value.value_type = BSON_TYPE_MINKEY;
+            break;
+        case type::k_maxkey:
+            _impl->_value.value_type = BSON_TYPE_MAXKEY;
+            break;
+        case type::k_undefined:
+            _impl->_value.value_type = BSON_TYPE_UNDEFINED;
+            break;
+        default:
+            throw bsoncxx::exception(error_code::k_invalid_bson_type_id);
+    }
+}
+
+value::value(b_code v) : value(v.type_id, v) {}
+value::value(b_symbol v) : value(v.type_id, v) {}
+value::value(b_regex v) : value(v.type_id, v.regex, v.options) {}
 value::value(const type id, stdx::string_view a, stdx::string_view b)
     : _impl{stdx::make_unique<impl>()} {
     switch (id) {
@@ -100,15 +116,6 @@ value::value(const type id, stdx::string_view a, stdx::string_view b)
             _impl->_value.value_type = BSON_TYPE_SYMBOL;
             _impl->_value.value.v_symbol.symbol = make_copy_for_libbson(a);
             _impl->_value.value.v_symbol.len = (uint32_t)a.length();
-            break;
-        case type::k_minkey:
-            _impl->_value.value_type = BSON_TYPE_MINKEY;
-            break;
-        case type::k_maxkey:
-            _impl->_value.value_type = BSON_TYPE_MAXKEY;
-            break;
-        case type::k_undefined:
-            _impl->_value.value_type = BSON_TYPE_UNDEFINED;
             break;
         default:
             throw bsoncxx::exception(error_code::k_invalid_bson_type_id);

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -90,25 +90,12 @@ value::value(decimal128 v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value.v_decimal128.low = v.low();
 }
 
-value::value(const type id, const char* a, const char* b)
-    : value(id, stdx::string_view{a}, stdx::string_view{b}) {}
-
-template <typename T1, typename T2>
-value::value(const type id, T1 a, T2 b) : _impl{stdx::make_unique<impl>()} {
-    switch (id) {
-        case type::k_regex:
-            _impl->_value.value_type = BSON_TYPE_REGEX;
-            // static_assert(std::is_convertible<T1, stdx::string_view>::value = true, "regex must
-            // be string");
-            (void)a, (void)b;
-            _impl->_value.value.v_regex.regex = make_copy_for_libbson(a);
-            _impl->_value.value.v_regex.options = make_copy_for_libbson(b);
-            //            else if (sizeof...(args) == 0)
-            //            else
-            //                throw bsoncxx::exception{bsoncxx::error_code::k_internal_error};
-            break;
-        default:
-            BSONCXX_UNREACHABLE;
+value::value(const type id, stdx::string_view a, stdx::string_view b)
+    : _impl{stdx::make_unique<impl>()} {
+    if (id == type::k_regex) {
+        _impl->_value.value_type = BSON_TYPE_REGEX;
+        _impl->_value.value.v_regex.regex = make_copy_for_libbson(a);
+        _impl->_value.value.v_regex.options = make_copy_for_libbson(b);
     }
 }
 

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -105,13 +105,9 @@ value::value(const type id, stdx::string_view a, bsoncxx::document::view_or_valu
         _impl->_value.value.v_codewscope.code = make_copy_for_libbson(a);
         _impl->_value.value.v_codewscope.code_len = (uint32_t)a.length();
         _impl->_value.value.v_codewscope.scope_len = (uint32_t)b.view().length();
-        if (b.view().empty()) {
-            _impl->_value.value.v_codewscope.scope_data = nullptr;
-        } else {
-            _impl->_value.value.v_codewscope.scope_data = (uint8_t*)bson_malloc0(b.view().length());
-            std::memcpy(
-                _impl->_value.value.v_codewscope.scope_data, b.view().data(), b.view().length());
-        }
+        _impl->_value.value.v_codewscope.scope_data = (uint8_t*)bson_malloc0(b.view().length());
+        std::memcpy(
+            _impl->_value.value.v_codewscope.scope_data, b.view().data(), b.view().length());
     }
 }
 value::value(bsoncxx::document::view_or_value v) : _impl{stdx::make_unique<impl>()} {

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -98,7 +98,23 @@ value::value(const type id, stdx::string_view a, oid b) : _impl{stdx::make_uniqu
         std::memcpy(_impl->_value.value.v_dbpointer.oid.bytes, b.bytes(), b.k_oid_length);
     }
 }
-
+value::value(const type id, stdx::string_view a, bsoncxx::document::view_or_value b)
+    : _impl{stdx::make_unique<impl>()} {
+    if (id == type::k_codewscope) {
+        _impl->_value.value_type = BSON_TYPE_CODEWSCOPE;
+        _impl->_value.value.v_codewscope.code = make_copy_for_libbson(a);
+        _impl->_value.value.v_codewscope.code_len = (uint32_t)a.length();
+        if (b.view().empty()) {
+            _impl->_value.value.v_codewscope.scope_data = nullptr;
+            _impl->_value.value.v_codewscope.scope_len = 0;
+        } else {
+            _impl->_value.value.v_codewscope.scope_data = (uint8_t*)bson_malloc0(b.view().length());
+            _impl->_value.value.v_codewscope.scope_len = (uint32_t)b.view().length();
+            std::memcpy(
+                _impl->_value.value.v_codewscope.scope_data, b.view().data(), b.view().length());
+        }
+    }
+}
 value::value(const type id, stdx::string_view a, stdx::string_view b)
     : _impl{stdx::make_unique<impl>()} {
     if (id == type::k_regex) {

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -27,21 +27,6 @@ BSONCXX_INLINE_NAMESPACE_BEGIN
 namespace types {
 namespace bson_value {
 
-value::value(b_maxkey) : value(type::k_maxkey) {}
-value::value(b_minkey) : value(type::k_minkey) {}
-value::value(b_undefined) : value(type::k_undefined) {}
-value::value(const type id) : _impl{stdx::make_unique<impl>()} {
-    if (id == type::k_minkey) {
-        _impl->_value.value_type = BSON_TYPE_MINKEY;
-    } else if (id == type::k_maxkey) {
-        _impl->_value.value_type = BSON_TYPE_MAXKEY;
-    } else if (id == type::k_undefined) {
-        _impl->_value.value_type = BSON_TYPE_UNDEFINED;
-    } else {
-        throw std::logic_error{"Must be min/max key or undefined"};
-    }
-}
-
 value::value(b_double v) : value(v.value) {}
 value::value(double v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_DOUBLE;
@@ -95,6 +80,9 @@ value::value(bool v) : _impl{stdx::make_unique<impl>()} {
 value::value(b_code v) : value(v.type_id, v) {}
 value::value(b_regex v) : value(v.type_id, std::string{v.regex}, std::string{v.options}) {}
 value::value(b_symbol v) : value(v.type_id, v) {}
+value::value(b_maxkey) : value(type::k_maxkey) {}
+value::value(b_minkey) : value(type::k_minkey) {}
+value::value(b_undefined) : value(type::k_undefined) {}
 value::value(const type id, stdx::string_view a, stdx::string_view b)
     : _impl{stdx::make_unique<impl>()} {
     if (id == type::k_regex) {
@@ -109,6 +97,12 @@ value::value(const type id, stdx::string_view a, stdx::string_view b)
         _impl->_value.value_type = BSON_TYPE_SYMBOL;
         _impl->_value.value.v_symbol.symbol = make_copy_for_libbson(a);
         _impl->_value.value.v_symbol.len = (uint32_t)a.length();
+    } else if (id == type::k_minkey) {
+        _impl->_value.value_type = BSON_TYPE_MINKEY;
+    } else if (id == type::k_maxkey) {
+        _impl->_value.value_type = BSON_TYPE_MAXKEY;
+    } else if (id == type::k_undefined) {
+        _impl->_value.value_type = BSON_TYPE_UNDEFINED;
     } else {
         throw std::logic_error{"Unknown type"};
     }

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -90,6 +90,15 @@ value::value(decimal128 v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value.v_decimal128.low = v.low();
 }
 
+value::value(const type id, stdx::string_view a, oid b) : _impl{stdx::make_unique<impl>()} {
+    if (id == type::k_dbpointer) {
+        _impl->_value.value_type = BSON_TYPE_DBPOINTER;
+        _impl->_value.value.v_dbpointer.collection = make_copy_for_libbson(a);
+        _impl->_value.value.v_dbpointer.collection_len = (uint32_t)a.length();
+        std::memcpy(_impl->_value.value.v_dbpointer.oid.bytes, b.bytes(), b.k_oid_length);
+    }
+}
+
 value::value(const type id, stdx::string_view a, stdx::string_view b)
     : _impl{stdx::make_unique<impl>()} {
     if (id == type::k_regex) {

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -120,6 +120,14 @@ value::value(bsoncxx::document::view_or_value v) : _impl{stdx::make_unique<impl>
     std::memcpy(_impl->_value.value.v_doc.data, v.view().data(), v.view().length());
 }
 
+value::value(b_array v) : value(v.value) {}
+value::value(bsoncxx::array::view_or_value v) : _impl{stdx::make_unique<impl>()} {
+    _impl->_value.value_type = BSON_TYPE_ARRAY;
+    _impl->_value.value.v_doc.data_len = (uint32_t)v.view().length();
+    _impl->_value.value.v_doc.data = (uint8_t*)bson_malloc0(v.view().length());
+    std::memcpy(_impl->_value.value.v_doc.data, v.view().data(), v.view().length());
+}
+
 value::value(b_minkey) : value(type::k_minkey) {}
 value::value(b_maxkey) : value(type::k_maxkey) {}
 value::value(const type id) : _impl{stdx::make_unique<impl>()} {

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -63,6 +63,7 @@ value::value(const type id) : _impl{stdx::make_unique<impl>()} {
         throw std::logic_error{"Must be min/max key or undefined"};
     }
 }
+
 value::value(double v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_DOUBLE;
     _impl->_value.value.v_double = v;
@@ -78,7 +79,6 @@ value::value(int64_t v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value.v_int64 = v;
 }
 
-// TODO: enable_if T in T* decays to char
 value::value(const char* v) : value(stdx::string_view{v}) {}
 value::value(std::string v) : value(stdx::string_view{v}) {}
 value::value(stdx::string_view v) : _impl{stdx::make_unique<impl>()} {
@@ -162,6 +162,7 @@ value::value(const type id, stdx::string_view a, bsoncxx::document::view_or_valu
             _impl->_value.value.v_codewscope.scope_data, b.view().data(), b.view().length());
     }
 }
+
 value::value(const type id, const binary_sub_type sub_id, uint32_t size, const uint8_t* data)
     : _impl{stdx::make_unique<impl>()} {
     if (id != type::k_binary)

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -105,6 +105,10 @@ value::value(const type id, stdx::string_view a, stdx::string_view b)
         _impl->_value.value_type = BSON_TYPE_REGEX;
         _impl->_value.value.v_regex.regex = make_copy_for_libbson(a);
         _impl->_value.value.v_regex.options = make_copy_for_libbson(b);
+    } else if (id == type::k_code) {
+        _impl->_value.value_type = BSON_TYPE_CODE;
+        _impl->_value.value.v_code.code = make_copy_for_libbson(a);
+        _impl->_value.value.v_code.code_len = (uint32_t)a.length();
     }
 }
 

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -112,6 +112,7 @@ value::value(const type id, stdx::string_view a, bsoncxx::document::view_or_valu
             _impl->_value.value.v_codewscope.scope_data, b.view().data(), b.view().length());
     }
 }
+value::value(b_document v) : value(v.view()) {}
 value::value(bsoncxx::document::view_or_value v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_DOCUMENT;
     _impl->_value.value.v_doc.data_len = (uint32_t)v.view().length();

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -117,12 +117,8 @@ value::value(const type id, stdx::string_view a, bsoncxx::document::view_or_valu
 value::value(bsoncxx::document::view_or_value v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_DOCUMENT;
     _impl->_value.value.v_doc.data_len = (uint32_t)v.view().length();
-    if (v.view().empty()) {
-        _impl->_value.value.v_doc.data = nullptr;
-    } else {
-        _impl->_value.value.v_doc.data = (uint8_t*)bson_malloc0(v.view().length());
-        std::memcpy(_impl->_value.value.v_doc.data, v.view().data(), v.view().length());
-    }
+    _impl->_value.value.v_doc.data = (uint8_t*)bson_malloc0(v.view().length());
+    std::memcpy(_impl->_value.value.v_doc.data, v.view().data(), v.view().length());
 }
 value::value(const type id, stdx::string_view a, stdx::string_view b)
     : _impl{stdx::make_unique<impl>()} {

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -35,9 +35,11 @@ value::value(b_int32 v) : _impl{stdx::make_unique<impl>()} {
     convert_to_libbson(v, &_impl->_value);
 }
 
-value::value(char const* v) : value(b_utf8{v}) {}  // TODO: consider different chars
-value::value(stdx::string_view v) : value(b_utf8{v}) {}
+value::value(const char* v) : value(b_utf8{v}) {}
+
 value::value(std::string v) : value(b_utf8{v}) {}
+value::value(stdx::string_view v) : value(b_utf8{v}) {}
+
 value::value(b_utf8 v) : _impl{stdx::make_unique<impl>()} {
     convert_to_libbson(v, &_impl->_value);
 }
@@ -48,7 +50,11 @@ value::value(b_utf8 v) : _impl{stdx::make_unique<impl>()} {
 // BSONCXX_ENUM(undefined, 0x06)
 // BSONCXX_ENUM(oid, 0x07)
 value::value(b_bool v) : value(v.value) {}
-value::value(bool v) {
+
+template <
+    typename T,
+    typename std::enable_if<std::is_same<bool, typename std::decay<T>::type>::value, int>::type = 0>
+value::value(T v) {
     _impl = stdx::make_unique<impl>();
     _impl->_value.value_type = BSON_TYPE_BOOL;
     _impl->_value.value.v_bool = v;

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -19,7 +19,6 @@
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/types/bson_value/private/value.hh>
 #include <bsoncxx/types/private/convert.hh>
-#include <iostream>
 
 #include <bsoncxx/config/private/prelude.hh>
 

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -111,7 +111,7 @@ value::value(const type id, stdx::string_view a, stdx::string_view b)
             _impl->_value.value_type = BSON_TYPE_UNDEFINED;
             break;
         default:
-            throw bsoncxx::exception(error_code::k_invalid_type);
+            throw bsoncxx::exception(error_code::k_invalid_bson_type_id);
     }
 }
 
@@ -131,7 +131,7 @@ value::value(type id, uint64_t a, uint64_t b) : _impl{stdx::make_unique<impl>()}
             _impl->_value.value.v_timestamp.timestamp = (uint32_t)b;
             break;
         default:
-            throw bsoncxx::exception(error_code::k_invalid_type);
+            throw bsoncxx::exception(error_code::k_invalid_bson_type_id);
     }
 }
 

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -133,18 +133,16 @@ value::value(stdx::string_view collection, oid value) : _impl{stdx::make_unique<
     std::memcpy(_impl->_value.value.v_dbpointer.oid.bytes, value.bytes(), value.k_oid_length);
 }
 
-value::value(b_codewscope v) : value(type::k_codewscope, v.code, v.scope) {}
-value::value(const type id, stdx::string_view a, bsoncxx::document::view_or_value b)
+value::value(b_codewscope v) : value(v.code, v.scope) {}
+value::value(stdx::string_view code, bsoncxx::document::view_or_value scope)
     : _impl{stdx::make_unique<impl>()} {
-    if (id == type::k_codewscope) {
-        _impl->_value.value_type = BSON_TYPE_CODEWSCOPE;
-        _impl->_value.value.v_codewscope.code = make_copy_for_libbson(a);
-        _impl->_value.value.v_codewscope.code_len = (uint32_t)a.length();
-        _impl->_value.value.v_codewscope.scope_len = (uint32_t)b.view().length();
-        _impl->_value.value.v_codewscope.scope_data = (uint8_t*)bson_malloc0(b.view().length());
-        std::memcpy(
-            _impl->_value.value.v_codewscope.scope_data, b.view().data(), b.view().length());
-    }
+    _impl->_value.value_type = BSON_TYPE_CODEWSCOPE;
+    _impl->_value.value.v_codewscope.code = make_copy_for_libbson(code);
+    _impl->_value.value.v_codewscope.code_len = (uint32_t)code.length();
+    _impl->_value.value.v_codewscope.scope_len = (uint32_t)scope.view().length();
+    _impl->_value.value.v_codewscope.scope_data = (uint8_t*)bson_malloc0(scope.view().length());
+    std::memcpy(
+        _impl->_value.value.v_codewscope.scope_data, scope.view().data(), scope.view().length());
 }
 
 value::value(b_binary v) : value(v.type_id, v.sub_type, v.size, v.bytes) {}

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -145,16 +145,14 @@ value::value(stdx::string_view code, bsoncxx::document::view_or_value scope)
         _impl->_value.value.v_codewscope.scope_data, scope.view().data(), scope.view().length());
 }
 
-value::value(b_binary v) : value(v.type_id, v.sub_type, v.size, v.bytes) {}
-value::value(const type id, const binary_sub_type sub_id, uint32_t size, const uint8_t* data)
+value::value(b_binary v) : value(v.bytes, v.size, v.sub_type) {}
+value::value(std::vector<unsigned char> v, binary_sub_type sub_type)
+    : value(v.data(), v.size(), sub_type) {}
+value::value(const uint8_t* data, size_t size, const binary_sub_type sub_type)
     : _impl{stdx::make_unique<impl>()} {
-    if (id != type::k_binary)
-        throw std::logic_error{"Not binary"};
-
     _impl->_value.value_type = BSON_TYPE_BINARY;
-
-    _impl->_value.value.v_binary.subtype = static_cast<bson_subtype_t>(sub_id);
-    _impl->_value.value.v_binary.data_len = size;
+    _impl->_value.value.v_binary.subtype = static_cast<bson_subtype_t>(sub_type);
+    _impl->_value.value.v_binary.data_len = (uint32_t)size;
     _impl->_value.value.v_binary.data = (uint8_t*)bson_malloc(size);
     std::memcpy(_impl->_value.value.v_binary.data, data, size);
 }
@@ -168,8 +166,6 @@ value::value(bsoncxx::document::view v) : _impl{stdx::make_unique<impl>()} {
 }
 
 value::value(b_array v) : value(v.value) {}
-value::value(std::vector<unsigned char> v, binary_sub_type sub_type)
-    : value(type::k_binary, sub_type, (uint32_t)v.size(), (uint8_t*)v.data()) {}
 value::value(bsoncxx::array::view v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_ARRAY;
     _impl->_value.value.v_doc.data_len = (uint32_t)v.length();

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -104,15 +104,24 @@ value::value(const type id, stdx::string_view a, bsoncxx::document::view_or_valu
         _impl->_value.value_type = BSON_TYPE_CODEWSCOPE;
         _impl->_value.value.v_codewscope.code = make_copy_for_libbson(a);
         _impl->_value.value.v_codewscope.code_len = (uint32_t)a.length();
+        _impl->_value.value.v_codewscope.scope_len = (uint32_t)b.view().length();
         if (b.view().empty()) {
             _impl->_value.value.v_codewscope.scope_data = nullptr;
-            _impl->_value.value.v_codewscope.scope_len = 0;
         } else {
             _impl->_value.value.v_codewscope.scope_data = (uint8_t*)bson_malloc0(b.view().length());
-            _impl->_value.value.v_codewscope.scope_len = (uint32_t)b.view().length();
             std::memcpy(
                 _impl->_value.value.v_codewscope.scope_data, b.view().data(), b.view().length());
         }
+    }
+}
+value::value(bsoncxx::document::view_or_value v) : _impl{stdx::make_unique<impl>()} {
+    _impl->_value.value_type = BSON_TYPE_DOCUMENT;
+    _impl->_value.value.v_doc.data_len = (uint32_t)v.view().length();
+    if (v.view().empty()) {
+        _impl->_value.value.v_doc.data = nullptr;
+    } else {
+        _impl->_value.value.v_doc.data = (uint8_t*)bson_malloc0(v.view().length());
+        std::memcpy(_impl->_value.value.v_doc.data, v.view().data(), v.view().length());
     }
 }
 value::value(const type id, stdx::string_view a, stdx::string_view b)

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -177,7 +177,8 @@ value::value(const uint8_t* data, size_t size, const binary_sub_type sub_type)
     _impl->_value.value.v_binary.subtype = static_cast<bson_subtype_t>(sub_type);
     _impl->_value.value.v_binary.data_len = (uint32_t)size;
     _impl->_value.value.v_binary.data = (uint8_t*)bson_malloc(size);
-    std::memcpy(_impl->_value.value.v_binary.data, data, size);
+    if (size)
+        std::memcpy(_impl->_value.value.v_binary.data, data, size);
 }
 
 value::value(b_document v) : value(v.view()) {}

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -78,7 +78,7 @@ value::value(bool v) : _impl{stdx::make_unique<impl>()} {
 }
 
 value::value(b_code v) : value(v.type_id, v) {}
-value::value(b_regex v) : value(v.type_id, std::string{v.regex}, std::string{v.options}) {}
+value::value(b_regex v) : value(v.type_id, v.regex, v.options) {}
 value::value(b_symbol v) : value(v.type_id, v) {}
 value::value(b_maxkey) : value(type::k_maxkey) {}
 value::value(b_minkey) : value(type::k_minkey) {}

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -119,16 +119,19 @@ value::value(b_decimal128 v) : value(v.value) {}
 value::value(decimal128 v) : value(type::k_decimal128, v.high(), v.low()) {}
 value::value(b_timestamp v) : value(v.type_id, v.increment, v.timestamp) {}
 value::value(type id, uint64_t a, uint64_t b) : _impl{stdx::make_unique<impl>()} {
-    if (id == type::k_decimal128) {
-        _impl->_value.value_type = BSON_TYPE_DECIMAL128;
-        _impl->_value.value.v_decimal128.high = a;
-        _impl->_value.value.v_decimal128.low = b;
-    } else if (id == type::k_timestamp) {
-        _impl->_value.value_type = BSON_TYPE_TIMESTAMP;
-        _impl->_value.value.v_timestamp.increment = (uint32_t)a;
-        _impl->_value.value.v_timestamp.timestamp = (uint32_t)b;
-    } else {
-        throw std::logic_error{"Not decimal128 or timestamp"};
+    switch (id) {
+        case type::k_decimal128:
+            _impl->_value.value_type = BSON_TYPE_DECIMAL128;
+            _impl->_value.value.v_decimal128.high = a;
+            _impl->_value.value.v_decimal128.low = b;
+            break;
+        case type::k_timestamp:
+            _impl->_value.value_type = BSON_TYPE_TIMESTAMP;
+            _impl->_value.value.v_timestamp.increment = (uint32_t)a;
+            _impl->_value.value.v_timestamp.timestamp = (uint32_t)b;
+            break;
+        default:
+            throw bsoncxx::exception(error_code::k_invalid_type);
     }
 }
 

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -52,10 +52,6 @@ value::value(b_utf8 v) : value(v.value) {}
 
 value::value(decimal128 v) : value(type::k_decimal128, v.high(), v.low()) {}
 
-template <typename T, typename... Targs>
-value::value(type id, T value, Targs... Fargs) {
-    std::cout << "REACHED" << std::endl;
-}
 value::value(const type id) : _impl{stdx::make_unique<impl>()} {
     if (id == type::k_minkey) {
         _impl->_value.value_type = BSON_TYPE_MINKEY;
@@ -67,23 +63,6 @@ value::value(const type id) : _impl{stdx::make_unique<impl>()} {
         throw std::logic_error{"Must be min/max key or undefined"};
     }
 }
-
-template value::value<int, int>(type, int, int);
-template value::value<int, int>(type, int, int);
-template value::value<uint32_t, uint32_t>(type, uint32_t, uint32_t);
-template value::value<uint64_t, uint64_t>(type, uint64_t, uint64_t);
-
-template value::value<stdx::string_view, stdx::string_view>(type,
-                                                            stdx::string_view,
-                                                            stdx::string_view);
-template value::value<stdx::string_view, oid>(type, stdx::string_view, oid);
-template value::value<stdx::string_view, document::view>(type, stdx::string_view, document::view);
-
-template value::value<const char*, const char*>(type, const char*, const char*);
-template value::value<const char*, oid>(type, const char*, oid);
-template value::value<const char*, document::view>(type, const char*, document::view);
-template value::value<const char*>(type, const char*);
-
 value::value(double v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_DOUBLE;
     _impl->_value.value.v_double = v;
@@ -121,79 +100,80 @@ value::value(oid v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_OID;
     std::memcpy(_impl->_value.value.v_oid.bytes, v.bytes(), v.k_oid_length);
 }
+
 value::value(bool v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_BOOL;
     _impl->_value.value.v_bool = v;
 }
 
-// value::value(const type id, stdx::string_view a, stdx::string_view b)
-//     : _impl{stdx::make_unique<impl>()} {
-//     if (id == type::k_regex) {
-//         _impl->_value.value_type = BSON_TYPE_REGEX;
-//         _impl->_value.value.v_regex.regex = make_copy_for_libbson(a);
-//         _impl->_value.value.v_regex.options = make_copy_for_libbson(b);
-//     } else if (id == type::k_code) {
-//         _impl->_value.value_type = BSON_TYPE_CODE;
-//         _impl->_value.value.v_code.code = make_copy_for_libbson(a);
-//         _impl->_value.value.v_code.code_len = (uint32_t)a.length();
-//     } else if (id == type::k_symbol) {
-//         _impl->_value.value_type = BSON_TYPE_SYMBOL;
-//         _impl->_value.value.v_symbol.symbol = make_copy_for_libbson(a);
-//         _impl->_value.value.v_symbol.len = (uint32_t)a.length();
-//     } else {
-//         throw std::logic_error{"Unknown type"};
-//     }
-// }
+value::value(const type id, stdx::string_view a, stdx::string_view b)
+    : _impl{stdx::make_unique<impl>()} {
+    if (id == type::k_regex) {
+        _impl->_value.value_type = BSON_TYPE_REGEX;
+        _impl->_value.value.v_regex.regex = make_copy_for_libbson(a);
+        _impl->_value.value.v_regex.options = make_copy_for_libbson(b);
+    } else if (id == type::k_code) {
+        _impl->_value.value_type = BSON_TYPE_CODE;
+        _impl->_value.value.v_code.code = make_copy_for_libbson(a);
+        _impl->_value.value.v_code.code_len = (uint32_t)a.length();
+    } else if (id == type::k_symbol) {
+        _impl->_value.value_type = BSON_TYPE_SYMBOL;
+        _impl->_value.value.v_symbol.symbol = make_copy_for_libbson(a);
+        _impl->_value.value.v_symbol.len = (uint32_t)a.length();
+    } else {
+        throw std::logic_error{"Unknown type"};
+    }
+}
 
-// value::value(type id, uint64_t a, uint64_t b) : _impl{stdx::make_unique<impl>()} {
-//    if (id == type::k_decimal128) {
-//        _impl->_value.value_type = BSON_TYPE_DECIMAL128;
-//        _impl->_value.value.v_decimal128.high = a;
-//        _impl->_value.value.v_decimal128.low = b;
-//    } else if (id == type::k_timestamp) {
-//        _impl->_value.value_type = BSON_TYPE_TIMESTAMP;
-//        _impl->_value.value.v_timestamp.increment = (uint32_t)a;
-//        _impl->_value.value.v_timestamp.timestamp = (uint32_t)b;
-//    } else {
-//        throw std::logic_error{"Not decimal128 or timestamp"};
-//    }
-//}
-//
-// value::value(const type id, stdx::string_view a, oid b) : _impl{stdx::make_unique<impl>()} {
-//    if (id == type::k_dbpointer) {
-//        _impl->_value.value_type = BSON_TYPE_DBPOINTER;
-//        _impl->_value.value.v_dbpointer.collection = make_copy_for_libbson(a);
-//        _impl->_value.value.v_dbpointer.collection_len = (uint32_t)a.length();
-//        std::memcpy(_impl->_value.value.v_dbpointer.oid.bytes, b.bytes(), b.k_oid_length);
-//    } else {
-//        throw std::logic_error{"Not dbpointer"};
-//    }
-//}
-//
-// value::value(const type id, stdx::string_view a, bsoncxx::document::view_or_value b)
-//    : _impl{stdx::make_unique<impl>()} {
-//    if (id == type::k_codewscope) {
-//        _impl->_value.value_type = BSON_TYPE_CODEWSCOPE;
-//        _impl->_value.value.v_codewscope.code = make_copy_for_libbson(a);
-//        _impl->_value.value.v_codewscope.code_len = (uint32_t)a.length();
-//        _impl->_value.value.v_codewscope.scope_len = (uint32_t)b.view().length();
-//        _impl->_value.value.v_codewscope.scope_data = (uint8_t*)bson_malloc0(b.view().length());
-//        std::memcpy(
-//            _impl->_value.value.v_codewscope.scope_data, b.view().data(), b.view().length());
-//    }
-//}
-// value::value(const type id, const binary_sub_type sub_id, uint32_t size, const uint8_t* data)
-//     : _impl{stdx::make_unique<impl>()} {
-//     if (id != type::k_binary)
-//         throw std::logic_error{"Not binary"};
-//
-//     _impl->_value.value_type = BSON_TYPE_BINARY;
-//
-//     _impl->_value.value.v_binary.subtype = static_cast<bson_subtype_t>(sub_id);
-//     _impl->_value.value.v_binary.data_len = size;
-//     _impl->_value.value.v_binary.data = (uint8_t*)bson_malloc(size);
-//     std::memcpy(_impl->_value.value.v_binary.data, data, size);
-// }
+value::value(type id, uint64_t a, uint64_t b) : _impl{stdx::make_unique<impl>()} {
+    if (id == type::k_decimal128) {
+        _impl->_value.value_type = BSON_TYPE_DECIMAL128;
+        _impl->_value.value.v_decimal128.high = a;
+        _impl->_value.value.v_decimal128.low = b;
+    } else if (id == type::k_timestamp) {
+        _impl->_value.value_type = BSON_TYPE_TIMESTAMP;
+        _impl->_value.value.v_timestamp.increment = (uint32_t)a;
+        _impl->_value.value.v_timestamp.timestamp = (uint32_t)b;
+    } else {
+        throw std::logic_error{"Not decimal128 or timestamp"};
+    }
+}
+
+value::value(const type id, stdx::string_view a, oid b) : _impl{stdx::make_unique<impl>()} {
+    if (id == type::k_dbpointer) {
+        _impl->_value.value_type = BSON_TYPE_DBPOINTER;
+        _impl->_value.value.v_dbpointer.collection = make_copy_for_libbson(a);
+        _impl->_value.value.v_dbpointer.collection_len = (uint32_t)a.length();
+        std::memcpy(_impl->_value.value.v_dbpointer.oid.bytes, b.bytes(), b.k_oid_length);
+    } else {
+        throw std::logic_error{"Not dbpointer"};
+    }
+}
+
+value::value(const type id, stdx::string_view a, bsoncxx::document::view_or_value b)
+    : _impl{stdx::make_unique<impl>()} {
+    if (id == type::k_codewscope) {
+        _impl->_value.value_type = BSON_TYPE_CODEWSCOPE;
+        _impl->_value.value.v_codewscope.code = make_copy_for_libbson(a);
+        _impl->_value.value.v_codewscope.code_len = (uint32_t)a.length();
+        _impl->_value.value.v_codewscope.scope_len = (uint32_t)b.view().length();
+        _impl->_value.value.v_codewscope.scope_data = (uint8_t*)bson_malloc0(b.view().length());
+        std::memcpy(
+            _impl->_value.value.v_codewscope.scope_data, b.view().data(), b.view().length());
+    }
+}
+value::value(const type id, const binary_sub_type sub_id, uint32_t size, const uint8_t* data)
+    : _impl{stdx::make_unique<impl>()} {
+    if (id != type::k_binary)
+        throw std::logic_error{"Not binary"};
+
+    _impl->_value.value_type = BSON_TYPE_BINARY;
+
+    _impl->_value.value.v_binary.subtype = static_cast<bson_subtype_t>(sub_id);
+    _impl->_value.value.v_binary.data_len = size;
+    _impl->_value.value.v_binary.data = (uint8_t*)bson_malloc(size);
+    std::memcpy(_impl->_value.value.v_binary.data, data, size);
+}
 
 value::value(bsoncxx::document::view v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_DOCUMENT;

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -90,35 +90,25 @@ value::value(decimal128 v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value.v_decimal128.low = v.low();
 }
 
-void value::variadic_value(const type) {
-    std::cout << "id: " << _impl->_value.value_type << std::endl;
-    std::cout << "regex: " << _impl->_value.value.v_regex.regex << std::endl;
-    std::cout << "options: " << _impl->_value.value.v_regex.options << std::endl;
-}
-
-template <typename T, typename... Args>
-void value::variadic_value(const type id, T value, Args... args) {
+value::value(const type id, stdx::string_view a, stdx::string_view b)
+    : _impl{stdx::make_unique<impl>()} {
     switch (id) {
         case type::k_regex:
             _impl->_value.value_type = BSON_TYPE_REGEX;
-            if (sizeof...(args) == 1)
-                _impl->_value.value.v_regex.regex = make_copy_for_libbson(value);
-            else if (sizeof...(args) == 0)
-                _impl->_value.value.v_regex.options = make_copy_for_libbson(value);
-            else
-                throw bsoncxx::exception{bsoncxx::error_code::k_internal_error};
-            return variadic_value(id, std::forward<Args>(args)...);
+            // static_assert(std::is_convertible<T1, stdx::string_view>::value = true, "regex must
+            // be string");
+            _impl->_value.value.v_regex.regex = make_copy_for_libbson(a);
+            _impl->_value.value.v_regex.options = make_copy_for_libbson(b);
+            //            else if (sizeof...(args) == 0)
+            //            else
+            //                throw bsoncxx::exception{bsoncxx::error_code::k_internal_error};
+            break;
         default:
             BSONCXX_UNREACHABLE;
     }
 }
 
 value::value(b_regex v) : value(v.type_id, std::string{v.regex}, std::string{v.options}) {}
-
-template <typename T, typename... Args>
-value::value(const type id, T value, Args... args) : _impl{stdx::make_unique<impl>()} {
-    variadic_value(id, std::forward<T>(value), std::forward<Args>(args)...);
-}
 
 // BSONCXX_ENUM(dbpointer, 0x0C)
 // BSONCXX_ENUM(code, 0x0D)

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -125,6 +125,10 @@ value::value(const type id, stdx::string_view a, stdx::string_view b)
         _impl->_value.value_type = BSON_TYPE_CODE;
         _impl->_value.value.v_code.code = make_copy_for_libbson(a);
         _impl->_value.value.v_code.code_len = (uint32_t)a.length();
+    } else if (id == type::k_minkey) {
+        _impl->_value.value_type = BSON_TYPE_MINKEY;
+    } else if (id == type::k_maxkey) {
+        _impl->_value.value_type = BSON_TYPE_MAXKEY;
     }
 }
 

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -111,7 +111,7 @@ value::value(const type id, stdx::string_view v) : _impl{stdx::make_unique<impl>
         case type::k_regex:
             _impl->_value.value_type = BSON_TYPE_REGEX;
             _impl->_value.value.v_regex.regex = make_copy_for_libbson(v);
-            _impl->_value.value.v_regex.options = make_copy_for_libbson({});
+            _impl->_value.value.v_regex.options = NULL;
             break;
         case type::k_code:
             _impl->_value.value_type = BSON_TYPE_CODE;

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -156,7 +156,8 @@ value::value(const type id) : _impl{stdx::make_unique<impl>()} {
     }
 }
 
-value::value(b_code v) : value(type::k_code, v) {}
+value::value(b_symbol v) : value(v.type_id, v) {}
+value::value(b_code v) : value(v.type_id, v) {}
 value::value(const type id, stdx::string_view a, stdx::string_view b)
     : _impl{stdx::make_unique<impl>()} {
     if (id == type::k_regex) {
@@ -167,20 +168,16 @@ value::value(const type id, stdx::string_view a, stdx::string_view b)
         _impl->_value.value_type = BSON_TYPE_CODE;
         _impl->_value.value.v_code.code = make_copy_for_libbson(a);
         _impl->_value.value.v_code.code_len = (uint32_t)a.length();
+    } else if (id == type::k_symbol) {
+        _impl->_value.value_type = BSON_TYPE_SYMBOL;
+        _impl->_value.value.v_symbol.symbol = make_copy_for_libbson(a);
+        _impl->_value.value.v_symbol.len = (uint32_t)a.length();
     } else {
         throw std::logic_error{"Unknown type"};
     }
 }
 
 value::value(b_regex v) : value(v.type_id, std::string{v.regex}, std::string{v.options}) {}
-
-// BSONCXX_ENUM(dbpointer, 0x0C)
-// BSONCXX_ENUM(code, 0x0D)
-// BSONCXX_ENUM(symbol, 0x0E)
-// BSONCXX_ENUM(codewscope, 0x0F)
-// BSONCXX_ENUM(timestamp, 0x11)
-// BSONCXX_ENUM(maxkey, 0x7F)
-// BSONCXX_ENUM(minkey, 0xFF)
 
 value::~value() = default;
 

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -57,7 +57,8 @@ class BSONCXX_API value {
     value(nullptr_t);
     value(bsoncxx::document::view_or_value v);
 
-    value(const type id, stdx::string_view a = {}, stdx::string_view b = {});
+    value(const type id);
+    value(const type id, stdx::string_view a, stdx::string_view b = {});
     value(const type id, stdx::string_view a, oid b);
     value(const type id, stdx::string_view a, bsoncxx::document::view_or_value b);
 

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -25,6 +25,20 @@ BSONCXX_INLINE_NAMESPACE_BEGIN
 
 namespace types {
 namespace bson_value {
+template <bool B, typename T = void>
+using enable_if_t = typename std::enable_if<B, T>::type;
+template <typename T, typename U>
+static constexpr bool is_same_v() {
+    return std::is_same<T, U>::value;
+}
+template <typename T>
+using decay_t = typename std::decay<T>::type;
+
+template <typename T>
+using value_t = typename T::value_type;
+
+template <typename T>
+using remove_const_t = typename std::remove_const<T>::type;
 
 ///
 /// A variant owning type that represents any BSON type. Owns its underlying
@@ -42,7 +56,8 @@ class BSONCXX_API value {
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
 
-    value(char const* v);
+    value(const char* v);
+
     value(std::string v);
     value(stdx::string_view v);
 
@@ -50,7 +65,10 @@ class BSONCXX_API value {
 
     value(double v);
 
-    value(bool v);
+    template <typename T,
+              typename std::enable_if<std::is_same<bool, typename std::decay<T>::type>::value,
+                                      int>::type = 0>
+    value(T v);
 
     ~value();
 

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -55,9 +55,7 @@ class BSONCXX_API value {
     value(std::chrono::milliseconds v);
     value(nullptr_t);
 
-    value(const type id, const char* a, const char* b);
-    template <typename T1, typename T2>
-    value(const type id, T1 a, T2 b);
+    value(const type id, stdx::string_view a = {}, stdx::string_view b = {});
 
     ~value();
 

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -167,6 +167,16 @@ class BSONCXX_API value {
     value(stdx::string_view code, bsoncxx::document::view_or_value scope);
 
     ///
+    /// Constructs a BSON regex value with options.
+    ///
+    /// @param regex
+    ///   The regex pattern
+    /// @param options
+    ///   The regex options
+    ///
+    value(stdx::string_view regex, stdx::string_view options);
+
+    ///
     /// Constructs one of the following BSON values (each specified by the parenthesized type):
     /// - BSON code value (type::k_code)
     /// - BSON regex value (type::k_regex)
@@ -174,11 +184,9 @@ class BSONCXX_API value {
     ///
     /// @param id
     ///     the type of BSON value to construct.
-    /// @param a
+    /// @param v
     ///     the symbol, JavaScript code, or regex pattern for the BSON symbol, code, or regex value
     ///     respectively.
-    /// @param b
-    ///     An optional string_view for BSON regex value options.
     ///
     /// @throws bsoncxx::exception if the type's value is not k_code, k_regex, or k_symbol.
     ///
@@ -187,7 +195,7 @@ class BSONCXX_API value {
     /// @deprecated
     ///   The BSON undefined type is deprecated and use by clients is discouraged.
     ///
-    value(const type id, stdx::string_view a, stdx::string_view b = {});
+    value(const type id, stdx::string_view v);
 
     ///
     /// Constructs one of the following BSON values (each specified by the parenthesized type):

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -124,7 +124,24 @@ class BSONCXX_API value {
     ///
     /// Constructs a BSON binary data value.
     ///
-    value(std::vector<unsigned char> v, binary_sub_type sub_type = {});
+    /// @param v
+    ///     a steam of bytes
+    /// @param sub_type
+    ///     an optional binary sub type. Defaults to type::k_binary
+    ///
+    value(std::vector<unsigned char> v, const binary_sub_type sub_type = {});
+
+    ///
+    /// Constructs a BSON binary data value.
+    ///
+    /// @param data
+    ///     pointer to a stream of bytes
+    /// @param size
+    ///     the size of the stream of bytes
+    /// @param sub_type
+    ///     an optional binary sub type. Defaults to type::k_binary
+    ///
+    value(const uint8_t* data, size_t size, const binary_sub_type sub_type = {});
 
     ///
     /// Constructs a BSON DBPointer value.
@@ -196,8 +213,6 @@ class BSONCXX_API value {
     ///   is discouraged.
     ///
     value(const type id, uint64_t a, uint64_t b);
-
-    value(const type id, const binary_sub_type sub_id, uint32_t size, const uint8_t* data);
 
     ~value();
 

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -145,6 +145,12 @@ class BSONCXX_API value {
     ///
     /// @throws bsoncxx::exception if the specified type is missing its required arguments.
     ///
+    /// @deprecated
+    ///   The BSON symbol type is deprecated and use by clients is discouraged.
+    /// @deprecated
+    ///   The BSON undefined type is deprecated and use by clients is discouraged.
+    ///
+    ///
     value(const type id, stdx::string_view a = {}, stdx::string_view b = {});
 
     ///
@@ -164,6 +170,23 @@ class BSONCXX_API value {
     /// @throws bsoncxx::exception if the specified type is missing its required arguments.
     ///
     value(const type id, uint64_t a, uint64_t b);
+
+    ///
+    /// Constructs one of the following BSON values (each specified by the parenthesized type):
+    /// - BSON decimal128 value (type::k_decimal128)
+    /// - BSON timestamp value (type::k_timestamp)
+    ///
+    /// @param id
+    ///     the type of the BSON value to construct.
+    /// @param a
+    ///     If a BSON decimal128 value is to be constructed, this is the high value.
+    ///     If a BSON timestamp value is to be constructed, this is the increment.
+    /// @param b
+    ///     If a BSON decimal128 value is to be constructed, this is the low value.
+    ///     If a BSON timestamp value is to be constructed, this is the timestamp.
+    ///
+    /// @throws bsoncxx::exception if the specified type is missing its required arguments.
+    ///
     value(const type id, stdx::string_view a, oid b);
     value(const type id, stdx::string_view a, bsoncxx::document::view_or_value b);
     value(const type id, const binary_sub_type sub_id, uint32_t size, const uint8_t* data);

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -140,6 +140,16 @@ class BSONCXX_API value {
     value(stdx::string_view collection, oid value);
 
     ///
+    /// Constructs a BSON JavaScript code with scope value.
+    ///
+    /// @param code
+    ///     the JavaScript code
+    /// @param scope
+    ///     a bson document view holding the scope environment
+    ///
+    value(stdx::string_view code, bsoncxx::document::view_or_value scope);
+
+    ///
     /// Constructs one of the following BSON values (each specified by the parenthesized type):
     /// - BSON code value (type::k_code)
     /// - BSON regex value (type::k_regex)
@@ -187,7 +197,6 @@ class BSONCXX_API value {
     ///
     value(const type id, uint64_t a, uint64_t b);
 
-    value(const type id, stdx::string_view a, bsoncxx::document::view_or_value b);
     value(const type id, const binary_sub_type sub_id, uint32_t size, const uint8_t* data);
 
     ~value();

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -136,7 +136,7 @@ class BSONCXX_API value {
     /// - BSON undefined value (type::k_undefined)
     ///
     /// @param id
-    ///     the type of the BSON value to construct.
+    ///     the type of BSON value to construct.
     /// @param a
     ///     A string_view. This is required to construct a BSON symbol, code, or regex value. This
     ///     is the symbol, JavaScript code, or regex pattern, respectively.
@@ -146,6 +146,23 @@ class BSONCXX_API value {
     /// @throws bsoncxx::exception if the specified type is missing its required arguments.
     ///
     value(const type id, stdx::string_view a = {}, stdx::string_view b = {});
+
+    ///
+    /// Constructs one of the following BSON values (each specified by the parenthesized type):
+    /// - BSON decimal128 value (type::k_decimal128)
+    /// - BSON timestamp value (type::k_timestamp)
+    ///
+    /// @param id
+    ///     the type of the BSON value to construct.
+    /// @param a
+    ///     If a BSON decimal128 value is to be constructed, this is the high value.
+    ///     If a BSON timestamp value is to be constructed, this is the increment.
+    /// @param b
+    ///     If a BSON decimal128 value is to be constructed, this is the low value.
+    ///     If a BSON timestamp value is to be constructed, this is the timestamp.
+    ///
+    /// @throws bsoncxx::exception if the specified type is missing its required arguments.
+    ///
     value(const type id, uint64_t a, uint64_t b);
     value(const type id, stdx::string_view a, oid b);
     value(const type id, stdx::string_view a, bsoncxx::document::view_or_value b);

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -16,6 +16,7 @@
 
 #include <memory>
 
+#include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
 
 #include <bsoncxx/config/prelude.hpp>
@@ -57,6 +58,7 @@ class BSONCXX_API value {
 
     value(const type id, stdx::string_view a = {}, stdx::string_view b = {});
     value(const type id, stdx::string_view a, oid b);
+    value(const type id, stdx::string_view a, bsoncxx::document::view_or_value b);
 
     ~value();
 

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -25,20 +25,6 @@ BSONCXX_INLINE_NAMESPACE_BEGIN
 
 namespace types {
 namespace bson_value {
-template <bool B, typename T = void>
-using enable_if_t = typename std::enable_if<B, T>::type;
-template <typename T, typename U>
-static constexpr bool is_same_v() {
-    return std::is_same<T, U>::value;
-}
-template <typename T>
-using decay_t = typename std::decay<T>::type;
-
-template <typename T>
-using value_t = typename T::value_type;
-
-template <typename T>
-using remove_const_t = typename std::remove_const<T>::type;
 
 ///
 /// A variant owning type that represents any BSON type. Owns its underlying
@@ -57,7 +43,6 @@ class BSONCXX_API value {
 #undef BSONCXX_ENUM
 
     value(const char* v);
-
     value(std::string v);
     value(stdx::string_view v);
 

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -57,11 +57,12 @@ class BSONCXX_API value {
     value(decimal128 v);
     value(std::chrono::milliseconds v);
     value(nullptr_t);
-    value(bsoncxx::document::view_or_value v);
-    value(bsoncxx::array::view_or_value v);
+    value(bsoncxx::document::view v);
+    value(bsoncxx::array::view v);
     value(std::vector<unsigned char> v, binary_sub_type sub_type = {});
 
     value(const type id);
+    value(const type id, uint64_t a, uint64_t b);
     value(const type id, stdx::string_view a, stdx::string_view b = {});
     value(const type id, stdx::string_view a, oid b);
     value(const type id, stdx::string_view a, bsoncxx::document::view_or_value b);

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -16,6 +16,7 @@
 
 #include <memory>
 
+#include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
 
@@ -56,6 +57,7 @@ class BSONCXX_API value {
     value(std::chrono::milliseconds v);
     value(nullptr_t);
     value(bsoncxx::document::view_or_value v);
+    value(bsoncxx::array::view_or_value v);
 
     value(const type id);
     value(const type id, stdx::string_view a, stdx::string_view b = {});

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -55,7 +55,9 @@ class BSONCXX_API value {
     value(std::chrono::milliseconds v);
     value(nullptr_t);
 
-    value(const type id, stdx::string_view a, stdx::string_view b);
+    value(const type id, const char* a, const char* b);
+    template <typename T1, typename T2>
+    value(const type id, T1 a, T2 b);
 
     ~value();
 

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -55,8 +55,7 @@ class BSONCXX_API value {
     value(std::chrono::milliseconds v);
     value(nullptr_t);
 
-    template <typename T, typename... Args>
-    value(const type id, T value, Args... args);
+    value(const type id, stdx::string_view a, stdx::string_view b);
 
     ~value();
 
@@ -93,10 +92,6 @@ class BSONCXX_API value {
     value(void* internal_value);
 
     friend value make_owning_bson(void* internal_value);
-
-    template <typename T, typename... Args>
-    void variadic_value(const type id, T value, Args... args);
-    void variadic_value(const type id);
 
     class BSONCXX_PRIVATE impl;
     std::unique_ptr<impl> _impl;

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
@@ -58,11 +59,13 @@ class BSONCXX_API value {
     value(nullptr_t);
     value(bsoncxx::document::view_or_value v);
     value(bsoncxx::array::view_or_value v);
+    value(std::vector<unsigned char> v, binary_sub_type sub_type = {});
 
     value(const type id);
     value(const type id, stdx::string_view a, stdx::string_view b = {});
     value(const type id, stdx::string_view a, oid b);
     value(const type id, stdx::string_view a, bsoncxx::document::view_or_value b);
+    value(const type id, const binary_sub_type sub_id, uint32_t size, const uint8_t* data);
 
     ~value();
 

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -127,16 +127,26 @@ class BSONCXX_API value {
     value(std::vector<unsigned char> v, binary_sub_type sub_type = {});
 
     ///
-    /// Constructs a BSON value of the specified type.
+    /// Constructs one of the following BSON values (each specified by the parenthesized type):
+    /// - BSON code value (type::k_code)
+    /// - BSON regex value (type::k_regex)
+    /// - BSON symbol value (type::k_symbol)
+    /// - BSON maxkey value (type::k_maxkey)
+    /// - BSON minkey value (type::k_minkey)
+    /// - BSON undefined value (type::k_undefined)
     ///
     /// @param id
-    ///     the type id of the BSON value to construct.
+    ///     the type of the BSON value to construct.
+    /// @param a
+    ///     A string_view. This is required to construct a BSON symbol, code, or regex value. This
+    ///     is the symbol, JavaScript code, or regex pattern, respectively.
+    /// @param b
+    ///     An optional string_view for BSON regex value options.
     ///
     /// @throws bsoncxx::exception if the specified type is missing its required arguments.
     ///
-    value(const type id);
+    value(const type id, stdx::string_view a = {}, stdx::string_view b = {});
     value(const type id, uint64_t a, uint64_t b);
-    value(const type id, stdx::string_view a, stdx::string_view b = {});
     value(const type id, stdx::string_view a, oid b);
     value(const type id, stdx::string_view a, bsoncxx::document::view_or_value b);
     value(const type id, const binary_sub_type sub_id, uint32_t size, const uint8_t* data);

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -127,6 +127,19 @@ class BSONCXX_API value {
     value(std::vector<unsigned char> v, binary_sub_type sub_type = {});
 
     ///
+    /// Constructs a BSON DBPointer value.
+    ///
+    /// @param collection
+    ///     the collection name
+    /// @param value
+    ///     the object id
+    ///
+    /// @deprecated
+    ///   A BSON DBPointer (aka DBRef) is still supported but deprecated.
+    ///
+    value(stdx::string_view collection, oid value);
+
+    ///
     /// Constructs one of the following BSON values (each specified by the parenthesized type):
     /// - BSON code value (type::k_code)
     /// - BSON regex value (type::k_regex)
@@ -150,7 +163,6 @@ class BSONCXX_API value {
     /// @deprecated
     ///   The BSON undefined type is deprecated and use by clients is discouraged.
     ///
-    ///
     value(const type id, stdx::string_view a = {}, stdx::string_view b = {});
 
     ///
@@ -169,25 +181,12 @@ class BSONCXX_API value {
     ///
     /// @throws bsoncxx::exception if the specified type is missing its required arguments.
     ///
+    /// @warning
+    ///   The BSON timestamp type is used internally by the MongoDB server - use by clients
+    ///   is discouraged.
+    ///
     value(const type id, uint64_t a, uint64_t b);
 
-    ///
-    /// Constructs one of the following BSON values (each specified by the parenthesized type):
-    /// - BSON decimal128 value (type::k_decimal128)
-    /// - BSON timestamp value (type::k_timestamp)
-    ///
-    /// @param id
-    ///     the type of the BSON value to construct.
-    /// @param a
-    ///     If a BSON decimal128 value is to be constructed, this is the high value.
-    ///     If a BSON timestamp value is to be constructed, this is the increment.
-    /// @param b
-    ///     If a BSON decimal128 value is to be constructed, this is the low value.
-    ///     If a BSON timestamp value is to be constructed, this is the timestamp.
-    ///
-    /// @throws bsoncxx::exception if the specified type is missing its required arguments.
-    ///
-    value(const type id, stdx::string_view a, oid b);
     value(const type id, stdx::string_view a, bsoncxx::document::view_or_value b);
     value(const type id, const binary_sub_type sub_id, uint32_t size, const uint8_t* data);
 

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -58,13 +58,12 @@ class BSONCXX_API value {
     value(oid v);
     value(decimal128 v);
     value(std::chrono::milliseconds v);
-    value(nullptr_t);
+    value(std::nullptr_t);
     value(bsoncxx::document::view v);
     value(bsoncxx::array::view v);
     value(std::vector<unsigned char> v, binary_sub_type sub_type = {});
 
     value(const type id);
-
     value(const type id, uint64_t a, uint64_t b);
     value(const type id, stdx::string_view a, stdx::string_view b = {});
     value(const type id, stdx::string_view a, oid b);

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -171,26 +171,36 @@ class BSONCXX_API value {
     /// - BSON code value (type::k_code)
     /// - BSON regex value (type::k_regex)
     /// - BSON symbol value (type::k_symbol)
-    /// - BSON maxkey value (type::k_maxkey)
-    /// - BSON minkey value (type::k_minkey)
-    /// - BSON undefined value (type::k_undefined)
     ///
     /// @param id
     ///     the type of BSON value to construct.
     /// @param a
-    ///     A string_view. This is required to construct a BSON symbol, code, or regex value. This
-    ///     is the symbol, JavaScript code, or regex pattern, respectively.
+    ///     the symbol, JavaScript code, or regex pattern for the BSON symbol, code, or regex value
+    ///     respectively.
     /// @param b
     ///     An optional string_view for BSON regex value options.
     ///
-    /// @throws bsoncxx::exception if the specified type is missing its required arguments.
+    /// @throws bsoncxx::exception if the type's value is not k_code, k_regex, or k_symbol.
     ///
     /// @deprecated
     ///   The BSON symbol type is deprecated and use by clients is discouraged.
     /// @deprecated
     ///   The BSON undefined type is deprecated and use by clients is discouraged.
     ///
-    value(const type id, stdx::string_view a = {}, stdx::string_view b = {});
+    value(const type id, stdx::string_view a, stdx::string_view b = {});
+
+    ///
+    /// Constructs one of the following BSON values (each specified by the parenthesized type):
+    /// - BSON maxkey value (type::k_maxkey)
+    /// - BSON minkey value (type::k_minkey)
+    /// - BSON undefined value (type::k_undefined)
+    ///
+    /// @param id
+    ///     the type of BSON value to construct.
+    ///
+    /// @throws bsoncxx::exception if the type's value is not k_maxkey, k_minkey, or k_undefined.
+    ///
+    value(const type id);
 
     ///
     /// Constructs one of the following BSON values (each specified by the parenthesized type):

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -43,24 +43,87 @@ namespace bson_value {
 ///
 class BSONCXX_API value {
    public:
+///
+/// Constructor for each BSON type.
+///
+/// These x-macros will expand to:
+///    value(b_double v);
+///    value(b_utf8 v);
+///    value(b_document v);
+///    value(b_array v); ...
+///
 #define BSONCXX_ENUM(name, val) value(b_##name v);
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
 
+    ///
+    /// Constructs a BSON UTF-8 string value.
+    ///
     value(const char* v);
+
+    ///
+    /// Constructs a BSON UTF-8 string value.
+    ///
     value(std::string v);
+
+    ///
+    /// Constructs a BSON UTF-8 string value.
+    ///
     value(stdx::string_view v);
 
+    ///
+    /// Constructs a BSON 32-bit signed integer value.
+    ///
     value(int32_t v);
+
+    ///
+    /// Constructs a BSON 64-bit signed integer value.
+    ///
     value(int64_t v);
+
+    ///
+    /// Constructs a BSON double value.
+    ///
     value(double v);
+
+    ///
+    /// Constructs a BSON boolean value.
+    ///
     value(bool v);
+
+    ///
+    /// Constructs a BSON ObjectId value.
+    ///
     value(oid v);
+
+    ///
+    /// Constructs a BSON Decimal128 value.
+    ///
     value(decimal128 v);
+
+    ///
+    /// Constructs a BSON date value.
+    ///
     value(std::chrono::milliseconds v);
+
+    ///
+    /// Constructs a BSON null value.
+    ///
     value(std::nullptr_t);
+
+    ///
+    /// Constructs a BSON document value.
+    ///
     value(bsoncxx::document::view v);
+
+    ///
+    /// Constructs a BSON array value.
+    ///
     value(bsoncxx::array::view v);
+
+    ///
+    /// Constructs a BSON binary data value.
+    ///
     value(std::vector<unsigned char> v, binary_sub_type sub_type = {});
 
     value(const type id);

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -55,8 +55,8 @@ class BSONCXX_API value {
     value(std::chrono::milliseconds v);
     value(nullptr_t);
 
-    template <typename... Args>
-    value(const type id, Args... args);
+    template <typename T, typename... Args>
+    value(const type id, T value, Args... args);
 
     ~value();
 
@@ -93,6 +93,10 @@ class BSONCXX_API value {
     value(void* internal_value);
 
     friend value make_owning_bson(void* internal_value);
+
+    template <typename T, typename... Args>
+    void variadic_value(const type id, T value, Args... args);
+    void variadic_value(const type id);
 
     class BSONCXX_PRIVATE impl;
     std::unique_ptr<impl> _impl;

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -47,13 +47,16 @@ class BSONCXX_API value {
     value(stdx::string_view v);
 
     value(int32_t v);
-
+    value(int64_t v);
     value(double v);
+    value(bool v);
+    value(oid v);
+    value(decimal128 v);
+    value(std::chrono::milliseconds v);
+    value(nullptr_t);
 
-    template <typename T,
-              typename std::enable_if<std::is_same<bool, typename std::decay<T>::type>::value,
-                                      int>::type = 0>
-    value(T v);
+    template <typename... Args>
+    value(const type id, Args... args);
 
     ~value();
 

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -14,11 +14,13 @@
 
 #pragma once
 
+#include <iostream>
 #include <memory>
 #include <vector>
 
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
+#include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
 
 #include <bsoncxx/config/prelude.hpp>
@@ -62,11 +64,15 @@ class BSONCXX_API value {
     value(std::vector<unsigned char> v, binary_sub_type sub_type = {});
 
     value(const type id);
-    value(const type id, uint64_t a, uint64_t b);
-    value(const type id, stdx::string_view a, stdx::string_view b = {});
-    value(const type id, stdx::string_view a, oid b);
-    value(const type id, stdx::string_view a, bsoncxx::document::view_or_value b);
-    value(const type id, const binary_sub_type sub_id, uint32_t size, const uint8_t* data);
+
+    template <typename T, typename... Targs>
+    value(type id, T value, Targs... Fargs);
+
+    // value(type id, uint64_t a, uint64_t b);
+    // value(const type id, stdx::string_view a, stdx::string_view b = {});
+    // value(const type id, stdx::string_view a, oid b);
+    // value(const type id, stdx::string_view a, bsoncxx::document::view_or_value b);
+    // value(const type id, const binary_sub_type sub_id, uint32_t size, const uint8_t* data);
 
     ~value();
 

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -65,14 +65,11 @@ class BSONCXX_API value {
 
     value(const type id);
 
-    template <typename T, typename... Targs>
-    value(type id, T value, Targs... Fargs);
-
-    // value(type id, uint64_t a, uint64_t b);
-    // value(const type id, stdx::string_view a, stdx::string_view b = {});
-    // value(const type id, stdx::string_view a, oid b);
-    // value(const type id, stdx::string_view a, bsoncxx::document::view_or_value b);
-    // value(const type id, const binary_sub_type sub_id, uint32_t size, const uint8_t* data);
+    value(const type id, uint64_t a, uint64_t b);
+    value(const type id, stdx::string_view a, stdx::string_view b = {});
+    value(const type id, stdx::string_view a, oid b);
+    value(const type id, stdx::string_view a, bsoncxx::document::view_or_value b);
+    value(const type id, const binary_sub_type sub_id, uint32_t size, const uint8_t* data);
 
     ~value();
 

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -126,6 +126,14 @@ class BSONCXX_API value {
     ///
     value(std::vector<unsigned char> v, binary_sub_type sub_type = {});
 
+    ///
+    /// Constructs a BSON value of the specified type.
+    ///
+    /// @param id
+    ///     the type id of the BSON value to construct.
+    ///
+    /// @throws bsoncxx::exception if the specified type is missing its required arguments.
+    ///
     value(const type id);
     value(const type id, uint64_t a, uint64_t b);
     value(const type id, stdx::string_view a, stdx::string_view b = {});

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -56,6 +56,7 @@ class BSONCXX_API value {
     value(nullptr_t);
 
     value(const type id, stdx::string_view a = {}, stdx::string_view b = {});
+    value(const type id, stdx::string_view a, oid b);
 
     ~value();
 

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -55,6 +55,7 @@ class BSONCXX_API value {
     value(decimal128 v);
     value(std::chrono::milliseconds v);
     value(nullptr_t);
+    value(bsoncxx::document::view_or_value v);
 
     value(const type id, stdx::string_view a = {}, stdx::string_view b = {});
     value(const type id, stdx::string_view a, oid b);

--- a/src/bsoncxx/types/private/convert.hh
+++ b/src/bsoncxx/types/private/convert.hh
@@ -260,7 +260,10 @@ BSONCXX_INLINE void convert_from_libbson(bson_value_t*, bsoncxx::types::b_null* 
 BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_regex* out) {
     const char* options = v->value.v_regex.options;
     const char* regex = v->value.v_regex.regex;
-    *out = bsoncxx::types::b_regex{stdx::string_view{regex}, stdx::string_view{options}};
+    if (options)
+        *out = bsoncxx::types::b_regex{stdx::string_view{regex}, stdx::string_view{options}};
+    else
+        *out = bsoncxx::types::b_regex{stdx::string_view{regex}};
 }
 
 BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_dbpointer* out) {

--- a/src/bsoncxx/types/private/convert.hh
+++ b/src/bsoncxx/types/private/convert.hh
@@ -260,10 +260,7 @@ BSONCXX_INLINE void convert_from_libbson(bson_value_t*, bsoncxx::types::b_null* 
 BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_regex* out) {
     const char* options = v->value.v_regex.options;
     const char* regex = v->value.v_regex.regex;
-    if (options)
-        *out = bsoncxx::types::b_regex{stdx::string_view{regex}, stdx::string_view{options}};
-    else
-        *out = bsoncxx::types::b_regex{stdx::string_view{regex}};
+    *out = bsoncxx::types::b_regex{regex, options ? options : stdx::string_view{}};
 }
 
 BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_dbpointer* out) {


### PR DESCRIPTION
All of the tests are done and works. I'm still trying to figure out how to combine the constructors in `value.cpp` and `value.hpp`. As far as generic programming goes, a variadic template could work like:
```
value(const type id); // base case

template<typename T, typename ... Args>
value(const type id, T t, Args ...args);

```
But it'd need to be defined in the `value.hpp`. IIUC that would create a new function for every different combination of arguments used. Which would cause a lot of overhead (memory and compilation) since it'd be a fairly large function. 

There's also the open issue of how to handle errors. As of now I just throw an error but I'm also working on that too.  