### PR TITLE
CXX-2234 Expect spaces after base64 in extJSON binary

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -135,7 +135,7 @@ functions:
                 export DRIVERS_TOOLS=$(pwd)
 
                 sh .evergreen/atlas_data_lake/run-mongohouse-local.sh
-              
+
     "test_mongohouse":
         command: shell.exec
         params:
@@ -157,8 +157,8 @@ functions:
 
                 ulimit -c unlimited || true
 
-                ./src/mongocxx/test/test_mongohouse_specs             
-              
+                ./src/mongocxx/test/test_mongohouse_specs
+
     "start_mongod":
         command: shell.exec
         params:
@@ -353,6 +353,9 @@ functions:
                   export MONGOCXX_TEST_AWS_ACCESS_KEY_ID="${cse_aws_access_key_id}"
                   set -o errexit
                   set -o xtrace
+
+                  # export MONGOC_VERSION for `test_bson` test binary.
+                  export MONGOC_VERSION="${mongoc_version|master}"
 
                   if [ "Windows_NT" == "$OS" ]; then
                       CRUD_TESTS_PATH=$(cygpath -m $CRUD_TESTS_PATH)
@@ -1009,7 +1012,7 @@ buildvariants:
       run_on: ubuntu1804-test
       tasks:
           - name: test_mongohouse
-      
+
     - name: ubuntu1804-zseries
       display_name: "s390x Ubuntu 18.04 (MongoDB 4.4)"
       batchtime: 1440 # 1 day

--- a/.mci.yml
+++ b/.mci.yml
@@ -354,6 +354,7 @@ functions:
                   set -o errexit
                   set -o xtrace
 
+                  # TODO CXX-2227: Remove export after minimum libmongoc version is bumped.
                   # export MONGOC_VERSION for `test_bson` test binary.
                   export MONGOC_VERSION="${mongoc_version|master}"
 

--- a/.mci.yml
+++ b/.mci.yml
@@ -135,7 +135,7 @@ functions:
                 export DRIVERS_TOOLS=$(pwd)
 
                 sh .evergreen/atlas_data_lake/run-mongohouse-local.sh
-
+              
     "test_mongohouse":
         command: shell.exec
         params:
@@ -157,8 +157,8 @@ functions:
 
                 ulimit -c unlimited || true
 
-                ./src/mongocxx/test/test_mongohouse_specs
-
+                ./src/mongocxx/test/test_mongohouse_specs             
+              
     "start_mongod":
         command: shell.exec
         params:
@@ -353,10 +353,6 @@ functions:
                   export MONGOCXX_TEST_AWS_ACCESS_KEY_ID="${cse_aws_access_key_id}"
                   set -o errexit
                   set -o xtrace
-
-                  # TODO CXX-2227: Remove export after minimum libmongoc version is bumped.
-                  # export MONGOC_VERSION for `test_bson` test binary.
-                  export MONGOC_VERSION="${mongoc_version|master}"
 
                   if [ "Windows_NT" == "$OS" ]; then
                       CRUD_TESTS_PATH=$(cygpath -m $CRUD_TESTS_PATH)
@@ -1013,7 +1009,7 @@ buildvariants:
       run_on: ubuntu1804-test
       tasks:
           - name: test_mongohouse
-
+      
     - name: ubuntu1804-zseries
       display_name: "s390x Ubuntu 18.04 (MongoDB 4.4)"
       batchtime: 1440 # 1 day

--- a/src/bsoncxx/test/json.cpp
+++ b/src/bsoncxx/test/json.cpp
@@ -99,9 +99,9 @@ TEST_CASE("CXX-1246: Relaxed Extended JSON") {
     auto doc = make_document(kvp("number", 42), kvp("bin", bin_val));
     auto output = to_json(doc.view(), ExtendedJsonMode::k_relaxed);
 
-    // TODO CXX-2227: Remove conditional result after minimum libmongoc version is bumped.
+    // TODO CXX-2227: Remove conditional result after minimum libbson version is bumped.
     //
-    // As of libmongoc 1.18.0, "base64" has correct spacing (see CDRIVER-3958) after extJSON
+    // As of libbson 1.18.0, "base64" has correct spacing (see CDRIVER-3958) after extJSON
     // marshalling.
     const char* expected;
     if ((BSON_MAJOR_VERSION == 1 && BSON_MINOR_VERSION >= 18) || BSON_MAJOR_VERSION > 1) {
@@ -121,9 +121,9 @@ TEST_CASE("CXX-1246: Canonical Extended JSON") {
     auto doc = make_document(kvp("number", 42), kvp("bin", bin_val));
     auto output = to_json(doc.view(), ExtendedJsonMode::k_canonical);
 
-    // TODO CXX-2227: Remove conditional result after minimum libmongoc version is bumped.
+    // TODO CXX-2227: Remove conditional result after minimum libbson version is bumped.
     //
-    // As of libmongoc 1.18.0, "base64" has correct spacing (see CDRIVER-3958) after extJSON
+    // As of libbson 1.18.0, "base64" has correct spacing (see CDRIVER-3958) after extJSON
     // marshalling.
     const char* expected;
     if ((BSON_MAJOR_VERSION == 1 && BSON_MINOR_VERSION >= 18) || BSON_MAJOR_VERSION > 1) {

--- a/src/bsoncxx/test/json.cpp
+++ b/src/bsoncxx/test/json.cpp
@@ -27,6 +27,7 @@ using bsoncxx::builder::basic::make_document;
 
 constexpr auto k_invalid_json = R"({])";
 constexpr auto k_valid_json = R"({ "a" : 1, "b" : 2.0 })";
+const char* mongoc_version = std::getenv("MONGOC_VERSION");
 
 TEST_CASE("invalid json throws") {
     using namespace bsoncxx;
@@ -93,24 +94,52 @@ TEST_CASE("CXX-1246: Legacy Extended JSON (Explicit)") {
 
 TEST_CASE("CXX-1246: Relaxed Extended JSON") {
     using namespace bsoncxx;
+    if (!mongoc_version) {
+        WARN("Skipping — environment variable MONGOC_VERSION must be set");
+        return;
+    }
+
     types::b_binary bin_val{
         binary_sub_type::k_uuid, 8, reinterpret_cast<const uint8_t*>("deadbeef")};
     auto doc = make_document(kvp("number", 42), kvp("bin", bin_val));
     auto output = to_json(doc.view(), ExtendedJsonMode::k_relaxed);
-    REQUIRE(
-        output ==
-        R"({ "number" : 42, "bin" : { "$binary" : { "base64" : "ZGVhZGJlZWY=", "subType" : "04" } } })");
+
+    // As of libmongoc 1.18.0, "base64" has correct spacing (see CDRIVER-3958) after extJSON
+    // marshalling.
+    const char* expected;
+    if (std::string(mongoc_version).compare("1.18.0") >= 0) {
+        expected =
+            R"({ "number" : 42, "bin" : { "$binary" : { "base64" : "ZGVhZGJlZWY=", "subType" : "04" } } })";
+    } else {
+        expected =
+            R"({ "number" : 42, "bin" : { "$binary" : { "base64": "ZGVhZGJlZWY=", "subType" : "04" } } })";
+    }
+    REQUIRE(output == expected);
 }
 
 TEST_CASE("CXX-1246: Canonical Extended JSON") {
     using namespace bsoncxx;
+    if (!mongoc_version) {
+        WARN("Skipping — environment variable MONGOC_VERSION must be set");
+        return;
+    }
+
     types::b_binary bin_val{
         binary_sub_type::k_uuid, 8, reinterpret_cast<const uint8_t*>("deadbeef")};
     auto doc = make_document(kvp("number", 42), kvp("bin", bin_val));
     auto output = to_json(doc.view(), ExtendedJsonMode::k_canonical);
-    REQUIRE(
-        output ==
-        R"({ "number" : { "$numberInt" : "42" }, "bin" : { "$binary" : { "base64" : "ZGVhZGJlZWY=", "subType" : "04" } } })");
+
+    // As of libmongoc 1.18.0, "base64" has correct spacing (see CDRIVER-3958) after extJSON
+    // marshalling.
+    const char* expected;
+    if (std::string(mongoc_version).compare("1.18.0") >= 0) {
+        expected =
+            R"({ "number" : { "$numberInt" : "42" }, "bin" : { "$binary" : { "base64" : "ZGVhZGJlZWY=", "subType" : "04" } } })";
+    } else {
+        expected =
+            R"({ "number" : { "$numberInt" : "42" }, "bin" : { "$binary" : { "base64": "ZGVhZGJlZWY=", "subType" : "04" } } })";
+    }
+    REQUIRE(output == expected);
 }
 
 TEST_CASE("UDL _bson works like from_json()") {

--- a/src/bsoncxx/test/json.cpp
+++ b/src/bsoncxx/test/json.cpp
@@ -94,6 +94,7 @@ TEST_CASE("CXX-1246: Legacy Extended JSON (Explicit)") {
 
 TEST_CASE("CXX-1246: Relaxed Extended JSON") {
     using namespace bsoncxx;
+    // TODO CXX-2227: Remove skip after minimum libmongoc version is bumped.
     if (!mongoc_version) {
         WARN("Skipping — environment variable MONGOC_VERSION must be set");
         return;
@@ -104,6 +105,8 @@ TEST_CASE("CXX-1246: Relaxed Extended JSON") {
     auto doc = make_document(kvp("number", 42), kvp("bin", bin_val));
     auto output = to_json(doc.view(), ExtendedJsonMode::k_relaxed);
 
+    // TODO CXX-2227: Remove conditional result after minimum libmongoc version is bumped.
+    //
     // As of libmongoc 1.18.0, "base64" has correct spacing (see CDRIVER-3958) after extJSON
     // marshalling.
     const char* expected;
@@ -119,6 +122,7 @@ TEST_CASE("CXX-1246: Relaxed Extended JSON") {
 
 TEST_CASE("CXX-1246: Canonical Extended JSON") {
     using namespace bsoncxx;
+    // TODO CXX-2227: Remove skip after minimum libmongoc version is bumped.
     if (!mongoc_version) {
         WARN("Skipping — environment variable MONGOC_VERSION must be set");
         return;
@@ -129,6 +133,8 @@ TEST_CASE("CXX-1246: Canonical Extended JSON") {
     auto doc = make_document(kvp("number", 42), kvp("bin", bin_val));
     auto output = to_json(doc.view(), ExtendedJsonMode::k_canonical);
 
+    // TODO CXX-2227: Remove conditional result after minimum libmongoc version is bumped.
+    //
     // As of libmongoc 1.18.0, "base64" has correct spacing (see CDRIVER-3958) after extJSON
     // marshalling.
     const char* expected;

--- a/src/bsoncxx/test/json.cpp
+++ b/src/bsoncxx/test/json.cpp
@@ -99,7 +99,7 @@ TEST_CASE("CXX-1246: Relaxed Extended JSON") {
     auto output = to_json(doc.view(), ExtendedJsonMode::k_relaxed);
     REQUIRE(
         output ==
-        R"({ "number" : 42, "bin" : { "$binary" : { "base64": "ZGVhZGJlZWY=", "subType" : "04" } } })");
+        R"({ "number" : 42, "bin" : { "$binary" : { "base64" : "ZGVhZGJlZWY=", "subType" : "04" } } })");
 }
 
 TEST_CASE("CXX-1246: Canonical Extended JSON") {
@@ -110,7 +110,7 @@ TEST_CASE("CXX-1246: Canonical Extended JSON") {
     auto output = to_json(doc.view(), ExtendedJsonMode::k_canonical);
     REQUIRE(
         output ==
-        R"({ "number" : { "$numberInt" : "42" }, "bin" : { "$binary" : { "base64": "ZGVhZGJlZWY=", "subType" : "04" } } })");
+        R"({ "number" : { "$numberInt" : "42" }, "bin" : { "$binary" : { "base64" : "ZGVhZGJlZWY=", "subType" : "04" } } })");
 }
 
 TEST_CASE("UDL _bson works like from_json()") {


### PR DESCRIPTION
CXX-2234

Adds spaces to two extended JSON tests that expect an output with "base64".

This should right a failure caused by the bug fix [CDRIVER-3958](https://jira.mongodb.org/browse/CDRIVER-3958). There are no other occurrences of `"base64":` in the CXX driver repo outside of spec test JSON.