### PR TITLE
update clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,7 +7,7 @@ BinPackParameters: false
 ColumnLimit: 100
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
-IncludeBlocks:   Preserve
+IncludeBlocksStyle:   Regroup
 IncludeCategories:
   - Regex:           '.*'
     Priority:        1

--- a/.clang-format
+++ b/.clang-format
@@ -1,12 +1,16 @@
-BasedOnStyle: Google
 AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
+BasedOnStyle: Google
 BinPackArguments: false
 BinPackParameters: false
 ColumnLimit: 100
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '.*'
+    Priority:        1
 IndentWidth: 4
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None

--- a/.clang-format
+++ b/.clang-format
@@ -7,10 +7,14 @@ BinPackParameters: false
 ColumnLimit: 100
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
-IncludeBlocksStyle:   Regroup
+IncludeBlocks: Regroup
 IncludeCategories:
-  - Regex:           '.*'
-    Priority:        1
+  - Regex:    'prelude\.(hpp|hh)' # preludes
+    Priority: 1
+  - Regex:    '<[[:alnum:].]+>' # system headers
+    Priority: 2
+  - Regex:    '.*' # driver headers
+    Priority: 3
 IndentWidth: 4
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None

--- a/.clang-format
+++ b/.clang-format
@@ -11,7 +11,7 @@ IncludeBlocks: Regroup
 IncludeCategories:
   - Regex:    'prelude\.(hpp|hh)' # preludes
     Priority: 1
-  - Regex:    '<[[:alnum:].]+>' # system headers
+  - Regex:    '<[[:alnum:]_.]+>' # system headers
     Priority: 2
   - Regex:    '.*' # driver headers
     Priority: 3

--- a/etc/clang_format.py
+++ b/etc/clang_format.py
@@ -40,17 +40,17 @@ if __name__ == "__main__" and __package__ is None:
 #
 
 # Expected version of clang-format
-CLANG_FORMAT_VERSION = "3.8.0"
-CLANG_FORMAT_SHORT_VERSION = "3.8"
+CLANG_FORMAT_VERSION = "7.0.1"
+CLANG_FORMAT_SHORT_VERSION = "7.0"
 
 # Name of clang-format as a binary
 CLANG_FORMAT_PROGNAME = "clang-format"
 
 # URL location of the "cached" copy of clang-format to download
 # for users which do not have clang-format installed
-CLANG_FORMAT_HTTP_LINUX_CACHE = "https://s3.amazonaws.com/boxes.10gen.com/build/clang-format-3.8-rhel55.tar.gz"
+CLANG_FORMAT_HTTP_LINUX_CACHE = "https://s3.amazonaws.com/boxes.10gen.com/build/clang-format-7.0.1-rhel70.tar.gz"
 
-CLANG_FORMAT_HTTP_DARWIN_CACHE = "https://s3.amazonaws.com/boxes.10gen.com/build/clang%2Bllvm-3.8.0-x86_64-apple-darwin.tar.xz"
+CLANG_FORMAT_HTTP_DARWIN_CACHE = "https://s3.amazonaws.com/boxes.10gen.com/build/clang-format-7.0.1-x86_64-apple-darwin.tar.gz"
 
 # Path in the tarball to the clang-format binary
 CLANG_FORMAT_SOURCE_TAR_BASE = string.Template("clang+llvm-$version-$tar_path/bin/" + CLANG_FORMAT_PROGNAME)

--- a/examples/add_subdirectory/hello_mongocxx.cpp
+++ b/examples/add_subdirectory/hello_mongocxx.cpp
@@ -17,7 +17,6 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/json.hpp>
-
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>

--- a/examples/bsoncxx/builder_basic.cpp
+++ b/examples/bsoncxx/builder_basic.cpp
@@ -55,8 +55,8 @@ int main(int, char**) {
     // as a parameter, which appends the keys in-place.
     // After the lambda returns, the builder will end the subdocument.
 
-    using bsoncxx::builder::basic::sub_document;
     using bsoncxx::builder::basic::sub_array;
+    using bsoncxx::builder::basic::sub_document;
 
     doc.append(kvp("subdocument key",
                    [](sub_document subdoc) {
@@ -65,14 +65,10 @@ int main(int, char**) {
                    }),
                kvp("subarray key", [](sub_array subarr) {
                    // subarrays work similarly
-                   subarr.append(1,
-                                 types::b_bool{false},
-                                 "hello",
-                                 5,
-                                 [](sub_document subdoc) {
-                                     // nesting works too!
-                                     subdoc.append(kvp("such", "nesting"), kvp("much", "recurse"));
-                                 });
+                   subarr.append(1, types::b_bool{false}, "hello", 5, [](sub_document subdoc) {
+                       // nesting works too!
+                       subdoc.append(kvp("such", "nesting"), kvp("much", "recurse"));
+                   });
                }));
 
     // We can get a view of the resulting bson by calling view()

--- a/examples/bsoncxx/builder_list.cpp
+++ b/examples/bsoncxx/builder_list.cpp
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
+
 #include <bsoncxx/builder/list.hpp>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/value.hpp>
-#include <chrono>
 
 using namespace bsoncxx;
 

--- a/examples/bsoncxx/builder_stream.cpp
+++ b/examples/bsoncxx/builder_stream.cpp
@@ -20,8 +20,8 @@
 using namespace bsoncxx;
 
 int main(int, char**) {
-    using builder::stream::document;
     using builder::stream::array;
+    using builder::stream::document;
 
     // bsoncxx::builder::stream presents an iostream like interface for succinctly
     // constructing complex BSON objects.
@@ -44,13 +44,13 @@ int main(int, char**) {
     // The stream namespace includes some helpers that can be used similarly
     // to the stream manipulators in <iomanip>
     // To build a subdocument, use open_document and close_document
-    using builder::stream::open_document;
     using builder::stream::close_document;
+    using builder::stream::open_document;
     doc << "mySubDoc" << open_document << "subdoc key"
         << "subdoc value" << close_document;
     // To build a subarray, use open_array and close_array
-    using builder::stream::open_array;
     using builder::stream::close_array;
+    using builder::stream::open_array;
     doc << "mySubArr" << open_array << 1 << types::b_bool{false} << "hello" << close_array;
 
     // There is a special finalize helper that converts a stream to its underlying bson value

--- a/examples/bsoncxx/getting_values.cpp
+++ b/examples/bsoncxx/getting_values.cpp
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <cstdlib>
 
 #include <bsoncxx/builder/stream/array.hpp>
 #include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/builder/stream/helpers.hpp>
-#include <bsoncxx/config/prelude.hpp>
 #include <bsoncxx/types.hpp>
 
 using namespace bsoncxx;

--- a/examples/bsoncxx/view_and_value.cpp
+++ b/examples/bsoncxx/view_and_value.cpp
@@ -18,7 +18,6 @@
 #include <vector>
 
 #include <bsoncxx/array/view.hpp>
-#include <bsoncxx/array/view.hpp>
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>

--- a/examples/mongocxx/automatic_client_side_field_level_encryption.cpp
+++ b/examples/mongocxx/automatic_client_side_field_level_encryption.cpp
@@ -31,15 +31,15 @@
 #include <mongocxx/options/data_key.hpp>
 #include <mongocxx/options/encrypt.hpp>
 
-using bsoncxx::builder::basic::make_document;
 using bsoncxx::builder::basic::kvp;
+using bsoncxx::builder::basic::make_document;
 
-using bsoncxx::builder::stream::document;
-using bsoncxx::builder::stream::open_array;
 using bsoncxx::builder::stream::close_array;
-using bsoncxx::builder::stream::open_document;
 using bsoncxx::builder::stream::close_document;
+using bsoncxx::builder::stream::document;
 using bsoncxx::builder::stream::finalize;
+using bsoncxx::builder::stream::open_array;
+using bsoncxx::builder::stream::open_document;
 
 using bsoncxx::types::bson_value::make_value;
 

--- a/examples/mongocxx/causal_consistency.cpp
+++ b/examples/mongocxx/causal_consistency.cpp
@@ -29,10 +29,10 @@
 #include <mongocxx/uri.hpp>
 #include <mongocxx/write_concern.hpp>
 
-using bsoncxx::builder::stream::document;
-using bsoncxx::builder::stream::open_document;
 using bsoncxx::builder::stream::close_document;
+using bsoncxx::builder::stream::document;
 using bsoncxx::builder::stream::finalize;
+using bsoncxx::builder::stream::open_document;
 
 int main() {
     using namespace mongocxx;

--- a/examples/mongocxx/client_session.cpp
+++ b/examples/mongocxx/client_session.cpp
@@ -21,9 +21,9 @@
 #include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>
 
+using bsoncxx::to_json;
 using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_document;
-using bsoncxx::to_json;
 using namespace mongocxx;
 
 int main() {

--- a/examples/mongocxx/connect.cpp
+++ b/examples/mongocxx/connect.cpp
@@ -20,7 +20,6 @@
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/stdx/make_unique.hpp>
-
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/logger.hpp>

--- a/examples/mongocxx/create.cpp
+++ b/examples/mongocxx/create.cpp
@@ -18,7 +18,6 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/types.hpp>
-
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>

--- a/examples/mongocxx/document_validation.cpp
+++ b/examples/mongocxx/document_validation.cpp
@@ -17,7 +17,6 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
-
 #include <mongocxx/client.hpp>
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/instance.hpp>

--- a/examples/mongocxx/exception.cpp
+++ b/examples/mongocxx/exception.cpp
@@ -27,8 +27,8 @@
 #include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>
 
-using bsoncxx::builder::basic::make_document;
 using bsoncxx::builder::basic::kvp;
+using bsoncxx::builder::basic::make_document;
 
 int main(int, char**) {
     // The mongocxx::instance constructor and destructor initialize and shut down the driver,

--- a/examples/mongocxx/explicit_encryption.cpp
+++ b/examples/mongocxx/explicit_encryption.cpp
@@ -30,13 +30,13 @@
 #include <mongocxx/options/data_key.hpp>
 #include <mongocxx/options/encrypt.hpp>
 
-using bsoncxx::builder::basic::make_document;
 using bsoncxx::builder::basic::kvp;
+using bsoncxx::builder::basic::make_document;
 
-using bsoncxx::builder::stream::document;
-using bsoncxx::builder::stream::open_document;
 using bsoncxx::builder::stream::close_document;
+using bsoncxx::builder::stream::document;
 using bsoncxx::builder::stream::finalize;
+using bsoncxx::builder::stream::open_document;
 
 using bsoncxx::types::bson_value::make_value;
 

--- a/examples/mongocxx/explicit_encryption_auto_decryption.cpp
+++ b/examples/mongocxx/explicit_encryption_auto_decryption.cpp
@@ -30,13 +30,13 @@
 #include <mongocxx/options/data_key.hpp>
 #include <mongocxx/options/encrypt.hpp>
 
-using bsoncxx::builder::basic::make_document;
 using bsoncxx::builder::basic::kvp;
+using bsoncxx::builder::basic::make_document;
 
-using bsoncxx::builder::stream::document;
-using bsoncxx::builder::stream::open_document;
 using bsoncxx::builder::stream::close_document;
+using bsoncxx::builder::stream::document;
 using bsoncxx::builder::stream::finalize;
+using bsoncxx::builder::stream::open_document;
 
 using bsoncxx::types::bson_value::make_value;
 

--- a/examples/mongocxx/get_values_from_documents.cpp
+++ b/examples/mongocxx/get_values_from_documents.cpp
@@ -20,10 +20,10 @@
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 
+using bsoncxx::type;
 using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_array;
 using bsoncxx::builder::basic::make_document;
-using bsoncxx::type;
 
 // Document model, showing array with nested documents:
 //

--- a/examples/mongocxx/instance_management.cpp
+++ b/examples/mongocxx/instance_management.cpp
@@ -18,7 +18,6 @@
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
-
 #include <mongocxx/instance.hpp>
 #include <mongocxx/logger.hpp>
 #include <mongocxx/pool.hpp>

--- a/examples/mongocxx/query.cpp
+++ b/examples/mongocxx/query.cpp
@@ -18,7 +18,6 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/json.hpp>
-
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/find.hpp>

--- a/examples/mongocxx/query_projection.cpp
+++ b/examples/mongocxx/query_projection.cpp
@@ -17,7 +17,6 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/json.hpp>
-
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/find.hpp>

--- a/examples/mongocxx/remove.cpp
+++ b/examples/mongocxx/remove.cpp
@@ -14,7 +14,6 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
-
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>

--- a/examples/mongocxx/server_side_field_level_encryption_enforcement.cpp
+++ b/examples/mongocxx/server_side_field_level_encryption_enforcement.cpp
@@ -30,15 +30,15 @@
 #include <mongocxx/options/data_key.hpp>
 #include <mongocxx/options/encrypt.hpp>
 
-using bsoncxx::builder::basic::make_document;
 using bsoncxx::builder::basic::kvp;
+using bsoncxx::builder::basic::make_document;
 
-using bsoncxx::builder::stream::document;
-using bsoncxx::builder::stream::open_array;
 using bsoncxx::builder::stream::close_array;
-using bsoncxx::builder::stream::open_document;
 using bsoncxx::builder::stream::close_document;
+using bsoncxx::builder::stream::document;
 using bsoncxx::builder::stream::finalize;
+using bsoncxx::builder::stream::open_array;
+using bsoncxx::builder::stream::open_document;
 
 using bsoncxx::types::bson_value::make_value;
 

--- a/examples/mongocxx/tailable_cursor.cpp
+++ b/examples/mongocxx/tailable_cursor.cpp
@@ -18,7 +18,6 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/json.hpp>
-
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/database.hpp>

--- a/examples/mongocxx/view_or_value_variant.cpp
+++ b/examples/mongocxx/view_or_value_variant.cpp
@@ -15,16 +15,15 @@
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
-
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/uri.hpp>
 
+using bsoncxx::builder::basic::array;
 using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_document;
-using bsoncxx::builder::basic::array;
 
 int main(int, char**) {
     // The mongocxx::instance constructor and destructor initialize and shut down the driver,

--- a/examples/projects/bsoncxx/hello_bsoncxx.cpp
+++ b/examples/projects/bsoncxx/hello_bsoncxx.cpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/json.hpp>
 
-int main(int, char* []) {
+int main(int, char*[]) {
     using bsoncxx::builder::basic::kvp;
     using bsoncxx::builder::basic::make_document;
 

--- a/examples/projects/mongocxx/hello_mongocxx.cpp
+++ b/examples/projects/mongocxx/hello_mongocxx.cpp
@@ -17,7 +17,6 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/json.hpp>
-
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>

--- a/src/bsoncxx/array/element.cpp
+++ b/src/bsoncxx/array/element.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/array/element.hpp>
-#include <bsoncxx/types/bson_value/view.hpp>
+#include <bsoncxx/config/private/prelude.hh>
 
 #include <stdexcept>
 
-#include <bsoncxx/config/private/prelude.hh>
+#include <bsoncxx/array/element.hpp>
+#include <bsoncxx/types/bson_value/view.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
@@ -47,6 +47,6 @@ bool BSONCXX_CALL operator!=(const types::bson_value::view& v, const element& el
     return !(elem == v);
 }
 
-}  // namespace document
+}  // namespace array
 BSONCXX_INLINE_NAMESPACE_END
 }  // namespace bsoncxx

--- a/src/bsoncxx/array/element.hpp
+++ b/src/bsoncxx/array/element.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <cstddef>
 #include <cstdint>
 
 #include <bsoncxx/document/element.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
@@ -47,38 +47,38 @@ class BSONCXX_API element : private document::element {
 
     using document::element::type;
 
-    using document::element::get_double;
-    using document::element::get_utf8;
-    using document::element::get_string;
-    using document::element::get_document;
     using document::element::get_array;
     using document::element::get_binary;
-    using document::element::get_undefined;
-    using document::element::get_oid;
     using document::element::get_bool;
-    using document::element::get_date;
-    using document::element::get_null;
-    using document::element::get_regex;
-    using document::element::get_dbpointer;
     using document::element::get_code;
-    using document::element::get_symbol;
     using document::element::get_codewscope;
-    using document::element::get_int32;
-    using document::element::get_timestamp;
-    using document::element::get_int64;
+    using document::element::get_date;
+    using document::element::get_dbpointer;
     using document::element::get_decimal128;
-    using document::element::get_minkey;
+    using document::element::get_document;
+    using document::element::get_double;
+    using document::element::get_int32;
+    using document::element::get_int64;
     using document::element::get_maxkey;
+    using document::element::get_minkey;
+    using document::element::get_null;
+    using document::element::get_oid;
+    using document::element::get_regex;
+    using document::element::get_string;
+    using document::element::get_symbol;
+    using document::element::get_timestamp;
+    using document::element::get_undefined;
+    using document::element::get_utf8;
 
     using document::element::get_value;
 
     using document::element::operator[];
 
-    using document::element::raw;
+    using document::element::key;
+    using document::element::keylen;
     using document::element::length;
     using document::element::offset;
-    using document::element::keylen;
-    using document::element::key;
+    using document::element::raw;
 
    private:
     friend class view;

--- a/src/bsoncxx/array/value.cpp
+++ b/src/bsoncxx/array/value.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/array/value.hpp>
+#include <bsoncxx/config/private/prelude.hh>
 
 #include <cstring>
 
-#include <bsoncxx/config/private/prelude.hh>
+#include <bsoncxx/array/value.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/array/value.hpp
+++ b/src/bsoncxx/array/value.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <cstdlib>
 #include <memory>
 
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/document/value.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/array/view.cpp
+++ b/src/bsoncxx/array/view.cpp
@@ -12,17 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/array/view.hpp>
+#include <bsoncxx/config/private/prelude.hh>
 
 #include <cstring>
 #include <tuple>
 
+#include <bsoncxx/array/view.hpp>
 #include <bsoncxx/private/itoa.hh>
 #include <bsoncxx/private/libbson.hh>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
-
-#include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/array/view.hpp
+++ b/src/bsoncxx/array/view.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
 
 #include <bsoncxx/array/element.hpp>
 #include <bsoncxx/document/view.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/array/view_or_value.hpp
+++ b/src/bsoncxx/array/view_or_value.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/view_or_value.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/basic/array.hpp
+++ b/src/bsoncxx/builder/basic/array.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/builder/basic/impl.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/builder/basic/sub_array.hpp>
 #include <bsoncxx/builder/core.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
@@ -42,7 +42,7 @@ class array : public sub_array {
     ///
     /// Move constructor
     ///
-    BSONCXX_INLINE array(array &&arr) noexcept : sub_array(&_core), _core(std::move(arr._core)) {}
+    BSONCXX_INLINE array(array&& arr) noexcept : sub_array(&_core), _core(std::move(arr._core)) {}
 
     ///
     /// Move assignment operator

--- a/src/bsoncxx/builder/basic/document.hpp
+++ b/src/bsoncxx/builder/basic/document.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <bsoncxx/builder/basic/impl.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/builder/basic/sub_document.hpp>
 #include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
@@ -44,8 +44,8 @@ class document : public sub_document {
     ///
     /// Move constructor
     ///
-    BSONCXX_INLINE document(document &&doc) noexcept : sub_document(&_core),
-                                                       _core(std::move(doc._core)) {}
+    BSONCXX_INLINE document(document&& doc) noexcept
+        : sub_document(&_core), _core(std::move(doc._core)) {}
 
     ///
     /// Move assignment operator

--- a/src/bsoncxx/builder/basic/helpers.hpp
+++ b/src/bsoncxx/builder/basic/helpers.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <bsoncxx/builder/concatenate.hpp>
-
 #include <bsoncxx/config/prelude.hpp>
+
+#include <bsoncxx/builder/concatenate.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/basic/impl.hpp
+++ b/src/bsoncxx/builder/basic/impl.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <bsoncxx/builder/basic/sub_array.hpp>
 #include <bsoncxx/builder/basic/sub_document.hpp>
 #include <bsoncxx/util/functor.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/basic/kvp.hpp
+++ b/src/bsoncxx/builder/basic/kvp.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <tuple>
-
 #include <bsoncxx/config/prelude.hpp>
+
+#include <tuple>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/basic/sub_array.hpp
+++ b/src/bsoncxx/builder/basic/sub_array.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <bsoncxx/builder/basic/helpers.hpp>
 #include <bsoncxx/builder/concatenate.hpp>
 #include <bsoncxx/builder/core.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/basic/sub_document.hpp
+++ b/src/bsoncxx/builder/basic/sub_document.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <bsoncxx/builder/basic/helpers.hpp>
 #include <bsoncxx/builder/concatenate.hpp>
 #include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/concatenate.hpp
+++ b/src/bsoncxx/builder/concatenate.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/core.cpp
+++ b/src/bsoncxx/builder/core.cpp
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/builder/core.hpp>
+#include <bsoncxx/config/private/prelude.hh>
 
 #include <cstring>
 
+#include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/exception/error_code.hpp>
 #include <bsoncxx/exception/exception.hpp>
 #include <bsoncxx/private/itoa.hh>
@@ -27,8 +28,6 @@
 #include <bsoncxx/string/to_string.hpp>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
-
-#include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/core.hpp
+++ b/src/bsoncxx/builder/core.hpp
@@ -14,9 +14,10 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <memory>
 #include <stdexcept>
-#include <type_traits>
 
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/array/view.hpp>
@@ -24,8 +25,7 @@
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/types.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
+#include <type_traits>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/core.hpp
+++ b/src/bsoncxx/builder/core.hpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <stdexcept>
+#include <type_traits>
 
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/array/view.hpp>
@@ -25,7 +26,6 @@
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/types.hpp>
-#include <type_traits>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/list.hpp
+++ b/src/bsoncxx/builder/list.hpp
@@ -14,12 +14,14 @@
 
 #pragma once
 
-#include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/config/prelude.hpp>
+
+#include <sstream>
+
+#include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/exception/error_code.hpp>
 #include <bsoncxx/exception/exception.hpp>
 #include <bsoncxx/types/bson_value/value.hpp>
-#include <sstream>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
@@ -181,6 +183,6 @@ class array : public list {
     ///
     array(initializer_list_t init) : list(init, false, true) {}
 };
-}
+}  // namespace builder
 BSONCXX_INLINE_NAMESPACE_END
-}
+}  // namespace bsoncxx

--- a/src/bsoncxx/builder/stream/array.hpp
+++ b/src/bsoncxx/builder/stream/array.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/builder/core.hpp>
@@ -21,8 +23,6 @@
 #include <bsoncxx/builder/stream/key_context.hpp>
 #include <bsoncxx/builder/stream/single_context.hpp>
 #include <bsoncxx/builder/stream/value_context.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/stream/array_context.hpp
+++ b/src/bsoncxx/builder/stream/array_context.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/builder/concatenate.hpp>
 #include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/builder/stream/closed_context.hpp>
 #include <bsoncxx/builder/stream/helpers.hpp>
 #include <bsoncxx/util/functor.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/stream/document.hpp
+++ b/src/bsoncxx/builder/stream/document.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/builder/stream/key_context.hpp>
 #include <bsoncxx/builder/stream/single_context.hpp>
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/stream/helpers.hpp
+++ b/src/bsoncxx/builder/stream/helpers.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <bsoncxx/builder/concatenate.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/stream/key_context.hpp
+++ b/src/bsoncxx/builder/stream/key_context.hpp
@@ -15,13 +15,13 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/builder/stream/closed_context.hpp>
 #include <bsoncxx/builder/stream/value_context.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/util/functor.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/stream/single_context.hpp
+++ b/src/bsoncxx/builder/stream/single_context.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/builder/stream/array_context.hpp>
 #include <bsoncxx/builder/stream/key_context.hpp>
 #include <bsoncxx/builder/stream/value_context.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/builder/stream/value_context.hpp
+++ b/src/bsoncxx/builder/stream/value_context.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/builder/stream/array_context.hpp>
 #include <bsoncxx/builder/stream/closed_context.hpp>
 #include <bsoncxx/builder/stream/helpers.hpp>
 #include <bsoncxx/util/functor.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/decimal128.cpp
+++ b/src/bsoncxx/decimal128.cpp
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/decimal128.hpp>
+#include <bsoncxx/config/private/prelude.hh>
 
+#include <bsoncxx/decimal128.hpp>
 #include <bsoncxx/exception/error_code.hpp>
 #include <bsoncxx/exception/exception.hpp>
 #include <bsoncxx/private/libbson.hh>
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/string/to_string.hpp>
-
-#include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/decimal128.hpp
+++ b/src/bsoncxx/decimal128.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <cstdint>
 #include <string>
 
 #include <bsoncxx/stdx/string_view.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/document/element.cpp
+++ b/src/bsoncxx/document/element.cpp
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/document/element.hpp>
+#include <bsoncxx/config/private/prelude.hh>
 
 #include <cstdlib>
 
+#include <bsoncxx/document/element.hpp>
 #include <bsoncxx/exception/error_code.hpp>
 #include <bsoncxx/exception/exception.hpp>
 #include <bsoncxx/private/libbson.hh>
@@ -23,8 +24,6 @@
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
-
-#include <bsoncxx/config/private/prelude.hh>
 
 #define BSONCXX_CITER \
     bson_iter_t iter; \

--- a/src/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/document/element.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <cstddef>
 #include <cstdint>
 
 #include <bsoncxx/stdx/string_view.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/document/value.cpp
+++ b/src/bsoncxx/document/value.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/document/value.hpp>
+#include <bsoncxx/config/private/prelude.hh>
 
 #include <utility>
 
-#include <bsoncxx/config/private/prelude.hh>
+#include <bsoncxx/document/value.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/document/value.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <cstdlib>
 #include <memory>
 
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/document/view.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/document/view.cpp
+++ b/src/bsoncxx/document/view.cpp
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/config/private/prelude.hh>
 
 #include <cstring>
 
+#include <bsoncxx/document/view.hpp>
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/private/libbson.hh>
 #include <bsoncxx/types.hpp>
-
-#include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/document/view.hpp
+++ b/src/bsoncxx/document/view.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
 
 #include <bsoncxx/document/element.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/document/view_or_value.hpp
+++ b/src/bsoncxx/document/view_or_value.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/view_or_value.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/exception/error_code.cpp
+++ b/src/bsoncxx/exception/error_code.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/exception/error_code.hpp>
+#include <bsoncxx/config/private/prelude.hh>
 
 #include <string>
 
-#include <bsoncxx/config/private/prelude.hh>
+#include <bsoncxx/exception/error_code.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/exception/error_code.hpp
+++ b/src/bsoncxx/exception/error_code.hpp
@@ -14,10 +14,11 @@
 
 #pragma once
 
-#include <cstdint>
-#include <system_error>
-
 #include <bsoncxx/config/prelude.hpp>
+
+#include <cstdint>
+
+#include <system_error>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/exception/error_code.hpp
+++ b/src/bsoncxx/exception/error_code.hpp
@@ -17,7 +17,6 @@
 #include <bsoncxx/config/prelude.hpp>
 
 #include <cstdint>
-
 #include <system_error>
 
 namespace bsoncxx {

--- a/src/bsoncxx/exception/exception.hpp
+++ b/src/bsoncxx/exception/exception.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <system_error>
-
 #include <bsoncxx/config/prelude.hpp>
+
+#include <system_error>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/json.cpp
+++ b/src/bsoncxx/json.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/json.hpp>
+#include <bsoncxx/config/private/prelude.hh>
 
 #include <memory>
 #include <vector>
@@ -20,13 +20,12 @@
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/exception/error_code.hpp>
 #include <bsoncxx/exception/exception.hpp>
+#include <bsoncxx/json.hpp>
 #include <bsoncxx/private/b64_ntop.hh>
 #include <bsoncxx/private/libbson.hh>
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
-
-#include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/json.hpp
+++ b/src/bsoncxx/json.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <string>
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 ///
 /// Top level namespace for MongoDB C++ BSON functionality.

--- a/src/bsoncxx/oid.cpp
+++ b/src/bsoncxx/oid.cpp
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/oid.hpp>
+#include <bsoncxx/config/private/prelude.hh>
 
 #include <cstring>
 
 #include <bsoncxx/exception/error_code.hpp>
 #include <bsoncxx/exception/exception.hpp>
+#include <bsoncxx/oid.hpp>
 #include <bsoncxx/private/libbson.hh>
-
-#include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/oid.hpp
+++ b/src/bsoncxx/oid.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <array>
 #include <ctime>
 #include <string>
 
 #include <bsoncxx/stdx/string_view.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/private/helpers.hh
+++ b/src/bsoncxx/private/helpers.hh
@@ -14,11 +14,11 @@
 
 #pragma once
 
+#include <bsoncxx/config/private/prelude.hh>
+
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/private/libbson.hh>
-
-#include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/private/itoa.cpp
+++ b/src/bsoncxx/private/itoa.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/private/itoa.hh>
-
 #include <bsoncxx/config/private/prelude.hh>
+
+#include <bsoncxx/private/itoa.hh>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/private/itoa.hh
+++ b/src/bsoncxx/private/itoa.hh
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <bsoncxx/config/private/prelude.hh>
+
 #include <cstddef>
 #include <cstdint>
 
 #include <bsoncxx/test_util/export_for_testing.hh>
-
-#include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/private/stack.hh
+++ b/src/bsoncxx/private/stack.hh
@@ -14,11 +14,12 @@
 
 #pragma once
 
+#include <bsoncxx/config/private/prelude.hh>
+
 #include <list>
 #include <memory>
-#include <type_traits>
 
-#include <bsoncxx/config/private/prelude.hh>
+#include <type_traits>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/private/stack.hh
+++ b/src/bsoncxx/private/stack.hh
@@ -18,7 +18,6 @@
 
 #include <list>
 #include <memory>
-
 #include <type_traits>
 
 namespace bsoncxx {

--- a/src/bsoncxx/stdx/optional.hpp
+++ b/src/bsoncxx/stdx/optional.hpp
@@ -28,9 +28,9 @@ namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
 namespace stdx {
 
-using ::core::optional;
-using ::core::nullopt;
 using ::core::make_optional;
+using ::core::nullopt;
+using ::core::optional;
 
 }  // namespace stdx
 BSONCXX_INLINE_NAMESPACE_END
@@ -64,9 +64,9 @@ namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
 namespace stdx {
 
-using ::std::experimental::optional;
-using ::std::experimental::nullopt;
 using ::std::experimental::make_optional;
+using ::std::experimental::nullopt;
+using ::std::experimental::optional;
 
 }  // namespace stdx
 BSONCXX_INLINE_NAMESPACE_END
@@ -80,9 +80,9 @@ namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
 namespace stdx {
 
-using ::std::optional;
-using ::std::nullopt;
 using ::std::make_optional;
+using ::std::nullopt;
+using ::std::optional;
 
 }  // namespace stdx
 BSONCXX_INLINE_NAMESPACE_END

--- a/src/bsoncxx/string/to_string.hpp
+++ b/src/bsoncxx/string/to_string.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <string>
 #include <utility>
 
 #include <bsoncxx/stdx/string_view.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/string/view_or_value.cpp
+++ b/src/bsoncxx/string/view_or_value.cpp
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/string/view_or_value.hpp>
+#include <bsoncxx/config/private/prelude.hh>
 
 #include <bsoncxx/string/to_string.hpp>
-
-#include <bsoncxx/config/private/prelude.hh>
+#include <bsoncxx/string/view_or_value.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/string/view_or_value.hpp
+++ b/src/bsoncxx/string/view_or_value.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <string>
 
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/view_or_value.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/test/bson_b_date.cpp
+++ b/src/bsoncxx/test/bson_b_date.cpp
@@ -20,9 +20,9 @@
 namespace {
 TEST_CASE("time_point is converted to b_date and back", "[bsoncxx::types::b_date]") {
     using bsoncxx::types::b_date;
+    using std::chrono::milliseconds;
     using std::chrono::system_clock;
     using std::chrono::time_point_cast;
-    using std::chrono::milliseconds;
 
     system_clock::time_point now1, now2;
 

--- a/src/bsoncxx/test/bson_builder.cpp
+++ b/src/bsoncxx/test/bson_builder.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstring>
+
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/core.hpp>
@@ -25,7 +27,6 @@
 #include <bsoncxx/test_util/catch.hh>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
-#include <cstring>
 
 namespace {
 

--- a/src/bsoncxx/test/bson_serialization.cpp
+++ b/src/bsoncxx/test/bson_serialization.cpp
@@ -56,7 +56,9 @@ void from_bson(Person& person, const bsoncxx::document::view& bson_object) {
 
 TEST_CASE("Convert between Person struct and BSON object") {
     test::Person expected_person{
-        "Lelouch", "Lamperouge", 18,
+        "Lelouch",
+        "Lamperouge",
+        18,
     };
 
     bsoncxx::document::value expected_doc =

--- a/src/bsoncxx/test/bson_types.cpp
+++ b/src/bsoncxx/test/bson_types.cpp
@@ -14,20 +14,19 @@
 
 #include <chrono>
 
-#include <bsoncxx/types.hpp>
-#include <bsoncxx/types/bson_value/view.hpp>
-
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/test_util/catch.hh>
+#include <bsoncxx/types.hpp>
+#include <bsoncxx/types/bson_value/view.hpp>
 
 namespace {
 
 using namespace bsoncxx;
 using namespace types;
-using bsoncxx::builder::basic::make_document;
 using bsoncxx::builder::basic::kvp;
+using bsoncxx::builder::basic::make_document;
 
 TEST_CASE("type to_string", "[bsoncxx::type::to_string]") {
     REQUIRE(to_string(bsoncxx::type::k_bool) == "bool");
@@ -356,4 +355,4 @@ TEST_CASE("bson_value::view with inequality for non-value and value",
     b_int64 int64_val{100};
     REQUIRE(int64_val != bson_value::view{b_int64{200}});
 }
-}
+}  // namespace

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <vector>
+
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
@@ -21,15 +23,14 @@
 #include <bsoncxx/types/bson_value/make_value.hpp>
 #include <bsoncxx/types/bson_value/value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
-#include <vector>
 
 namespace {
 using namespace bsoncxx;
 
 using bsoncxx::to_json;
+using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_array;
 using bsoncxx::builder::basic::make_document;
-using bsoncxx::builder::basic::kvp;
 
 using namespace bsoncxx::types;
 

--- a/src/bsoncxx/test/oid.cpp
+++ b/src/bsoncxx/test/oid.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <stdlib.h>
 #include <chrono>
 #include <cstring>
 #include <ctime>
 #include <iomanip>
 #include <sstream>
+#include <stdlib.h>
 
 #include <bsoncxx/oid.hpp>
 #include <bsoncxx/private/libbson.hh>

--- a/src/bsoncxx/test/view_or_value.cpp
+++ b/src/bsoncxx/test/view_or_value.cpp
@@ -25,8 +25,8 @@ namespace {
 using namespace bsoncxx;
 
 using bsoncxx::to_json;
-using bsoncxx::builder::basic::make_document;
 using bsoncxx::builder::basic::kvp;
+using bsoncxx::builder::basic::make_document;
 
 TEST_CASE("document::view_or_value", "[bsoncxx::document::view_or_value]") {
     auto empty = make_document();

--- a/src/bsoncxx/test_util/catch.hh
+++ b/src/bsoncxx/test_util/catch.hh
@@ -14,13 +14,12 @@
 
 #pragma once
 
+#include <bsoncxx/config/private/prelude.hh>
+
+#include "catch.hpp"
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/stdx/optional.hpp>
-
-#include "catch.hpp"
-
-#include <bsoncxx/config/private/prelude.hh>
 
 namespace Catch {
 using namespace bsoncxx;

--- a/src/bsoncxx/types.cpp
+++ b/src/bsoncxx/types.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/types.hpp>
-
 #include <bsoncxx/config/private/prelude.hh>
+
+#include <bsoncxx/types.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/types.hpp
+++ b/src/bsoncxx/types.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <chrono>
 #include <cstring>
 
@@ -22,8 +24,6 @@
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/oid.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/types/bson_value/make_value.hpp
+++ b/src/bsoncxx/types/bson_value/make_value.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/types/bson_value/value.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/types/bson_value/private/value.hh
+++ b/src/bsoncxx/types/bson_value/private/value.hh
@@ -17,6 +17,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 #include <bsoncxx/private/libbson.hh>
+#include <bsoncxx/types/bson_value/value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
 
 namespace bsoncxx {

--- a/src/bsoncxx/types/bson_value/private/value.hh
+++ b/src/bsoncxx/types/bson_value/private/value.hh
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <bsoncxx/config/private/prelude.hh>
+
 #include <bsoncxx/private/libbson.hh>
 #include <bsoncxx/types/bson_value/view.hpp>
-
-#include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
@@ -63,6 +63,6 @@ BSONCXX_INLINE bson_value::value make_owning_bson(void* internal_value) {
 }  // namespace types
 
 BSONCXX_INLINE_NAMESPACE_END
-}  // namespace bsoncx
+}  // namespace bsoncxx
 
 #include <bsoncxx/config/private/postlude.hh>

--- a/src/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/types/bson_value/value.cpp
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/types/bson_value/value.hpp>
+#include <bsoncxx/config/private/prelude.hh>
 
 #include <bsoncxx/exception/error_code.hpp>
 #include <bsoncxx/exception/exception.hpp>
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/types/bson_value/private/value.hh>
+#include <bsoncxx/types/bson_value/value.hpp>
 #include <bsoncxx/types/private/convert.hh>
-
-#include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/types/bson_value/value.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <iostream>
 #include <memory>
 #include <vector>
@@ -22,8 +24,6 @@
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/types/bson_value/view.cpp
+++ b/src/bsoncxx/types/bson_value/view.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/types/bson_value/view.hpp>
+#include <bsoncxx/config/private/prelude.hh>
 
 #include <cstdlib>
 
@@ -20,9 +20,8 @@
 #include <bsoncxx/exception/exception.hpp>
 #include <bsoncxx/private/libbson.hh>
 #include <bsoncxx/private/suppress_deprecation_warnings.hh>
+#include <bsoncxx/types/bson_value/view.hpp>
 #include <bsoncxx/types/private/convert.hh>
-
-#include <bsoncxx/config/private/prelude.hh>
 
 #define BSONCXX_CITER \
     bson_iter_t iter; \
@@ -46,16 +45,16 @@ view::view() noexcept : view(nullptr) {}
 // so we can't rely on automatic noexcept propagation. It really is though, so it is OK.
 #if !defined(BSONCXX_POLY_USE_BOOST)
 #define BSONCXX_ENUM(name, val)                                                                \
-    view::view(b_##name value) noexcept : _type(static_cast<bsoncxx::type>(val)),              \
-                                          _b_##name(std::move(value)) {                        \
+    view::view(b_##name value) noexcept                                                        \
+        : _type(static_cast<bsoncxx::type>(val)), _b_##name(std::move(value)) {                \
         static_assert(std::is_nothrow_copy_constructible<b_##name>::value, "Copy may throw");  \
         static_assert(std::is_nothrow_copy_assignable<b_##name>::value, "Copy may throw");     \
         static_assert(std::is_nothrow_destructible<b_##name>::value, "Destruction may throw"); \
     }
 #else
 #define BSONCXX_ENUM(name, val)                                                                \
-    view::view(b_##name value) noexcept : _type(static_cast<bsoncxx::type>(val)),              \
-                                          _b_##name(std::move(value)) {                        \
+    view::view(b_##name value) noexcept                                                        \
+        : _type(static_cast<bsoncxx::type>(val)), _b_##name(std::move(value)) {                \
         static_assert(std::is_nothrow_destructible<b_##name>::value, "Destruction may throw"); \
     }
 #endif

--- a/src/bsoncxx/types/bson_value/view.hpp
+++ b/src/bsoncxx/types/bson_value/view.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <cstddef>
 #include <cstdint>
-#include <type_traits>
 
 #include <bsoncxx/types.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
+#include <type_traits>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/types/bson_value/view.hpp
+++ b/src/bsoncxx/types/bson_value/view.hpp
@@ -18,9 +18,9 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 
 #include <bsoncxx/types.hpp>
-#include <type_traits>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/types/bson_value/view_or_value.hpp
+++ b/src/bsoncxx/types/bson_value/view_or_value.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <bsoncxx/types/bson_value/value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
 #include <bsoncxx/view_or_value.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/types/private/convert.hh
+++ b/src/bsoncxx/types/private/convert.hh
@@ -14,13 +14,14 @@
 
 #pragma once
 
+#include <bsoncxx/config/private/prelude.hh>
+
+#include <cstdlib>
+
 #include <bsoncxx/private/libbson.hh>
 #include <bsoncxx/private/suppress_deprecation_warnings.hh>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
-#include <cstdlib>
-
-#include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/types/value.hpp
+++ b/src/bsoncxx/types/value.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <bsoncxx/types/bson_value/view.hpp>
-
 #include <bsoncxx/config/prelude.hpp>
+
+#include <bsoncxx/types/bson_value/view.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/util/functor.hpp
+++ b/src/bsoncxx/util/functor.hpp
@@ -17,7 +17,6 @@
 #include <bsoncxx/config/prelude.hpp>
 
 #include <functional>
-
 #include <type_traits>
 
 namespace bsoncxx {

--- a/src/bsoncxx/util/functor.hpp
+++ b/src/bsoncxx/util/functor.hpp
@@ -14,10 +14,11 @@
 
 #pragma once
 
-#include <functional>
-#include <type_traits>
-
 #include <bsoncxx/config/prelude.hpp>
+
+#include <functional>
+
+#include <type_traits>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/validate.cpp
+++ b/src/bsoncxx/validate.cpp
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/validate.hpp>
+#include <bsoncxx/config/private/prelude.hh>
 
 #include <bsoncxx/private/libbson.hh>
 #include <bsoncxx/stdx/make_unique.hpp>
-
-#include <bsoncxx/config/private/prelude.hh>
+#include <bsoncxx/validate.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/validate.hpp
+++ b/src/bsoncxx/validate.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <cstdint>
 #include <memory>
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/bsoncxx/view_or_value.hpp
+++ b/src/bsoncxx/view_or_value.hpp
@@ -14,11 +14,10 @@
 
 #pragma once
 
-#include <type_traits>
+#include <bsoncxx/config/prelude.hpp>
 
 #include <bsoncxx/stdx/optional.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
+#include <type_traits>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN
@@ -87,9 +86,8 @@ class view_or_value {
     ///
 
     /// TODO CXX-800: Create a noexcept expression to check the conditions that must be met.
-    BSONCXX_INLINE view_or_value(view_or_value &&other) noexcept
-        : _value{std::move(other._value)},
-          _view(_value ? *_value : std::move(other._view)) {
+    BSONCXX_INLINE view_or_value(view_or_value&& other) noexcept
+        : _value{std::move(other._value)}, _view(_value ? *_value : std::move(other._view)) {
         other._view = View();
         other._value = stdx::nullopt;
     }

--- a/src/bsoncxx/view_or_value.hpp
+++ b/src/bsoncxx/view_or_value.hpp
@@ -16,8 +16,9 @@
 
 #include <bsoncxx/config/prelude.hpp>
 
-#include <bsoncxx/stdx/optional.hpp>
 #include <type_traits>
+
+#include <bsoncxx/stdx/optional.hpp>
 
 namespace bsoncxx {
 BSONCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/bulk_write.cpp
+++ b/src/mongocxx/bulk_write.cpp
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <mongocxx/bulk_write.hpp>
 #include <mongocxx/collection.hpp>
-#include <mongocxx/config/private/prelude.hh>
 #include <mongocxx/exception/bulk_write_exception.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/exception/private/mongoc_error.hh>

--- a/src/mongocxx/bulk_write.hpp
+++ b/src/mongocxx/bulk_write.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <mongocxx/client_session.hpp>
 #include <mongocxx/model/write.hpp>
 #include <mongocxx/options/bulk_write.hpp>
 #include <mongocxx/result/bulk_write.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/change_stream.cpp
+++ b/src/mongocxx/change_stream.cpp
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/change_stream.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <string>
 
 #include <bsoncxx/stdx/make_unique.hpp>
+#include <mongocxx/change_stream.hpp>
 #include <mongocxx/private/change_stream.hh>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/change_stream.hpp
+++ b/src/mongocxx/change_stream.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <memory>
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/client.cpp
+++ b/src/mongocxx/client.cpp
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/client.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/stdx/make_unique.hpp>
+#include <mongocxx/client.hpp>
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/exception/operation_exception.hpp>
@@ -31,8 +32,6 @@
 #include <mongocxx/private/read_preference.hh>
 #include <mongocxx/private/uri.hh>
 #include <mongocxx/private/write_concern.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/client.hpp
+++ b/src/mongocxx/client.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <memory>
 
 #include <mongocxx/client_session.hpp>
@@ -26,8 +28,6 @@
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/uri.hpp>
 #include <mongocxx/write_concern.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 ///
 /// Top level namespace for the MongoDB C++ driver.

--- a/src/mongocxx/client_encryption.cpp
+++ b/src/mongocxx/client_encryption.cpp
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/client_encryption.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/stdx/make_unique.hpp>
+#include <mongocxx/client_encryption.hpp>
 #include <mongocxx/private/client_encryption.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/client_encryption.hpp
+++ b/src/mongocxx/client_encryption.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/types/bson_value/value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
 #include <mongocxx/options/client_encryption.hpp>
 #include <mongocxx/options/data_key.hpp>
 #include <mongocxx/options/encrypt.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/client_session.cpp
+++ b/src/mongocxx/client_session.cpp
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/exception/private/mongoc_error.hh>
 #include <mongocxx/private/client.hh>
 #include <mongocxx/private/client_session.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/client_session.hpp
+++ b/src/mongocxx/client_session.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <functional>
 #include <memory>
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/options/client_session.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/collection.cpp
+++ b/src/mongocxx/collection.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/collection.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <chrono>
 #include <cstdint>
@@ -33,6 +33,7 @@
 #include <bsoncxx/types.hpp>
 #include <mongocxx/bulk_write.hpp>
 #include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/exception/operation_exception.hpp>
@@ -58,14 +59,12 @@
 #include <mongocxx/result/update.hpp>
 #include <mongocxx/write_concern.hpp>
 
-#include <mongocxx/config/private/prelude.hh>
-
+using bsoncxx::builder::concatenate;
 using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_array;
 using bsoncxx::builder::basic::make_document;
 using bsoncxx::builder::basic::sub_array;
 using bsoncxx::builder::basic::sub_document;
-using bsoncxx::builder::concatenate;
 using bsoncxx::document::view_or_value;
 
 namespace {
@@ -1204,9 +1203,8 @@ void collection::_drop(const client_session* session,
     // Throw an exception if the command failed, unless the failure was due to a non-existent
     // collection. We check for this failure using 'code', but we fall back to checking 'message'
     // for old server versions (3.0 and earlier) that do not send a code with the command response.
-    if (!result &&
-        !(error.code == ::MONGOC_ERROR_COLLECTION_DOES_NOT_EXIST ||
-          stdx::string_view{error.message} == stdx::string_view{"ns not found"})) {
+    if (!result && !(error.code == ::MONGOC_ERROR_COLLECTION_DOES_NOT_EXIST ||
+                     stdx::string_view{error.message} == stdx::string_view{"ns not found"})) {
         throw_exception<operation_exception>(error);
     }
 }

--- a/src/mongocxx/collection.hpp
+++ b/src/mongocxx/collection.hpp
@@ -14,7 +14,11 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <algorithm>
+#include <string>
+
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
@@ -26,7 +30,6 @@
 #include <mongocxx/bulk_write.hpp>
 #include <mongocxx/change_stream.hpp>
 #include <mongocxx/client_session.hpp>
-#include <mongocxx/config/prelude.hpp>
 #include <mongocxx/cursor.hpp>
 #include <mongocxx/index_view.hpp>
 #include <mongocxx/model/insert_one.hpp>
@@ -56,7 +59,6 @@
 #include <mongocxx/result/replace_one.hpp>
 #include <mongocxx/result/update.hpp>
 #include <mongocxx/write_concern.hpp>
-#include <string>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/cursor.cpp
+++ b/src/mongocxx/cursor.cpp
@@ -12,16 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/cursor.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/private/libbson.hh>
 #include <bsoncxx/stdx/make_unique.hpp>
+#include <mongocxx/cursor.hpp>
 #include <mongocxx/exception/private/mongoc_error.hh>
 #include <mongocxx/exception/query_exception.hpp>
 #include <mongocxx/private/cursor.hh>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/cursor.hpp
+++ b/src/mongocxx/cursor.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <memory>
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/database.cpp
+++ b/src/mongocxx/database.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/database.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <utility>
 
@@ -22,6 +22,7 @@
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/string/to_string.hpp>
 #include <mongocxx/client.hpp>
+#include <mongocxx/database.hpp>
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/exception/operation_exception.hpp>
@@ -34,8 +35,6 @@
 #include <mongocxx/private/pipeline.hh>
 #include <mongocxx/private/read_concern.hh>
 #include <mongocxx/private/read_preference.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 using bsoncxx::builder::concatenate;
 using bsoncxx::builder::basic::kvp;

--- a/src/mongocxx/database.hpp
+++ b/src/mongocxx/database.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <memory>
 #include <string>
 
@@ -26,8 +28,6 @@
 #include <mongocxx/options/gridfs/bucket.hpp>
 #include <mongocxx/read_preference.hpp>
 #include <mongocxx/write_concern.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/command_failed_event.cpp
+++ b/src/mongocxx/events/command_failed_event.cpp
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/events/command_failed_event.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/stdx/make_unique.hpp>
+#include <mongocxx/events/command_failed_event.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/command_failed_event.hpp
+++ b/src/mongocxx/events/command_failed_event.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <memory>
 
 #include <bsoncxx/document/view.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/command_started_event.cpp
+++ b/src/mongocxx/events/command_started_event.cpp
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/events/command_started_event.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/stdx/make_unique.hpp>
+#include <mongocxx/events/command_started_event.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/command_started_event.hpp
+++ b/src/mongocxx/events/command_started_event.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <memory>
 
 #include <bsoncxx/document/view.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/command_succeeded_event.cpp
+++ b/src/mongocxx/events/command_succeeded_event.cpp
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/events/command_succeeded_event.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/stdx/make_unique.hpp>
+#include <mongocxx/events/command_succeeded_event.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/command_succeeded_event.hpp
+++ b/src/mongocxx/events/command_succeeded_event.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <memory>
 
 #include <bsoncxx/document/view.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/heartbeat_failed_event.cpp
+++ b/src/mongocxx/events/heartbeat_failed_event.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <mongocxx/events/heartbeat_failed_event.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/heartbeat_failed_event.hpp
+++ b/src/mongocxx/events/heartbeat_failed_event.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <bsoncxx/stdx/string_view.hpp>
-
 #include <mongocxx/config/prelude.hpp>
+
+#include <bsoncxx/stdx/string_view.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/heartbeat_started_event.cpp
+++ b/src/mongocxx/events/heartbeat_started_event.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <mongocxx/events/heartbeat_started_event.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/heartbeat_started_event.hpp
+++ b/src/mongocxx/events/heartbeat_started_event.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <bsoncxx/stdx/string_view.hpp>
-
 #include <mongocxx/config/prelude.hpp>
+
+#include <bsoncxx/stdx/string_view.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/heartbeat_succeeded_event.cpp
+++ b/src/mongocxx/events/heartbeat_succeeded_event.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <mongocxx/events/heartbeat_succeeded_event.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/heartbeat_succeeded_event.hpp
+++ b/src/mongocxx/events/heartbeat_succeeded_event.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/server_changed_event.cpp
+++ b/src/mongocxx/events/server_changed_event.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <mongocxx/events/server_changed_event.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/server_changed_event.hpp
+++ b/src/mongocxx/events/server_changed_event.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/oid.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 #include <mongocxx/events/server_description.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/server_closed_event.cpp
+++ b/src/mongocxx/events/server_closed_event.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <mongocxx/events/server_closed_event.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/server_closed_event.hpp
+++ b/src/mongocxx/events/server_closed_event.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/oid.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/server_description.cpp
+++ b/src/mongocxx/events/server_description.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <mongocxx/events/server_description.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/server_description.hpp
+++ b/src/mongocxx/events/server_description.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/server_opening_event.cpp
+++ b/src/mongocxx/events/server_opening_event.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <mongocxx/events/server_opening_event.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/server_opening_event.hpp
+++ b/src/mongocxx/events/server_opening_event.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <bsoncxx/oid.hpp>
-
 #include <mongocxx/config/prelude.hpp>
+
+#include <bsoncxx/oid.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/topology_changed_event.cpp
+++ b/src/mongocxx/events/topology_changed_event.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <mongocxx/events/topology_changed_event.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/topology_changed_event.hpp
+++ b/src/mongocxx/events/topology_changed_event.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/oid.hpp>
 #include <mongocxx/events/topology_description.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/topology_closed_event.cpp
+++ b/src/mongocxx/events/topology_closed_event.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <mongocxx/events/topology_closed_event.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/topology_closed_event.hpp
+++ b/src/mongocxx/events/topology_closed_event.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <bsoncxx/oid.hpp>
-
 #include <mongocxx/config/prelude.hpp>
+
+#include <bsoncxx/oid.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/topology_description.cpp
+++ b/src/mongocxx/events/topology_description.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <mongocxx/events/topology_description.hpp>
 #include <mongocxx/private/libmongoc.hh>
 #include <mongocxx/private/read_preference.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/topology_description.hpp
+++ b/src/mongocxx/events/topology_description.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <vector>
 
 #include <bsoncxx/stdx/string_view.hpp>
 #include <mongocxx/events/server_description.hpp>
 #include <mongocxx/read_preference.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/topology_opening_event.cpp
+++ b/src/mongocxx/events/topology_opening_event.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <mongocxx/events/topology_opening_event.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/events/topology_opening_event.hpp
+++ b/src/mongocxx/events/topology_opening_event.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/oid.hpp>
 #include <mongocxx/events/topology_description.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/authentication_exception.hpp
+++ b/src/mongocxx/exception/authentication_exception.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/document/value.hpp>
 #include <mongocxx/exception/operation_exception.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/bulk_write_exception.hpp
+++ b/src/mongocxx/exception/bulk_write_exception.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/document/value.hpp>
 #include <mongocxx/exception/operation_exception.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/error_code.cpp
+++ b/src/mongocxx/exception/error_code.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <string>
 
-#include <mongocxx/config/private/prelude.hh>
+#include <mongocxx/exception/error_code.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/error_code.hpp
+++ b/src/mongocxx/exception/error_code.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <system_error>
-
 #include <mongocxx/config/prelude.hpp>
+
+#include <system_error>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/exception.hpp
+++ b/src/mongocxx/exception/exception.hpp
@@ -14,10 +14,11 @@
 
 #pragma once
 
-#include <string>
-#include <system_error>
-
 #include <mongocxx/config/prelude.hpp>
+
+#include <string>
+
+#include <system_error>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/exception.hpp
+++ b/src/mongocxx/exception/exception.hpp
@@ -17,7 +17,6 @@
 #include <mongocxx/config/prelude.hpp>
 
 #include <string>
-
 #include <system_error>
 
 namespace mongocxx {

--- a/src/mongocxx/exception/gridfs_exception.hpp
+++ b/src/mongocxx/exception/gridfs_exception.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <mongocxx/exception/exception.hpp>
-
 #include <mongocxx/config/prelude.hpp>
+
+#include <mongocxx/exception/exception.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/logic_error.hpp
+++ b/src/mongocxx/exception/logic_error.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <mongocxx/exception/exception.hpp>
-
 #include <mongocxx/config/prelude.hpp>
+
+#include <mongocxx/exception/exception.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/operation_exception.cpp
+++ b/src/mongocxx/exception/operation_exception.cpp
@@ -12,16 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/exception/operation_exception.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <string>
 #include <utility>
 
 #include <bsoncxx/string/to_string.hpp>
+#include <mongocxx/exception/operation_exception.hpp>
 #include <mongocxx/private/libbson.hh>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/operation_exception.hpp
+++ b/src/mongocxx/exception/operation_exception.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/private/mongoc_error.hh
+++ b/src/mongocxx/exception/private/mongoc_error.hh
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <bsoncxx/document/value.hpp>
 #include <mongocxx/exception/operation_exception.hpp>
 #include <mongocxx/exception/server_error_code.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/query_exception.hpp
+++ b/src/mongocxx/exception/query_exception.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <mongocxx/exception/operation_exception.hpp>
-
 #include <mongocxx/config/prelude.hpp>
+
+#include <mongocxx/exception/operation_exception.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/server_error_code.cpp
+++ b/src/mongocxx/exception/server_error_code.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/exception/server_error_code.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <string>
 
-#include <mongocxx/config/private/prelude.hh>
+#include <mongocxx/exception/server_error_code.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/server_error_code.hpp
+++ b/src/mongocxx/exception/server_error_code.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <system_error>
-
 #include <mongocxx/config/prelude.hpp>
+
+#include <system_error>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/exception/write_exception.hpp
+++ b/src/mongocxx/exception/write_exception.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <mongocxx/exception/operation_exception.hpp>
-
 #include <mongocxx/config/prelude.hpp>
+
+#include <mongocxx/exception/operation_exception.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/gridfs/bucket.cpp
+++ b/src/mongocxx/gridfs/bucket.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/gridfs/bucket.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <ios>
 #include <string>
@@ -26,12 +26,11 @@
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/gridfs_exception.hpp>
 #include <mongocxx/exception/logic_error.hpp>
+#include <mongocxx/gridfs/bucket.hpp>
 #include <mongocxx/gridfs/private/bucket.hh>
 #include <mongocxx/options/delete.hpp>
 #include <mongocxx/options/index.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/gridfs/bucket.hpp
+++ b/src/mongocxx/gridfs/bucket.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <istream>
 #include <memory>
 #include <ostream>
@@ -29,8 +31,6 @@
 #include <mongocxx/options/gridfs/upload.hpp>
 #include <mongocxx/result/gridfs/upload.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/gridfs/downloader.cpp
+++ b/src/mongocxx/gridfs/downloader.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/gridfs/downloader.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <algorithm>
 #include <cstring>
@@ -22,9 +22,8 @@
 #include <bsoncxx/types.hpp>
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
+#include <mongocxx/gridfs/downloader.hpp>
 #include <mongocxx/gridfs/private/downloader.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/gridfs/downloader.hpp
+++ b/src/mongocxx/gridfs/downloader.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -24,8 +26,6 @@
 #include <bsoncxx/types/bson_value/view.hpp>
 #include <mongocxx/cursor.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/gridfs/private/bucket.hh
+++ b/src/mongocxx/gridfs/private/bucket.hh
@@ -14,13 +14,13 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <cstddef>
 #include <string>
 
 #include <mongocxx/collection.hpp>
 #include <mongocxx/gridfs/bucket.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/gridfs/private/downloader.hh
+++ b/src/mongocxx/gridfs/private/downloader.hh
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <cstdlib>
 
 #include <mongocxx/exception/gridfs_exception.hpp>
 #include <mongocxx/gridfs/downloader.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/gridfs/private/uploader.hh
+++ b/src/mongocxx/gridfs/private/uploader.hh
@@ -14,14 +14,14 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <string>
 #include <vector>
 
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/string/to_string.hpp>
 #include <mongocxx/gridfs/uploader.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/gridfs/uploader.cpp
+++ b/src/mongocxx/gridfs/uploader.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/gridfs/uploader.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <algorithm>
 #include <chrono>
@@ -26,8 +26,7 @@
 #include <mongocxx/exception/gridfs_exception.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/gridfs/private/uploader.hh>
-
-#include <mongocxx/config/private/prelude.hh>
+#include <mongocxx/gridfs/uploader.hpp>
 
 namespace {
 std::size_t chunks_collection_documents_max_length(std::size_t chunk_size) {

--- a/src/mongocxx/gridfs/uploader.hpp
+++ b/src/mongocxx/gridfs/uploader.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -27,8 +29,6 @@
 #include <mongocxx/collection.hpp>
 #include <mongocxx/result/gridfs/upload.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/hint.cpp
+++ b/src/mongocxx/hint.cpp
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/hint.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/builder/basic/sub_document.hpp>
 #include <bsoncxx/builder/concatenate.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
+#include <mongocxx/hint.hpp>
 
 using bsoncxx::builder::concatenate;
 using bsoncxx::builder::basic::kvp;

--- a/src/mongocxx/hint.hpp
+++ b/src/mongocxx/hint.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/index_model.cpp
+++ b/src/mongocxx/index_model.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/index_model.hpp>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/index_model.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/index_model.hpp
+++ b/src/mongocxx/index_model.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <mongocxx/options/index.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/index_view.cpp
+++ b/src/mongocxx/index_view.cpp
@@ -12,16 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/index_view.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/string/to_string.hpp>
 #include <mongocxx/client_session.hpp>
 #include <mongocxx/exception/private/mongoc_error.hh>
+#include <mongocxx/index_view.hpp>
 #include <mongocxx/options/index_view.hpp>
 #include <mongocxx/private/index_view.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/index_view.hpp
+++ b/src/mongocxx/index_view.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <string>
 #include <vector>
 
@@ -23,8 +25,6 @@
 #include <mongocxx/cursor.hpp>
 #include <mongocxx/index_model.hpp>
 #include <mongocxx/options/index_view.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/instance.cpp
+++ b/src/mongocxx/instance.cpp
@@ -12,19 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/instance.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <atomic>
-#include <type_traits>
 #include <utility>
 
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
+#include <mongocxx/instance.hpp>
 #include <mongocxx/logger.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
+#include <type_traits>
 
 #if !defined(__has_feature)
 #define __has_feature(x) 0

--- a/src/mongocxx/instance.cpp
+++ b/src/mongocxx/instance.cpp
@@ -15,6 +15,7 @@
 #include <mongocxx/config/private/prelude.hh>
 
 #include <atomic>
+#include <type_traits>
 #include <utility>
 
 #include <bsoncxx/stdx/make_unique.hpp>
@@ -23,7 +24,6 @@
 #include <mongocxx/instance.hpp>
 #include <mongocxx/logger.hpp>
 #include <mongocxx/private/libmongoc.hh>
-#include <type_traits>
 
 #if !defined(__has_feature)
 #define __has_feature(x) 0

--- a/src/mongocxx/instance.hpp
+++ b/src/mongocxx/instance.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <memory>
-
 #include <mongocxx/config/prelude.hpp>
+
+#include <memory>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/logger.cpp
+++ b/src/mongocxx/logger.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/logger.hpp>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/logger.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/logger.hpp
+++ b/src/mongocxx/logger.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <memory>
 
 #include <bsoncxx/stdx/string_view.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/delete_many.cpp
+++ b/src/mongocxx/model/delete_many.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/model/delete_many.hpp>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/model/delete_many.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/delete_many.hpp
+++ b/src/mongocxx/model/delete_many.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/hint.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/delete_one.cpp
+++ b/src/mongocxx/model/delete_one.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/model/delete_one.hpp>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/model/delete_one.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/delete_one.hpp
+++ b/src/mongocxx/model/delete_one.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/hint.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/insert_one.cpp
+++ b/src/mongocxx/model/insert_one.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/model/insert_one.hpp>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/model/insert_one.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/insert_one.hpp
+++ b/src/mongocxx/model/insert_one.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <bsoncxx/document/view_or_value.hpp>
-
 #include <mongocxx/config/prelude.hpp>
+
+#include <bsoncxx/document/view_or_value.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/replace_one.cpp
+++ b/src/mongocxx/model/replace_one.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/model/replace_one.hpp>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/model/replace_one.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/replace_one.hpp
+++ b/src/mongocxx/model/replace_one.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/hint.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/update_many.cpp
+++ b/src/mongocxx/model/update_many.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/model/update_many.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/array/view_or_value.hpp>
-#include <mongocxx/config/private/prelude.hh>
+#include <mongocxx/model/update_many.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/update_many.hpp
+++ b/src/mongocxx/model/update_many.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/hint.hpp>
-#include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 #include <mongocxx/pipeline.hpp>
+#include <mongocxx/stdx.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/update_one.cpp
+++ b/src/mongocxx/model/update_one.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/model/update_one.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/array/view_or_value.hpp>
-#include <mongocxx/config/private/prelude.hh>
+#include <mongocxx/model/update_one.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/update_one.hpp
+++ b/src/mongocxx/model/update_one.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/hint.hpp>
-#include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 #include <mongocxx/pipeline.hpp>
+#include <mongocxx/stdx.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/write.cpp
+++ b/src/mongocxx/model/write.cpp
@@ -14,8 +14,9 @@
 
 #include <mongocxx/config/private/prelude.hh>
 
-#include <mongocxx/model/write.hpp>
 #include <type_traits>
+
+#include <mongocxx/model/write.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/write.cpp
+++ b/src/mongocxx/model/write.cpp
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/model/write.hpp>
-
-#include <type_traits>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/model/write.hpp>
+#include <type_traits>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/model/write.hpp
+++ b/src/mongocxx/model/write.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <cstdint>
 
 #include <bsoncxx/stdx/optional.hpp>
@@ -24,8 +26,6 @@
 #include <mongocxx/model/update_many.hpp>
 #include <mongocxx/model/update_one.hpp>
 #include <mongocxx/write_type.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/aggregate.cpp
+++ b/src/mongocxx/options/aggregate.cpp
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/aggregate.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/builder/basic/document.hpp>
+#include <mongocxx/options/aggregate.hpp>
 #include <mongocxx/private/read_preference.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/aggregate.hpp
+++ b/src/mongocxx/options/aggregate.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <chrono>
 #include <cstdint>
 
@@ -25,8 +27,6 @@
 #include <mongocxx/read_preference.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/write_concern.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/apm.cpp
+++ b/src/mongocxx/options/apm.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/apm.hpp>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/options/apm.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/apm.hpp
+++ b/src/mongocxx/options/apm.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <functional>
 
 #include <mongocxx/events/command_failed_event.hpp>
@@ -28,8 +30,6 @@
 #include <mongocxx/events/topology_changed_event.hpp>
 #include <mongocxx/events/topology_closed_event.hpp>
 #include <mongocxx/events/topology_opening_event.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/auto_encryption.cpp
+++ b/src/mongocxx/options/auto_encryption.cpp
@@ -12,18 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/auto_encryption.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <mongocxx/client.hpp>
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
+#include <mongocxx/options/auto_encryption.hpp>
 #include <mongocxx/pool.hpp>
 #include <mongocxx/private/client.hh>
 #include <mongocxx/private/libbson.hh>
 #include <mongocxx/private/libmongoc.hh>
 #include <mongocxx/private/pool.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/auto_encryption.hpp
+++ b/src/mongocxx/options/auto_encryption.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <string>
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/bulk_write.cpp
+++ b/src/mongocxx/options/bulk_write.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/bulk_write.hpp>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/options/bulk_write.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/bulk_write.hpp
+++ b/src/mongocxx/options/bulk_write.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/write_concern.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/change_stream.cpp
+++ b/src/mongocxx/options/change_stream.cpp
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/change_stream.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/builder/core.hpp>
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
+#include <mongocxx/options/change_stream.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/change_stream.hpp
+++ b/src/mongocxx/options/change_stream.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <chrono>
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
 #include <bsoncxx/types.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/client.cpp
+++ b/src/mongocxx/options/client.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/client.hpp>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/options/client.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/client.hpp
+++ b/src/mongocxx/options/client.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <string>
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/options/apm.hpp>
 #include <mongocxx/options/auto_encryption.hpp>
 #include <mongocxx/options/tls.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/client_encryption.cpp
+++ b/src/mongocxx/options/client_encryption.cpp
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/client_encryption.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <mongocxx/client.hpp>
+#include <mongocxx/options/client_encryption.hpp>
 #include <mongocxx/private/client.hh>
 #include <mongocxx/private/libbson.hh>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/client_encryption.hpp
+++ b/src/mongocxx/options/client_encryption.hpp
@@ -56,7 +56,7 @@ class MONGOCXX_API client_encryption {
     /// @return
     ///   An optional pointer to the key vault client.
     ///
-    const stdx::optional<client*>& key_vault_client() const;
+    const stdx::optional<mongocxx::client*>& key_vault_client() const;
 
     ///
     /// Sets the namespace to use to access the key vault collection, which

--- a/src/mongocxx/options/client_encryption.hpp
+++ b/src/mongocxx/options/client_encryption.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <string>
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/client_session.cpp
+++ b/src/mongocxx/options/client_session.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/client_session.hpp>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/options/client_session.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/client_session.hpp
+++ b/src/mongocxx/options/client_session.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/options/transaction.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/count.cpp
+++ b/src/mongocxx/options/count.cpp
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/count.hpp>
-
-#include <mongocxx/private/read_preference.hh>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/options/count.hpp>
+#include <mongocxx/private/read_preference.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/count.hpp
+++ b/src/mongocxx/options/count.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <chrono>
 #include <cstdint>
 #include <string>
@@ -22,8 +24,6 @@
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/hint.hpp>
 #include <mongocxx/read_preference.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/create_collection.cpp
+++ b/src/mongocxx/options/create_collection.cpp
@@ -12,17 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/create_collection.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/builder/concatenate.hpp>
 #include <bsoncxx/types.hpp>
+#include <mongocxx/options/create_collection.hpp>
 
-#include <mongocxx/config/private/prelude.hh>
-
-using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::concatenate;
+using bsoncxx::builder::basic::kvp;
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/create_collection.hpp
+++ b/src/mongocxx/options/create_collection.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/validation_criteria.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/data_key.cpp
+++ b/src/mongocxx/options/data_key.cpp
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/data_key.hpp>
+#include <mongocxx/config/prelude.hpp>
 
+#include <mongocxx/options/data_key.hpp>
 #include <mongocxx/private/libbson.hh>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/data_key.hpp
+++ b/src/mongocxx/options/data_key.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <string>
 #include <vector>
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/delete.cpp
+++ b/src/mongocxx/options/delete.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <mongocxx/config/private/prelude.hh>
+
 #include <mongocxx/hint.hpp>
 #include <mongocxx/options/delete.hpp>
 

--- a/src/mongocxx/options/delete.hpp
+++ b/src/mongocxx/options/delete.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/hint.hpp>
 #include <mongocxx/write_concern.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/distinct.cpp
+++ b/src/mongocxx/options/distinct.cpp
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/distinct.hpp>
-
-#include <mongocxx/private/read_preference.hh>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/options/distinct.hpp>
+#include <mongocxx/private/read_preference.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/distinct.hpp
+++ b/src/mongocxx/options/distinct.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <chrono>
 #include <cstdint>
 #include <string>
@@ -21,8 +23,6 @@
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/read_preference.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/encrypt.cpp
+++ b/src/mongocxx/options/encrypt.cpp
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/types/private/convert.hh>
 #include <mongocxx/config/private/prelude.hh>
+
+#include <bsoncxx/types/private/convert.hh>
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/options/encrypt.hpp>
 #include <mongocxx/private/libbson.hh>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/estimated_document_count.cpp
+++ b/src/mongocxx/options/estimated_document_count.cpp
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/estimated_document_count.hpp>
-
-#include <mongocxx/private/read_preference.hh>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/options/estimated_document_count.hpp>
+#include <mongocxx/private/read_preference.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/estimated_document_count.hpp
+++ b/src/mongocxx/options/estimated_document_count.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <chrono>
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/read_preference.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/find.cpp
+++ b/src/mongocxx/options/find.cpp
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/find.hpp>
-
-#include <mongocxx/private/read_preference.hh>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/options/find.hpp>
+#include <mongocxx/private/read_preference.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/find.hpp
+++ b/src/mongocxx/options/find.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <chrono>
 #include <cstdint>
 
@@ -23,8 +25,6 @@
 #include <mongocxx/cursor.hpp>
 #include <mongocxx/hint.hpp>
 #include <mongocxx/read_preference.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/find_one_and_delete.cpp
+++ b/src/mongocxx/options/find_one_and_delete.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/find_one_and_delete.hpp>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/options/find_one_and_delete.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/find_one_and_delete.hpp
+++ b/src/mongocxx/options/find_one_and_delete.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <chrono>
 #include <cstdint>
 
@@ -21,8 +23,6 @@
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/hint.hpp>
 #include <mongocxx/write_concern.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/find_one_and_replace.cpp
+++ b/src/mongocxx/options/find_one_and_replace.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/find_one_and_replace.hpp>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/options/find_one_and_replace.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/find_one_and_replace.hpp
+++ b/src/mongocxx/options/find_one_and_replace.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <chrono>
 #include <cstdint>
 
@@ -23,8 +25,6 @@
 #include <mongocxx/options/find_one_common_options.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/write_concern.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/find_one_and_update.cpp
+++ b/src/mongocxx/options/find_one_and_update.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/find_one_and_update.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/array/view_or_value.hpp>
-#include <mongocxx/config/private/prelude.hh>
+#include <mongocxx/options/find_one_and_update.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/find_one_and_update.hpp
+++ b/src/mongocxx/options/find_one_and_update.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <chrono>
 #include <cstdint>
 
@@ -24,8 +26,6 @@
 #include <mongocxx/options/find_one_common_options.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/write_concern.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/gridfs/bucket.cpp
+++ b/src/mongocxx/options/gridfs/bucket.cpp
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/gridfs/bucket.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/stdx/optional.hpp>
+#include <mongocxx/options/gridfs/bucket.hpp>
 #include <mongocxx/read_concern.hpp>
 #include <mongocxx/read_preference.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/write_concern.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -75,4 +74,4 @@ const stdx::optional<class write_concern>& bucket::write_concern() const {
 }  // namespace gridfs
 }  // namespace options
 MONGOCXX_INLINE_NAMESPACE_END
-}
+}  // namespace mongocxx

--- a/src/mongocxx/options/gridfs/bucket.hpp
+++ b/src/mongocxx/options/gridfs/bucket.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <string>
 
 #include <bsoncxx/stdx/optional.hpp>
@@ -21,8 +23,6 @@
 #include <mongocxx/read_preference.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/write_concern.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/gridfs/upload.cpp
+++ b/src/mongocxx/options/gridfs/upload.cpp
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/gridfs/upload.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/view_or_value.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
+#include <mongocxx/options/gridfs/upload.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/gridfs/upload.hpp
+++ b/src/mongocxx/options/gridfs/upload.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/index.cpp
+++ b/src/mongocxx/options/index.cpp
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/index.hpp>
-
-#include <bsoncxx/stdx/make_unique.hpp>
-#include <mongocxx/private/libmongoc.hh>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/builder/basic/document.hpp>
-#include <mongocxx/config/private/prelude.hh>
+#include <bsoncxx/stdx/make_unique.hpp>
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
+#include <mongocxx/options/index.hpp>
+#include <mongocxx/private/libmongoc.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/index.hpp
+++ b/src/mongocxx/options/index.hpp
@@ -14,17 +14,17 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <chrono>
 #include <memory>
 
+#include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
+#include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <bsoncxx/document/value.hpp>
-#include <bsoncxx/document/view_or_value.hpp>
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/index_view.cpp
+++ b/src/mongocxx/options/index_view.cpp
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/types.hpp>
-#include <mongocxx/config/private/prelude.hh>
 #include <mongocxx/options/index_view.hpp>
 
 using bsoncxx::builder::basic::kvp;

--- a/src/mongocxx/options/index_view.hpp
+++ b/src/mongocxx/options/index_view.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <chrono>
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/write_concern.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/insert.cpp
+++ b/src/mongocxx/options/insert.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/insert.hpp>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/options/insert.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/insert.hpp
+++ b/src/mongocxx/options/insert.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/write_concern.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/pool.cpp
+++ b/src/mongocxx/options/pool.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/pool.hpp>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/options/pool.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/pool.hpp
+++ b/src/mongocxx/options/pool.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <mongocxx/options/client.hpp>
-
 #include <mongocxx/config/prelude.hpp>
+
+#include <mongocxx/options/client.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/private/apm.hh
+++ b/src/mongocxx/options/private/apm.hh
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <mongocxx/options/apm.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/private/ssl.hh
+++ b/src/mongocxx/options/private/ssl.hh
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <list>
 
 #include <mongocxx/options/tls.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/private/transaction.hh
+++ b/src/mongocxx/options/private/transaction.hh
@@ -14,14 +14,14 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <chrono>
 #include <memory>
 
 #include <mongocxx/private/read_concern.hh>
 #include <mongocxx/private/read_preference.hh>
 #include <mongocxx/private/write_concern.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/replace.cpp
+++ b/src/mongocxx/options/replace.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/replace.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/document/view_or_value.hpp>
-#include <mongocxx/config/private/prelude.hh>
+#include <mongocxx/options/replace.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/replace.hpp
+++ b/src/mongocxx/options/replace.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/hint.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/write_concern.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/ssl.hpp
+++ b/src/mongocxx/options/ssl.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <string>
 
 #include <mongocxx/options/tls.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/tls.cpp
+++ b/src/mongocxx/options/tls.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/tls.hpp>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/options/tls.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/tls.hpp
+++ b/src/mongocxx/options/tls.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <string>
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/transaction.cpp
+++ b/src/mongocxx/options/transaction.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/options/private/transaction.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/transaction.hpp
+++ b/src/mongocxx/options/transaction.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <chrono>
 #include <memory>
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/update.cpp
+++ b/src/mongocxx/options/update.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/options/update.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
-#include <mongocxx/config/private/prelude.hh>
+#include <mongocxx/options/update.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/options/update.hpp
+++ b/src/mongocxx/options/update.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/hint.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/write_concern.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/pipeline.cpp
+++ b/src/mongocxx/pipeline.cpp
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/pipeline.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/builder/basic/sub_document.hpp>
 #include <bsoncxx/stdx/make_unique.hpp>
+#include <mongocxx/pipeline.hpp>
 #include <mongocxx/private/pipeline.hh>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
 
 using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::sub_document;

--- a/src/mongocxx/pipeline.hpp
+++ b/src/mongocxx/pipeline.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -22,8 +24,6 @@
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/pool.cpp
+++ b/src/mongocxx/pool.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/pool.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <utility>
 
@@ -24,11 +24,10 @@
 #include <mongocxx/exception/private/mongoc_error.hh>
 #include <mongocxx/options/private/apm.hh>
 #include <mongocxx/options/private/ssl.hh>
+#include <mongocxx/pool.hpp>
 #include <mongocxx/private/client.hh>
 #include <mongocxx/private/pool.hh>
 #include <mongocxx/private/uri.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/pool.hpp
+++ b/src/mongocxx/pool.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <functional>
 #include <memory>
 
@@ -21,8 +23,6 @@
 #include <mongocxx/options/pool.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/uri.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/private/bulk_write.hh
+++ b/src/mongocxx/private/bulk_write.hh
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <mongocxx/bulk_write.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/private/change_stream.hh
+++ b/src/mongocxx/private/change_stream.hh
@@ -14,16 +14,15 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/change_stream.hpp>
-#include <mongocxx/config/private/prelude.hh>
 #include <mongocxx/exception/private/mongoc_error.hh>
 #include <mongocxx/exception/query_exception.hpp>
 #include <mongocxx/private/libbson.hh>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/private/client.hh
+++ b/src/mongocxx/private/client.hh
@@ -14,13 +14,13 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <list>
 
 #include <mongocxx/client.hpp>
 #include <mongocxx/private/libmongoc.hh>
 #include <mongocxx/private/write_concern.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/private/client_encryption.hh
+++ b/src/mongocxx/private/client_encryption.hh
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <bsoncxx/private/libbson.hh>
 #include <bsoncxx/types/bson_value/private/value.hh>
 #include <bsoncxx/types/bson_value/value.hpp>
@@ -24,11 +26,8 @@
 #include <mongocxx/exception/private/mongoc_error.hh>
 #include <mongocxx/options/client_encryption.hpp>
 #include <mongocxx/private/client.hh>
-
 #include <mongocxx/private/libbson.hh>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/private/client_session.hh
+++ b/src/mongocxx/private/client_session.hh
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <exception>
 
 #include <bsoncxx/private/helpers.hh>
@@ -27,8 +29,6 @@
 #include <mongocxx/private/client.hh>
 #include <mongocxx/private/libbson.hh>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/private/collection.hh
+++ b/src/mongocxx/private/collection.hh
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/private/helpers.hh>
 #include <bsoncxx/stdx/string_view.hpp>
@@ -23,8 +25,6 @@
 #include <mongocxx/private/libbson.hh>
 #include <mongocxx/private/read_preference.hh>
 #include <mongocxx/private/write_concern.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/private/conversions.cpp
+++ b/src/mongocxx/private/conversions.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/private/conversions.hh>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/private/conversions.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/private/conversions.hh
+++ b/src/mongocxx/private/conversions.hh
@@ -14,11 +14,11 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <mongocxx/private/libmongoc.hh>
 #include <mongocxx/read_preference.hpp>
 #include <mongocxx/test_util/export_for_testing.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/private/cursor.hh
+++ b/src/mongocxx/private/cursor.hh
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/cursor.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -35,8 +35,9 @@ class cursor::impl {
         : cursor_t(cursor),
           status{cursor ? state::k_pending : state::k_dead},
           exhausted(!cursor),
-          tailable{cursor && cursor_type && (*cursor_type == cursor::type::k_tailable ||
-                                             *cursor_type == cursor::type::k_tailable_await)} {}
+          tailable{cursor && cursor_type &&
+                   (*cursor_type == cursor::type::k_tailable ||
+                    *cursor_type == cursor::type::k_tailable_await)} {}
 
     ~impl() {
         libmongoc::cursor_destroy(cursor_t);

--- a/src/mongocxx/private/database.hh
+++ b/src/mongocxx/private/database.hh
@@ -14,13 +14,13 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/database.hpp>
 #include <mongocxx/private/client.hh>
 #include <mongocxx/private/libmongoc.hh>
 #include <mongocxx/private/write_concern.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/private/index_view.hh
+++ b/src/mongocxx/private/index_view.hh
@@ -14,12 +14,15 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
+#include <vector>
+
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/string/to_string.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
-#include <mongocxx/config/private/prelude.hh>
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/exception/operation_exception.hpp>
@@ -28,13 +31,12 @@
 #include <mongocxx/private/client_session.hh>
 #include <mongocxx/private/libbson.hh>
 #include <mongocxx/private/libmongoc.hh>
-#include <vector>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 
-using bsoncxx::builder::basic::make_document;
 using bsoncxx::builder::basic::kvp;
+using bsoncxx::builder::basic::make_document;
 
 class index_view::impl {
    public:

--- a/src/mongocxx/private/libbson.cpp
+++ b/src/mongocxx/private/libbson.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/private/libbson.hh>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/private/libbson.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/private/libbson.hh
+++ b/src/mongocxx/private/libbson.hh
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
@@ -21,8 +23,6 @@
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/test_util/export_for_testing.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/private/libmongoc.hh
+++ b/src/mongocxx/private/libmongoc.hh
@@ -34,9 +34,9 @@
 // TODO: CXX-1366 Disable MSVC warnings for libmongoc
 #endif
 
-#include <mongocxx/test_util/mock.hh>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/test_util/mock.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/private/pipeline.hh
+++ b/src/mongocxx/private/pipeline.hh
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <bsoncxx/builder/basic/array.hpp>
 #include <mongocxx/pipeline.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/private/pool.hh
+++ b/src/mongocxx/private/pool.hh
@@ -14,13 +14,13 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <list>
 #include <utility>
 
 #include <mongocxx/pool.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/private/read_concern.hh
+++ b/src/mongocxx/private/read_concern.hh
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <mongocxx/private/libmongoc.hh>
 #include <mongocxx/read_concern.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/private/read_preference.hh
+++ b/src/mongocxx/private/read_preference.hh
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <mongocxx/private/libmongoc.hh>
 #include <mongocxx/read_preference.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/private/uri.hh
+++ b/src/mongocxx/private/uri.hh
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <mongocxx/private/libmongoc.hh>
 #include <mongocxx/uri.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/private/write_concern.hh
+++ b/src/mongocxx/private/write_concern.hh
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <mongocxx/private/libmongoc.hh>
 #include <mongocxx/write_concern.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/read_concern.cpp
+++ b/src/mongocxx/read_concern.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/read_concern.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/stdx/make_unique.hpp>
@@ -21,8 +21,7 @@
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/private/libmongoc.hh>
 #include <mongocxx/private/read_concern.hh>
-
-#include <mongocxx/config/private/prelude.hh>
+#include <mongocxx/read_concern.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/read_concern.hpp
+++ b/src/mongocxx/read_concern.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <memory>
 
 #include <bsoncxx/document/value.hpp>
@@ -21,8 +23,6 @@
 #include <bsoncxx/stdx/string_view.hpp>
 #include <mongocxx/options/transaction.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/read_preference.cpp
+++ b/src/mongocxx/read_preference.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/read_preference.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <mongocxx/exception/error_code.hpp>
@@ -21,8 +21,7 @@
 #include <mongocxx/private/libbson.hh>
 #include <mongocxx/private/libmongoc.hh>
 #include <mongocxx/private/read_preference.hh>
-
-#include <mongocxx/config/private/prelude.hh>
+#include <mongocxx/read_preference.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/read_preference.hpp
+++ b/src/mongocxx/read_preference.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <chrono>
 #include <cstdint>
 #include <memory>
@@ -23,8 +25,6 @@
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/options/transaction.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/bulk_write.cpp
+++ b/src/mongocxx/result/bulk_write.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/result/bulk_write.hpp>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/result/bulk_write.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/bulk_write.hpp
+++ b/src/mongocxx/result/bulk_write.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <cstdint>
 #include <map>
 #include <vector>
@@ -21,8 +23,6 @@
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/types.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/delete.cpp
+++ b/src/mongocxx/result/delete.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/result/delete.hpp>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/result/delete.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/delete.hpp
+++ b/src/mongocxx/result/delete.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <cstdint>
 
 #include <mongocxx/result/bulk_write.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/gridfs/upload.cpp
+++ b/src/mongocxx/result/gridfs/upload.cpp
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/result/gridfs/upload.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/builder/basic/array.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
+#include <mongocxx/result/gridfs/upload.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/gridfs/upload.hpp
+++ b/src/mongocxx/result/gridfs/upload.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/insert_many.cpp
+++ b/src/mongocxx/result/insert_many.cpp
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/result/insert_many.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/types/bson_value/view.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
+#include <mongocxx/result/insert_many.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/insert_many.hpp
+++ b/src/mongocxx/result/insert_many.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <cstdint>
 #include <map>
 
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/types.hpp>
 #include <mongocxx/result/bulk_write.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/insert_one.cpp
+++ b/src/mongocxx/result/insert_one.cpp
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/result/insert_one.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/builder/basic/array.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
+#include <mongocxx/result/insert_one.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/insert_one.hpp
+++ b/src/mongocxx/result/insert_one.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
 #include <mongocxx/result/bulk_write.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/replace_one.cpp
+++ b/src/mongocxx/result/replace_one.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/result/replace_one.hpp>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/result/replace_one.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/replace_one.hpp
+++ b/src/mongocxx/result/replace_one.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <cstdint>
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types.hpp>
 #include <mongocxx/result/bulk_write.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/update.cpp
+++ b/src/mongocxx/result/update.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/result/update.hpp>
-
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/result/update.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/result/update.hpp
+++ b/src/mongocxx/result/update.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <cstdint>
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types.hpp>
 #include <mongocxx/result/bulk_write.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/test/bulk_write.cpp
+++ b/src/mongocxx/test/bulk_write.cpp
@@ -46,7 +46,6 @@ TEST_CASE("a bulk_write will setup a mongoc bulk operation", "[bulk_write]") {
             /* if no "ordered" field is passed, libmongoc defaults to true. */
             ordered_value = true;
         }
-
     });
 
     SECTION("with an ordered bulk write") {

--- a/src/mongocxx/test/change_streams.cpp
+++ b/src/mongocxx/test/change_streams.cpp
@@ -26,7 +26,6 @@
 #include <mongocxx/private/libbson.hh>
 #include <mongocxx/test_util/client_helpers.hh>
 #include <mongocxx/write_concern.hpp>
-
 #include <third_party/catch/include/helpers.hpp>
 
 namespace {
@@ -325,14 +324,15 @@ TEST_CASE("Mock streams and error-handling") {
             REQUIRE(opts["resumeAfter"].get_document().view() == resume_after);
         };
 
-        collection_watch->interpose([&](
-            const mongoc_collection_t* coll, const bson_t* pipeline, const bson_t* opts) {
-            std::string name = mongoc_collection_get_name(const_cast<mongoc_collection_t*>(coll));
-            REQUIRE(name == "collection");
-            check_pipeline_and_opts(pipeline, opts);
-            collection_watch_called = true;
-            return nullptr;
-        });
+        collection_watch->interpose(
+            [&](const mongoc_collection_t* coll, const bson_t* pipeline, const bson_t* opts) {
+                std::string name =
+                    mongoc_collection_get_name(const_cast<mongoc_collection_t*>(coll));
+                REQUIRE(name == "collection");
+                check_pipeline_and_opts(pipeline, opts);
+                collection_watch_called = true;
+                return nullptr;
+            });
 
         database_watch->interpose(
             [&](const mongoc_database_t* db, const bson_t* pipeline, const bson_t* opts) {
@@ -756,4 +756,4 @@ TEST_CASE("Watch a Collection", "[min36]") {
     }
 }
 
-}  // namepsace
+}  // namespace

--- a/src/mongocxx/test/client.cpp
+++ b/src/mongocxx/test/client.cpp
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "helpers.hpp"
-
 #include <mongocxx/config/private/prelude.hh>
 
+#include "helpers.hpp"
 #include <bsoncxx/string/to_string.hpp>
 #include <bsoncxx/test_util/catch.hh>
 #include <mongocxx/client.hpp>
@@ -73,9 +72,9 @@ TEST_CASE("A client lists its databases with a filter applied", "[client]") {
 }
 
 TEST_CASE("list databases passes authorizedDatabases option", "[client]") {
+    using bsoncxx::to_json;
     using bsoncxx::builder::basic::kvp;
     using bsoncxx::builder::basic::make_document;
-    using bsoncxx::to_json;
 
     MOCK_CLIENT
 

--- a/src/mongocxx/test/client_session.cpp
+++ b/src/mongocxx/test/client_session.cpp
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <sstream>
-
 #include <helpers.hpp>
+#include <sstream>
 
 #include <bsoncxx/private/helpers.hh>
 #include <bsoncxx/stdx/make_unique.hpp>
@@ -29,9 +28,9 @@
 
 namespace {
 using bsoncxx::from_json;
-using bsoncxx::document::value;
 using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_document;
+using bsoncxx::document::value;
 using bsoncxx::types::b_timestamp;
 
 using namespace mongocxx;

--- a/src/mongocxx/test/client_side_encryption.cpp
+++ b/src/mongocxx/test/client_side_encryption.cpp
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <helpers.hpp>
-
 #include <fstream>
+#include <helpers.hpp>
 #include <sstream>
 #include <string>
 
@@ -56,16 +55,16 @@ const auto kAwsKeyUUID = "\x01\x64\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x
 
 using bsoncxx::builder::concatenate;
 
-using bsoncxx::builder::basic::make_document;
 using bsoncxx::builder::basic::kvp;
+using bsoncxx::builder::basic::make_document;
 
 using bsoncxx::builder::basic::sub_document;
-using bsoncxx::builder::stream::document;
-using bsoncxx::builder::stream::open_array;
 using bsoncxx::builder::stream::close_array;
-using bsoncxx::builder::stream::open_document;
 using bsoncxx::builder::stream::close_document;
+using bsoncxx::builder::stream::document;
 using bsoncxx::builder::stream::finalize;
+using bsoncxx::builder::stream::open_array;
+using bsoncxx::builder::stream::open_document;
 
 using bsoncxx::types::bson_value::make_value;
 
@@ -341,7 +340,6 @@ TEST_CASE("Datakey and double encryption", "[client_side_encryption]") {
             options::data_key data_key_opts;
             data_key_opts.key_alt_names({"local_altname"});
             return client_encryption.create_data_key("local", data_key_opts);
-
         },
         "local",
         &setup_client,
@@ -364,7 +362,6 @@ TEST_CASE("Datakey and double encryption", "[client_side_encryption]") {
             data_key_opts.master_key(doc.view());
 
             return client_encryption.create_data_key("aws", data_key_opts);
-
         },
         "aws",
         &setup_client,
@@ -882,9 +879,8 @@ void _run_corpus_test(bool use_schema_map) {
 
                     corpus_copied_builder.append(kvp(field_name, std::move(new_field)));
                 } catch (const std::exception& e) {
-                    FAIL("caught an exception for encrypting an allowed field " << field_name
-                                                                                << ": "
-                                                                                << e.what());
+                    FAIL("caught an exception for encrypting an allowed field "
+                         << field_name << ": " << e.what());
                 }
             } else {
                 REQUIRE_THROWS(client_encryption.encrypt(to_encrypt, std::move(encrypt_opts)));

--- a/src/mongocxx/test/collection_mocked.cpp
+++ b/src/mongocxx/test/collection_mocked.cpp
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "helpers.hpp"
-
 #include <chrono>
 #include <string>
 
+#include "helpers.hpp"
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/document/element.hpp>
 #include <bsoncxx/json.hpp>
@@ -76,14 +75,15 @@ TEST_CASE("Collection", "[collection]") {
         read_concern rc{};
         rc.acknowledge_level(read_concern::level::k_majority);
 
-        collection_set_read_concern->interpose([&collection_set_rc_called](
-            ::mongoc_collection_t*, const ::mongoc_read_concern_t* rc_t) {
-            REQUIRE(rc_t);
-            const auto result = libmongoc::read_concern_get_level(rc_t);
-            REQUIRE(result);
-            REQUIRE(strcmp(result, "majority") == 0);
-            collection_set_rc_called = true;
-        });
+        collection_set_read_concern->interpose(
+            [&collection_set_rc_called](::mongoc_collection_t*,
+                                        const ::mongoc_read_concern_t* rc_t) {
+                REQUIRE(rc_t);
+                const auto result = libmongoc::read_concern_get_level(rc_t);
+                REQUIRE(result);
+                REQUIRE(strcmp(result, "majority") == 0);
+                collection_set_rc_called = true;
+            });
 
         mongo_coll.read_concern(rc);
         REQUIRE(collection_set_rc_called);
@@ -861,8 +861,10 @@ TEST_CASE("Collection", "[collection]") {
 
         SECTION("Delete One", "[collection::delete_one]") {
             expected_order_setting = true;
-            bulk_operation_remove_one_with_opts->interpose([&](
-                mongoc_bulk_operation_t*, const bson_t* doc, const bson_t* options, bson_error_t*) {
+            bulk_operation_remove_one_with_opts->interpose([&](mongoc_bulk_operation_t*,
+                                                               const bson_t* doc,
+                                                               const bson_t* options,
+                                                               bson_error_t*) {
                 bulk_operation_op_called = true;
                 REQUIRE(bson_get_data(doc) == filter_doc.view().data());
 
@@ -904,8 +906,10 @@ TEST_CASE("Collection", "[collection]") {
 
         SECTION("Delete Many", "[collection::delete_many]") {
             expected_order_setting = true;
-            bulk_operation_remove_many_with_opts->interpose([&](
-                mongoc_bulk_operation_t*, const bson_t* doc, const bson_t* options, bson_error_t*) {
+            bulk_operation_remove_many_with_opts->interpose([&](mongoc_bulk_operation_t*,
+                                                                const bson_t* doc,
+                                                                const bson_t* options,
+                                                                bson_error_t*) {
                 bulk_operation_op_called = true;
                 REQUIRE(bson_get_data(doc) == filter_doc.view().data());
 

--- a/src/mongocxx/test/database.cpp
+++ b/src/mongocxx/test/database.cpp
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "helpers.hpp"
-
 #include <set>
 
+#include "helpers.hpp"
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/string/to_string.hpp>
 #include <bsoncxx/test_util/catch.hh>

--- a/src/mongocxx/test/gridfs/bucket.cpp
+++ b/src/mongocxx/test/gridfs/bucket.cpp
@@ -13,6 +13,15 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <functional>
+#include <numeric>
+#include <sstream>
+#include <vector>
+
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/document/value.hpp>
@@ -20,11 +29,6 @@
 #include <bsoncxx/test_util/catch.hh>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
-#include <chrono>
-#include <cstdint>
-#include <cstdlib>
-#include <fstream>
-#include <functional>
 #include <mongocxx/client.hpp>
 #include <mongocxx/database.hpp>
 #include <mongocxx/exception/gridfs_exception.hpp>
@@ -35,9 +39,6 @@
 #include <mongocxx/options/gridfs/upload.hpp>
 #include <mongocxx/options/index.hpp>
 #include <mongocxx/uri.hpp>
-#include <numeric>
-#include <sstream>
-#include <vector>
 
 namespace {
 using namespace mongocxx;
@@ -648,7 +649,6 @@ TEST_CASE("mongocxx::gridfs::uploader::write with arbitrary sizes", "[gridfs::up
     std::int32_t write_size;
 
     auto run_test = [&]() {
-
         std::vector<std::uint8_t> bytes;
 
         // Populate the vector with arbitrary values.

--- a/src/mongocxx/test/hint.cpp
+++ b/src/mongocxx/test/hint.cpp
@@ -24,9 +24,9 @@ namespace {
 using namespace mongocxx;
 using namespace bsoncxx;
 
+using bsoncxx::builder::concatenate;
 using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_document;
-using bsoncxx::builder::concatenate;
 
 TEST_CASE("Hint", "[hint]") {
     instance::current();

--- a/src/mongocxx/test/index_view.cpp
+++ b/src/mongocxx/test/index_view.cpp
@@ -28,8 +28,8 @@
 #include <mongocxx/test_util/client_helpers.hh>
 
 namespace {
-using bsoncxx::builder::basic::make_document;
 using bsoncxx::builder::basic::kvp;
+using bsoncxx::builder::basic::make_document;
 using namespace mongocxx;
 
 bool test_commands_enabled(const client& conn) {
@@ -465,4 +465,4 @@ TEST_CASE("index creation and deletion with different collation") {
         db.drop();
     }
 }
-}
+}  // namespace

--- a/src/mongocxx/test/model/delete_many.cpp
+++ b/src/mongocxx/test/model/delete_many.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "helpers.hpp"
-
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/test_util/catch.hh>
 #include <mongocxx/instance.hpp>

--- a/src/mongocxx/test/model/delete_one.cpp
+++ b/src/mongocxx/test/model/delete_one.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "helpers.hpp"
-
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/test_util/catch.hh>
 #include <mongocxx/instance.hpp>

--- a/src/mongocxx/test/model/replace_one.cpp
+++ b/src/mongocxx/test/model/replace_one.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "helpers.hpp"
-
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/test_util/catch.hh>
 #include <mongocxx/instance.hpp>

--- a/src/mongocxx/test/model/update_many.cpp
+++ b/src/mongocxx/test/model/update_many.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "helpers.hpp"
-
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/test_util/catch.hh>

--- a/src/mongocxx/test/model/update_one.cpp
+++ b/src/mongocxx/test/model/update_one.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "helpers.hpp"
-
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/test_util/catch.hh>

--- a/src/mongocxx/test/options/aggregate.cpp
+++ b/src/mongocxx/test/options/aggregate.cpp
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "helpers.hpp"
-
 #include <chrono>
 
+#include "helpers.hpp"
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/test_util/catch.hh>

--- a/src/mongocxx/test/options/bulk_write.cpp
+++ b/src/mongocxx/test/options/bulk_write.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "helpers.hpp"
-
 #include <bsoncxx/test_util/catch.hh>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/bulk_write.hpp>

--- a/src/mongocxx/test/options/count.cpp
+++ b/src/mongocxx/test/options/count.cpp
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "helpers.hpp"
-
 #include <chrono>
 
+#include "helpers.hpp"
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/test_util/catch.hh>
 #include <mongocxx/instance.hpp>

--- a/src/mongocxx/test/options/create_collection.cpp
+++ b/src/mongocxx/test/options/create_collection.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "helpers.hpp"
-
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/private/suppress_deprecation_warnings.hh>

--- a/src/mongocxx/test/options/delete.cpp
+++ b/src/mongocxx/test/options/delete.cpp
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "helpers.hpp"
-
 #include <chrono>
 
+#include "helpers.hpp"
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/test_util/catch.hh>
 #include <mongocxx/instance.hpp>

--- a/src/mongocxx/test/options/distinct.cpp
+++ b/src/mongocxx/test/options/distinct.cpp
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "helpers.hpp"
-
 #include <chrono>
 
+#include "helpers.hpp"
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/test_util/catch.hh>
 #include <mongocxx/instance.hpp>

--- a/src/mongocxx/test/options/find.cpp
+++ b/src/mongocxx/test/options/find.cpp
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "helpers.hpp"
-
 #include <chrono>
 
+#include "helpers.hpp"
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/test_util/catch.hh>
 #include <mongocxx/instance.hpp>

--- a/src/mongocxx/test/options/find_one_and_delete.cpp
+++ b/src/mongocxx/test/options/find_one_and_delete.cpp
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "helpers.hpp"
-
 #include <chrono>
 
+#include "helpers.hpp"
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/test_util/catch.hh>
 #include <mongocxx/instance.hpp>

--- a/src/mongocxx/test/options/find_one_and_replace.cpp
+++ b/src/mongocxx/test/options/find_one_and_replace.cpp
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "helpers.hpp"
-
 #include <chrono>
 
+#include "helpers.hpp"
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/test_util/catch.hh>
 #include <mongocxx/instance.hpp>

--- a/src/mongocxx/test/options/find_one_and_update.cpp
+++ b/src/mongocxx/test/options/find_one_and_update.cpp
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "helpers.hpp"
-
 #include <chrono>
 
+#include "helpers.hpp"
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/test_util/catch.hh>

--- a/src/mongocxx/test/options/gridfs/bucket.cpp
+++ b/src/mongocxx/test/options/gridfs/bucket.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "helpers.hpp"
-
 #include <bsoncxx/test_util/catch.hh>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/gridfs/bucket.hpp>

--- a/src/mongocxx/test/options/gridfs/upload.cpp
+++ b/src/mongocxx/test/options/gridfs/upload.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "helpers.hpp"
-
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/test_util/catch.hh>

--- a/src/mongocxx/test/options/index.cpp
+++ b/src/mongocxx/test/options/index.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "helpers.hpp"
-
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/test_util/catch.hh>

--- a/src/mongocxx/test/options/insert.cpp
+++ b/src/mongocxx/test/options/insert.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "helpers.hpp"
-
 #include <bsoncxx/test_util/catch.hh>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/insert.hpp>

--- a/src/mongocxx/test/options/replace.cpp
+++ b/src/mongocxx/test/options/replace.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "helpers.hpp"
-
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/test_util/catch.hh>
 #include <mongocxx/instance.hpp>

--- a/src/mongocxx/test/options/update.cpp
+++ b/src/mongocxx/test/options/update.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "helpers.hpp"
-
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/test_util/catch.hh>
 #include <mongocxx/instance.hpp>

--- a/src/mongocxx/test/pool.cpp
+++ b/src/mongocxx/test/pool.cpp
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "helpers.hpp"
+#include <mongocxx/config/private/prelude.hh>
 
 #include <cstddef>
 #include <string>
 
-#include <mongocxx/config/private/prelude.hh>
-
+#include "helpers.hpp"
 #include <bsoncxx/test_util/catch.hh>
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>

--- a/src/mongocxx/test/read_preference.cpp
+++ b/src/mongocxx/test/read_preference.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "helpers.hpp"
-
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/test_util/catch.hh>

--- a/src/mongocxx/test/result/bulk_write.cpp
+++ b/src/mongocxx/test/result/bulk_write.cpp
@@ -23,8 +23,8 @@ namespace {
 using namespace bsoncxx;
 
 using bsoncxx::builder::basic::kvp;
-using bsoncxx::builder::basic::make_document;
 using bsoncxx::builder::basic::make_array;
+using bsoncxx::builder::basic::make_document;
 
 TEST_CASE("bulk_write result", "[bulk_write][result]") {
     mongocxx::instance::current();
@@ -83,4 +83,4 @@ TEST_CASE("bulk_write result inequals", "[bulk_write][result]") {
 
     REQUIRE(bw1 != bw2);
 }
-}
+}  // namespace

--- a/src/mongocxx/test/result/delete.cpp
+++ b/src/mongocxx/test/result/delete.cpp
@@ -20,8 +20,8 @@
 
 namespace {
 
-using bsoncxx::builder::basic::make_document;
 using bsoncxx::builder::basic::kvp;
+using bsoncxx::builder::basic::make_document;
 
 TEST_CASE("delete", "[delete][result]") {
     mongocxx::instance::current();

--- a/src/mongocxx/test/result/replace_one.cpp
+++ b/src/mongocxx/test/result/replace_one.cpp
@@ -18,8 +18,8 @@
 #include <mongocxx/result/replace_one.hpp>
 
 namespace {
-using bsoncxx::builder::basic::make_document;
 using bsoncxx::builder::basic::kvp;
+using bsoncxx::builder::basic::make_document;
 
 TEST_CASE("replace_one", "[replace_one][result]") {
     mongocxx::instance::current();

--- a/src/mongocxx/test/result/update.cpp
+++ b/src/mongocxx/test/result/update.cpp
@@ -18,8 +18,8 @@
 #include <mongocxx/result/update.hpp>
 
 namespace {
-using bsoncxx::builder::basic::make_document;
 using bsoncxx::builder::basic::kvp;
+using bsoncxx::builder::basic::make_document;
 
 TEST_CASE("update", "[update][result]") {
     mongocxx::instance::current();

--- a/src/mongocxx/test/sdam-monitoring.cpp
+++ b/src/mongocxx/test/sdam-monitoring.cpp
@@ -27,10 +27,10 @@
 
 namespace {
 using namespace mongocxx;
-using bsoncxx::string::to_string;
+using bsoncxx::oid;
 using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_document;
-using bsoncxx::oid;
+using bsoncxx::string::to_string;
 
 void open_and_close_client(const uri& test_uri, const options::apm& apm_opts) {
     // Apply listeners and trigger connection.

--- a/src/mongocxx/test/spec/gridfs.cpp
+++ b/src/mongocxx/test/spec/gridfs.cpp
@@ -404,9 +404,9 @@ void initialize_collections(database db, document::view data) {
     REQUIRE(data["files"]);
     REQUIRE(data["chunks"]);
 
-    auto sanitize = [](
-        test_util::item_t pair,
-        builder::basic::array* context) -> bsoncxx::stdx::optional<test_util::item_t> {
+    auto sanitize =
+        [](test_util::item_t pair,
+           builder::basic::array* context) -> bsoncxx::stdx::optional<test_util::item_t> {
         auto new_pair = transform_hex(pair, context);
 
         if (!new_pair) {

--- a/src/mongocxx/test/spec/monitoring.cpp
+++ b/src/mongocxx/test/spec/monitoring.cpp
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/json.hpp>
+#include <mongocxx/config/private/prelude.hh>
+
 #include <iostream>
 
 #include <bsoncxx/builder/basic/document.hpp>
+#include <bsoncxx/json.hpp>
 #include <mongocxx/test/spec/monitoring.hh>
 #include <mongocxx/test_util/client_helpers.hh>
 #include <third_party/catch/include/catch.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/test/spec/monitoring.hh
+++ b/src/mongocxx/test/spec/monitoring.hh
@@ -14,8 +14,9 @@
 
 #pragma once
 
-#include <mongocxx/client.hpp>
 #include <mongocxx/config/private/prelude.hh>
+
+#include <mongocxx/client.hpp>
 #include <mongocxx/test_util/client_helpers.hh>
 
 namespace mongocxx {

--- a/src/mongocxx/test/spec/operation.cpp
+++ b/src/mongocxx/test/spec/operation.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/test/spec/operation.hh>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <functional>
 #include <vector>
@@ -42,8 +42,7 @@
 #include <mongocxx/result/insert_one.hpp>
 #include <mongocxx/result/replace_one.hpp>
 #include <mongocxx/result/update.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
+#include <mongocxx/test/spec/operation.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/test/spec/operation.hh
+++ b/src/mongocxx/test/spec/operation.hh
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <map>
 #include <string>
 
@@ -22,8 +24,6 @@
 #include <mongocxx/client_session.hpp>
 #include <mongocxx/pipeline.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/test/spec/util.hh
+++ b/src/mongocxx/test/spec/util.hh
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <functional>
 #include <set>
 
@@ -21,8 +23,6 @@
 #include <mongocxx/client.hpp>
 #include <mongocxx/test/spec/operation.hh>
 #include <mongocxx/uri.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/test/transactions.cpp
+++ b/src/mongocxx/test/transactions.cpp
@@ -43,7 +43,8 @@ TEST_CASE("Transaction tests", "[transactions]") {
 
     // The test run in first 3 SECTIONs below
     auto successful_insert_test = [&mongodb_client](
-        client_session session, stdx::optional<options::transaction> transaction_opts) {
+                                      client_session session,
+                                      stdx::optional<options::transaction> transaction_opts) {
         auto db = mongodb_client["test"];
         auto coll = db["txn_test"];
 

--- a/src/mongocxx/test/validation_criteria.cpp
+++ b/src/mongocxx/test/validation_criteria.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "helpers.hpp"
-
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/document/element.hpp>
 #include <bsoncxx/string/to_string.hpp>

--- a/src/mongocxx/test_util/client_helpers.cpp
+++ b/src/mongocxx/test_util/client_helpers.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/test_util/client_helpers.hh>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <algorithm>
 #include <fstream>
@@ -36,9 +36,8 @@
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/exception/operation_exception.hpp>
 #include <mongocxx/private/libmongoc.hh>
+#include <mongocxx/test_util/client_helpers.hh>
 #include <third_party/catch/include/catch.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/test_util/client_helpers.hh
+++ b/src/mongocxx/test_util/client_helpers.hh
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <cstdint>
 #include <functional>
 #include <string>
@@ -27,10 +29,8 @@
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
-#include <mongocxx/stdx.hpp>
-
 #include <mongocxx/collection.hpp>
-#include <mongocxx/config/private/prelude.hh>
+#include <mongocxx/stdx.hpp>
 #include <third_party/catch/include/catch.hpp>
 
 namespace mongocxx {

--- a/src/mongocxx/test_util/mock.hh
+++ b/src/mongocxx/test_util/mock.hh
@@ -24,10 +24,9 @@
 #include <mutex>
 #include <stack>
 #include <thread>
-#include <vector>
-
 #include <type_traits>
 #include <unordered_map>
+#include <vector>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/test_util/mock.hh
+++ b/src/mongocxx/test_util/mock.hh
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/private/prelude.hh>
+
 #include <array>
 #include <cassert>
 #include <functional>
@@ -22,11 +24,10 @@
 #include <mutex>
 #include <stack>
 #include <thread>
-#include <type_traits>
-#include <unordered_map>
 #include <vector>
 
-#include <mongocxx/config/private/prelude.hh>
+#include <type_traits>
+#include <unordered_map>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/uri.cpp
+++ b/src/mongocxx/uri.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/uri.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/types.hpp>
@@ -23,8 +23,7 @@
 #include <mongocxx/private/read_preference.hh>
 #include <mongocxx/private/uri.hh>
 #include <mongocxx/private/write_concern.hh>
-
-#include <mongocxx/config/private/prelude.hh>
+#include <mongocxx/uri.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/uri.hpp
+++ b/src/mongocxx/uri.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -23,8 +25,6 @@
 #include <mongocxx/read_concern.hpp>
 #include <mongocxx/read_preference.hpp>
 #include <mongocxx/write_concern.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/validation_criteria.cpp
+++ b/src/mongocxx/validation_criteria.cpp
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/validation_criteria.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/builder/basic/document.hpp>
-
-#include <mongocxx/config/private/prelude.hh>
+#include <mongocxx/validation_criteria.hpp>
 
 namespace {
 

--- a/src/mongocxx/validation_criteria.hpp
+++ b/src/mongocxx/validation_criteria.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN

--- a/src/mongocxx/write_concern.cpp
+++ b/src/mongocxx/write_concern.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/write_concern.hpp>
+#include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/stdx/make_unique.hpp>
@@ -22,8 +22,7 @@
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/private/libmongoc.hh>
 #include <mongocxx/private/write_concern.hh>
-
-#include <mongocxx/config/private/prelude.hh>
+#include <mongocxx/write_concern.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
@@ -153,8 +152,8 @@ bool write_concern::is_acknowledged() const {
 }
 
 bsoncxx::document::value write_concern::to_document() const {
-    using bsoncxx::builder::basic::make_document;
     using bsoncxx::builder::basic::kvp;
+    using bsoncxx::builder::basic::make_document;
 
     bsoncxx::builder::basic::document doc;
 

--- a/src/mongocxx/write_concern.hpp
+++ b/src/mongocxx/write_concern.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/config/prelude.hpp>
+
 #include <chrono>
 #include <cstdint>
 #include <memory>
@@ -24,8 +26,6 @@
 #include <bsoncxx/stdx/string_view.hpp>
 #include <mongocxx/options/transaction.hpp>
 #include <mongocxx/stdx.hpp>
-
-#include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN


### PR DESCRIPTION
This updates the version of clang-format used by clang_format.py from 3.8 to 7.0.1 (the same version as the server) and corrects include directives according to our contribution guidelines ([here](http://mongocxx.org/contributing/)). 

7.0 has the `IncludeBlocks` key which separates sections of includes into blocks as required.