### PR TITLE
remove raw pointers from operation class

### DIFF
--- a/src/mongocxx/test/spec/change_stream.cpp
+++ b/src/mongocxx/test/spec/change_stream.cpp
@@ -130,7 +130,8 @@ void run_change_stream_tests_in_file(const std::string& test_path) {
                 auto dbname = to_string(operation["database"].get_string().value);
                 auto collname = to_string(operation["collection"].get_string().value);
                 auto coll = global_client[dbname][collname];
-                operation_runner op_runner{&coll};
+                auto op_runner =
+                    operation_runner{}.set_collection(std::make_shared<collection>(coll));
                 op_runner.run(operation.get_document().value);
             }
 

--- a/src/mongocxx/test/spec/client_side_encryption.cpp
+++ b/src/mongocxx/test/spec/client_side_encryption.cpp
@@ -205,7 +205,9 @@ void run_encryption_tests_in_file(const std::string& test_path) {
             }
 
             run_operation_check_result(op.get_document().value, [&]() {
-                return operation_runner{&db, &test_coll};
+                return operation_runner{}
+                    .set_database(std::make_shared<database>(db))
+                    .set_collection(std::make_shared<collection>(test_coll));
             });
 
             if (check_results_logging) {

--- a/src/mongocxx/test/spec/command_monitoring.cpp
+++ b/src/mongocxx/test/spec/command_monitoring.cpp
@@ -166,7 +166,8 @@ void run_command_monitoring_tests_in_file(std::string test_path) {
 
         document::view operation = test["operation"].get_document().value;
         std::string operation_name = string::to_string(operation["name"].get_string().value);
-        spec::operation_runner op_runner{&coll};
+        auto op_runner =
+            spec::operation_runner{}.set_collection(std::make_shared<collection>(coll));
 
         try {
             op_runner.run(operation);

--- a/src/mongocxx/test/spec/operation.hh
+++ b/src/mongocxx/test/spec/operation.hh
@@ -39,23 +39,29 @@ bsoncxx::stdx::optional<read_preference> lookup_read_preference(document::view d
 
 class operation_runner {
    public:
-    explicit operation_runner(collection* coll);
-    operation_runner(database* db,
-                     collection* coll,
-                     client_session* session0 = nullptr,
-                     client_session* session1 = nullptr,
-                     client* client = nullptr);
+    explicit operation_runner() noexcept = default;
+
     document::value run(document::view operation);
 
-   private:
-    collection* _coll;
-    database* _db;
-    client_session* _session0;
-    client_session* _session1;
-    client* _client;
+    operation_runner& set_collection(std::shared_ptr<collection> coll);
 
-    client_session* _lookup_session(document::view doc);
-    client_session* _lookup_session(stdx::string_view key);
+    operation_runner& set_database(std::shared_ptr<database> db);
+
+    operation_runner& set_session0(std::shared_ptr<client_session> session0);
+
+    operation_runner& set_session1(std::shared_ptr<client_session> session1);
+
+    operation_runner& set_client(std::shared_ptr<client> client);
+
+   private:
+    std::shared_ptr<collection> _coll;
+    std::shared_ptr<database> _db;
+    std::shared_ptr<client_session> _session0;
+    std::shared_ptr<client_session> _session1;
+    std::shared_ptr<client> _client;
+
+    std::shared_ptr<client_session> _lookup_session(document::view doc);
+    std::shared_ptr<client_session> _lookup_session(stdx::string_view key);
     document::value _run_aggregate(document::view operation);
     document::value _run_count(document::view operation);
     document::value _run_distinct(document::view operation);


### PR DESCRIPTION
**Note to reviewers: it'd be easiest to start with `operation.hh`.**

This PR makes two changes to `operation.hh`:
1) replaces raw pointers to a client, database, etc. with a shared pointer
2) adds setters for a client, databases, etc.

I ran into both of these issues frequently while building the new test runner.

**Why change raw pointers to a shared pointer?**
`operation.hh` took a raw pointer to an object. We frequently passed the address of local variables to the operation class. This works until the local variable is destroyed at the end of its scope and leaves the operation class with a pointer to a destroyed value. For example:

```
operation_runner create_op_runner() {
    client client{uri{}};
    auto db = client["my_db"]; 
    return operation_runner{&db, nullptr}; // bad: 'db' will be destroyed at the end  of this function
}

void run_operation() {
   auto doc = make_document(); 
   auto op_runner = create_op_runner();
   op_runner.run(doc); // bad: refers to a destroyed database. Will segfault
}
```
The solution _could_ be to create a real pointer rather than use a local address, but this will require us to manually management that pointer's resources. A shared pointer does this for us.

**Why add setters to `operation.hh`?**
`operation.hh` had two constructors: one that took a collection and one that took five other objects. If you run an operation that only needs a database object, you will still have to pass `nullptr` in place of every other object. The solution to the common problem of having a constructor with a ton of optional arguments is the builder pattern. This is a simplified version of it.