### PR TITLE
Cxx2257 jfw versioned api examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB Inc.
+# Copyright 2016-present MongoDB Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Provide examples in the C++ driver documentation for calling the versioned API and some utilities, in order to satisfy:
https://jira.mongodb.org/browse/CXX-2257?filter=-1

Whether this is corrected by a documentation change or by the underlying implementation, this depends upon:
https://jira.mongodb.org/browse/CXX-2329

Note: the namespace expansions feel verbose to me, I can be easily convinced to use aliases, as I think (a'la Boost) it
will actually be easier for the reader to understand.