### PR TITLE
Fix python on Ubuntu 18.04 hosts

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -284,7 +284,12 @@ functions:
                   fi
                   export CMAKE=${cmake}
 
-                  python -m virtualenv venv
+                  if [ -f /opt/mongodbtoolchain/v3/bin/python3 ]; then
+                      /opt/mongodbtoolchain/v3/bin/python3 -m venv venv
+                  else
+                      python -m virtualenv venv
+                  fi
+
                   cd venv
                   if [ -f bin/activate ]; then
                       . bin/activate

--- a/.mci.yml
+++ b/.mci.yml
@@ -284,10 +284,8 @@ functions:
                   fi
                   export CMAKE=${cmake}
 
-                  if [ -f /opt/mongodbtoolchain/v3/bin/python3 ]; then
+                  if ! python -m virtualenv venv 2>/dev/null; then
                       /opt/mongodbtoolchain/v3/bin/python3 -m venv venv
-                  else
-                      python -m virtualenv venv
                   fi
 
                   cd venv


### PR DESCRIPTION
`python -m virtualenv venv` stopped working because `virtualenv` is no longer installed on Ubuntu 18.04 hosts. I think this is related to MONGOCRYPT-297.

This changes to use the version of python available in the MongoDB toolchain on hosts that have it (which should be hosts aside from Windows).