### PR TITLE
Add coding style to contribution guidelines

### DIFF
--- a/docs/content/contributing/_index.md
+++ b/docs/content/contributing/_index.md
@@ -8,7 +8,7 @@ title = "Contribution Guidelines"
 
 ### Code Style
 
-When contributing code, in addition to following the [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines), please follow the same [code style](https://github.com/mongodb/mongo/wiki/Server-Code-Style), [design guidelines](https://github.com/mongodb/mongo/wiki/Server-Design-Guidelines), and [style guidelines](https://github.com/mongodb/mongo/wiki/Style-Guidelines) as [mongodb/mongo](https://github.com/mongodb/mongo). Additions and exceptions are listed below.
+When contributing code, in addition to following the [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines), please follow the same [design guidelines](https://github.com/mongodb/mongo/wiki/Server-Design-Guidelines) and [style guidelines](https://github.com/mongodb/mongo/wiki/Style-Guidelines) as [mongodb/mongo](https://github.com/mongodb/mongo). Additions and exceptions are listed below. For anything that isn't explicitly covered here, default to the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html#Scoping). Running [clang-format](https://clang.llvm.org/docs/ClangFormat.html) with our configuration file, [mongo-cxx-driver/.clang-format](https://github.com/mongodb/mongo-cxx-driver/blob/master/.clang-format), will help ensure your code conforms to the above standards.
 
 ### Commit Messages
 

--- a/docs/content/contributing/_index.md
+++ b/docs/content/contributing/_index.md
@@ -6,6 +6,10 @@ title = "Contribution Guidelines"
   parent="contributing"
 +++
 
+### Code Style
+
+When contributing code, in addition to following the [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines), please follow the same [code style](https://github.com/mongodb/mongo/wiki/Server-Code-Style), [design guidelines](https://github.com/mongodb/mongo/wiki/Server-Design-Guidelines), and [style guidelines](https://github.com/mongodb/mongo/wiki/Style-Guidelines) as [mongodb/mongo](https://github.com/mongodb/mongo). Additions and exceptions are listed below.
+
 ### Commit Messages
 
 If a pull-request addresses a JIRA ticket, for a single-commit PR, prefix


### PR DESCRIPTION
@kevinAlbs Per our conversation yesterday, this is an attempt to provide clear guidelines for contributing to our codebase. The server's guidelines are well defined, pretty close to how we already code, and default to the Google C++ style guide. I also linked the C++ Core Guidelines. Those guidelines should be a given but I linked them to avoid ambiguity.