### PR TITLE
CXX-1871 create entities (db,coll,session,bucket)

### DIFF
--- a/src/mongocxx/test/spec/entity.cpp
+++ b/src/mongocxx/test/spec/entity.cpp
@@ -37,6 +37,13 @@ collection& map::get_collection(const key_type& key) {
     return e.get<1>();
 }
 
+void map::clear() noexcept {
+    // Clients must outlive the entities created from it.
+    // @see: https://isocpp.org/wiki/faq/dtors#order-dtors-for-members
+    _map.clear();
+    _client_map.clear();
+}
+
 }  // namespace entity
 MONGOCXX_INLINE_NAMESPACE_END
 }  // namespace mongocxx

--- a/src/mongocxx/test/spec/entity.cpp
+++ b/src/mongocxx/test/spec/entity.cpp
@@ -18,12 +18,23 @@ namespace mongocxx {
 MONGOCXX_INLINE_NAMESPACE_BEGIN
 namespace entity {
 
-void map::insert(const key_type& key, mongocxx::client&& client) {
-    _map[key] = std::move(client);
+bool map::insert(const key_type& key, client&& c) {
+    _client_map.emplace(key, std::move(c));
+    return _client_map.find(key) != std::end(_client_map);
 }
 
-bool map::contains(const key_type& key) const {
-    return _map.find(key) != std::end(_map);
+client& map::get_client(const key_type& key) {
+    return _client_map.at(key);
+}
+
+database& map::get_database(const key_type& key) {
+    auto& e = _map.at(key);
+    return e.get<0>();
+}
+
+collection& map::get_collection(const key_type& key) {
+    auto& e = _map.at(key);
+    return e.get<1>();
 }
 
 }  // namespace entity

--- a/src/mongocxx/test/spec/entity.hh
+++ b/src/mongocxx/test/spec/entity.hh
@@ -28,9 +28,8 @@ namespace entity {
 
 class map {
    public:
-    using key_type = mongocxx::stdx::string_view;
-    using mapped_type = bsoncxx::stdx::variant<mongocxx::client,
-                                               mongocxx::database,
+    using key_type = std::string;
+    using mapped_type = bsoncxx::stdx::variant<mongocxx::database,
                                                mongocxx::collection,
                                                mongocxx::client_session,
                                                mongocxx::gridfs::bucket>;
@@ -43,11 +42,28 @@ class map {
     map(map&&) = default;
     map& operator=(map&&) = default;
 
-    void insert(const key_type& key, mongocxx::client&& client);
+    ~map() = default;
 
-    bool contains(const key_type& key) const;
+    template <typename Entity>
+    bool insert(const key_type& key, Entity&& e) {
+        _map.emplace(key, std::forward<Entity>(e));
+        return _map.find(key) != std::end(_map);
+    }
+
+    bool insert(const key_type& key, client&& c);
+
+    client& get_client(const key_type& key);
+    database& get_database(const key_type& key);
+    collection& get_collection(const key_type& key);
 
    private:
+    // Objects are destroyed in reverse order of their appearance in the class definition. Since the
+    // client must outlive the objects created from it, the client objects are held in a separate
+    // map and declared first.
+    //
+    // @see: http://mongoc.org/libmongoc/current/lifecycle.html#object-lifecycle
+    // @see: https://isocpp.org/wiki/faq/dtors#order-dtors-for-members
+    std::unordered_map<key_type, client> _client_map;
     std::unordered_map<key_type, mapped_type> _map;
 };
 }  // namespace entity

--- a/src/mongocxx/test/spec/entity.hh
+++ b/src/mongocxx/test/spec/entity.hh
@@ -46,8 +46,9 @@ class map {
 
     template <typename Entity>
     bool insert(const key_type& key, Entity&& e) {
-        _map.emplace(key, std::forward<Entity>(e));
-        return _map.find(key) != std::end(_map);
+        bool result{};
+        std::tie(std::ignore, result) = _map.emplace(key, std::forward<Entity>(e));
+        return result;
     }
 
     bool insert(const key_type& key, client&& c);
@@ -55,6 +56,8 @@ class map {
     client& get_client(const key_type& key);
     database& get_database(const key_type& key);
     collection& get_collection(const key_type& key);
+
+    void clear() noexcept;
 
    private:
     // Objects are destroyed in reverse order of their appearance in the class definition. Since the

--- a/src/mongocxx/test/spec/unified_test_format.cpp
+++ b/src/mongocxx/test/spec/unified_test_format.cpp
@@ -277,7 +277,7 @@ options::gridfs::bucket get_bucket_options(document::view object) {
         opts.bucket_name(name.get_string().value.to_string());
     if (auto size = object["bucketOptions"]["chunkSizeBytes"])
         opts.chunk_size_bytes(size.get_int32().value);
-    REQUIRE_FALSE(/* TODO */ object["bucketOptions"]["disableMD5"]);
+    REQUIRE_FALSE(object["bucketOptions"]["disableMD5"]);
 
     return opts;
 }

--- a/src/mongocxx/test/spec/unified_test_format.cpp
+++ b/src/mongocxx/test/spec/unified_test_format.cpp
@@ -388,6 +388,7 @@ void create_entities(const document::view test) {
     if (!test["createEntities"])
         return;
 
+    get_entity_map().clear();
     auto entities = test["createEntities"].get_array().value;
     REQUIRE(std::all_of(std::begin(entities), std::end(entities), add_to_map));
 }


### PR DESCRIPTION
This PR adds the logic for creating the rest of the entities. The only entities left are change streams which should should be done with operations. 

Note: the entity map keeps clients and other entities separate since the client must outlive all entities created from it. I left a comment above the member variables in "entity.hh" with more details.