### PR TITLE
add std/any.hpp

### DIFF
--- a/src/bsoncxx/CMakeLists.txt
+++ b/src/bsoncxx/CMakeLists.txt
@@ -281,6 +281,7 @@ set_local_dist (src_bsoncxx_DIST_local
    private/libbson.hh
    private/stack.hh
    private/suppress_deprecation_warnings.hh
+   stdx/any.hpp
    stdx/make_unique.hpp
    stdx/optional.hpp
    stdx/string_view.hpp

--- a/src/bsoncxx/stdx/any.hpp
+++ b/src/bsoncxx/stdx/any.hpp
@@ -1,0 +1,90 @@
+// Copyright 2020 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/config/prelude.hpp>
+
+#if defined(BSONCXX_POLY_USE_MNMLSTC)
+
+#if defined(MONGO_CXX_DRIVER_COMPILING) || defined(BSONCXX_POLY_USE_SYSTEM_MNMLSTC)
+#include <core/any.hpp>
+#else
+#include <bsoncxx/third_party/mnmlstc/core/any.hpp>
+#endif
+
+namespace bsoncxx {
+BSONCXX_INLINE_NAMESPACE_BEGIN
+namespace stdx {
+
+using ::core::any;
+using ::core::any_cast;
+using ::core::bad_any_cast;
+
+}  // namespace stdx
+BSONCXX_INLINE_NAMESPACE_END
+}  // namespace bsoncxx
+
+#elif defined(BSONCXX_POLY_USE_BOOST)
+#include <boost/any.hpp>
+
+namespace bsoncxx {
+BSONCXX_INLINE_NAMESPACE_BEGIN
+namespace stdx {
+
+using ::boost::any;
+using ::boost::any_cast;
+using ::boost::bad_any_cast;
+
+}  // namespace stdx
+BSONCXX_INLINE_NAMESPACE_END
+}  // namespace bsoncxx
+
+#elif defined(BSONCXX_POLY_USE_STD_EXPERIMENTAL)
+
+#include <experimental/any>
+
+namespace bsoncxx {
+BSONCXX_INLINE_NAMESPACE_BEGIN
+namespace stdx {
+
+using ::std::experimental::any;
+using ::std::experimental::any_cast;
+using ::std::experimental::bad_any_cast;
+
+}  // namespace stdx
+BSONCXX_INLINE_NAMESPACE_END
+}  // namespace bsoncxx
+
+#elif defined(BSONCXX_POLY_USE_STD)
+
+#include <any>
+
+namespace bsoncxx {
+BSONCXX_INLINE_NAMESPACE_BEGIN
+namespace stdx {
+
+using ::std::any;
+using ::std::any_cast;
+using ::std::bad_any_cast;
+
+}  // namespace stdx
+BSONCXX_INLINE_NAMESPACE_END
+}  // namespace bsoncxx
+
+#else
+#error "Cannot find a valid polyfill for any"
+#endif
+
+#include <bsoncxx/config/postlude.hpp>


### PR DESCRIPTION
This adds [std::any](https://en.cppreference.com/w/cpp/utility/any) to our library. This type-safe, opaque structure will help create the [entity map](https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.rst#entity-map) in the unified-test-runner spec. For example:
```
std::map<std::string, mongocxx::client> entity_map; // Bad: cannot add other entity types, e.g., a database, to the map
...
std::map<std::string, std::any> entity_map; // Good: we can now retrieve a client, database or any other type like so
auto client = std::any_cast<mongocxx::client>(entity_map["my_client"]); // This will error if the std::any is not a client
auto db = std::any_cast<mongocxx::database>(entity_map["my_db"]);
```