### PR TITLE
CXX-2370 fix lint

### DIFF
--- a/src/bsoncxx/private/helpers.hh
+++ b/src/bsoncxx/private/helpers.hh
@@ -44,8 +44,7 @@ something that can be improved as part of CXX-2350 (migration to more recent C++
 standards).
 */
 inline bsoncxx::oid make_oid(const bson_oid_t* bson_oid) {
-    return bsoncxx::oid(reinterpret_cast<const char*>(bson_oid),
-                        bsoncxx::oid::size());
+    return bsoncxx::oid(reinterpret_cast<const char*>(bson_oid), bsoncxx::oid::size());
 }
 
 }  // namespace helpers

--- a/src/bsoncxx/types/bson_value/view.cpp
+++ b/src/bsoncxx/types/bson_value/view.cpp
@@ -89,7 +89,8 @@ view& view::operator=(const view& rhs) noexcept {
         break;
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
-default : break;
+        default:
+            break;
     }
 
     _type = rhs._type;

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -2333,10 +2333,10 @@ TEST_CASE("read_concern is inherited from parent", "[collection]") {
     }
 }
 
-void find_index_and_validate(
-    collection& coll,
-    stdx::string_view index_name,
-    const std::function<void(bsoncxx::document::view)>& validate = [](bsoncxx::document::view) {}) {
+void find_index_and_validate(collection& coll,
+                             stdx::string_view index_name,
+                             const std::function<void(bsoncxx::document::view)>& validate =
+                                 [](bsoncxx::document::view) {}) {
     auto cursor = coll.list_indexes();
 
     for (auto&& index : cursor) {

--- a/src/mongocxx/test/database.cpp
+++ b/src/mongocxx/test/database.cpp
@@ -495,7 +495,7 @@ TEST_CASE("Database integration tests", "[database]") {
 // As C++11 lacks generic lambdas, and "ordinary" templates can't appear at block scope,
 // we'll have to define our helper for the serviceId tests here. This implementation would
 // be more straightforward in newer versions of C++ (C++14 and on allow generic lambdas),
-// see CXX-2350 (migration to more recent C++ standards); our C++17 optional<> implementation 
+// see CXX-2350 (migration to more recent C++ standards); our C++17 optional<> implementation
 // also has a few inconsistencies with the standard, which appear to vary across platforms.
 template <typename EventT>
 struct check_service_id {
@@ -544,10 +544,10 @@ TEST_CASE("serviceId presence depends on load-balancing mode") {
     // Set up mocked functions that DO emit a service_id:
     if (expect_service_id) {
         // Return a bson_oid_t with data where the service_id has some value:
-	const auto make_service_id_bson_oid_t = [](const void *) -> const bson_oid_t* {
-		static bson_oid_t tmp = { 0x65 };
-		return &tmp;
-	};
+        const auto make_service_id_bson_oid_t = [](const void*) -> const bson_oid_t* {
+            static bson_oid_t tmp = {0x65};
+            return &tmp;
+        };
 
         // Add forever() so that the mock function also extends to endSession:
         apm_command_started_get_service_id->interpose(make_service_id_bson_oid_t).forever();

--- a/src/mongocxx/test/uri.cpp
+++ b/src/mongocxx/test/uri.cpp
@@ -333,20 +333,18 @@ TEST_CASE("uri::compressors()", "[uri]") {
 
 // Zero is not allowed for heartbeatFrequencyMS.
 TEST_CASE("uri::heartbeat_frequency_ms()", "[uri]") {
-    _test_int32_option(
-        "heartbeatFrequencyMS",
-        [](mongocxx::uri& uri) { return uri.heartbeat_frequency_ms(); },
-        "1234",
-        false);
+    _test_int32_option("heartbeatFrequencyMS",
+                       [](mongocxx::uri& uri) { return uri.heartbeat_frequency_ms(); },
+                       "1234",
+                       false);
 }
 
 // -1 to 9 are only valid values of zlib compression level.
 TEST_CASE("uri::zlib_compression_level()", "[uri]") {
-    _test_int32_option(
-        "zlibCompressionLevel",
-        [](mongocxx::uri& uri) { return uri.zlib_compression_level(); },
-        "5",
-        true);
+    _test_int32_option("zlibCompressionLevel",
+                       [](mongocxx::uri& uri) { return uri.zlib_compression_level(); },
+                       "5",
+                       true);
 }
 
 // End special cases.

--- a/src/mongocxx/uri.cpp
+++ b/src/mongocxx/uri.cpp
@@ -97,14 +97,14 @@ std::string uri::password() const {
 
 class read_concern uri::read_concern() const {
     auto rc = libmongoc::uri_get_read_concern(_impl->uri_t);
-    return (class read_concern)(stdx::make_unique<read_concern::impl>(
-        libmongoc::read_concern_copy(rc)));
+    return (class read_concern)(
+        stdx::make_unique<read_concern::impl>(libmongoc::read_concern_copy(rc)));
 }
 
 class read_preference uri::read_preference() const {
     auto rp = libmongoc::uri_get_read_prefs_t(_impl->uri_t);
-    return (class read_preference)(stdx::make_unique<read_preference::impl>(
-        libmongoc::read_prefs_copy(rp)));
+    return (class read_preference)(
+        stdx::make_unique<read_preference::impl>(libmongoc::read_prefs_copy(rp)));
 }
 
 std::string uri::replica_set() const {
@@ -129,8 +129,8 @@ std::string uri::username() const {
 
 class write_concern uri::write_concern() const {
     auto wc = libmongoc::uri_get_write_concern(_impl->uri_t);
-    return (class write_concern)(stdx::make_unique<write_concern::impl>(
-        libmongoc::write_concern_copy(wc)));
+    return (class write_concern)(
+        stdx::make_unique<write_concern::impl>(libmongoc::write_concern_copy(wc)));
 }
 
 static stdx::optional<stdx::string_view> _string_option(mongoc_uri_t* uri, std::string opt_name) {


### PR DESCRIPTION
Result of `python2 ./etc/clang_format.py format`.