### PR TITLE
Add instructions to enable fail points for test suite

### DIFF
--- a/docs/content/contributing/testing-mongocxx.md
+++ b/docs/content/contributing/testing-mongocxx.md
@@ -61,14 +61,14 @@ the [mongodb server](https://www.mongodb.com/download-center).
 Then deploy a mongod on the default port with the command:
 
 ```
-mongod
+mongod --setParameter enableTestCommands=1
 ```
 
 if it is installed, otherwise navigate to the directory holding the mongod
 executable, and run:
 
 ```
-./mongod
+./mongod --setParameter enableTestCommands=1
 ```
 
 following either command with any flags you wish to use, excluding


### PR DESCRIPTION
Several tests require use of the [`configureFailPoint` command](https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.rst#configuring-fail-points) to trigger server-side errors. The command must be enabled via configuration file or command line option when starting `mongod`.

The `configureFailPoint` command is not yet documented; see [DOCS-10784](https://jira.mongodb.org/browse/DOCS-10784).

---

This PR is motivated by my experience following written instructions to run the test suite locally. After following instructions, several tests were failing due to the error: `no such command: 'configureFailPoint'`.

Diagnosing this issue was difficult due to the `configureFailPoint` command having little to no documentation. It is however mentioned in the [unified test format specification](https://github.com/mongodb/specifications/blob/df6be82f865e9b72444488fd62ae1eb5fca18569/source/unified-test-format/unified-test-format.rst#server-fail-points). To _correctly_ run the entire test suite, fail points must be enabled via the `enableTestCommands` server parameter. Discovering this was difficult due to relevant information being scattered around in unusual locations; notably, it is not mentioned in any official documentation pages (though it is mentioned in the [legacy C++ driver testing documentation](https://github.com/mongodb/mongo-cxx-driver/blob/2fdfd62c60370f660c935f82c1f67b7d4b26d9ab/docs/content/contributing/testing-legacy.md#integration-tests)).

This PR seeks to improve the accuracy of testing instructions by explicitly including the command line option when starting `mongod`.