### PR TITLE
move clang-tidy check opts to file

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,2 @@
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,cert-*,cppcoreguidelines-*,clang-analyzer-*'
+WarningsAsErrors: ''

--- a/.mci.yml
+++ b/.mci.yml
@@ -198,8 +198,7 @@ functions:
             set -o errexit
             set -o xtrace
             set -o pipefail
-            cd etc
-            ./run-clang-tidy.sh
+            ./etc/run-clang-tidy.sh
 
     "compile":
         - command: shell.exec

--- a/etc/run-clang-tidy.sh
+++ b/etc/run-clang-tidy.sh
@@ -21,14 +21,11 @@ clang-tidy -version
 #
 # see https://clang.llvm.org/extra/clang-tidy
 #
-BUILD="../build"
-CHECKS="\"-*,cert-*,cppcoreguidelines-*,clang-analyzer-*\""
-CMD="clang-tidy -p=$BUILD -checks=$CHECKS"
+CMD="clang-tidy -p=build"
 
 echo "Running clang-tidy with configuration:"
 eval $CMD -dump-config
-clang-tidy -checks=$CHECKS -list-checks
 
 # all source and header files, excluding third party libraries
-FIND="find ../src -type f \( -name \*.hh -o -name \*.hpp -o -name \*.cpp \) -not -path \"*third_party*\""
+FIND="find src -type f \( -name \*.hh -o -name \*.hpp -o -name \*.cpp \) -not -path \"*third_party*\""
 eval $FIND | xargs $CMD


### PR DESCRIPTION
Moving the `check` options out of the script and into a file makes it easier to run clang-tidy locally. The next step would be actually fixing some of these bugs.

To run locally:
```
FIND="find src -type f \( -name \*.hh -o -name \*.hpp -o -name \*.cpp \) -not -path \"*third_party*\""
eval $FIND | xargs clang-tidy -p build
```
