### PR TITLE
CXX-2282 use arm64 hosts for rpm-package-build

### DIFF
--- a/.evergreen/build_snapshot_rpm.sh
+++ b/.evergreen/build_snapshot_rpm.sh
@@ -39,7 +39,7 @@ done
 
 package=mongo-cxx-driver
 spec_file=../mongo-cxx-driver.spec
-config=${MOCK_TARGET_CONFIG:=fedora-35-x86_64}
+config=${MOCK_TARGET_CONFIG:=fedora-35-aarch64}
 
 if [ ! -x /usr/bin/rpmbuild -o ! -x /usr/bin/rpmspec ]; then
   echo "Missing the rpmbuild or rpmspec utility from the rpm-build package"

--- a/.mci.yml
+++ b/.mci.yml
@@ -1362,4 +1362,4 @@ buildvariants:
          - name: debian-package-build-mnmlstc
          - name: rpm-package-build
            distros:
-           - rhel80-test
+           - rhel82-arm64-small


### PR DESCRIPTION
Patch build: https://spruce.mongodb.com/version/6103241dc9ec440971d9d8f8/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC