### PR TITLE
CXX-2290: Validate command filtering in event monitoring

### DIFF
--- a/data/unified-format/test_files.txt
+++ b/data/unified-format/test_files.txt
@@ -8,3 +8,4 @@ valid-pass/poc-sessions.json
 valid-pass/poc-transactions-convenient-api.json
 valid-pass/poc-transactions.json
 valid-pass/poc-transactions-mongos-pin-auto.json
+valid-pass/redacted-commands.json

--- a/data/unified-format/valid-pass/redacted-commands.json
+++ b/data/unified-format/valid-pass/redacted-commands.json
@@ -1,0 +1,703 @@
+{
+  "description": "redacted-commands",
+  "schemaVersion": "1.5",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "5.0",
+      "auth": false
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent"
+        ],
+        "observeSensitiveCommands": true
+      }
+    },
+    {
+      "client": {
+        "id": "client-no-observe",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent"
+        ],
+        "observeSensitiveCommands": false
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "command-monitoring-tests"
+      }
+    },
+    {
+      "database": {
+        "id": "unobserved-database",
+        "client": "client-no-observe",
+        "databaseName": "command-monitoring-tests-2"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "authenticate",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "authenticate",
+            "command": {
+              "authenticate": 1,
+              "mechanism": "MONGODB-X509",
+              "user": "CN=myName,OU=myOrgUnit,O=myOrg,L=myLocality,ST=myState,C=myCountry",
+              "db": "$external"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "authenticate",
+                "command": {
+                  "authenticate": {
+                    "$$exists": false
+                  },
+                  "mechanism": {
+                    "$$exists": false
+                  },
+                  "user": {
+                    "$$exists": false
+                  },
+                  "db": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "authenticate-without-observing",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "unobserved-database",
+          "arguments": {
+            "commandName": "authenticate",
+            "command": {
+              "authenticate": 1,
+              "mechanism": "MONGODB-X509",
+              "user": "CN=myName,OU=myOrgUnit,O=myOrg,L=myLocality,ST=myState,C=myCountry",
+              "db": "$external"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client-no-observe",
+          "events": []
+        }
+      ]
+    },
+    {
+      "description": "saslStart",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "saslStart",
+            "command": {
+              "saslStart": 1,
+              "payload": "definitely-invalid-payload",
+              "db": "admin"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "saslStart",
+                "command": {
+                  "saslStart": {
+                    "$$exists": false
+                  },
+                  "payload": {
+                    "$$exists": false
+                  },
+                  "db": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "saslContinue",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "saslContinue",
+            "command": {
+              "saslContinue": 1,
+              "conversationId": 0,
+              "payload": "definitely-invalid-payload"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "saslContinue",
+                "command": {
+                  "saslContinue": {
+                    "$$exists": false
+                  },
+                  "conversationId": {
+                    "$$exists": false
+                  },
+                  "payload": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "getnonce",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "getnonce",
+            "command": {
+              "getnonce": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "getnonce",
+                "command": {
+                  "getnonce": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "getnonce",
+                "reply": {
+                  "ok": {
+                    "$$exists": false
+                  },
+                  "nonce": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "createUser",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "createUser",
+            "command": {
+              "createUser": "private",
+              "pwd": {},
+              "roles": []
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "createUser",
+                "command": {
+                  "createUser": {
+                    "$$exists": false
+                  },
+                  "pwd": {
+                    "$$exists": false
+                  },
+                  "roles": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "updateUser",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "updateUser",
+            "command": {
+              "updateUser": "private",
+              "pwd": {},
+              "roles": []
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "updateUser",
+                "command": {
+                  "updateUser": {
+                    "$$exists": false
+                  },
+                  "pwd": {
+                    "$$exists": false
+                  },
+                  "roles": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "copydbgetnonce",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "copydbgetnonce",
+            "command": {
+              "copydbgetnonce": "private"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "copydbgetnonce",
+                "command": {
+                  "copydbgetnonce": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "copydbsaslstart",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "copydbsaslstart",
+            "command": {
+              "copydbsaslstart": "private"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "copydbsaslstart",
+                "command": {
+                  "copydbsaslstart": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "copydb",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "copydb",
+            "command": {
+              "copydb": "private"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "copydb",
+                "command": {
+                  "copydb": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "hello with speculative authenticate",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.9"
+        }
+      ],
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "hello",
+            "command": {
+              "hello": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "hello",
+                "command": {
+                  "hello": {
+                    "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "hello",
+                "reply": {
+                  "isWritablePrimary": {
+                    "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "legacy hello with speculative authenticate",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "ismaster",
+            "command": {
+              "ismaster": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "isMaster",
+            "command": {
+              "isMaster": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "ismaster",
+                "command": {
+                  "ismaster": {
+                    "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "ismaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "isMaster",
+                "command": {
+                  "isMaster": {
+                    "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "isMaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "hello without speculative authenticate is not redacted",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.9"
+        }
+      ],
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "hello",
+            "command": {
+              "hello": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "hello",
+                "command": {
+                  "hello": 1
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "hello",
+                "reply": {
+                  "isWritablePrimary": {
+                    "$$exists": true
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "legacy hello without speculative authenticate is not redacted",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "ismaster",
+            "command": {
+              "ismaster": 1
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "isMaster",
+            "command": {
+              "isMaster": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "ismaster",
+                "command": {
+                  "ismaster": 1
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "ismaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": true
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "isMaster",
+                "command": {
+                  "isMaster": 1
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "isMaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": true
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/mongocxx/test/spec/monitoring.hh
+++ b/src/mongocxx/test/spec/monitoring.hh
@@ -73,6 +73,9 @@ class apm_checker {
     void set_command_failed_unified(options::apm& apm);
     void set_command_succeeded_unified(options::apm& apm);
 
+    /// Whether we should record "sensitive" events
+    bool observe_sensitive_events = false;
+
    private:
     event_vector _events;
     std::vector<std::string> _ignore;

--- a/src/mongocxx/test/spec/unified_tests/assert.cpp
+++ b/src/mongocxx/test/spec/unified_tests/assert.cpp
@@ -34,7 +34,7 @@ using bsoncxx::types::bson_value::value;
 
 namespace {
 
-/// When we are matching two documents, we walk down them recursively. To aide test debugging, store
+/// When we are matching two documents, we walk down them recursively. To aid test debugging, store
 /// a path as we go, in this variable:
 thread_local std::vector<std::string> S_match_doc_path;
 

--- a/src/mongocxx/test/spec/unified_tests/assert.cpp
+++ b/src/mongocxx/test/spec/unified_tests/assert.cpp
@@ -15,6 +15,7 @@
 #include "assert.hh"
 
 #include <iomanip>
+#include <numeric>
 #include <sstream>
 #include <string>
 

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -46,6 +46,8 @@ using bsoncxx::builder::basic::make_document;
 
 using schema_versions_t =
     std::array<std::array<int, 3 /* major.minor.patch */>, 2 /* supported version */>;
+// NOTE: 1.5.0 support is only *partial*: Enough for to support the redacted-commands.json
+// test cases.
 constexpr schema_versions_t schema_versions{{{{1, 1, 0}}, {{1, 5, 0}}}};
 
 std::pair<std::unordered_map<std::string, spec::apm_checker>&, entity::map&> init_maps() {

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -45,8 +45,8 @@ using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_document;
 
 using schema_versions_t =
-    std::array<std::array<int, 3 /* major.minor.patch */>, 1 /* supported version */>;
-constexpr schema_versions_t schema_versions{{{{1, 1, 0}}}};
+    std::array<std::array<int, 3 /* major.minor.patch */>, 2 /* supported version */>;
+constexpr schema_versions_t schema_versions{{{{1, 1, 0}}, {{1, 5, 0}}}};
 
 std::pair<std::unordered_map<std::string, spec::apm_checker>&, entity::map&> init_maps() {
     // Below initializes the static apm map and entity map if needed, in that order. This will also

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -259,6 +259,9 @@ void add_observe_events(options::apm& apm_opts, document::view object) {
     auto name = string::to_string(object["id"].get_string().value);
     auto& apm = get_apm_map()[name];
 
+    auto observe_sensitive = object["observeSensitiveCommands"];
+    apm.observe_sensitive_events = observe_sensitive && observe_sensitive.get_bool();
+
     auto events = object["observeEvents"].get_array().value;
     if (std::end(events) !=
         std::find(std::begin(events), std::end(events), value("commandStartedEvent")))


### PR DESCRIPTION
No functional changes, but checks that we see filtered events that bubble-up from the C driver. Also cleans up the unified-test-spec runner with some more thorough checking and error messages.