### PR TITLE
CXX-1248 Document disabling extra alignment on windows

### DIFF
--- a/docs/content/mongocxx-v3/installation/windows.md
+++ b/docs/content/mongocxx-v3/installation/windows.md
@@ -33,6 +33,9 @@ or newer. The MongoDB C Driver supports TLS 1.1 on Linux if OpenSSL is
 at least version 1.0.1. On macOS and Windows, the C Driver uses native
 TLS implementations that support TLS 1.1.
 
+If you are compiling on Windows, you should also use the
+`--DENABLE_EXTRA_ALIGNMENT` cmake flag when configuring the C driver.
+
 ### Step 2: Choose a C++17 polyfill
 
 The mongocxx driver uses the C++17 features `std::optional` and

--- a/docs/content/mongocxx-v3/installation/windows.md
+++ b/docs/content/mongocxx-v3/installation/windows.md
@@ -33,8 +33,8 @@ or newer. The MongoDB C Driver supports TLS 1.1 on Linux if OpenSSL is
 at least version 1.0.1. On macOS and Windows, the C Driver uses native
 TLS implementations that support TLS 1.1.
 
-If you are compiling on Windows, you should also use the
-`--DENABLE_EXTRA_ALIGNMENT` cmake flag when configuring the C driver.
+If you are compiling on Windows, you should disable extra alignment with
+`-DENABLE_EXTRA_ALIGNMENT=0` when configuring the C driver.
 
 ### Step 2: Choose a C++17 polyfill
 


### PR DESCRIPTION
[CXX-1248](https://jira.mongodb.org/browse/CXX-1248)

Documents that Windows users should use `-DENABLE_EXTRA_ALIGNMENT` when configuring the C driver during installation.