### PR TITLE
CXX-2254 Add testing for versioned API

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -346,7 +346,12 @@ functions:
 
                   if [ "Windows_NT" == "$OS" ]; then
                       CTEST_OUTPUT_ON_FAILURE=1 MSBuild.exe /p:Configuration=${build_type} RUN_TESTS.vcxproj
-                      CTEST_OUTPUT_ON_FAILURE=1 MSBuild.exe /p:Configuration=${build_type} examples/run-examples.vcxproj
+                      # Only run examples if MONGODB_API_VERSION is unset. We do not append
+                      # API version to example clients, so examples will fail when requireApiVersion
+                      # is true.
+                      if [[ -z "$MONGODB_API_VERSION" ]]; then
+                        CTEST_OUTPUT_ON_FAILURE=1 MSBuild.exe /p:Configuration=${build_type} examples/run-examples.vcxproj
+                      fi
                   else
                       # ENABLE_SLOW_TESTS is required to run the slow tests that are disabled by default. The slow tests should not be run if explicitly disabled.
                       if [ -z "${disable_slow_tests}" ]; then

--- a/.mci.yml
+++ b/.mci.yml
@@ -174,6 +174,9 @@ functions:
                 export MONGODB_VERSION=${mongodb_version}
                 export AUTH=${AUTH}
                 export TOPOLOGY=${TOPOLOGY|server}
+                export REQUIRE_API_VERSION=${REQUIRE_API_VERSION}
+                export ORCHESTRATION_FILE=${ORCHESTRATION_FILE}
+                export PATH="$MONGODB_BINARIES:$PATH"
 
                 echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
                 ./.evergreen/run-orchestration.sh
@@ -332,6 +335,8 @@ functions:
                   export READ_WRITE_CONCERN_OPERATION_TESTS_PATH="$(pwd)/../data/read-write-concern/operation"
                   export UNIFIED_FORMAT_TESTS_PATH=$(pwd)/../data/unified-format
                   export VERSIONED_API_TESTS_PATH=$(pwd)/../data/versioned-api
+
+                  export MONGODB_API_VERSION="${MONGODB_API_VERSION}"
 
                   # export environment variables for encryption tests
                   set +o errexit
@@ -752,6 +757,32 @@ tasks:
         - func: "run_mongohouse"
         - func: "test_mongohouse"
 
+    - name: test_versioned_api
+      commands:
+        - func: "setup"
+        - func: "start_mongod"
+          vars:
+              REQUIRE_API_VERSION: true
+              AUTH: auth
+        - func: "install_c_driver"
+        - func: "compile"
+        - func: "test"
+          vars:
+              MONGODB_API_VERSION: 1
+
+    - name: test_versioned_api_accept_version_two
+      commands:
+        - func: "setup"
+        - func: "start_mongod"
+          vars:
+              ORCHESTRATION_FILE: versioned-api-testing.json
+              AUTH: noauth
+        - func: "install_c_driver"
+        - func: "compile"
+        - func: "test"
+          vars:
+              MONGODB_API_VERSION: 1
+
 #######################################
 #           MongoDB Version Matrix    #
 #######################################
@@ -829,6 +860,13 @@ buildvariants:
       display_name: "${os} ${mongodb_version} Auth"
       tasks:
           - name: compile_and_test_auth_with_shared_libs
+
+    - matrix_name: "versioned api"
+      matrix_spec: {os: "*", mongodb_version: "latest"}
+      display_name: "${os} ${mongodb_version} Versioned API"
+      tasks:
+          - name: test_versioned_api
+          - name: test_versioned_api_accept_version_two
 
     #######################################
     #         Linux Buildvariants         #
@@ -1073,6 +1111,20 @@ buildvariants:
           - name: compile_and_test_with_shared_libs_extra_alignment
           - name: compile_and_test_with_static_libs
           - name: compile_and_test_with_static_libs_extra_alignment
+
+    - name: macos-1014-versioned-api
+      display_name: "MacOS 10.14 Release Versioned API"
+      expansions:
+          build_type: "Release"
+          extra_path: *macos_extra_path
+          cmake_flags: *macos_cmake_flags
+          poly_flags: *poly_boost_flags
+          mongodb_version: *version_latest
+      run_on:
+          - macos-1014
+      tasks:
+          - name: test_versioned_api
+          - name: test_versioned_api_accept_version_two
 
     - name: windows-2k8-release
       display_name: "Windows (VS 2015) Release (MongoDB 4.2)"

--- a/.mci.yml
+++ b/.mci.yml
@@ -375,28 +375,34 @@ functions:
                       # of find(1), and some platforms like Ubuntu 16.04 don't support the +mode
                       # syntax, so we use Perl to help us find executable files.
                       EXAMPLES=$(find examples -type f | sort | perl -nlwe 'print if -x')
-                      for test in $EXAMPLES; do
-                        case "$test" in
-                          *encryption*)
-                            echo "Skipping client side encryption example"
-                            ;;
-                          *change_stream*)
-                            echo "TODO CXX-1201, enable for servers that support change streams"
-                            ;;
-                          *client_session*)
-                            echo "TODO CXX-1201, enable for servers that support change streams"
-                            ;;
-                          *with_transaction*)
-                            echo "TODO CXX-1201, enable for servers that support transactions"
-                            ;;
-                          *causal_consistency*)
-                            echo "TODO CXX-1201, enable for servers that support transactions"
-                            ;;
-                          *)
-                            ${test_params} $test
-                            ;;
-                        esac
-                      done
+
+                      # Only run examples if MONGODB_API_VERSION is unset. We do not append
+                      # API version to example clients, so examples will fail when requireApiVersion
+                      # is true.
+                      if [[ -z "$MONGODB_API_VERSION" ]]; then
+                          for test in $EXAMPLES; do
+                            case "$test" in
+                              *encryption*)
+                                echo "Skipping client side encryption example"
+                                ;;
+                              *change_stream*)
+                                echo "TODO CXX-1201, enable for servers that support change streams"
+                                ;;
+                              *client_session*)
+                                echo "TODO CXX-1201, enable for servers that support change streams"
+                                ;;
+                              *with_transaction*)
+                                echo "TODO CXX-1201, enable for servers that support transactions"
+                                ;;
+                              *causal_consistency*)
+                                echo "TODO CXX-1201, enable for servers that support transactions"
+                                ;;
+                              *)
+                                ${test_params} $test
+                                ;;
+                            esac
+                          done
+                      fi
                   fi
 
                   cd ..
@@ -420,7 +426,14 @@ functions:
                   fi
                   # The example projects never run under valgrind, since we haven't added execution
                   # logic to handle ${test_params}.
-                  MONGOC_VERSION=${mongoc_version|master} .evergreen/build_example_projects.sh
+                  #
+                  # Only run example projects if MONGODB_API_VERSION is unset. We do not append
+                  # API version to example clients, so example projects will fail when requireApiVersion
+                  # is true.
+                  if [[ -z "$MONGODB_API_VERSION" ]]; then
+                    MONGOC_VERSION=${mongoc_version|master} .evergreen/build_example_projects.sh
+                  fi
+                  unset MONGODB_API_VERSION
 
     "test auth":
         - command: shell.exec
@@ -763,7 +776,9 @@ tasks:
         - func: "start_mongod"
           vars:
               REQUIRE_API_VERSION: true
-              AUTH: auth
+              # Authentication with versioned API should already be tested
+              # in the C driver.
+              AUTH: noauth
         - func: "install_c_driver"
         - func: "compile"
         - func: "test"
@@ -780,8 +795,6 @@ tasks:
         - func: "install_c_driver"
         - func: "compile"
         - func: "test"
-          vars:
-              MONGODB_API_VERSION: 1
 
 #######################################
 #           MongoDB Version Matrix    #

--- a/src/mongocxx/test/change_streams.cpp
+++ b/src/mongocxx/test/change_streams.cpp
@@ -88,7 +88,7 @@ const auto destroy_interpose = [](mongoc_change_stream_t*) -> void {};
 
 TEST_CASE("Change stream options") {
     instance::current();
-    client mongodb_client{uri{}};
+    client mongodb_client{uri{}, test_util::add_test_server_api()};
 
     if (!test_util::is_replica_set(mongodb_client)) {
         WARN("skip: change streams require replica set");
@@ -111,7 +111,7 @@ TEST_CASE("Change stream options") {
 
 TEST_CASE("Spec Prose Tests") {
     instance::current();
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
 
     if (!test_util::is_replica_set(client)) {
         WARN("skip: change streams require replica set");
@@ -176,7 +176,7 @@ TEST_CASE("Mock streams and error-handling") {
     MOCK_CHANGE_STREAM
 
     instance::current();
-    client mongodb_client{uri{}};
+    client mongodb_client{uri{}, test_util::add_test_server_api()};
     options::change_stream options{};
     database db = mongodb_client["streams"];
     collection events = db["events"];
@@ -365,7 +365,7 @@ TEST_CASE("Mock streams and error-handling") {
 // Put this before other tests which assume the collections already exists.
 TEST_CASE("Create streams.events and assert we can read a single event", "[min36]") {
     instance::current();
-    client mongodb_client{uri{}};
+    client mongodb_client{uri{}, test_util::add_test_server_api()};
     if (!test_util::is_replica_set(mongodb_client)) {
         WARN("skip: change streams require replica set");
         return;
@@ -386,7 +386,7 @@ TEST_CASE("Create streams.events and assert we can read a single event", "[min36
 
 TEST_CASE("Give an invalid pipeline", "[min36]") {
     instance::current();
-    client mongodb_client{uri{}};
+    client mongodb_client{uri{}, test_util::add_test_server_api()};
     if (!test_util::is_replica_set(mongodb_client)) {
         WARN("skip: change streams require replica set");
         return;
@@ -416,7 +416,7 @@ TEST_CASE("Give an invalid pipeline", "[min36]") {
 
 TEST_CASE("Documentation Examples", "[min36]") {
     instance::current();
-    client mongodb_client{uri{}};
+    client mongodb_client{uri{}, test_util::add_test_server_api()};
     if (!test_util::is_replica_set(mongodb_client)) {
         WARN("skip: change streams require replica set");
         return;
@@ -485,7 +485,7 @@ TEST_CASE("Documentation Examples", "[min36]") {
 
 TEST_CASE("Watch 2 collections", "[min36]") {
     instance::current();
-    client mongodb_client{uri{}};
+    client mongodb_client{uri{}, test_util::add_test_server_api()};
     if (!test_util::is_replica_set(mongodb_client)) {
         WARN("skip: change streams require replica set");
         return;
@@ -533,7 +533,7 @@ TEST_CASE("Watch 2 collections", "[min36]") {
 
 TEST_CASE("Watch a Collection", "[min36]") {
     instance::current();
-    client mongodb_client{uri{}};
+    client mongodb_client{uri{}, test_util::add_test_server_api()};
     if (!test_util::is_replica_set(mongodb_client)) {
         WARN("skip: change streams require replica set");
         return;

--- a/src/mongocxx/test/client.cpp
+++ b/src/mongocxx/test/client.cpp
@@ -66,7 +66,7 @@ TEST_CASE("A client lists its databases with a filter applied", "[client]") {
         })
         .forever();
 
-    client mongo_client{uri{}};
+    client mongo_client{uri{}, test_util::add_test_server_api()};
     mongo_client.list_databases(filter_view);
     REQUIRE(client_list_databases_called);
 }
@@ -90,7 +90,7 @@ TEST_CASE("list databases passes authorizedDatabases option", "[client]") {
         return nullptr;
     });
 
-    mongocxx::client client{mongocxx::uri{}};
+    mongocxx::client client{mongocxx::uri{}, test_util::add_test_server_api()};
 
     SECTION("list_databases with no arguments") {
         client.list_databases();
@@ -117,7 +117,7 @@ TEST_CASE("A client constructed with a URI is truthy", "[client]") {
 
     instance::current();
 
-    client a{uri{}};
+    client a{uri{}, test_util::add_test_server_api()};
     REQUIRE(a);
 }
 
@@ -158,7 +158,7 @@ TEST_CASE("A client cleans up its underlying mongoc client on destruction", "[cl
     client_destroy->visit([&](mongoc_client_t*) { destroy_called = true; });
 
     {
-        client object{uri{}};
+        client object{uri{}, test_util::add_test_server_api()};
         REQUIRE(!destroy_called);
     }
 
@@ -170,7 +170,7 @@ TEST_CASE("A client supports move operations", "[client]") {
 
     instance::current();
 
-    client a{uri{}};
+    client a{uri{}, test_util::add_test_server_api()};
 
     bool called = false;
     client_new->visit([&](const mongoc_uri_t*) { called = true; });
@@ -187,7 +187,7 @@ TEST_CASE("A client has a settable Read Concern", "[client]") {
 
     instance::current();
 
-    client mongo_client{uri{}};
+    client mongo_client{uri{}, test_util::add_test_server_api()};
 
     auto client_set_rc_called = false;
     read_concern rc{};
@@ -211,7 +211,7 @@ TEST_CASE("A client's read preferences may be set and obtained", "[client]") {
 
     instance::current();
 
-    client mongo_client{uri{}};
+    client mongo_client{uri{}, test_util::add_test_server_api()};
     read_preference preference{};
     preference.mode(read_preference::read_mode::k_secondary_preferred);
 
@@ -250,7 +250,7 @@ TEST_CASE("A client may not change apm callbacks after they are set", "[client]"
 
     options::client client_opts;
     client_opts.apm_opts(apm_opts);
-    client mongo_client(uri{}, client_opts);
+    client mongo_client(uri{}, test_util::add_test_server_api(client_opts));
 
     apm_opts.on_command_started([&](const events::command_started_event& event) {
         INFO(event.command_name());
@@ -281,7 +281,7 @@ TEST_CASE("A client can delete apm options and the callbacks will still work pro
         client_opts.apm_opts(apm_opts);
     }  // destructor for apm_opts is called
 
-    client mongo_client(uri{}, client_opts);
+    client mongo_client(uri{}, test_util::add_test_server_api(client_opts));
 
     mongo_client["test"]["test_apm"].insert_one(
         bsoncxx::builder::basic::make_document(bsoncxx::builder::basic::kvp("x", 2)));
@@ -294,7 +294,7 @@ TEST_CASE("A client's write concern may be set and obtained", "[client]") {
 
     instance::current();
 
-    client mongo_client{uri{}};
+    client mongo_client{uri{}, test_util::add_test_server_api()};
     write_concern concern;
     concern.majority(std::chrono::milliseconds(100));
 
@@ -338,7 +338,7 @@ TEST_CASE("A client can be reset", "[client]") {
     bool reset_called = false;
     client_reset->interpose([&](const mongoc_client_t*) { reset_called = true; });
 
-    client mongo_client{uri{}};
+    client mongo_client{uri{}, test_util::add_test_server_api()};
     mongo_client.reset();
 
     REQUIRE(reset_called);
@@ -362,7 +362,7 @@ TEST_CASE("A client can create a named database object", "[client]") {
 
     stdx::string_view name("database");
 
-    client mongo_client{uri{}};
+    client mongo_client{uri{}, test_util::add_test_server_api()};
     database obtained_database = mongo_client[name];
     REQUIRE(obtained_database.name() == name);
 }
@@ -425,12 +425,12 @@ TEST_CASE("integration tests for client metadata handshake feature") {
     };
 
     SECTION("with client") {
-        mongocxx::client client{uri};
+        mongocxx::client client{uri, test_util::add_test_server_api()};
         run_test(client);
     }
 
     SECTION("with pool") {
-        mongocxx::pool pool{uri};
+        mongocxx::pool pool{uri, options::pool(test_util::add_test_server_api())};
         auto client = pool.acquire();
         run_test(*client);
     }

--- a/src/mongocxx/test/client_session.cpp
+++ b/src/mongocxx/test/client_session.cpp
@@ -39,7 +39,7 @@ using test_util::server_has_sessions;
 TEST_CASE("session options", "[session]") {
     instance::current();
 
-    client c{uri{}};
+    client c{uri{}, test_util::add_test_server_api()};
 
     if (!server_has_sessions(c)) {
         return;
@@ -76,7 +76,7 @@ TEST_CASE("start_session failure", "[session]") {
         })
         .forever();
 
-    client c{uri{}};
+    client c{uri{}, test_util::add_test_server_api()};
 
     REQUIRE_THROWS_MATCHES(
         c.start_session(), mongocxx::exception, mongocxx_exception_matcher{"foo"});
@@ -87,7 +87,7 @@ TEST_CASE("session", "[session]") {
 
     instance::current();
 
-    client c{uri{}};
+    client c{uri{}, test_util::add_test_server_api()};
 
     if (!server_has_sessions(c)) {
         return;
@@ -146,7 +146,7 @@ TEST_CASE("session", "[session]") {
 
         // "Session argument is for the right client" test from Driver Sessions Spec.
         // Passing a session from client "c" should fail with client "c2" and related objects.
-        client c2{uri{}};
+        client c2{uri{}, test_util::add_test_server_api()};
         auto db2 = c2["db"];
         auto collection2 = db2["collection"];
 
@@ -238,7 +238,7 @@ class session_test {
         });
 
         client_opts.apm_opts(apm_opts);
-        client = mongocxx::client(uri{}, client_opts);
+        client = mongocxx::client(uri{}, test_util::add_test_server_api(client_opts));
     }
 
     void test_method_with_session(const std::function<void(bool)>& f, const client_session& s) {

--- a/src/mongocxx/test/client_side_encryption.cpp
+++ b/src/mongocxx/test/client_side_encryption.cpp
@@ -295,7 +295,7 @@ TEST_CASE("Datakey and double encryption", "[client_side_encryption]") {
     client_opts.apm_opts(apm_checker.get_apm_opts(true /* command_started_events_only */));
 
     class client setup_client {
-        uri{}, std::move(client_opts)
+        uri{}, test_util::add_test_server_api(client_opts),
     };
 
     if (!mongocxx::test_util::should_run_client_side_encryption_test()) {
@@ -327,7 +327,7 @@ TEST_CASE("Datakey and double encryption", "[client_side_encryption]") {
     auto kms_doc = _make_kms_doc();
     _add_client_encrypted_opts(&encrypted_client_opts, std::move(schema_map), std::move(kms_doc));
     class client client_encrypted {
-        uri{}, std::move(encrypted_client_opts)
+        uri{}, test_util::add_test_server_api(encrypted_client_opts),
     };
 
     // Configure both with aws and local KMS providers, and schema map
@@ -382,7 +382,7 @@ void run_external_key_vault_test(bool with_external_key_vault) {
 
     // Create a MongoClient without encryption enabled (referred to as client).
     class client client {
-        uri {}
+        uri{}, test_util::add_test_server_api(),
     };
 
     // Using client, drop the collections keyvault.datakeys and db.coll.
@@ -418,7 +418,7 @@ void run_external_key_vault_test(bool with_external_key_vault) {
     }
 
     class client client_encrypted {
-        uri{}, std::move(encrypted_client_opts)
+        uri{}, test_util::add_test_server_api(encrypted_client_opts),
     };
 
     // A ClientEncryption object (referred to as client_encryption) that is configured with an
@@ -467,7 +467,7 @@ TEST_CASE("External key vault", "[client_side_encryption]") {
     instance::current();
 
     class client setup_client {
-        uri {}
+        uri{}, test_util::add_test_server_api(),
     };
     if (test_util::get_max_wire_version(setup_client) < 8) {
         // Automatic encryption requires wire version 8.
@@ -488,7 +488,7 @@ TEST_CASE("BSON size limits and batch splitting", "[client_side_encryption]") {
 
     // Create a MongoClient without encryption enabled (referred to as client).
     class client client {
-        uri {}
+        uri{}, test_util::add_test_server_api(),
     };
 
     if (test_util::get_max_wire_version(client) < 8) {
@@ -545,7 +545,7 @@ TEST_CASE("BSON size limits and batch splitting", "[client_side_encryption]") {
     client_encrypted_opts.apm_opts(apm_opts);
 
     class client client_encrypted {
-        uri{}, std::move(client_encrypted_opts)
+        uri{}, test_util::add_test_server_api(client_encrypted_opts),
     };
 
     // Using client_encrypted perform the following operations:
@@ -652,7 +652,7 @@ TEST_CASE("Views are prohibited", "[client_side_encryption]") {
 
     // Create a MongoClient without encryption enabled (referred to as client).
     class client client {
-        uri {}
+        uri{}, test_util::add_test_server_api(),
     };
 
     if (test_util::get_max_wire_version(client) < 8) {
@@ -681,7 +681,7 @@ TEST_CASE("Views are prohibited", "[client_side_encryption]") {
     auto kms_doc = _make_kms_doc();
     _add_client_encrypted_opts(&opts, {}, std::move(kms_doc));
     class client client_encrypted {
-        uri{}, std::move(opts)
+        uri{}, test_util::add_test_server_api(opts),
     };
 
     // Using client_encrypted, attempt to insert a document into db.view.
@@ -698,7 +698,7 @@ void _run_corpus_test(bool use_schema_map) {
 
     // Create a MongoClient without encryption enabled (referred to as client).
     class client client {
-        uri {}
+        uri{}, test_util::add_test_server_api(),
     };
 
     auto corpus_schema = _doc_from_file("/corpus/corpus-schema.json");
@@ -779,7 +779,7 @@ void _run_corpus_test(bool use_schema_map) {
     }
 
     class client client_encrypted {
-        uri{}, std::move(client_encrypted_opts)
+        uri{}, test_util::add_test_server_api(client_encrypted_opts),
     };
 
     // A ClientEncryption object (referred to as client_encryption)
@@ -1028,7 +1028,7 @@ TEST_CASE("Custom endpoint", "[client_side_encryption]") {
     // (instead of the default endpoint derived from the AWS region).
 
     class client setup_client {
-        uri {}
+        uri{}, test_util::add_test_server_api(),
     };
 
     if (test_util::get_max_wire_version(setup_client) < 8) {
@@ -1157,7 +1157,7 @@ TEST_CASE("Bypass spawning mongocryptd", "[client_side_encryption]") {
     instance::current();
 
     class client setup_client {
-        uri {}
+        uri{}, test_util::add_test_server_api(),
     };
     if (test_util::get_max_wire_version(setup_client) < 8) {
         // Automatic encryption requires wire version 8.
@@ -1206,7 +1206,7 @@ TEST_CASE("Bypass spawning mongocryptd", "[client_side_encryption]") {
     client_encrypted_opts.auto_encryption_opts(std::move(auto_encrypt_opts));
 
     class client client_encrypted {
-        uri{}, std::move(client_encrypted_opts)
+        uri{}, test_util::add_test_server_api(client_encrypted_opts)
     };
 
     // Use client_encrypted to insert the document {"encrypted": "test"} into db.coll.
@@ -1246,7 +1246,7 @@ TEST_CASE("Bypass spawning mongocryptd", "[client_side_encryption]") {
     client_encrypted_opts2.auto_encryption_opts(std::move(auto_encrypt_opts2));
 
     class client client_encrypted2 {
-        uri{}, std::move(client_encrypted_opts2)
+        uri{}, test_util::add_test_server_api(client_encrypted_opts2)
     };
 
     // Use client_encrypted to insert the document {"unencrypted": "test"} into db.coll.
@@ -1259,9 +1259,8 @@ TEST_CASE("Bypass spawning mongocryptd", "[client_side_encryption]") {
     // command and ensure it fails with a server selection timeout.
     options::client ping_client_opts;
     class client ping_client {
-        uri {
-            "mongodb://localhost:27021/?serverSelectionTimeoutMS=1000"
-        }
+        uri{"mongodb://localhost:27021/?serverSelectionTimeoutMS=1000"},
+            test_util::add_test_server_api(),
     };
     REQUIRE_THROWS(ping_client["admin"].run_command(make_document(kvp("isMaster", 1))));
 }

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -57,7 +57,7 @@ TEST_CASE("A default constructed collection cannot perform operations", "[collec
 TEST_CASE("mongocxx::collection copy constructor", "[collection]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     database db = client["collection_copy_constructor"];
 
     SECTION("constructing from valid") {
@@ -77,7 +77,7 @@ TEST_CASE("mongocxx::collection copy constructor", "[collection]") {
 TEST_CASE("mongocxx::collection copy assignment operator", "[collection]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     database db = client["collection_copy_assignment"];
 
     SECTION("assigning valid to valid") {
@@ -114,7 +114,7 @@ TEST_CASE("mongocxx::collection copy assignment operator", "[collection]") {
 TEST_CASE("collection renaming", "[collection]") {
     instance::current();
 
-    client mongodb_client{uri{}};
+    client mongodb_client{uri{}, test_util::add_test_server_api()};
     database db = mongodb_client["collection_renaming"];
 
     auto filter = make_document(kvp("key--------unique", "value"));
@@ -150,7 +150,7 @@ TEST_CASE("collection renaming", "[collection]") {
 TEST_CASE("collection dropping") {
     instance::current();
 
-    client mongodb_client{uri{}};
+    client mongodb_client{uri{}, test_util::add_test_server_api()};
     database db = mongodb_client["collection_dropping"];
 
     std::string collname{"mongo_cxx_driver"};
@@ -163,7 +163,7 @@ TEST_CASE("collection dropping") {
 TEST_CASE("CRUD functionality", "[driver::collection]") {
     instance::current();
 
-    client mongodb_client{uri{}};
+    client mongodb_client{uri{}, test_util::add_test_server_api()};
     database db = mongodb_client["collection_crud_functionality"];
 
     auto case_insensitive_collation = make_document(kvp("locale", "en_US"), kvp("strength", 2));
@@ -2276,7 +2276,7 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
 }
 
 TEST_CASE("read_concern is inherited from parent", "[collection]") {
-    client mongo_client{uri{}};
+    client mongo_client{uri{}, test_util::add_test_server_api()};
     database db = mongo_client["collection_read_concern_inheritance"];
 
     read_concern::level majority = read_concern::level::k_majority;
@@ -2327,7 +2327,7 @@ TEST_CASE("create_index tests", "[collection]") {
 
     instance::current();
 
-    client mongodb_client{uri{}};
+    client mongodb_client{uri{}, test_util::add_test_server_api()};
     database db = mongodb_client["collection_create_index"];
 
     SECTION("returns index name") {
@@ -2484,7 +2484,7 @@ TEST_CASE("create_index tests", "[collection]") {
 TEST_CASE("list_indexes", "[collection]") {
     instance::current();
 
-    client mongodb_client{uri{}};
+    client mongodb_client{uri{}, test_util::add_test_server_api()};
     database db = mongodb_client["collection_list_indexes"];
 
     collection coll = db["list_indexes_works"];
@@ -2524,7 +2524,7 @@ TEST_CASE("list_indexes", "[collection]") {
 // use it with all three cursor types.
 TEST_CASE("Cursor iteration", "[collection][cursor]") {
     instance::current();
-    client mongodb_client{uri{}};
+    client mongodb_client{uri{}, test_util::add_test_server_api()};
     database db = mongodb_client["collection_cursor_iteration"];
 
     auto capped_name = std::string("mongo_cxx_driver_capped");
@@ -2651,14 +2651,14 @@ TEST_CASE("Cursor iteration", "[collection][cursor]") {
 TEST_CASE("regressions", "CXX-986") {
     instance::current();
     mongocxx::uri mongo_uri{"mongodb://non-existent-host.invalid/"};
-    mongocxx::client client{mongo_uri};
+    mongocxx::client client{mongo_uri, test_util::add_test_server_api()};
     REQUIRE_THROWS(client.database("irrelevant")["irrelevant"].find_one_and_update(
         make_document(kvp("irrelevant", 1)), make_document(kvp("irrelevant", 2))));
 }
 
 TEST_CASE("bulk_write with container", "[collection]") {
     instance::current();
-    mongocxx::client client{uri{}};
+    mongocxx::client client{uri{}, test_util::add_test_server_api()};
 
     std::vector<model::write> vec;
     for (int32_t i = 0; i != 10; ++i) {
@@ -2677,7 +2677,7 @@ TEST_CASE("bulk_write with container", "[collection]") {
 /* Regression test for CXX-2028. */
 TEST_CASE("find_and_x operations append write concern correctly", "[collection]") {
     instance::current();
-    mongocxx::client client{uri{}};
+    mongocxx::client client{uri{}, test_util::add_test_server_api()};
     mongocxx::write_concern wc;
     wc.acknowledge_level(mongocxx::write_concern::level::k_acknowledged);
 
@@ -2731,7 +2731,7 @@ TEST_CASE("Ensure that the WriteConcernError 'errInfo' object is propagated", "[
     using namespace bsoncxx;
     instance::current();
 
-    client mongodb_client{uri{}};
+    client mongodb_client{uri{}, test_util::add_test_server_api()};
 
     using bsoncxx::builder::basic::sub_document;
     auto err_info = builder::basic::document{};

--- a/src/mongocxx/test/database.cpp
+++ b/src/mongocxx/test/database.cpp
@@ -74,7 +74,7 @@ TEST_CASE("A default constructed database cannot perform operations", "[database
 TEST_CASE("mongocxx::database copy constructor", "[database]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
 
     SECTION("constructing from valid") {
         database database_a = client["a"];
@@ -93,7 +93,7 @@ TEST_CASE("mongocxx::database copy constructor", "[database]") {
 TEST_CASE("mongocxx::database copy assignment operator", "[database]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
 
     SECTION("assigning valid to valid") {
         database database_a = client["a1"];
@@ -133,7 +133,7 @@ TEST_CASE("A database", "[database]") {
 
     instance::current();
 
-    client mongo_client{uri{}};
+    client mongo_client{uri{}, test_util::add_test_server_api()};
 
     SECTION("is created by a client") {
         bool called = false;
@@ -180,7 +180,7 @@ TEST_CASE("A database", "[database]") {
         database_destroy->interpose([&](mongoc_database_t*) { destroy_called = true; });
 
         {
-            client mongo_client{uri{}};
+            client mongo_client{uri{}, test_util::add_test_server_api()};
             database a = mongo_client[database_name];
 
             database b{std::move(a)};
@@ -321,7 +321,7 @@ TEST_CASE("A database", "[database]") {
 TEST_CASE("Database integration tests", "[database]") {
     instance::current();
 
-    client mongo_client{uri{}};
+    client mongo_client{uri{}, test_util::add_test_server_api()};
     stdx::string_view database_name{"database"};
     database database = mongo_client[database_name];
 

--- a/src/mongocxx/test/gridfs/bucket.cpp
+++ b/src/mongocxx/test/gridfs/bucket.cpp
@@ -38,6 +38,7 @@
 #include <mongocxx/options/find.hpp>
 #include <mongocxx/options/gridfs/upload.hpp>
 #include <mongocxx/options/index.hpp>
+#include <mongocxx/test_util/client_helpers.hh>
 #include <mongocxx/uri.hpp>
 
 namespace {
@@ -228,7 +229,7 @@ TEST_CASE("mongocxx::gridfs::bucket default constructor makes invalid bucket", "
 TEST_CASE("mongocxx::gridfs::bucket copy constructor", "[gridfs::bucket]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     database db = client["gridfs_bucket_copy_constructor"];
 
     SECTION("constructing from valid") {
@@ -248,7 +249,7 @@ TEST_CASE("mongocxx::gridfs::bucket copy constructor", "[gridfs::bucket]") {
 TEST_CASE("mongocxx::gridfs::bucket copy assignment operator", "[gridfs::bucket]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     database db = client["gridfs_bucket_copy_assignment"];
 
     SECTION("assigning valid to valid") {
@@ -285,7 +286,7 @@ TEST_CASE("mongocxx::gridfs::bucket copy assignment operator", "[gridfs::bucket]
 TEST_CASE("database::gridfs_bucket() throws error when options are invalid", "[gridfs::bucket]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     database db = client["gridfs_bucket_error_invalid_options"];
 
     options::gridfs::bucket bucket_options;
@@ -307,7 +308,7 @@ TEST_CASE("database::gridfs_bucket() throws error when options are invalid", "[g
 TEST_CASE("uploading throws error when options are invalid", "[gridfs::bucket]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     database db = client["gridfs_upload_error_invalid_options"];
     gridfs::bucket bucket = db.gridfs_bucket();
 
@@ -344,7 +345,7 @@ TEST_CASE("uploading throws error when options are invalid", "[gridfs::bucket]")
 TEST_CASE("downloading throws error when files document is corrupt", "[gridfs::bucket]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     database db = client["gridfs_files_doc_corrupt"];
     gridfs::bucket bucket = db.gridfs_bucket();
 
@@ -441,7 +442,7 @@ TEST_CASE("downloading throws error when files document is corrupt", "[gridfs::b
 TEST_CASE("downloading throws error when chunks document is corrupt", "[gridfs::bucket]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     database db = client["gridfs_chunk_doc_corrupt"];
     gridfs::bucket bucket = db.gridfs_bucket();
 
@@ -522,7 +523,7 @@ TEST_CASE("downloading throws error when chunks document is corrupt", "[gridfs::
 TEST_CASE("mongocxx::gridfs::downloader::read with arbitrary sizes", "[gridfs::downloader]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     database db = client["gridfs_download_read_test"];
     gridfs::bucket bucket = db.gridfs_bucket();
 
@@ -601,7 +602,7 @@ TEST_CASE("mongocxx::gridfs::downloader::read with arbitrary sizes", "[gridfs::d
 TEST_CASE("mongocxx::gridfs::uploader::abort works", "[gridfs::uploader]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     database db = client["gridfs_upload_abort_test"];
     gridfs::bucket bucket = db.gridfs_bucket();
 
@@ -634,7 +635,7 @@ TEST_CASE("mongocxx::gridfs::uploader::abort works", "[gridfs::uploader]") {
 TEST_CASE("mongocxx::gridfs::uploader::write with arbitrary sizes", "[gridfs::uploader]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     database db = client["gridfs_upload_write_test"];
     gridfs::bucket bucket = db.gridfs_bucket();
 
@@ -708,7 +709,7 @@ TEST_CASE("mongocxx::gridfs::uploader::write with arbitrary sizes", "[gridfs::up
 TEST_CASE("gridfs upload/download round trip", "[gridfs::uploader] [gridfs::downloader]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     database db = client["gridfs_upload_download_round_trip_test"];
     gridfs::bucket bucket = db.gridfs_bucket();
 
@@ -741,7 +742,7 @@ TEST_CASE("gridfs upload/download round trip", "[gridfs::uploader] [gridfs::down
 TEST_CASE("gridfs::bucket::open_upload_stream_with_id works", "[gridfs::bucket]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     auto db = client["gridfs_bucket_open_upload_stream_with_id"];
     gridfs::bucket bucket = db.gridfs_bucket();
 
@@ -768,7 +769,7 @@ TEST_CASE("gridfs::bucket::open_upload_stream_with_id works", "[gridfs::bucket]"
 TEST_CASE("gridfs::bucket::upload_from_stream works", "[gridfs::bucket]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     auto db = client["gridfs_bucket_upload_from_stream_works"];
     gridfs::bucket bucket = db.gridfs_bucket();
 
@@ -809,7 +810,7 @@ TEST_CASE("gridfs::bucket::upload_from_stream doesn't infinite loop when passed 
           "[gridfs::bucket]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     database db = client["gridfs_upload_from_stream_no_infinite_loop_ifstream"];
     gridfs::bucket bucket = db.gridfs_bucket();
 
@@ -828,7 +829,7 @@ TEST_CASE("gridfs::bucket::upload_from_stream doesn't infinite loop when passed 
 TEST_CASE("gridfs upload_from_stream aborts on failure", "[gridfs::bucket]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     database db = client["gridfs_upload_from_stream_abort_on_failure"];
     gridfs::bucket bucket = db.gridfs_bucket();
 
@@ -849,7 +850,7 @@ TEST_CASE("gridfs upload_from_stream aborts on failure", "[gridfs::bucket]") {
 TEST_CASE("gridfs::bucket::download_to_stream works", "[gridfs::bucket]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     database db = client["gridfs_download_to_stream_works"];
     gridfs::bucket bucket = db.gridfs_bucket();
 
@@ -873,7 +874,7 @@ TEST_CASE("gridfs::bucket::download_to_stream works", "[gridfs::bucket]") {
 TEST_CASE("gridfs::bucket::delete_file works", "[gridfs::bucket]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     database db = client["gridfs_delete_file_works"];
     gridfs::bucket bucket = db.gridfs_bucket();
 
@@ -894,7 +895,7 @@ TEST_CASE("gridfs::bucket::delete_file works", "[gridfs::bucket]") {
 TEST_CASE("gridfs::bucket::find works", "[gridfs::bucket]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     database db = client["gridfs_find_works"];
     gridfs::bucket bucket = db.gridfs_bucket();
 
@@ -940,7 +941,7 @@ TEST_CASE("gridfs upload large file", "[gridfs::bucket]") {
         return;
     }
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     database db = client["gridfs_upload_large_file"];
     gridfs::bucket bucket = db.gridfs_bucket();
 
@@ -997,7 +998,7 @@ TEST_CASE("gridfs download large file", "[gridfs::bucket]") {
         return;
     }
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     database db = client["gridfs_download_large_file"];
     gridfs::bucket bucket = db.gridfs_bucket();
 
@@ -1070,7 +1071,7 @@ TEST_CASE("gridfs does not create additional indexes", "[gridfs::uploader] [grid
     using bsoncxx::builder::basic::sub_array;
 
     instance::current();
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     auto db_name = _gen_database_name("gridfs_index_creation");
     database db = client[db_name];
 

--- a/src/mongocxx/test/index_view.cpp
+++ b/src/mongocxx/test/index_view.cpp
@@ -71,7 +71,7 @@ void disable_fail_point(const client& conn) {
 TEST_CASE("create_one", "[index_view]") {
     instance::current();
 
-    client mongodb_client{uri{}};
+    client mongodb_client{uri{}, test_util::add_test_server_api()};
     database db = mongodb_client["index_view_create_one"];
 
     SECTION("works with document and options") {
@@ -217,7 +217,7 @@ TEST_CASE("create_one", "[index_view]") {
 TEST_CASE("create_many", "[index_view]") {
     instance::current();
 
-    client mongodb_client{uri{}};
+    client mongodb_client{uri{}, test_util::add_test_server_api()};
     database db = mongodb_client["index_view_create_many"];
 
     std::vector<index_model> models{index_model(make_document(kvp("a", 1))),
@@ -271,7 +271,7 @@ TEST_CASE("create_many", "[index_view]") {
 TEST_CASE("drop_one", "[index_view]") {
     instance::current();
 
-    client mongodb_client{uri{}};
+    client mongodb_client{uri{}, test_util::add_test_server_api()};
     database db = mongodb_client["index_view_drop_one"];
 
     SECTION("drops index by name") {
@@ -366,7 +366,7 @@ TEST_CASE("drop_one", "[index_view]") {
 TEST_CASE("drop_all", "[index_view]") {
     instance::current();
 
-    client mongodb_client{uri{}};
+    client mongodb_client{uri{}, test_util::add_test_server_api()};
     database db = mongodb_client["index_view_drop_all"];
 
     std::vector<index_model> models{index_model{make_document(kvp("a", 1))},
@@ -422,7 +422,7 @@ TEST_CASE("drop_all", "[index_view]") {
 TEST_CASE("index creation and deletion with different collation") {
     instance::current();
 
-    client mongodb_client{uri{}};
+    client mongodb_client{uri{}, test_util::add_test_server_api()};
 
     if (test_util::get_max_wire_version(mongodb_client) >= 5) {
         database db = mongodb_client["index_view_collation"];

--- a/src/mongocxx/test/sdam-monitoring.cpp
+++ b/src/mongocxx/test/sdam-monitoring.cpp
@@ -36,7 +36,7 @@ void open_and_close_client(const uri& test_uri, const options::apm& apm_opts) {
     // Apply listeners and trigger connection.
     options::client client_opts;
     client_opts.apm_opts(apm_opts);
-    client client{test_uri, client_opts};
+    client client{test_uri, test_util::add_test_server_api(client_opts)};
     client["admin"].run_command(make_document(kvp("ping", 1)));
 }
 
@@ -45,7 +45,7 @@ TEST_CASE("SDAM Monitoring", "[sdam_monitoring]") {
     std::string rs_name;
     uri test_uri;
 
-    client discoverer{uri{}};
+    client discoverer{uri{}, test_util::add_test_server_api()};
     auto topology_type = test_util::get_topology(discoverer);
     if (topology_type == "replicaset") {
         rs_name = test_util::replica_set_name(discoverer);

--- a/src/mongocxx/test/spec/change_stream.cpp
+++ b/src/mongocxx/test/spec/change_stream.cpp
@@ -51,7 +51,7 @@ bool should_skip(const array::element& test) {
 
 void test_setup(document::view test, document::view test_spec) {
     // Step 1. "clean up any open transactions from previous test failures"
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     try {
         client["admin"].run_command(make_document(kvp("killAllSessions", make_array())));
     } catch (const operation_exception& e) {
@@ -93,7 +93,7 @@ void run_change_stream_tests_in_file(const std::string& test_path) {
             // "Begin monitoring all APM events for `client`"
             apm_checker.set_ignore_command_monitoring_event("killCursors");
             client_opts.apm_opts(apm_checker.get_apm_opts(true));
-            class client client(uri{}, client_opts);
+            class client client(uri{}, test_util::add_test_server_api(client_opts));
 
             options::change_stream cs_opts{};
             if (test["changeStreamOptions"]) {
@@ -124,7 +124,7 @@ void run_change_stream_tests_in_file(const std::string& test_path) {
 
             // "Using `globalClient`, run every operation in operations in serial against the
             // server."
-            mongocxx::client global_client(uri{});
+            mongocxx::client global_client(uri{}, test_util::add_test_server_api());
             for (auto&& operation : test["operations"].get_array().value) {
                 std::string operation_name = to_string(operation["name"].get_string().value);
                 auto dbname = to_string(operation["database"].get_string().value);
@@ -187,7 +187,7 @@ void run_change_stream_tests_in_file(const std::string& test_path) {
 TEST_CASE("Change stream spec tests", "[change_stream_spec]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     if (!test_util::is_replica_set(client)) {
         WARN("Skipping - not a replica set");
         return;

--- a/src/mongocxx/test/spec/client_side_encryption.cpp
+++ b/src/mongocxx/test/spec/client_side_encryption.cpp
@@ -140,13 +140,13 @@ void run_encryption_tests_in_file(const std::string& test_path) {
     auto tests = test_spec_view["tests"].get_array().value;
 
     /* we may not have a supported topology */
-    if (should_skip_spec_test(client{uri{}}, test_spec_view)) {
+    if (should_skip_spec_test(client{uri{}, test_util::add_test_server_api()}, test_spec_view)) {
         WARN("File skipped - " + test_path);
         return;
     }
 
     class client setup_client {
-        uri {}
+        uri{}, test_util::add_test_server_api(),
     };
 
     write_concern wc_majority;
@@ -155,7 +155,8 @@ void run_encryption_tests_in_file(const std::string& test_path) {
     for (auto&& test : tests) {
         auto description = test["description"].get_string().value;
         INFO("Test description: " << description);
-        if (should_skip_spec_test(client{uri{}}, test.get_document().value)) {
+        if (should_skip_spec_test(client{uri{}, test_util::add_test_server_api()},
+                                  test.get_document().value)) {
             continue;
         }
 
@@ -182,7 +183,7 @@ void run_encryption_tests_in_file(const std::string& test_path) {
         }
 
         class client client {
-            get_uri(test.get_document().value), std::move(client_opts)
+            get_uri(test.get_document().value), test_util::add_test_server_api(client_opts),
         };
 
         auto db = client[db_name];
@@ -227,7 +228,7 @@ void run_encryption_tests_in_file(const std::string& test_path) {
 
         if (test["outcome"] && test["outcome"]["collection"]) {
             class client plaintext_client {
-                uri {}
+                uri{}, test_util::add_test_server_api(),
             };
 
             read_preference rp;

--- a/src/mongocxx/test/spec/command_monitoring.cpp
+++ b/src/mongocxx/test/spec/command_monitoring.cpp
@@ -32,7 +32,7 @@ void initialize_collection(document::view test_spec_view) {
     std::string db_name = string::to_string(test_spec_view["database_name"].get_string().value);
     std::string col_name = string::to_string(test_spec_view["collection_name"].get_string().value);
 
-    client temp_client{uri{}};
+    client temp_client{uri{}, test_util::add_test_server_api()};
     collection temp_col = temp_client[db_name][col_name];
 
     temp_col.drop();
@@ -67,7 +67,7 @@ void run_command_monitoring_tests_in_file(std::string test_path) {
         array::view expectations = test["expectations"].get_array().value;
 
         // Use a separate client to check version info, so as not to interfere with APM
-        client temp_client{uri{}};
+        client temp_client{uri{}, test_util::add_test_server_api()};
         if (spec::should_skip_spec_test(temp_client, test.get_document().value)) {
             return;
         }
@@ -160,7 +160,7 @@ void run_command_monitoring_tests_in_file(std::string test_path) {
 
         // Apply listeners, and run operations.
         client_opts.apm_opts(apm_opts);
-        client client{uri{}, client_opts};
+        client client{uri{}, test_util::add_test_server_api(client_opts)};
 
         collection coll = client[db_name][col_name];
 

--- a/src/mongocxx/test/spec/gridfs.cpp
+++ b/src/mongocxx/test/spec/gridfs.cpp
@@ -499,7 +499,7 @@ void run_gridfs_tests_in_file(std::string test_path, client* client) {
 TEST_CASE("GridFS spec automated tests", "[gridfs_spec]") {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
 
     // Because the GridFS spec tests use write commands that were only added to MongoDB in version
     // 2.6, the tests will not run against any server versions older than that.

--- a/src/mongocxx/test/spec/mongohouse.cpp
+++ b/src/mongocxx/test/spec/mongohouse.cpp
@@ -159,7 +159,7 @@ void test_kill_cursors() {
 void test_connection_without_auth() {
     instance::current();
 
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     client["admin"].run_command(make_document(kvp("ping", 1)));
 }
 

--- a/src/mongocxx/test/spec/retryable-reads.cpp
+++ b/src/mongocxx/test/spec/retryable-reads.cpp
@@ -40,6 +40,7 @@ void run_retryable_reads_tests_in_file(std::string test_path) {
     apm_checker apm_checker;
     apm_checker.set_ignore_command_monitoring_event("killCursors");
     client_opts.apm_opts(apm_checker.get_apm_opts(true /* command_started_events_only */));
+    client_opts = test_util::add_test_server_api(client_opts);
 
     document::view test_spec_view = test_spec->view();
     for (auto&& test : test_spec_view["tests"].get_array().value) {

--- a/src/mongocxx/test/spec/unified_tests/operations.cpp
+++ b/src/mongocxx/test/spec/unified_tests/operations.cpp
@@ -835,7 +835,7 @@ document::value assert_session_transaction_state(client_session& session, docume
 }
 
 bool collection_exists(document::view op) {
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     auto coll_name = string::to_string(op["arguments"]["collectionName"].get_string().value);
     auto db_name = string::to_string(op["arguments"]["databaseName"].get_string().value);
     return client.database(db_name).has_collection(coll_name);
@@ -858,7 +858,7 @@ document::value create_index(collection& coll,
 }
 
 bool index_exists(document::view op) {
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
     auto coll_name = string::to_string(op["arguments"]["collectionName"].get_string().value);
     auto db_name = string::to_string(op["arguments"]["databaseName"].get_string().value);
     auto coll = client.database(db_name).collection(coll_name);

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -425,9 +425,12 @@ client create_client(document::view object) {
     auto conn = "mongodb://" + get_hostnames(object) + "/?" + uri_options_to_string(object);
     auto apm_opts = options::apm{};
     auto client_opts = options::client{};
+    // Use specified serverApi or default if none is provided.
     if (object["serverApi"]) {
         auto server_api_opts = create_server_api(object);
         client_opts.server_api_opts(server_api_opts);
+    } else {
+        client_opts = test_util::add_test_server_api();
     }
 
     add_observe_events(apm_opts, object);

--- a/src/mongocxx/test/transactions.cpp
+++ b/src/mongocxx/test/transactions.cpp
@@ -31,7 +31,7 @@ using bsoncxx::builder::basic::make_document;
 // Run on replica set with 1 node
 TEST_CASE("Transaction tests", "[transactions]") {
     instance::current();
-    client mongodb_client{uri{}};
+    client mongodb_client{uri{}, test_util::add_test_server_api()};
 
     if (!test_util::is_replica_set(mongodb_client)) {
         WARN("Skipping: transactions tests require replica set");
@@ -218,7 +218,7 @@ TEST_CASE("Transaction tests", "[transactions]") {
 
 TEST_CASE("Transactions Documentation Examples", "[transactions]") {
     instance::current();
-    client client{uri{}};
+    client client{uri{}, test_util::add_test_server_api()};
 
     if (!test_util::is_replica_set(client)) {
         WARN("Skipping: transactions tests require replica set");

--- a/src/mongocxx/test_util/client_helpers.cpp
+++ b/src/mongocxx/test_util/client_helpers.cpp
@@ -199,6 +199,16 @@ std::basic_string<std::uint8_t> convert_hex_string_to_bytes(stdx::string_view he
     return bytes;
 }
 
+options::client add_test_server_api(options::client opts) {
+    auto api_version = std::getenv("MONGODB_API_VERSION");
+    // Check if MONGODB_API_VERSION is set and not empty.
+    if (api_version && std::string(api_version).length() > 0) {
+        auto version = options::server_api::version_from_string(api_version);
+        opts.server_api_opts(options::server_api(version));
+    }
+    return opts;
+}
+
 std::int32_t get_max_wire_version(const client& client) {
     auto reply = get_is_master(client);
     auto max_wire_version = reply.view()["maxWireVersion"];

--- a/src/mongocxx/test_util/client_helpers.hh
+++ b/src/mongocxx/test_util/client_helpers.hh
@@ -66,6 +66,17 @@ bool newer_than(const client& client, std::string version);
 std::basic_string<std::uint8_t> convert_hex_string_to_bytes(bsoncxx::stdx::string_view hex);
 
 //
+// Adds server API options to passed-in options if MONGODB_API_VERSION
+// environment variable is set.
+//
+// @param opts
+//   The options to add server API options to.
+//
+// @return The new options with appended server API options.
+//
+options::client add_test_server_api(options::client opts = {});
+
+//
 // Determines the max wire version associated with the given client, by running the "isMaster"
 // command.
 //
@@ -76,12 +87,12 @@ std::int32_t get_max_wire_version(const client& client);
 ///
 /// Determines the server version number by running "serverStatus".
 ///
-std::string get_server_version(const client& client = {uri{}});
+std::string get_server_version(const client& client = {uri{}, add_test_server_api()});
 
 ///
 /// Determines the setting of all server parameters by running "getParameter, *".
 ///
-bsoncxx::document::value get_server_params(const client& client = {uri{}});
+bsoncxx::document::value get_server_params(const client& client = {uri{}, add_test_server_api()});
 
 ///
 /// Get replica set name, or empty string.
@@ -91,17 +102,17 @@ std::string replica_set_name(const client& client);
 ///
 /// Determines if the server is a replica set member.
 ///
-bool is_replica_set(const client& client = {uri{}});
+bool is_replica_set(const client& client = {uri{}, add_test_server_api()});
 
 ///
 /// Returns "standalone", "replicaset", or "sharded".
 ///
-std::string get_topology(const client& client = {uri{}});
+std::string get_topology(const client& client = {uri{}, add_test_server_api()});
 
 ///
 /// Returns the "host" field of the config.shards collection.
 ///
-std::string get_hosts(const client& client = {uri{}});
+std::string get_hosts(const client& client = {uri{}, add_test_server_api()});
 
 ///
 /// Parses a JSON file at a given path and return it as a BSON document value.


### PR DESCRIPTION
CXX-2254

Adds two new tasks `test_versioned_api` and `test_versioned_api_accept_version_two`. Adds a new test utility `test_util::add_test_server_api` to append server API options when `MONGODB_API_VERSION` environment variable is set. Uses `add_test_server_api` to add API version to connecting clients in tests where necessary.