### PR TITLE
build type debug for workflow

### DIFF
--- a/.github/workflows/compile-and-test-latest.yml
+++ b/.github/workflows/compile-and-test-latest.yml
@@ -20,6 +20,6 @@ jobs:
                 PREFIX=$INSTALL_PREFIX ./.evergreen/install_c_driver.sh master
                 mkdir cmake-build
                 cd cmake-build
-                cmake -DCMAKE_PREFIX_PATH=$INSTALL_PREFIX ..
+                cmake -DCMAKE_PREFIX_PATH=$INSTALL_PREFIX -DCMAKE_BUILD_TYPE=Debug ..
                 cmake --build . --target all
                 cmake --build . --target test


### PR DESCRIPTION
As of now, the failing "compile-and-test-latest" workflow shows no useful output when tests fail. This changes the build type in the GitHub action from our default (release) to debug. This should fix that problem.