### PR TITLE
allow underscore and capitals in Github token

### DIFF
--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -524,7 +524,7 @@ def read_github_creds(github_token_file):
     Read the GitHub token from the specified file and return it as a string.
     """
 
-    token_re = re.compile('^(?:Token - )?(?P<tok>[0-9a-f]{40}).*$')
+    token_re = re.compile('^(?:Token - )?(?P<tok>\w{40}).*$')
     github_token = None
 
     with open(github_token_file, 'rb') as token_stream:


### PR DESCRIPTION
This script throws the error "No Github token found in file 'github_token.txt'" if the file contains a token with underscores and/or capital letters. This commit fixes that issue.