### PR TITLE
CXX-2230 Upgrade unified test runner to version 1.1

### DIFF
--- a/src/mongocxx/test/CMakeLists.txt
+++ b/src/mongocxx/test/CMakeLists.txt
@@ -240,7 +240,7 @@ set_tests_properties(client_side_encryption_specs PROPERTIES
 
 set_tests_properties(driver PROPERTIES
     ENVIRONMENT "ENCRYPTION_TESTS_PATH=${PROJECT_SOURCE_DIR}/../../data/client_side_encryption")
-  
+
 set_tests_properties(command_monitoring_specs PROPERTIES
     ENVIRONMENT "COMMAND_MONITORING_TESTS_PATH=${PROJECT_SOURCE_DIR}/../../data/command-monitoring")
 

--- a/src/mongocxx/test/CMakeLists.txt
+++ b/src/mongocxx/test/CMakeLists.txt
@@ -240,7 +240,7 @@ set_tests_properties(client_side_encryption_specs PROPERTIES
 
 set_tests_properties(driver PROPERTIES
     ENVIRONMENT "ENCRYPTION_TESTS_PATH=${PROJECT_SOURCE_DIR}/../../data/client_side_encryption")
-
+  
 set_tests_properties(command_monitoring_specs PROPERTIES
     ENVIRONMENT "COMMAND_MONITORING_TESTS_PATH=${PROJECT_SOURCE_DIR}/../../data/command-monitoring")
 

--- a/src/mongocxx/test/spec/unified_tests/operations.cpp
+++ b/src/mongocxx/test/spec/unified_tests/operations.cpp
@@ -1149,12 +1149,15 @@ document::value update_many(collection& coll, document::view operation) {
     auto result = builder::basic::document{};
     result.append(builder::basic::kvp(
         "result",
-        [matched_count, modified_count, upserted_id](builder::basic::sub_document subdoc) {
+        [matched_count, modified_count, upserted_count, upserted_id](
+            builder::basic::sub_document subdoc) {
             subdoc.append(builder::basic::kvp("matchedCount", matched_count));
 
             if (modified_count) {
                 subdoc.append(builder::basic::kvp("modifiedCount", *modified_count));
             }
+
+            subdoc.append(builder::basic::kvp("upsertedCount", upserted_count));
 
             if (upserted_id) {
                 subdoc.append(builder::basic::kvp("upsertedId", *upserted_id));

--- a/src/mongocxx/test/spec/unified_tests/operations.cpp
+++ b/src/mongocxx/test/spec/unified_tests/operations.cpp
@@ -1174,11 +1174,9 @@ document::value count_documents(collection& coll, document::view operation) {
     }
 
     int64_t count = coll.count_documents(filter, options);
-    auto result = builder::basic::document{};
-    result.append(builder::basic::kvp("result", [count](builder::basic::sub_document subdoc) {
-        subdoc.append(builder::basic::kvp("count", count));
-    }));
 
+    auto result = builder::basic::document{};
+    result.append(builder::basic::kvp("result", count));
     return result.extract();
 }
 
@@ -1186,10 +1184,7 @@ document::value estimated_document_count(collection& coll) {
     int64_t edc = coll.estimated_document_count();
 
     auto result = builder::basic::document{};
-    result.append(builder::basic::kvp("result", [edc](builder::basic::sub_document subdoc) {
-        subdoc.append(builder::basic::kvp("count", edc));
-    }));
-
+    result.append(builder::basic::kvp("result", edc));
     return result.extract();
 }
 

--- a/src/mongocxx/test/spec/unified_tests/operations.cpp
+++ b/src/mongocxx/test/spec/unified_tests/operations.cpp
@@ -1180,8 +1180,16 @@ document::value count_documents(collection& coll, document::view operation) {
     return result.extract();
 }
 
-document::value estimated_document_count(collection& coll) {
-    int64_t edc = coll.estimated_document_count();
+document::value estimated_document_count(collection& coll, document::view operation) {
+    options::estimated_document_count options{};
+    if (operation["arguments"]) {
+        auto arguments = operation["arguments"].get_document().value;
+        if (auto max_time_ms = arguments["maxTimeMS"]) {
+            options.max_time(std::chrono::milliseconds(max_time_ms.get_int32()));
+        }
+    }
+
+    int64_t edc = coll.estimated_document_count(options);
 
     auto result = builder::basic::document{};
     result.append(builder::basic::kvp("result", edc));
@@ -1430,7 +1438,7 @@ document::value operations::run(entity::map& entity_map,
         return count_documents(entity_map.get_collection(object), op_view);
     }
     if (name == "estimatedDocumentCount") {
-        return estimated_document_count(entity_map.get_collection(object));
+        return estimated_document_count(entity_map.get_collection(object), op_view);
     }
     if (name == "distinct") {
         auto& coll = entity_map.get_collection(object);

--- a/src/mongocxx/test/spec/unified_tests/operations.cpp
+++ b/src/mongocxx/test/spec/unified_tests/operations.cpp
@@ -899,6 +899,13 @@ client_session* get_session(document::view op, entity::map& map) {
     return &map.get_client_session(session_name);
 }
 
+document::value run_command(database& db, document::view operation) {
+    document::view arguments = operation["arguments"].get_document().value;
+    document::view command = arguments["command"].get_document().value;
+
+    return db.run_command(command);
+}
+
 document::value operations::run(entity::map& entity_map,
                                 std::unordered_map<std::string, spec::apm_checker>& apm_map,
                                 const array::element& op) {
@@ -1073,6 +1080,10 @@ document::value operations::run(entity::map& entity_map,
     if (name == "deleteOne") {
         auto& coll = entity_map.get_collection(object);
         return delete_one(coll, get_session(op_view, entity_map), op_view);
+    }
+    if (name == "runCommand") {
+        auto& db = entity_map.get_database(object);
+        return run_command(db, op_view);
     }
 
     throw std::logic_error{"unsupported operation: " + name};

--- a/src/mongocxx/test/spec/unified_tests/operations.cpp
+++ b/src/mongocxx/test/spec/unified_tests/operations.cpp
@@ -578,7 +578,7 @@ document::value find_one_and_delete(collection& coll,
         document = coll.find_one_and_delete(filter, options);
     }
 
-    // Server versions below 3.0 sometimes return an empty document rather than null when no
+    // Using an unacknowledged write concern returns an empty document rather than null when no
     // documents match.
     auto result = builder::basic::document{};
     if (document && !(document->view().empty())) {
@@ -635,7 +635,7 @@ document::value find_one_and_replace(collection& coll,
         document = coll.find_one_and_replace(filter, replacement, options);
     }
 
-    // Server versions below 3.0 sometimes return an empty document rather than null when no
+    // Using an unacknowledged write concern returns an empty document rather than null when no
     // documents match.
     auto result = builder::basic::document{};
     if (document && !(document->view().empty())) {

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -573,8 +573,12 @@ void assert_error(const mongocxx::operation_exception& exception,
         REQUIRE(std::none_of(std::begin(labels), std::end(labels), has_error_label));
     }
 
+    if (auto expected_error = expect_error["errorCode"]) {
+        auto actual_error = exception.code().value();
+        REQUIRE(actual_error == expected_error.get_int32());
+    }
+
     REQUIRE_FALSE(/* TODO */ expect_error["errorContains"]);
-    REQUIRE_FALSE(/* TODO */ expect_error["errorCode"]);
     REQUIRE_FALSE(/* TODO */ expect_error["errorCodeName"]);
 }
 

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -46,7 +46,7 @@ using bsoncxx::builder::basic::make_document;
 
 using schema_versions_t =
     std::array<std::array<int, 3 /* major.minor.patch */>, 1 /* supported version */>;
-constexpr schema_versions_t schema_versions{{{{1, 0, 0}}}};
+constexpr schema_versions_t schema_versions{{{{1, 1, 0}}}};
 
 std::pair<std::unordered_map<std::string, spec::apm_checker>&, entity::map&> init_maps() {
     // Below initializes the static apm map and entity map if needed, in that order. This will also
@@ -135,6 +135,17 @@ bool compatible_with_server(const bsoncxx::array::element& requirement) {
 
     if (auto topologies = requirement["topologies"])
         return equals_server_topology(topologies);
+
+    if (auto server_params = requirement["serverParameters"]) {
+        auto actual = test_util::get_server_params();
+        for (auto kvp : server_params.get_document().view()) {
+            auto param = kvp.key();
+            auto value = kvp.get_value();
+            if (actual[param].get_bool() != value.get_bool()) {
+                return false;
+            }
+        }
+    }
     return true;
 }
 
@@ -259,6 +270,28 @@ void add_ignore_command_monitoring_events(document::view object) {
     }
 }
 
+/* TODO CXX-2138: Actually implement add_server_api below with new server_api options class.
+void add_server_api(options::server_api& sapi_opts, document::view object) {
+    if (!object["serverApi"])
+        return;
+
+    if (auto sav = object["serverApi"]["version"]) {
+        REQUIRE(sav.type() == type::k_string);
+        sapi_opts.version(sav);
+    } else {
+        FAIL("must specify a version when using serverApi");
+    }
+
+    if (auto de = object["serverApi"]["deprecationErrors"]) {
+        REQUIRE(de.type() == type::k_bool);
+        sapi_opts.deprecation_errors(de);
+    }
+    if (auto strict = object["serverApi"]["strict"]) {
+        REQUIRE(strict.type() == type::k_bool);
+        sapi_opts.strict(strict);
+    }
+} */
+
 write_concern get_write_concern(const document::element& opts) {
     if (!opts["writeConcern"])
         return {};
@@ -380,6 +413,8 @@ client create_client(document::view object) {
 
     add_observe_events(opts, object);
     add_ignore_command_monitoring_events(object);
+    // TODO CXX-2138: Actually add server api options to client.
+    // add_server_api(server_api_opts, object);
 
     CAPTURE(conn);
     return client{uri{conn}, options::client{}.apm_opts(opts)};
@@ -759,4 +794,21 @@ TEST_CASE("unified format spec automated tests", "[unified_format_spec]") {
         run_tests_in_file(path + '/' + file);
     }
 }
+
+/* TODO CXX-2138: Uncomment versioned API spec TEST_CASE below.
+TEST_CASE("versioned API spec automated tests", "[unified_format_spec]") {
+    instance::current();
+
+    std::string path = std::getenv("VERSIONED_API_TESTS_PATH");
+    CAPTURE(path);
+    REQUIRE(path.size());
+
+    std::ifstream files{path + "/test_files.txt"};
+    REQUIRE(files.good());
+
+    for (std::string file; std::getline(files, file);) {
+        CAPTURE(file);
+        run_tests_in_file(path + '/' + file);
+    }
+} */
 }  // namespace

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -141,7 +141,8 @@ bool compatible_with_server(const bsoncxx::array::element& requirement) {
         for (auto kvp : server_params.get_document().view()) {
             auto param = kvp.key();
             auto value = kvp.get_value();
-            if (actual[param].get_bool() != value.get_bool()) {
+            // If actual parameter is unset or unequal to requirement, skip test.
+            if (!actual[param] || actual[param].get_bool() != value.get_bool()) {
                 return false;
             }
         }

--- a/src/mongocxx/test_util/client_helpers.cpp
+++ b/src/mongocxx/test_util/client_helpers.cpp
@@ -218,6 +218,11 @@ std::string get_server_version(const client& client) {
     return bsoncxx::string::to_string(output.view()["version"].get_string().value);
 }
 
+document::value get_server_params(const client& client) {
+    auto reply = client["admin"].run_command(make_document(kvp("getParameter", "*")));
+    return reply;
+}
+
 std::string replica_set_name(const client& client) {
     auto reply = get_is_master(client);
     auto name = reply.view()["setName"];

--- a/src/mongocxx/test_util/client_helpers.hh
+++ b/src/mongocxx/test_util/client_helpers.hh
@@ -79,6 +79,11 @@ std::int32_t get_max_wire_version(const client& client);
 std::string get_server_version(const client& client = {uri{}});
 
 ///
+/// Determines the setting of all server parameters by running "getParameter, *".
+///
+bsoncxx::document::value get_server_params(const client& client = {uri{}});
+
+///
 /// Get replica set name, or empty string.
 ///
 std::string replica_set_name(const client& client);


### PR DESCRIPTION
CXX-2230

Bumps supported UTF schema version to 1.1.0. Allows `serverParameters` in `runOnRequirement`. Drafts test runner changes for defining `serverApi` on a `client` entity (can't actually implement this until CXX-2138). Adds a dozen missing functions to supported UTF operations.

Tested new features above against new versioned API spec tests. `serverParameters` seem to skip correctly and new operations appear to run without error.