### PR TITLE
Header file addition for stream

### DIFF
--- a/docs/content/mongocxx-v3/tutorial.md
+++ b/docs/content/mongocxx-v3/tutorial.md
@@ -25,6 +25,10 @@ title = "Tutorial for mongocxx"
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/uri.hpp>
 #include <mongocxx/instance.hpp>
+#include <bsoncxx/builder/stream/helpers.hpp>
+#include <bsoncxx/builder/stream/document.hpp>
+#include <bsoncxx/builder/stream/array.hpp>
+
 
 using bsoncxx::builder::stream::close_array;
 using bsoncxx::builder::stream::close_document;


### PR DESCRIPTION
The stream builder and the basic builder are defined in separate headers. We should see the stream builder convenience methods in bsoncxx/builder/stream/helpers.hpp. To use the stream builder in our code, include the following header files.