### PR TITLE
CXX-2286 sync command-monitoring and unified-format tests

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -223,8 +223,7 @@ functions:
                     if [ "1" == "${BSON_EXTRA_ALIGNMENT}" ]; then
                         echo "Building C driver with BSON extra alignment"
                     fi
-                    # TODO: CXX-2286 update from 1.18.0-alpha2 to master
-                    BSON_EXTRA_ALIGNMENT=${BSON_EXTRA_ALIGNMENT} ./.evergreen/install_c_driver.sh ${mongoc_version|1.18.0-alpha2}
+                    BSON_EXTRA_ALIGNMENT=${BSON_EXTRA_ALIGNMENT} ./.evergreen/install_c_driver.sh ${mongoc_version|master}
 
     "lint":
         - command: shell.exec
@@ -437,8 +436,7 @@ functions:
                   # API version to example clients, so example projects will fail when requireApiVersion
                   # is true.
                   if [[ -z "$MONGODB_API_VERSION" ]]; then
-                    # TODO: CXX-2286 update from 1.18.0-alpha2 to master
-                    MONGOC_VERSION=${mongoc_version|1.18.0-alpha2} .evergreen/build_example_projects.sh
+                    MONGOC_VERSION=${mongoc_version|master} .evergreen/build_example_projects.sh
                   fi
                   unset MONGODB_API_VERSION
 
@@ -1104,7 +1102,7 @@ buildvariants:
           tar_options: *linux_tar_options
           cmake_flags: *linux_cmake_flags
           mongodb_version: *version_latest
-          mongoc_version: "1.18.0-alpha2" # TODO: CXX-2220 update to 1.18.0 after release.
+          mongoc_version: "master" # TODO: CXX-2220 update to 1.18.0 after release.
       run_on:
           - ubuntu1804-build
       tasks:

--- a/.mci.yml
+++ b/.mci.yml
@@ -223,7 +223,8 @@ functions:
                     if [ "1" == "${BSON_EXTRA_ALIGNMENT}" ]; then
                         echo "Building C driver with BSON extra alignment"
                     fi
-                    BSON_EXTRA_ALIGNMENT=${BSON_EXTRA_ALIGNMENT} ./.evergreen/install_c_driver.sh ${mongoc_version|master}
+                    # TODO: CXX-2286 update from 1.18.0-alpha2 to master
+                    BSON_EXTRA_ALIGNMENT=${BSON_EXTRA_ALIGNMENT} ./.evergreen/install_c_driver.sh ${mongoc_version|1.18.0-alpha2}
 
     "lint":
         - command: shell.exec
@@ -436,7 +437,8 @@ functions:
                   # API version to example clients, so example projects will fail when requireApiVersion
                   # is true.
                   if [[ -z "$MONGODB_API_VERSION" ]]; then
-                    MONGOC_VERSION=${mongoc_version|master} .evergreen/build_example_projects.sh
+                    # TODO: CXX-2286 update from 1.18.0-alpha2 to master
+                    MONGOC_VERSION=${mongoc_version|1.18.0-alpha2} .evergreen/build_example_projects.sh
                   fi
                   unset MONGODB_API_VERSION
 
@@ -1102,7 +1104,7 @@ buildvariants:
           tar_options: *linux_tar_options
           cmake_flags: *linux_cmake_flags
           mongodb_version: *version_latest
-          mongoc_version: "master" # TODO: CXX-2220 update to 1.18.0 after release.
+          mongoc_version: "1.18.0-alpha2" # TODO: CXX-2220 update to 1.18.0 after release.
       run_on:
           - ubuntu1804-build
       tasks:

--- a/data/command-monitoring/find.json
+++ b/data/command-monitoring/find.json
@@ -413,8 +413,9 @@
       ]
     },
     {
-      "description": "A successful find event with a getmore and the server kills the cursor",
+      "description": "A successful find event with a getmore and the server kills the cursor (<= 4.4)",
       "ignore_if_server_version_less_than": "3.1",
+      "ignore_if_server_version_greater_than": "4.4",
       "ignore_if_topology_type": [
         "sharded"
       ],

--- a/data/unified-format/valid-pass/poc-command-monitoring.json
+++ b/data/unified-format/valid-pass/poc-command-monitoring.json
@@ -57,10 +57,11 @@
   ],
   "tests": [
     {
-      "description": "A successful find event with a getmore and the server kills the cursor",
+      "description": "A successful find event with a getmore and the server kills the cursor (<= 4.4)",
       "runOnRequirements": [
         {
           "minServerVersion": "3.1",
+          "maxServerVersion": "4.4.99",
           "topologies": [
             "single",
             "replicaset"
@@ -149,7 +150,7 @@
                     ]
                   },
                   "collection": "test",
-                  "batchSize": 3
+                  "batchSize": 1
                 },
                 "commandName": "getMore",
                 "databaseName": "command-monitoring-tests"

--- a/data/unified-format/valid-pass/poc-transactions.json
+++ b/data/unified-format/valid-pass/poc-transactions.json
@@ -61,14 +61,15 @@
           "object": "session0"
         },
         {
-          "name": "insertOne",
+          "name": "updateOne",
           "object": "collection0",
           "arguments": {
             "session": "session0",
-            "document": {
-              "_id": {
-                ".": "."
-              }
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "x": 1
             }
           },
           "expectError": {


### PR DESCRIPTION
Some of the recent changes in the C driver cause many tasks in the C++ driver build to fail (until CXX-2286 is done).  This change restores the failing tasks on the waterfall to a working state so that other work can continue.

Full patch build: https://spruce.mongodb.com/version/60e49b5ae3c33126420ccab1/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC