### PR TITLE
cache test network calls

### DIFF
--- a/src/mongocxx/test_util/client_helpers.cpp
+++ b/src/mongocxx/test_util/client_helpers.cpp
@@ -58,7 +58,7 @@ document::value get_is_master(const client& client) {
 }
 
 document::value get_server_status(const client& client) {
-    static auto status = client["test"].run_command(make_document(kvp("serverStatus", 1)));
+    static auto status = client["admin"].run_command(make_document(kvp("serverStatus", 1)));
     return status;
 }
 }  // namespace

--- a/src/mongocxx/test_util/client_helpers.cpp
+++ b/src/mongocxx/test_util/client_helpers.cpp
@@ -50,6 +50,19 @@ using namespace bsoncxx;
 using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_document;
 
+namespace {
+// These frequently used network calls are cached to avoid bottlenecks during tests.
+document::value get_is_master(const client& client) {
+    static auto reply = client["admin"].run_command(make_document(kvp("isMaster", 1)));
+    return reply;
+}
+
+document::value get_server_status(const client& client) {
+    static auto status = client["test"].run_command(make_document(kvp("serverStatus", 1)));
+    return status;
+}
+}  // namespace
+
 std::vector<std::int32_t> parse_version(std::string version) {
     std::vector<std::int32_t> elements;
     std::stringstream ss{version};
@@ -181,7 +194,7 @@ std::basic_string<std::uint8_t> convert_hex_string_to_bytes(stdx::string_view he
 }
 
 std::int32_t get_max_wire_version(const client& client) {
-    auto reply = client["admin"].run_command(make_document(kvp("isMaster", 1)));
+    auto reply = get_is_master(client);
     auto max_wire_version = reply.view()["maxWireVersion"];
     if (!max_wire_version) {
         // If wire version is not available (i.e. server version too old), it is assumed to be
@@ -195,15 +208,12 @@ std::int32_t get_max_wire_version(const client& client) {
 }
 
 std::string get_server_version(const client& client) {
-    bsoncxx::builder::basic::document server_status{};
-    server_status.append(bsoncxx::builder::basic::kvp("serverStatus", 1));
-    bsoncxx::document::value output = client["test"].run_command(server_status.extract());
-
+    auto output = get_server_status(client);
     return bsoncxx::string::to_string(output.view()["version"].get_string().value);
 }
 
 std::string replica_set_name(const client& client) {
-    auto reply = client["admin"].run_command(make_document(kvp("isMaster", 1)));
+    auto reply = get_is_master(client);
     auto name = reply.view()["setName"];
     if (name) {
         return bsoncxx::string::to_string(name.get_string().value);
@@ -213,12 +223,12 @@ std::string replica_set_name(const client& client) {
 }
 
 bool is_replica_set(const client& client) {
-    auto reply = client["admin"].run_command(make_document(kvp("isMaster", 1)));
+    auto reply = get_is_master(client);
     return static_cast<bool>(reply.view()["setName"]);
 }
 
 std::string get_topology(const client& client) {
-    auto reply = client["admin"].run_command(make_document(kvp("isMaster", 1)));
+    auto reply = get_is_master(client);
     if (reply.view()["setName"]) {
         return "replicaset";
     } else if (reply.view()["msg"] &&
@@ -409,7 +419,7 @@ void check_outcome_collection(mongocxx::collection* coll, bsoncxx::document::vie
 }
 
 bool server_has_sessions(const client& conn) {
-    auto result = conn["admin"].run_command(make_document(kvp("isMaster", 1)));
+    auto result = get_is_master(conn);
     auto result_view = result.view();
 
     if (result_view["logicalSessionTimeoutMinutes"]) {


### PR DESCRIPTION
I realized we were making _a lot_ (hundreds) of **isMaster** and **serverStatus** calls to the server per spec test. Profiler results for transaction tests (see images below) show that currently, 16.70% of the time is spent in the function `should_skip_spec_tests`. That function makes multiple roundtrips to the server. After this change, only 2.26% of the time is spent in `should_skip_spec_tests`—a pretty big improvement. 

I also timed `test_transactions_spec` locally before and after caching server results. Here's the results:

```
Before optimization
n=10 | min    | Q1     | med    | mean   | Q3     | max    | std
wall | 28.30  | 28.44  | 28.63  | 28.70  | 28.88  | 29.60  | 0.3865
user | 0.6500 | 0.6550 | 0.6750 | 0.6770 | 0.6975 | 0.7100 | 0.0226
sys  | 0.110  | 0.120  | 0.140  | 0.138  | 0.150  | 0.170  | 0.0230
rss  | 13368  | 13408  | 13556  | 13564  | 13722  | 13740  | 159.2700

After optimization
n=10 | min   | Q1    | med   | mean  | Q3    | max   | std
wall | 27.66 | 27.70 | 27.89 | 28.03 | 28.13 | 28.84 | 0.4206
user | 0.500 | 0.520 | 0.520 | 0.524 | 0.530 | 0.550 | 0.0143
sys  | 0.080 | 0.090 | 0.100 | 0.098 | 0.100 | 0.120 | 0.0140
rss  | 13544 | 13635 | 13740 | 13735 | 13860 | 13908 | 136.2227
```
The transaction tests were run 10 times (n=10) using a script which called `time test_transactions_spec` on Linux and used a Rscript to calculate the mean, median, etc.

Profile results from CLion:
![before-optimization](https://user-images.githubusercontent.com/34226620/108432285-22937900-7212-11eb-84a0-c59342e8c2a1.png)
![after-optimization](https://user-images.githubusercontent.com/34226620/108432290-245d3c80-7212-11eb-92ec-74236b1c8f15.png)
