### PR TITLE
CXX-1774 - Documentation for countDocuments MUST mention estimatedDoc…

### DIFF
--- a/src/mongocxx/collection.hpp
+++ b/src/mongocxx/collection.hpp
@@ -413,6 +413,9 @@ class MONGOCXX_API collection {
     ///
     /// @throws mongocxx::query_exception if the count operation fails.
     ///
+    /// @note For a fast count of the total documents in a collection, see estimated_document_count().
+    /// @see mongocxx::estimated_document_count
+    ///
     std::int64_t count_documents(bsoncxx::document::view_or_value filter,
                                  const options::count& options = options::count());
 
@@ -448,6 +451,8 @@ class MONGOCXX_API collection {
     /// @return The count of the documents that matched the filter.
     ///
     /// @throws mongocxx::query_exception if the count operation fails.
+    ///
+    /// @see mongocxx::count_documents
     ///
     std::int64_t estimated_document_count(
         const options::estimated_document_count& options = options::estimated_document_count());


### PR DESCRIPTION
…umentCount

Update Doxygen text for count_documents() to mention
estimated_document_count() and vice-versa, some users found it difficult to discover
one from the other.

https://jira.mongodb.org/browse/CXX-1774

Signed-off-by: Jesse Williamson <jesse.williamson@mongodb.com>