### PR TITLE
(Debian packaging) CXX-1747 allow building Debian packages with MNMLSTC

### DIFF
--- a/.evergreen/debian_package_build.sh
+++ b/.evergreen/debian_package_build.sh
@@ -17,6 +17,10 @@ on_exit () {
 }
 trap on_exit EXIT
 
+if [ ! -z "${DEB_BUILD_PROFILES}" ]; then
+   echo "DEB_BUILD_PROFILES was set; building with profiles: ${DEB_BUILD_PROFILES}"
+fi
+
 if [ "${IS_PATCH}" = "true" ]; then
   git diff HEAD -- . ':!debian' > ../upstream.patch
   git diff HEAD -- debian > ../debian.patch
@@ -36,6 +40,10 @@ if [ "${IS_PATCH}" = "true" ]; then
     git log -n1 -p
   fi
 fi
+if [ "${DEB_BUILD_PROFILES#*pkg.mongo-cxx-driver.mnmlstc}" != "${DEB_BUILD_PROFILES}" ]; then
+   MNMLSTC_DEPS="git ca-certificates"
+fi
+
 
 cd ..
 
@@ -43,8 +51,8 @@ git clone https://salsa.debian.org/installer-team/debootstrap.git debootstrap.gi
 export DEBOOTSTRAP_DIR=`pwd`/debootstrap.git
 sudo -E ./debootstrap.git/debootstrap unstable ./unstable-chroot/ http://cdn-aws.deb.debian.org/debian
 cp -a mongo-cxx-driver ./unstable-chroot/tmp/
-sudo chroot ./unstable-chroot /bin/bash -c "(set -o xtrace && \
-  apt-get install -y build-essential git-buildpackage fakeroot debhelper cmake curl ca-certificates libboost-dev libsasl2-dev libicu-dev doxygen && \
+sudo DEB_BUILD_PROFILES="${DEB_BUILD_PROFILES}" chroot ./unstable-chroot /bin/bash -c "(set -o xtrace && \
+  apt-get install -y build-essential git-buildpackage fakeroot debhelper cmake curl ca-certificates libboost-dev libsasl2-dev libicu-dev doxygen ${MNMLSTC_DEPS} && \
   mkdir /tmp/mongo-c-driver && \
   curl -o deb.tar.gz -L https://s3.amazonaws.com/mciuploads/mongo-c-driver/master/mongo-c-driver-debian-packages-latest.tar.gz && \
   tar zxvf deb.tar.gz && \
@@ -55,7 +63,7 @@ sudo chroot ./unstable-chroot /bin/bash -c "(set -o xtrace && \
   python3 etc/calc_release_version.py > build/VERSION_CURRENT && \
   git add --force build/VERSION_CURRENT && \
   git commit build/VERSION_CURRENT -m 'Set current version' && \
-  LANG=C /bin/bash ./debian/build_snapshot.sh && \
+  LANG=C /bin/bash -x ./debian/build_snapshot.sh && \
   debc ../*.changes && \
   dpkg -i ../*.deb && \
   /usr/bin/g++ -I/usr/include/bsoncxx/v_noabi -I/usr/include/mongocxx/v_noabi -o runcommand_examples examples/mongocxx/mongodb.com/runcommand_examples.cpp -lmongocxx -lbsoncxx && \

--- a/.mci.yml
+++ b/.mci.yml
@@ -651,6 +651,31 @@ tasks:
           content_type: ${content_type|application/x-gzip}
           display_name: "deb.tar.gz"
 
+    - name: debian-package-build-mnmlstc
+      commands:
+      - func: "setup"
+      - command: shell.exec
+        type: test
+        params:
+          working_dir: "mongo-cxx-driver"
+          shell: bash
+          script: |-
+            set -o errexit
+            set -o xtrace
+            export IS_PATCH="${is_patch}"
+            export DEB_BUILD_PROFILES="pkg.mongo-cxx-driver.mnmlstc"
+            sh .evergreen/debian_package_build.sh
+      - command: s3.put
+        params:
+          aws_key: ${aws_key}
+          aws_secret: ${aws_secret}
+          local_file: deb.tar.gz
+          remote_file: mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/debian-packages-mnmlstc.tar.gz
+          bucket: mciuploads
+          permissions: public-read
+          content_type: ${content_type|application/x-gzip}
+          display_name: "deb.tar.gz"
+
     - name: rpm-package-build
       commands:
       - func: "setup"
@@ -1009,6 +1034,7 @@ buildvariants:
       run_on: ubuntu1604-test
       tasks:
          - name: debian-package-build
+         - name: debian-package-build-mnmlstc
          - name: rpm-package-build
            distros:
            - rhel80-test

--- a/debian/README.Debian
+++ b/debian/README.Debian
@@ -1,0 +1,18 @@
+Using the MongoDB C++ Driver with MNMLSTC instead of Boost
+----------------------------------------------------------
+
+The MongoDB C++ driver Debian package is built with the Boost C++17 polyfill.
+In the event that you would rather use the MNMLSTC/core C++17 polyfill, you can
+simply obtain the mongo-cxx-driver source package and rebuild it.
+
+To enable the MNMLSTC/core C++17 polyfill use the pkg.mongo-cxx-driver.mnmlstc
+build profile and ensure that your build environment has network access enabled.
+The first can be accomplished by setting the environment variable
+DEB_BUILD_PROFILES="pkg.mongo-cxx-driver.mnmlstc" and the second when building
+by passing the option --git-pbuilder-options="--use-network yes" (for building
+with git-buildpackage) or possibly just "--use-network yes" (for building with
+pbuilder).  Enabling network access is required so that the upstream part of the
+build can clone the MNMLSTC/core GitHub project.
+
+General instructions for rebuilding Debian packages can be found here:
+https://wiki.debian.org/BuildingTutorial

--- a/debian/build_snapshot.sh
+++ b/debian/build_snapshot.sh
@@ -75,5 +75,9 @@ if [ "$(dpkg-parsechangelog | sed -E -n 's/^Version: +(.*)/\1/p')" != "${snapsho
 fi
 
 echo "Calling git-buildpackage ..."
-gbp buildpackage --git-no-pbuilder --git-export=WC --git-verbose
+if [ "${DEB_BUILD_PROFILES#*pkg.mongo-cxx-driver.mnmlstc}" != "${DEB_BUILD_PROFILES}" ]; then
+   gbp buildpackage --git-no-pbuilder --git-export=WC --git-verbose --git-pbuilder-options="--use-network yes"
+else
+   gbp buildpackage --git-no-pbuilder --git-export=WC --git-verbose
+fi
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+mongo-cxx-driver (3.6.1-2) UNRELEASED; urgency=medium
+
+  * Implement build profile: pkg.mongo-cxx-driver.mnmlstc
+    + the build profile allows interested users to rebuild with the
+      MNMLSTC/core C++17 polyfill instead of Boost
+    + consult README.Debian for details
+
+ -- Roberto C. Sanchez <roberto@connexer.com>  Fri, 06 Nov 2020 10:55:50 -0500
+
 mongo-cxx-driver (3.6.1-1) experimental; urgency=medium
 
   * New upstream release

--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,8 @@ Uploaders: A. Jesse Jiryu Davis <jesse@mongodb.com>,
            Samantha Ritter <samantha.ritter@mongodb.com>,
            Roberto C. Sanchez <roberto@connexer.com>
 Build-Depends: debhelper (>= 11),
+               git <pkg.mongo-cxx-driver.mnmlstc>,
+               ca-certificates <pkg.mongo-cxx-driver.mnmlstc>,
                cmake,
                libmongoc-dev (>= 1.17.0),
                libboost-dev,

--- a/debian/patches/0002_skip_mnmlstc_extra_step.patch
+++ b/debian/patches/0002_skip_mnmlstc_extra_step.patch
@@ -1,0 +1,21 @@
+Description: Remove an extra step in the MNMLSTC external project build; this is not used for official Debian packages and the step needs to be removed for users customizing the Debian package to build with MNMLSTC rather than Boost.
+Author: Roberto C. Sánchez <roberto@connexer.com>
+Forwarded: not-needed
+--- a/src/bsoncxx/third_party/CMakeLists.txt
++++ b/src/bsoncxx/third_party/CMakeLists.txt
+@@ -29,15 +29,6 @@
+         CMAKE_ARGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DBUILD_TESTING=Off -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}/${BSONCXX_HEADER_INSTALL_DIR}/bsoncxx/third_party/mnmlstc -DINCLUDE_INSTALL_DIR=.
+     )
+ 
+-    ExternalProject_Add_Step(
+-        EP_mnmlstc_core
+-        fix-includes
+-        WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/${BSONCXX_HEADER_INSTALL_DIR}/bsoncxx/third_party/mnmlstc
+-        COMMAND find . -type f | xargs perl -pi.bak -e "s|#include <core|#include <bsoncxx/third_party/mnmlstc/core|g"
+-        COMMAND find . -name *.bak | xargs rm
+-        DEPENDEES install
+-    )
+-
+ endif()
+ 
+ set_dist_list (src_bsoncxx_third_party_DIST

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 0001_remove_embedded_js.patch
+0002_skip_mnmlstc_extra_step.patch

--- a/debian/rules
+++ b/debian/rules
@@ -22,18 +22,39 @@ export DEB_LDFLAGS_MAINT_APPEND := -lpthread
 	dh $@
 
 override_dh_auto_configure:
+ifneq (,$(filter pkg.mongo-cxx-driver.mnmlstc,$(DEB_BUILD_PROFILES)))
+	dh_auto_configure -B$(CURDIR)/build -- \
+	-DBUILD_VERSION=$(DEB_VERSION_UPSTREAM) \
+	-DBSONCXX_POLY_USE_MNMLSTC=1 \
+	-DENABLE_UNINSTALL=OFF
+else
 	dh_auto_configure -B$(CURDIR)/build -- \
 	-DBUILD_VERSION=$(DEB_VERSION_UPSTREAM) \
 	-DBSONCXX_POLY_USE_BOOST=1 \
 	-DENABLE_UNINSTALL=OFF
+endif
 
 override_dh_auto_build:
+ifneq (,$(filter pkg.mongo-cxx-driver.mnmlstc,$(DEB_BUILD_PROFILES)))
+	dh_auto_build -B$(CURDIR)/build -- all doxygen-current DESTDIR=$(CURDIR)/debian/tmp-mnmlstc
+else
 	dh_auto_build -B$(CURDIR)/build -- all doxygen-current
+endif
 
 override_dh_auto_install:
 	dh_auto_install -B$(CURDIR)/build
 	find $(CURDIR)/debian/tmp -type d -empty -delete
 	rm -f $(CURDIR)/debian/tmp/usr/share/mongo-cxx-driver/LICENSE
+ifneq (,$(filter pkg.mongo-cxx-driver.mnmlstc,$(DEB_BUILD_PROFILES)))
+	# Drop MNMLSTC headers in a location where dh_install will pick them up
+	mv $(CURDIR)/debian/tmp-mnmlstc/usr/include/bsoncxx/v_noabi/bsoncxx/third_party \
+	   $(CURDIR)/debian/tmp/usr/include/bsoncxx/v_noabi/bsoncxx/
+	rm -rf $(CURDIR)/debian/tmp-mnmlstc
+	# Fix MNMLSTC headers; handle the CMake external project step patched out
+	# by debian/patches/0002_skip_mnmlstc_extra_step.patch
+	( cd $(CURDIR)/debian/tmp/usr/include/bsoncxx/v_noabi/bsoncxx/third_party/mnmlstc; \
+	   find . -type f | xargs perl -pi -e "s|#include <core|#include <bsoncxx/third_party/mnmlstc/core|g" )
+endif
 
 override_dh_auto_test:
 	# do nothing


### PR DESCRIPTION
Evergreen patch build: https://spruce.mongodb.com/version/5fa5a13b9ccd4e7a05535ca8/tasks

Note that after this PR is approved and merged I will cherry-pick the change onto the `releases/v3.6` branch.