### PR TITLE
CXX-2329 Change type of thrown exception to match documentation

### DIFF
--- a/src/mongocxx/collection.hpp
+++ b/src/mongocxx/collection.hpp
@@ -413,7 +413,8 @@ class MONGOCXX_API collection {
     ///
     /// @throws mongocxx::query_exception if the count operation fails.
     ///
-    /// @note For a fast count of the total documents in a collection, see estimated_document_count().
+    /// @note For a fast count of the total documents in a collection, see
+    /// estimated_document_count().
     /// @see mongocxx::estimated_document_count
     ///
     std::int64_t count_documents(bsoncxx::document::view_or_value filter,

--- a/src/mongocxx/exception/error_code.cpp
+++ b/src/mongocxx/exception/error_code.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015-present MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -84,6 +84,8 @@ class error_category final : public std::error_category {
                 return "an invalid client session was provided";
             case error_code::k_invalid_transaction_options_object:
                 return "an invalid transactions options object was provided";
+	    case error_code::k_create_resource_fail:
+		return "could not create resource";
             default:
                 return "unknown mongocxx error";
         }

--- a/src/mongocxx/exception/error_code.cpp
+++ b/src/mongocxx/exception/error_code.cpp
@@ -84,8 +84,8 @@ class error_category final : public std::error_category {
                 return "an invalid client session was provided";
             case error_code::k_invalid_transaction_options_object:
                 return "an invalid transactions options object was provided";
-	    case error_code::k_create_resource_fail:
-		return "could not create resource";
+            case error_code::k_create_resource_fail:
+                return "could not create resource";
             default:
                 return "unknown mongocxx error";
         }

--- a/src/mongocxx/exception/error_code.hpp
+++ b/src/mongocxx/exception/error_code.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015-present MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -89,6 +89,9 @@ enum class error_code : std::int32_t {
 
     /// A moved-from mongocxx::options::transaction object has been used.
     k_invalid_transaction_options_object,
+
+    // A resource (server API handle, etc.) could not be created:
+    k_create_resource_fail,
 
     // Add new constant string message to error_code.cpp as well!
 };

--- a/src/mongocxx/options/private/server_api.hh
+++ b/src/mongocxx/options/private/server_api.hh
@@ -14,9 +14,10 @@
 
 #pragma once
 
+#include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/options/apm.hpp>
 #include <mongocxx/private/libmongoc.hh>
-#include <mongocxx/exception/logic_error.hpp>
+
 #include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
@@ -33,13 +34,15 @@ static unique_server_api make_server_api(const server_api& opts) {
     auto result = libmongoc::server_api_version_from_string(
         server_api::version_to_string(opts.get_version()).c_str(), &mongoc_api_version);
     if (!result) {
-        throw mongocxx::logic_error{mongocxx::error_code::k_invalid_parameter, "invalid server API version" +
-                      		         server_api::version_to_string(opts.get_version())};
+        throw mongocxx::logic_error{
+            mongocxx::error_code::k_invalid_parameter,
+            "invalid server API version" + server_api::version_to_string(opts.get_version())};
     }
 
     auto mongoc_server_api_opts = libmongoc::server_api_new(mongoc_api_version);
     if (!mongoc_server_api_opts) {
-        throw mongocxx::logic_error{mongocxx::error_code::k_create_resource_fail ,"could not create server API"};
+        throw mongocxx::logic_error{mongocxx::error_code::k_create_resource_fail,
+                                    "could not create server API"};
     }
 
     if (opts.strict().value_or(false)) {

--- a/src/mongocxx/options/private/server_api.hh
+++ b/src/mongocxx/options/private/server_api.hh
@@ -16,7 +16,7 @@
 
 #include <mongocxx/options/apm.hpp>
 #include <mongocxx/private/libmongoc.hh>
-
+#include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/config/private/prelude.hh>
 
 namespace mongocxx {
@@ -33,13 +33,13 @@ static unique_server_api make_server_api(const server_api& opts) {
     auto result = libmongoc::server_api_version_from_string(
         server_api::version_to_string(opts.get_version()).c_str(), &mongoc_api_version);
     if (!result) {
-        throw std::logic_error{"invalid server API version" +
-                               server_api::version_to_string(opts.get_version())};
+        throw mongocxx::logic_error{mongocxx::error_code::k_invalid_parameter, "invalid server API version" +
+                      		         server_api::version_to_string(opts.get_version())};
     }
 
     auto mongoc_server_api_opts = libmongoc::server_api_new(mongoc_api_version);
     if (!mongoc_server_api_opts) {
-        throw std::logic_error{"could not create server API"};
+        throw mongocxx::logic_error{mongocxx::error_code::k_create_resource_fail ,"could not create server API"};
     }
 
     if (opts.strict().value_or(false)) {

--- a/src/mongocxx/options/server_api.cpp
+++ b/src/mongocxx/options/server_api.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <system_error>
+
 #include <bsoncxx/stdx/string_view.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/options/server_api.hpp>
@@ -29,7 +31,7 @@ std::string server_api::version_to_string(server_api::version version) {
         case server_api::version::k_version_1:
             return "1";
         default:
-            throw std::logic_error{"invalid server API version"};
+            throw mongocxx::logic_error{std::make_error_code(std::errc::invalid_argument), "invalid server API version"};
     }
 }
 
@@ -37,7 +39,7 @@ server_api::version server_api::version_from_string(stdx::string_view version) {
     if (!version.compare("1")) {
         return server_api::version::k_version_1;
     }
-    throw std::logic_error{"invalid server API version"};
+    throw mongocxx::logic_error{std::make_error_code(std::errc::invalid_argument), "invalid server API version"};
 }
 
 server_api::server_api(server_api::version version) : _version(std::move(version)) {}

--- a/src/mongocxx/options/server_api.cpp
+++ b/src/mongocxx/options/server_api.cpp
@@ -32,7 +32,8 @@ std::string server_api::version_to_string(server_api::version version) {
         case server_api::version::k_version_1:
             return "1";
         default:
-            throw mongocxx::logic_error { mongocxx::error_code::k_invalid_parameter, "invalid server API version" };
+            throw mongocxx::logic_error{mongocxx::error_code::k_invalid_parameter,
+                                        "invalid server API version"};
     }
 }
 
@@ -40,7 +41,8 @@ server_api::version server_api::version_from_string(stdx::string_view version) {
     if (!version.compare("1")) {
         return server_api::version::k_version_1;
     }
-    throw mongocxx::logic_error { mongocxx::error_code::k_invalid_parameter, "invalid server API version" };
+    throw mongocxx::logic_error{mongocxx::error_code::k_invalid_parameter,
+                                "invalid server API version"};
 }
 
 server_api::server_api(server_api::version version) : _version(std::move(version)) {}

--- a/src/mongocxx/options/server_api.cpp
+++ b/src/mongocxx/options/server_api.cpp
@@ -15,6 +15,7 @@
 #include <system_error>
 
 #include <bsoncxx/stdx/string_view.hpp>
+#include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/options/server_api.hpp>
 #include <mongocxx/private/libmongoc.hh>
@@ -31,7 +32,7 @@ std::string server_api::version_to_string(server_api::version version) {
         case server_api::version::k_version_1:
             return "1";
         default:
-            throw mongocxx::logic_error{std::make_error_code(std::errc::invalid_argument), "invalid server API version"};
+            throw mongocxx::logic_error { mongocxx::logic_error::k_invalid_argument, "invalid server API version" };
     }
 }
 
@@ -39,7 +40,7 @@ server_api::version server_api::version_from_string(stdx::string_view version) {
     if (!version.compare("1")) {
         return server_api::version::k_version_1;
     }
-    throw mongocxx::logic_error{std::make_error_code(std::errc::invalid_argument), "invalid server API version"};
+    throw mongocxx::logic_error { mongocxx::logic_error::k_invalid_argument, "invalid server API version" };
 }
 
 server_api::server_api(server_api::version version) : _version(std::move(version)) {}

--- a/src/mongocxx/options/server_api.cpp
+++ b/src/mongocxx/options/server_api.cpp
@@ -32,7 +32,7 @@ std::string server_api::version_to_string(server_api::version version) {
         case server_api::version::k_version_1:
             return "1";
         default:
-            throw mongocxx::logic_error { mongocxx::logic_error::k_invalid_argument, "invalid server API version" };
+            throw mongocxx::logic_error { mongocxx::error_code::k_invalid_parameter, "invalid server API version" };
     }
 }
 
@@ -40,7 +40,7 @@ server_api::version server_api::version_from_string(stdx::string_view version) {
     if (!version.compare("1")) {
         return server_api::version::k_version_1;
     }
-    throw mongocxx::logic_error { mongocxx::logic_error::k_invalid_argument, "invalid server API version" };
+    throw mongocxx::logic_error { mongocxx::error_code::k_invalid_parameter, "invalid server API version" };
 }
 
 server_api::server_api(server_api::version version) : _version(std::move(version)) {}

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -2333,10 +2333,10 @@ TEST_CASE("read_concern is inherited from parent", "[collection]") {
     }
 }
 
-void find_index_and_validate(collection& coll,
-                             stdx::string_view index_name,
-                             const std::function<void(bsoncxx::document::view)>& validate =
-                                 [](bsoncxx::document::view) {}) {
+void find_index_and_validate(
+    collection& coll,
+    stdx::string_view index_name,
+    const std::function<void(bsoncxx::document::view)>& validate = [](bsoncxx::document::view) {}) {
     auto cursor = coll.list_indexes();
 
     for (auto&& index : cursor) {

--- a/src/mongocxx/test/uri.cpp
+++ b/src/mongocxx/test/uri.cpp
@@ -333,18 +333,20 @@ TEST_CASE("uri::compressors()", "[uri]") {
 
 // Zero is not allowed for heartbeatFrequencyMS.
 TEST_CASE("uri::heartbeat_frequency_ms()", "[uri]") {
-    _test_int32_option("heartbeatFrequencyMS",
-                       [](mongocxx::uri& uri) { return uri.heartbeat_frequency_ms(); },
-                       "1234",
-                       false);
+    _test_int32_option(
+        "heartbeatFrequencyMS",
+        [](mongocxx::uri& uri) { return uri.heartbeat_frequency_ms(); },
+        "1234",
+        false);
 }
 
 // -1 to 9 are only valid values of zlib compression level.
 TEST_CASE("uri::zlib_compression_level()", "[uri]") {
-    _test_int32_option("zlibCompressionLevel",
-                       [](mongocxx::uri& uri) { return uri.zlib_compression_level(); },
-                       "5",
-                       true);
+    _test_int32_option(
+        "zlibCompressionLevel",
+        [](mongocxx::uri& uri) { return uri.zlib_compression_level(); },
+        "5",
+        true);
 }
 
 // End special cases.

--- a/src/mongocxx/uri.cpp
+++ b/src/mongocxx/uri.cpp
@@ -97,14 +97,14 @@ std::string uri::password() const {
 
 class read_concern uri::read_concern() const {
     auto rc = libmongoc::uri_get_read_concern(_impl->uri_t);
-    return (class read_concern)(
-        stdx::make_unique<read_concern::impl>(libmongoc::read_concern_copy(rc)));
+    return (class read_concern)(stdx::make_unique<read_concern::impl>(
+        libmongoc::read_concern_copy(rc)));
 }
 
 class read_preference uri::read_preference() const {
     auto rp = libmongoc::uri_get_read_prefs_t(_impl->uri_t);
-    return (class read_preference)(
-        stdx::make_unique<read_preference::impl>(libmongoc::read_prefs_copy(rp)));
+    return (class read_preference)(stdx::make_unique<read_preference::impl>(
+        libmongoc::read_prefs_copy(rp)));
 }
 
 std::string uri::replica_set() const {
@@ -129,8 +129,8 @@ std::string uri::username() const {
 
 class write_concern uri::write_concern() const {
     auto wc = libmongoc::uri_get_write_concern(_impl->uri_t);
-    return (class write_concern)(
-        stdx::make_unique<write_concern::impl>(libmongoc::write_concern_copy(wc)));
+    return (class write_concern)(stdx::make_unique<write_concern::impl>(
+        libmongoc::write_concern_copy(wc)));
 }
 
 static stdx::optional<stdx::string_view> _string_option(mongoc_uri_t* uri, std::string opt_name) {


### PR DESCRIPTION
The documentation says that we should throw mongocxx::logic_error, but std::logic_error is thrown instead.

Note: at this time mongocxx::logic_error does not have support for error messages (the C++ standard does) 
Note: it's unclear to me why we don't throw mongocxx::invalid_argument instead (the C++ standard has this)

See: https://jira.mongodb.org/browse/CXX-2329

Signed-off-by: Jesse Williamson <jesse.williamson@mongodb.com>