### PR TITLE
CXX-2458 Avoid warnings when compiling with -Wfloat-equal

### DIFF
--- a/src/bsoncxx/types.hpp
+++ b/src/bsoncxx/types.hpp
@@ -16,6 +16,8 @@
 
 #include <chrono>
 #include <cstring>
+#include <float.h>
+#include <math.h>
 
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/decimal128.hpp>
@@ -106,7 +108,7 @@ struct BSONCXX_API b_double {
 /// @relatesalso b_double
 ///
 BSONCXX_INLINE bool operator==(const b_double& lhs, const b_double& rhs) {
-    return lhs.value == rhs.value;
+    return fabs(lhs.value - rhs.value) < DBL_EPSILON;
 }
 
 ///

--- a/src/bsoncxx/types.hpp
+++ b/src/bsoncxx/types.hpp
@@ -13,11 +13,16 @@
 // limitations under the License.
 
 #pragma once
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wfloat-equal"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
 
 #include <chrono>
 #include <cstring>
-#include <cmath>
-#include <limits>
 
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/decimal128.hpp>
@@ -108,7 +113,7 @@ struct BSONCXX_API b_double {
 /// @relatesalso b_double
 ///
 BSONCXX_INLINE bool operator==(const b_double& lhs, const b_double& rhs) {
-    return std::fabs(lhs.value - rhs.value) <= ( (std::fabs(lhs.value) > std::fabs(rhs.value) ? std::fabs(rhs.value) : std::fabs(lhs.value)) * std::numeric_limits<double>::epsilon());
+    return lhs.value == rhs.value;
 }
 
 ///
@@ -684,3 +689,9 @@ BSONCXX_INLINE_NAMESPACE_END
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif

--- a/src/bsoncxx/types.hpp
+++ b/src/bsoncxx/types.hpp
@@ -16,8 +16,8 @@
 
 #include <chrono>
 #include <cstring>
-#include <math.h>
-#include <limits.h>
+#include <cmath>
+#include <limits>
 
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/decimal128.hpp>
@@ -108,7 +108,7 @@ struct BSONCXX_API b_double {
 /// @relatesalso b_double
 ///
 BSONCXX_INLINE bool operator==(const b_double& lhs, const b_double& rhs) {
-    return fabs(lhs.value - rhs.value) <= ( (fabs(lhs.value) > fabs(rhs.value) ? fabs(rhs.value) : fabs(lhs.value)) * std::numeric_limits<double>::epsilon());
+    return std::fabs(lhs.value - rhs.value) <= ( (std::fabs(lhs.value) > std::fabs(rhs.value) ? std::fabs(rhs.value) : std::fabs(lhs.value)) * std::numeric_limits<double>::epsilon());
 }
 
 ///

--- a/src/bsoncxx/types.hpp
+++ b/src/bsoncxx/types.hpp
@@ -16,8 +16,8 @@
 
 #include <chrono>
 #include <cstring>
-#include <float.h>
 #include <math.h>
+#include <limits.h>
 
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/decimal128.hpp>
@@ -108,7 +108,7 @@ struct BSONCXX_API b_double {
 /// @relatesalso b_double
 ///
 BSONCXX_INLINE bool operator==(const b_double& lhs, const b_double& rhs) {
-    return fabs(lhs.value - rhs.value) < DBL_EPSILON;
+    return fabs(lhs.value - rhs.value) <= ( (fabs(lhs.value) > fabs(rhs.value) ? fabs(rhs.value) : fabs(lhs.value)) * std::numeric_limits<double>::epsilon());
 }
 
 ///


### PR DESCRIPTION
Other code that use the mongo-cxx-driver library might very well be compiled with -Wfloat-equal or even stricter compiler settings. Please include this minor fix to avoid such problems for people using the driver.
Used standard solution in types.hpp to compare double values, to avoid the warnings produced when compiling with -Wfloat-equal.