### PR TITLE
CXX-2332 use Python from toolchain on Ubuntu 14.04 Evergreen hosts

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -280,7 +280,9 @@ functions:
                   fi
                   export CMAKE=${cmake}
 
-                  if ! python -m virtualenv venv 2>/dev/null; then
+                  if [ "x$(lsb_release -cs)" = "xtrusty" -a -f /opt/mongodbtoolchain/v2/bin/python ]; then
+                      /opt/mongodbtoolchain/v2/bin/python -m virtualenv venv
+                  elif ! python -m virtualenv venv 2>/dev/null; then
                       /opt/mongodbtoolchain/v3/bin/python3 -m venv venv
                   fi
 


### PR DESCRIPTION
Evergreen patch build: https://spruce.mongodb.com/version/614145d53627e0056293ee65/tasks

This is essentially the same change as mongodb/mongo-c-driver#867