### PR TITLE
CXX-1842 Make values have a superset of the view API

### DIFF
--- a/src/bsoncxx/document/value.cpp
+++ b/src/bsoncxx/document/value.cpp
@@ -57,11 +57,11 @@ document::view::const_iterator value::cend() const {
 }
 
 document::view::const_iterator value::begin() const {
-    return this->view().begin();
+    return cbegin();
 }
 
 document::view::const_iterator value::end() const {
-    return this->view().end();
+    return cend();
 }
 
 document::view::const_iterator value::find(stdx::string_view key) const {
@@ -74,7 +74,7 @@ element value::operator[](stdx::string_view key) const {
 }
 
 const std::uint8_t* value::data() const {
-    return static_cast<uint8_t*>(_data.get());
+    return _data.get();
 }
 
 std::size_t value::length() const {

--- a/src/bsoncxx/document/value.cpp
+++ b/src/bsoncxx/document/value.cpp
@@ -48,9 +48,41 @@ value& value::operator=(const value& rhs) {
     return *this;
 }
 
+view::const_iterator value::cbegin() const {
+    return this->view().cbegin();
+}
+
+view::const_iterator value::cend() const {
+    return this->view().cend();
+}
+
+view::const_iterator value::begin() const {
+    return this->view().begin();
+}
+
+view::const_iterator value::end() const {
+    return this->view().end();
+}
+
+view::const_iterator value::find(stdx::string_view key) const {
+    return this->view().find(key);
+}
+
 element value::operator[](stdx::string_view key) const {
     auto view = this->view();
     return view[key];
+}
+
+const std::uint8_t* value::data() const {
+    return static_cast<uint8_t*>(_data.get());
+}
+
+std::size_t value::length() const {
+    return _length;
+}
+
+bool value::empty() const {
+    return _length == 5;
 }
 
 value::unique_ptr_type value::release() {

--- a/src/bsoncxx/document/value.cpp
+++ b/src/bsoncxx/document/value.cpp
@@ -48,23 +48,23 @@ value& value::operator=(const value& rhs) {
     return *this;
 }
 
-view::const_iterator value::cbegin() const {
+document::view::const_iterator value::cbegin() const {
     return this->view().cbegin();
 }
 
-view::const_iterator value::cend() const {
+document::view::const_iterator value::cend() const {
     return this->view().cend();
 }
 
-view::const_iterator value::begin() const {
+document::view::const_iterator value::begin() const {
     return this->view().begin();
 }
 
-view::const_iterator value::end() const {
+document::view::const_iterator value::end() const {
     return this->view().end();
 }
 
-view::const_iterator value::find(stdx::string_view key) const {
+document::view::const_iterator value::find(stdx::string_view key) const {
     return this->view().find(key);
 }
 

--- a/src/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/document/value.hpp
@@ -79,22 +79,22 @@ class BSONCXX_API value {
     ///
     /// @returns A const_iterator to the first element of the document.
     ///
-    view::const_iterator cbegin() const;
+    document::view::const_iterator cbegin() const;
 
     ///
     /// @returns A const_iterator to the past-the-end element of the document.
     ///
-    view::const_iterator cend() const;
+    document::view::const_iterator cend() const;
 
     ///
     /// @returns A const_iterator to the first element of the document.
     ///
-    view::const_iterator begin() const;
+    document::view::const_iterator begin() const;
 
     ///
     /// @returns A const_iterator to the past-the-end element of the document.
     ///
-    view::const_iterator end() const;
+    document::view::const_iterator end() const;
 
     ///
     /// Finds the first element of the document with the provided key. If there is
@@ -111,7 +111,7 @@ class BSONCXX_API value {
     ///
     /// @return An iterator to the matching element, if found, or the past-the-end iterator.
     ///
-    view::const_iterator find(stdx::string_view key) const;
+    document::view::const_iterator find(stdx::string_view key) const;
 
     ///
     /// Finds the first element of the document with the provided key. If there is no

--- a/src/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/document/value.hpp
@@ -77,6 +77,43 @@ class BSONCXX_API value {
     value& operator=(value&&) noexcept = default;
 
     ///
+    /// @returns A const_iterator to the first element of the document.
+    ///
+    view::const_iterator cbegin() const;
+
+    ///
+    /// @returns A const_iterator to the past-the-end element of the document.
+    ///
+    view::const_iterator cend() const;
+
+    ///
+    /// @returns A const_iterator to the first element of the document.
+    ///
+    view::const_iterator begin() const;
+
+    ///
+    /// @returns A const_iterator to the past-the-end element of the document.
+    ///
+    view::const_iterator end() const;
+
+    ///
+    /// Finds the first element of the document with the provided key. If there is
+    /// no such element, the past-the-end iterator will be returned. The runtime of
+    /// find() is linear in the length of the document. This method only searches
+    /// the top-level document, and will not recurse to any subdocuments.
+    ///
+    /// @remark In BSON, keys are not required to be unique. If there are multiple
+    /// elements with a matching key in the document, the first matching element from
+    /// the start will be returned.
+    ///
+    /// @param key
+    ///   The key to search for.
+    ///
+    /// @return An iterator to the matching element, if found, or the past-the-end iterator.
+    ///
+    view::const_iterator find(stdx::string_view key) const;
+
+    ///
     /// Finds the first element of the document with the provided key. If there is no
     /// such element, the invalid document::element will be returned. The runtime of operator[]
     /// is linear in the length of the document.
@@ -87,6 +124,31 @@ class BSONCXX_API value {
     /// @return The matching element, if found, or the invalid element.
     ///
     element operator[](stdx::string_view key) const;
+
+    ///
+    /// Access the raw bytes of the underlying document.
+    ///
+    /// @return A (non-owning) pointer to the view's buffer.
+    ///
+    const std::uint8_t* data() const;
+
+    ///
+    /// Gets the length of the underlying buffer.
+    ///
+    /// @remark This is not the number of elements in the document.
+    /// To compute the number of elements, use std::distance.
+    ///
+    /// @return The length of the document, in bytes.
+    ///
+    std::size_t length() const;
+
+    ///
+    /// Checks if the underlying document is empty, i.e. it is equivalent to
+    /// the trivial document '{}'.
+    ///
+    /// @return true if the underlying document is empty.
+    ///
+    bool empty() const;
 
     ///
     /// Get a view over the document owned by this value.

--- a/src/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/document/value.hpp
@@ -128,7 +128,7 @@ class BSONCXX_API value {
     ///
     /// Access the raw bytes of the underlying document.
     ///
-    /// @return A (non-owning) pointer to the view's buffer.
+    /// @return A pointer to the value's buffer.
     ///
     const std::uint8_t* data() const;
 

--- a/src/bsoncxx/test/bson_get_values.cpp
+++ b/src/bsoncxx/test/bson_get_values.cpp
@@ -364,4 +364,32 @@ TEST_CASE("can use operator[] with document::value") {
     }
 }
 
+TEST_CASE("document::values have a superset of document::view's methods") {
+    document::value doc = make_document(kvp("int", 5), kvp("alice", "Bob"));
+    document::view view = doc.view();
+
+    SECTION("iterators provide the same results") {
+        REQUIRE(doc.cbegin() == view.cbegin());
+        REQUIRE(doc.cend() == view.cend());
+        REQUIRE(doc.begin() == view.begin());
+        REQUIRE(doc.end() == view.end());
+        REQUIRE(doc.find("alice") == view.find("alice"));
+    }
+
+    SECTION("getters return the same results") {
+        REQUIRE(doc.data() == view.data());
+        REQUIRE(doc.length() == view.length());
+    }
+
+    SECTION("empty doc and empty view yield same results") {
+        document::value empty_doc = make_document();
+        document::view empty_view = empty_doc.view();
+
+        REQUIRE(empty_doc.empty());
+        REQUIRE(empty_view.empty());
+        REQUIRE(!doc.empty());
+        REQUIRE(!view.empty());
+    }
+}
+
 }  // namespace


### PR DESCRIPTION
[The ticket](https://jira.mongodb.org/browse/CXX-1842) asked to let values be implicitly converted to views, but it seems to already be able to do that. This PR focuses on the second half, which is to let values use view's methods.