### PR TITLE
Use BSONCXX_POLY_USE_STD in stdx/make_unique.hpp

### DIFF
--- a/src/bsoncxx/stdx/make_unique.hpp
+++ b/src/bsoncxx/stdx/make_unique.hpp
@@ -48,7 +48,7 @@ using ::boost::make_unique;
 BSONCXX_INLINE_NAMESPACE_END
 }  // namespace bsoncxx
 
-#elif __cplusplus >= 201402L
+#elif defined(BSONCXX_POLY_USE_STD)
 
 #include <memory>
 


### PR DESCRIPTION
It will make the code more symmetric.

And I think it should be controlled by the cmake flags which version of stdx we use.