### PR TITLE
Disabled static_assert in value_context for intel compiler

### DIFF
--- a/src/bsoncxx/builder/stream/value_context.hpp
+++ b/src/bsoncxx/builder/stream/value_context.hpp
@@ -114,7 +114,7 @@ class value_context {
     ///
     operator single_context();
 
-#if !defined(_MSC_VER)
+#if !defined(_MSC_VER) && !defined(__INTEL_COMPILER)
     // TODO(MSVC): Causes an ICE under VS2015U1
     static_assert(
         std::is_same<value_context, decltype(std::declval<value_context>() << 1 << "str")>::value,


### PR DESCRIPTION
The static assert also fails for the latest intel compiler release (2021.4) with:
```
/root/mongo-cxx-driver-r3.6.2/src/bsoncxx/builder/stream/value_context.hpp(120): error: function "bsoncxx::v_noabi::builder::stream::key_context<base>::operator<<(const char (&)[n]) [with base=bsoncxx::v_noabi::builder::stream::closed_context, n=4UL]" returns incomplete type "bsoncxx::v_noabi::builder::stream::value_context<bsoncxx::v_noabi::builder::stream::key_context<bsoncxx::v_noabi::builder::stream::closed_context>>"
          std::is_same<value_context, decltype(std::declval<value_context>() << 1 << "str")>::value,
                                                                                  ^
          detected during instantiation of class "bsoncxx::v_noabi::builder::stream::value_context<base> [with base=bsoncxx::v_noabi::builder::stream::key_context<bsoncxx::v_noabi::builder::stream::closed_context>]" at line 318 of "/root/mongo-cxx-driver-r3.6.2/src/mongocxx/test/client_side_encryption.cpp"

/root/mongo-cxx-driver-r3.6.2/src/bsoncxx/builder/stream/value_context.hpp(119): error: static assertion failed with "value_context must be templatized on a key_context"
      static_assert(
```