### PR TITLE
CXX-1646 Include server replies in all exceptions

### DIFF
--- a/src/mongocxx/collection.cpp
+++ b/src/mongocxx/collection.cpp
@@ -1149,18 +1149,13 @@ cursor collection::_distinct(const client_session* session,
         throw bsoncxx::exception{bsoncxx::error_code::k_internal_error};
     }
 
-    const bson_t* error_document;
+    scoped_bson_t error_document;
+    const bson_t *error_doc = error_document.bson_for_init();
 
     cursor fake_cursor{libmongoc::cursor_new_from_command_reply_with_opts(
         _get_impl().client_impl->client_t, reply_bson, nullptr)};
-    if (libmongoc::cursor_error_document(fake_cursor._impl->cursor_t, &error, &error_document)) {
-        if (error_document) {
-            bsoncxx::document::value error_doc{
-                bsoncxx::document::view{bson_get_data(error_document), error_document->len}};
-            throw_exception<operation_exception>(error_doc, error);
-        } else {
-            throw_exception<operation_exception>(error);
-        }
+    if (libmongoc::cursor_error_document(fake_cursor._impl->cursor_t, &error, &error_doc)) {
+        throw_exception<operation_exception>(error_document.steal(), error);
     }
 
     return fake_cursor;

--- a/src/mongocxx/collection.cpp
+++ b/src/mongocxx/collection.cpp
@@ -1149,10 +1149,18 @@ cursor collection::_distinct(const client_session* session,
         throw bsoncxx::exception{bsoncxx::error_code::k_internal_error};
     }
 
+    const bson_t* error_document;
+
     cursor fake_cursor{libmongoc::cursor_new_from_command_reply_with_opts(
         _get_impl().client_impl->client_t, reply_bson, nullptr)};
-    if (libmongoc::cursor_error(fake_cursor._impl->cursor_t, &error)) {
-        throw_exception<operation_exception>(error);
+    if (libmongoc::cursor_error_document(fake_cursor._impl->cursor_t, &error, &error_document)) {
+        if (error_document) {
+            bsoncxx::document::value error_doc{
+                bsoncxx::document::view{bson_get_data(error_document), error_document->len}};
+            throw_exception<operation_exception>(error_doc, error);
+        } else {
+            throw_exception<operation_exception>(error);
+        }
     }
 
     return fake_cursor;

--- a/src/mongocxx/private/index_view.hh
+++ b/src/mongocxx/private/index_view.hh
@@ -163,7 +163,7 @@ class index_view::impl {
             _coll, command_bson.bson(), opts_bson.bson(), reply.bson_for_init(), &error);
 
         if (!result) {
-            throw_exception<operation_exception>(error);
+            throw_exception<operation_exception>(reply.steal(), error);
         }
 
         return reply.steal();
@@ -202,7 +202,7 @@ class index_view::impl {
             _coll, command_bson.bson(), opts_bson.bson(), reply.bson_for_init(), &error);
 
         if (!result) {
-            throw_exception<operation_exception>(error);
+            throw_exception<operation_exception>(reply.steal(), error);
         }
     }
 
@@ -236,7 +236,7 @@ class index_view::impl {
             _coll, command_bson.bson(), opts_bson.bson(), reply.bson_for_init(), &error);
 
         if (!result) {
-            throw_exception<operation_exception>(error);
+            throw_exception<operation_exception>(reply.steal(), error);
         }
     }
 


### PR DESCRIPTION
[CXX-1646](https://jira.mongodb.org/browse/CXX-1646)

We want to include a server reply in all thrown exceptions where possible. After a small audit, I've found only one potential instance of an unreturned raw server response after an error, and even this one is arguably unimportant.

I've looked through all calls of `throw_exception` and all creations of `operation_exception` and its implementers: `authentication_exception`, `bulk_write_exception`, `query_exception`, and `write_exception`. I'm fairly certain all exceptions created have no relevant server response to include (many wrap libmongoc functions that do not return the raw server reply) or already include a raw server response (`steal()`ing the BSON error document).