### PR TITLE
CXX-1985 Rename filter to opts for list_databases

### DIFF
--- a/src/mongocxx/client.cpp
+++ b/src/mongocxx/client.cpp
@@ -195,9 +195,9 @@ cursor client::list_databases(const client_session& session) const {
     return libmongoc::client_find_databases_with_opts(_get_impl().client_t, options_bson.bson());
 }
 
-cursor client::list_databases(const bsoncxx::document::view_or_value filter) const {
-    scoped_bson_t filter_bson{filter.view()};
-    return libmongoc::client_find_databases_with_opts(_get_impl().client_t, filter_bson.bson());
+cursor client::list_databases(const bsoncxx::document::view_or_value opts) const {
+    scoped_bson_t opts_bson{opts.view()};
+    return libmongoc::client_find_databases_with_opts(_get_impl().client_t, opts_bson.bson());
 }
 
 std::vector<std::string> client::list_database_names(

--- a/src/mongocxx/client.hpp
+++ b/src/mongocxx/client.hpp
@@ -259,7 +259,6 @@ class MONGOCXX_API client {
     /// @throws mongocxx::operation_exception if the underlying 'listDatabases' command fails.
     ///
     /// @see https://docs.mongodb.com/master/reference/command/listDatabases
-    ///   for a list of all possible options to pass to 'listDatabases'.
     ///
     cursor list_databases(const bsoncxx::document::view_or_value opts) const;
 

--- a/src/mongocxx/client.hpp
+++ b/src/mongocxx/client.hpp
@@ -247,8 +247,8 @@ class MONGOCXX_API client {
     ///
     /// Enumerates the databases in the client.
     ///
-    /// @param filter
-    ///   The filter that documents must match in order to be listed.
+    /// @param opts
+    ///   Options passed directly to the 'listDatabases' command.
     ///
     /// @return A mongocxx::cursor containing a BSON document for each
     ///   database. Each document contains a name field with the database
@@ -259,8 +259,9 @@ class MONGOCXX_API client {
     /// @throws mongocxx::operation_exception if the underlying 'listDatabases' command fails.
     ///
     /// @see https://docs.mongodb.com/master/reference/command/listDatabases
+    ///   for a list of all possible options to pass to 'listDatabases'.
     ///
-    cursor list_databases(const bsoncxx::document::view_or_value filter) const;
+    cursor list_databases(const bsoncxx::document::view_or_value opts) const;
 
     ///
     /// Queries the MongoDB server for a list of known databases.

--- a/src/mongocxx/test/client.cpp
+++ b/src/mongocxx/test/client.cpp
@@ -131,7 +131,7 @@ TEST_CASE("list databases passes authorizedDatabases option", "[client]") {
         bsoncxx::document::value opts = make_document(kvp("authorizedDatabases", true));
         client.list_databases(opts.view());
         REQUIRE(num_called == 1);
-        REQUIRE_BSON_MATCHES(*opts_passed, make_document(kvp("authorizedDatabase", true)));
+        REQUIRE_BSON_MATCHES(*opts_passed, make_document(kvp("authorizedDatabases", true)));
     }
 }
 

--- a/src/mongocxx/test/client.cpp
+++ b/src/mongocxx/test/client.cpp
@@ -73,37 +73,19 @@ TEST_CASE("A client lists its databases with a filter applied", "[client]") {
     REQUIRE(client_list_databases_called);
 }
 
-TEST_CASE("list databases with a filter works", "[client]") {
-    using bsoncxx::builder::basic::kvp;
-    using bsoncxx::builder::basic::make_document;
-
-    instance::current();
-
-    mongocxx::client client{mongocxx::uri{"mongodb://localhost:27017"}};
-    // auto filter_doc = make_document(kvp("filter", make_document(kvp("name", "admin"))));
-    auto cursor = client.list_databases();
-    for (auto&& doc : cursor) {
-        std::cout << bsoncxx::to_json(doc) << std::endl;
-    }
-}
-
 TEST_CASE("list databases passes authorizedDatabases option", "[client]") {
     using bsoncxx::builder::basic::kvp;
     using bsoncxx::builder::basic::make_document;
     using bsoncxx::to_json;
 
-    auto mock_client_find_databases_with_opts =
-        mongocxx::libmongoc::client_find_databases_with_opts.create_instance();
-    int num_called = 0;
+    MOCK_CLIENT
+
+    bool called = false;
     stdx::optional<bsoncxx::document::value> opts_passed;
 
-    mock_client_find_databases_with_opts->interpose([&](mongoc_client_t* client,
+    client_find_databases_with_opts->visit([&](mongoc_client_t*,
                                                         const bson_t* opts) {
-        (void)client;
-        (void)opts;
-        std::cout << "mock interpose has been called" << std::endl;
-        num_called++;
-
+        called = true;
         if (opts) {
             opts_passed =
                 bsoncxx::document::value{bsoncxx::document::view{bson_get_data(opts), opts->len}};
@@ -111,27 +93,25 @@ TEST_CASE("list databases passes authorizedDatabases option", "[client]") {
         return nullptr;
     });
 
-    mongocxx::client client{mongocxx::uri{"mongodb://localhost:27017"}};
-
-    std::cout << "running test" << std::endl;
+    mongocxx::client client{mongocxx::uri{}};
 
     SECTION("list_databases with no arguments") {
         client.list_databases();
-        REQUIRE(num_called == 1);
+        REQUIRE(called);
     }
 
     SECTION("list_databases with filter") {
         bsoncxx::document::value opts = make_document(kvp("filter", 1));
         client.list_databases(opts.view());
-        REQUIRE(num_called == 1);
-        REQUIRE_BSON_MATCHES(*opts_passed, make_document(kvp("filter", 1)));
+        REQUIRE(called);
+        REQUIRE_BSON_MATCHES(*opts_passed, opts);
     }
 
     SECTION("list_databases with authorizedDatabases") {
         bsoncxx::document::value opts = make_document(kvp("authorizedDatabases", true));
         client.list_databases(opts.view());
-        REQUIRE(num_called == 1);
-        REQUIRE_BSON_MATCHES(*opts_passed, make_document(kvp("authorizedDatabases", true)));
+        REQUIRE(called);
+        REQUIRE_BSON_MATCHES(*opts_passed, opts);
     }
 }
 

--- a/src/mongocxx/test/client.cpp
+++ b/src/mongocxx/test/client.cpp
@@ -83,8 +83,7 @@ TEST_CASE("list databases passes authorizedDatabases option", "[client]") {
     bool called = false;
     stdx::optional<bsoncxx::document::value> opts_passed;
 
-    client_find_databases_with_opts->visit([&](mongoc_client_t*,
-                                                        const bson_t* opts) {
+    client_find_databases_with_opts->visit([&](mongoc_client_t*, const bson_t* opts) {
         called = true;
         if (opts) {
             opts_passed =

--- a/src/mongocxx/test/client.cpp
+++ b/src/mongocxx/test/client.cpp
@@ -57,8 +57,7 @@ TEST_CASE("A client lists its databases with a filter applied", "[client]") {
     auto filter_doc = make_document(kvp("filter", make_document(kvp("name", "admin"))));
     auto filter_view = filter_doc.view();
 
-    auto client_list_databases = libmongoc::client_find_databases_with_opts.create_instance();
-    client_list_databases
+    client_find_databases_with_opts
         ->interpose([&](mongoc_client_t*, const bson_t* opts) {
             REQUIRE(opts);
             bsoncxx::document::view opts_view{bson_get_data(opts), opts->len};

--- a/src/third_party/catch/include/helpers.hpp
+++ b/src/third_party/catch/include/helpers.hpp
@@ -92,7 +92,9 @@ MONGOCXX_INLINE_NAMESPACE_END
     client_reset->interpose([](const mongoc_client_t*){}).forever();                            \
     auto client_get_concern = libmongoc::client_get_write_concern.create_instance();            \
     client_get_concern->interpose([](const mongoc_client_t*) { return nullptr; }).forever();    \
-    auto client_start_session = libmongoc::client_start_session.create_instance();
+    auto client_start_session = libmongoc::client_start_session.create_instance();              \
+    auto client_find_databases_with_opts = mongocxx::libmongoc::client_find_databases_with_opts.create_instance(); \
+    client_find_databases_with_opts->interpose([](const mongoc_client_t*, const bson_t*) {return nullptr; }).forever();
 
 #if defined(MONGOCXX_ENABLE_SSL) && defined(MONGOC_ENABLE_SSL)
 #define MOCK_CLIENT                                                              \

--- a/src/third_party/catch/include/helpers.hpp
+++ b/src/third_party/catch/include/helpers.hpp
@@ -93,8 +93,7 @@ MONGOCXX_INLINE_NAMESPACE_END
     auto client_get_concern = libmongoc::client_get_write_concern.create_instance();            \
     client_get_concern->interpose([](const mongoc_client_t*) { return nullptr; }).forever();    \
     auto client_start_session = libmongoc::client_start_session.create_instance();              \
-    auto client_find_databases_with_opts = mongocxx::libmongoc::client_find_databases_with_opts.create_instance(); \
-    client_find_databases_with_opts->interpose([](const mongoc_client_t*, const bson_t*) {return nullptr; }).forever();
+    auto client_find_databases_with_opts = mongocxx::libmongoc::client_find_databases_with_opts.create_instance();
 
 #if defined(MONGOCXX_ENABLE_SSL) && defined(MONGOC_ENABLE_SSL)
 #define MOCK_CLIENT                                                              \


### PR DESCRIPTION
As it turns out, the `list_databases` overload that accepted a `bsoncxx::document::view_or_value` "filter" was really applying it as an options document. So we already support the `authorizedDatabases` option, and all options that can be passed to the `listDatabases` command.

This PR renames the argument and adds a test to ensure we can pass `authorizedDatabases` through.