### PR TITLE
CXX-2274 support 'let' option for aggregate command

### DIFF
--- a/data/crud/unified/aggregate-let.json
+++ b/data/crud/unified/aggregate-let.json
@@ -1,0 +1,478 @@
+{
+  "description": "aggregate-let",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database0",
+        "collectionName": "coll1"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    },
+    {
+      "collectionName": "coll1",
+      "databaseName": "crud-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Aggregate with let option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "$expr": {
+                    "$eq": [
+                      "$_id",
+                      "$$id"
+                    ]
+                  }
+                }
+              },
+              {
+                "$project": {
+                  "_id": 0,
+                  "x": "$$x",
+                  "y": "$$y",
+                  "rand": "$$rand"
+                }
+              }
+            ],
+            "let": {
+              "id": 1,
+              "x": "foo",
+              "y": {
+                "$literal": "bar"
+              },
+              "rand": {
+                "$rand": {}
+              }
+            }
+          },
+          "expectResult": [
+            {
+              "x": "foo",
+              "y": "bar",
+              "rand": {
+                "$$type": "double"
+              }
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "$expr": {
+                          "$eq": [
+                            "$_id",
+                            "$$id"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 0,
+                        "x": "$$x",
+                        "y": "$$y",
+                        "rand": "$$rand"
+                      }
+                    }
+                  ],
+                  "let": {
+                    "id": 1,
+                    "x": "foo",
+                    "y": {
+                      "$literal": "bar"
+                    },
+                    "rand": {
+                      "$rand": {}
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate with let option and dollar-prefixed $literal value",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0",
+          "topologies": [
+            "single",
+            "replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "$expr": {
+                    "$eq": [
+                      "$_id",
+                      "$$id"
+                    ]
+                  }
+                }
+              },
+              {
+                "$project": {
+                  "_id": 0,
+                  "x": "$$x",
+                  "y": "$$y",
+                  "rand": "$$rand"
+                }
+              }
+            ],
+            "let": {
+              "id": 1,
+              "x": "foo",
+              "y": {
+                "$literal": "$bar"
+              },
+              "rand": {
+                "$rand": {}
+              }
+            }
+          },
+          "expectResult": [
+            {
+              "x": "foo",
+              "y": "$bar",
+              "rand": {
+                "$$type": "double"
+              }
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "$expr": {
+                          "$eq": [
+                            "$_id",
+                            "$$id"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 0,
+                        "x": "$$x",
+                        "y": "$$y",
+                        "rand": "$$rand"
+                      }
+                    }
+                  ],
+                  "let": {
+                    "id": 1,
+                    "x": "foo",
+                    "y": {
+                      "$literal": "$bar"
+                    },
+                    "rand": {
+                      "$rand": {}
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate with let option unsupported (server-side error)",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "2.6.0",
+          "maxServerVersion": "4.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": 1
+                }
+              }
+            ],
+            "let": {
+              "x": "foo"
+            }
+          },
+          "expectError": {
+            "errorContains": "unrecognized field 'let'",
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": 1
+                      }
+                    }
+                  ],
+                  "let": {
+                    "x": "foo"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate to collection with let option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "$expr": {
+                    "$eq": [
+                      "$_id",
+                      "$$id"
+                    ]
+                  }
+                }
+              },
+              {
+                "$project": {
+                  "_id": 1
+                }
+              },
+              {
+                "$out": "coll1"
+              }
+            ],
+            "let": {
+              "id": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "$expr": {
+                          "$eq": [
+                            "$_id",
+                            "$$id"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$out": "coll1"
+                    }
+                  ],
+                  "let": {
+                    "id": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate to collection with let option unsupported (server-side error)",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "2.6.0",
+          "maxServerVersion": "4.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "$expr": {
+                    "$eq": [
+                      "$_id",
+                      "$$id"
+                    ]
+                  }
+                }
+              },
+              {
+                "$project": {
+                  "_id": 1
+                }
+              },
+              {
+                "$out": "coll1"
+              }
+            ],
+            "let": {
+              "id": 1
+            }
+          },
+          "expectError": {
+            "errorContains": "unrecognized field 'let'",
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "$expr": {
+                          "$eq": [
+                            "$_id",
+                            "$$id"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$out": "coll1"
+                    }
+                  ],
+                  "let": {
+                    "id": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/crud/unified/test_files.txt
+++ b/data/crud/unified/test_files.txt
@@ -1,1 +1,2 @@
+aggregate-let.json
 estimatedDocumentCount.json

--- a/src/mongocxx/options/aggregate.cpp
+++ b/src/mongocxx/options/aggregate.cpp
@@ -38,6 +38,10 @@ void aggregate::append(bsoncxx::builder::basic::document& builder) const {
         builder.append(kvp("collation", *this->collation()));
     }
 
+    if (this->let()) {
+        builder.append(kvp("let", *this->let()));
+    }
+
     if (this->max_time()) {
         builder.append(kvp("maxTimeMS", bsoncxx::types::b_int64{this->max_time()->count()}));
     }
@@ -61,6 +65,11 @@ void aggregate::append(bsoncxx::builder::basic::document& builder) const {
 
 aggregate& aggregate::collation(bsoncxx::document::view_or_value collation) {
     _collation = std::move(collation);
+    return *this;
+}
+
+aggregate& aggregate::let(bsoncxx::document::view_or_value let) {
+    _let = std::move(let);
     return *this;
 }
 
@@ -109,6 +118,10 @@ const stdx::optional<std::int32_t>& aggregate::batch_size() const {
 
 const stdx::optional<bsoncxx::document::view_or_value>& aggregate::collation() const {
     return _collation;
+}
+
+const stdx::optional<bsoncxx::document::view_or_value>& aggregate::let() const {
+    return _let;
 }
 
 const stdx::optional<std::chrono::milliseconds>& aggregate::max_time() const {

--- a/src/mongocxx/options/aggregate.hpp
+++ b/src/mongocxx/options/aggregate.hpp
@@ -109,6 +109,30 @@ class MONGOCXX_API aggregate {
     const stdx::optional<bsoncxx::document::view_or_value>& collation() const;
 
     ///
+    /// Sets the variable mapping for this operation.
+    ///
+    /// @param let
+    ///   The new variable mapping.
+    ///
+    /// @return
+    ///   A reference to the object on which this member function is being called. This facilitates
+    ///   method chaining.
+    ///
+    /// @see https://docs.mongodb.com/manual/reference/command/aggregate/
+    ///
+    aggregate& let(bsoncxx::document::view_or_value let);
+
+    ///
+    /// Retrieves the current variable mapping for this operation.
+    ///
+    /// @return
+    ///   The current variable mapping.
+    ///
+    /// @see https://docs.mongodb.com/manual/reference/command/aggregate/
+    ///
+    const stdx::optional<bsoncxx::document::view_or_value>& let() const;
+
+    ///
     /// Sets the maximum amount of time for this operation to run server-side in milliseconds.
     ///
     /// @param max_time
@@ -261,6 +285,7 @@ class MONGOCXX_API aggregate {
     stdx::optional<bool> _allow_disk_use;
     stdx::optional<std::int32_t> _batch_size;
     stdx::optional<bsoncxx::document::view_or_value> _collation;
+    stdx::optional<bsoncxx::document::view_or_value> _let;
     stdx::optional<std::chrono::milliseconds> _max_time;
     stdx::optional<class read_preference> _read_preference;
     stdx::optional<bool> _bypass_document_validation;

--- a/src/mongocxx/test/spec/unified_tests/assert.cpp
+++ b/src/mongocxx/test/spec/unified_tests/assert.cpp
@@ -144,6 +144,8 @@ type to_type(const Element& type) {
         return bsoncxx::type::k_int64;
     if (type_str == "int")
         return bsoncxx::type::k_int32;
+    if (type_str == "double")
+        return bsoncxx::type::k_double;
     if (type_str == "objectId")
         return bsoncxx::type::k_oid;
     if (type_str == "object")

--- a/src/mongocxx/test/spec/unified_tests/operations.cpp
+++ b/src/mongocxx/test/spec/unified_tests/operations.cpp
@@ -435,6 +435,10 @@ document::value aggregate(Entity& entity, client_session* session, document::vie
         options.collation(arguments["collation"].get_document().value);
     }
 
+    if (arguments["let"]) {
+        options.let(arguments["let"].get_document().value);
+    }
+
     stdx::optional<cursor> result_cursor;
 
     if (session) {

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -603,8 +603,6 @@ void assert_error(const mongocxx::operation_exception& exception,
     }
 
     if (auto is_client_error = expect_error["isClientError"]) {
-        REQUIRE(is_client_error.get_bool());
-
         // Alas, C++20's std::string::start_with() isn't available:
         const std::string snapshot_required_msg = "Snapshot reads require MongoDB 5.0 or later";
         std::string exception_msg{exception.what()};


### PR DESCRIPTION
Full patch build: https://spruce.mongodb.com/version/62101824a4cf473735b8a229/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC