### PR TITLE
CXX2183 - expose document validation failure details

### DIFF
--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -2337,10 +2337,10 @@ TEST_CASE("read_concern is inherited from parent", "[collection]") {
     }
 }
 
-void find_index_and_validate(
-    collection& coll,
-    stdx::string_view index_name,
-    const std::function<void(bsoncxx::document::view)>& validate = [](bsoncxx::document::view) {}) {
+void find_index_and_validate(collection& coll,
+                             stdx::string_view index_name,
+                             const std::function<void(bsoncxx::document::view)>& validate =
+                                 [](bsoncxx::document::view) {}) {
     auto cursor = coll.list_indexes();
 
     for (auto&& index : cursor) {

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -2851,7 +2851,7 @@ TEST_CASE("expose writeErrors[].errInfo", "[collection]") {
     // Listen to the insertion-failed event: we want to get a copy of the server's
     // response so that we can compare it to the thrown exception later:
     apm_opts.on_command_succeeded(
-        [&writeErrors_well_formed](const mongocxx::events::command_succeeded_event& ev) {
+        [&writeErrors_well_formed, &insert_succeeded](const mongocxx::events::command_succeeded_event& ev) {
             if (0 != ev.command_name().compare("insert")) {
                 return;
             }

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -2337,10 +2337,10 @@ TEST_CASE("read_concern is inherited from parent", "[collection]") {
     }
 }
 
-void find_index_and_validate(collection& coll,
-                             stdx::string_view index_name,
-                             const std::function<void(bsoncxx::document::view)>& validate =
-                                 [](bsoncxx::document::view) {}) {
+void find_index_and_validate(
+    collection& coll,
+    stdx::string_view index_name,
+    const std::function<void(bsoncxx::document::view)>& validate = [](bsoncxx::document::view) {}) {
     auto cursor = coll.list_indexes();
 
     for (auto&& index : cursor) {

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -2813,7 +2813,7 @@ TEST_CASE("Ensure that the WriteConcernError 'errInfo' object is propagated", "[
 }
 
 TEST_CASE("expose writeErrors[].errInfo", "[collection]") {
-    bool insert_succeeded = false;  // this is checked by side-effect in writeErrors_well_formed
+    bool insert_succeeded = false;  // this is checked by side-effect
 
     // A helper for checking that an error document is well-formed according to our requirements:
     auto writeErrors_well_formed =
@@ -2838,8 +2838,6 @@ TEST_CASE("expose writeErrors[].errInfo", "[collection]") {
             throw std::runtime_error("no \"details\" field in \"writeErrors\"");
         }
 
-        insert_succeeded = true;
-
         return true;
     };
 
@@ -2859,6 +2857,9 @@ TEST_CASE("expose writeErrors[].errInfo", "[collection]") {
             }
 
             REQUIRE(writeErrors_well_formed(ev.reply()));
+
+            // Make sure that "we" were actually called:
+            insert_succeeded = true;
         });
 
     client_opts.apm_opts(apm_opts);

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -2882,7 +2882,7 @@ TEST_CASE("expose writeErrors[].errInfo", "[collection]") {
         try {
             coll.insert_one(entry.view());
 
-            // We should not make it here:
+            // We should not make it here (i.e. this is an error):
             CHECK(false);
         } catch (const operation_exception& e) {
             auto rse = e.raw_server_error();

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -2813,7 +2813,6 @@ TEST_CASE("Ensure that the WriteConcernError 'errInfo' object is propagated", "[
 }
 
 TEST_CASE("expose writeErrors[].errInfo", "[collection]") {
-
     // A helper for checking that an error document is well-formed according to our requirements:
     auto writeErrors_well_formed = [](const bsoncxx::document::view& reply_view) -> bool {
         if (!reply_view["writeErrors"]) {

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -2813,6 +2813,7 @@ TEST_CASE("Ensure that the WriteConcernError 'errInfo' object is propagated", "[
 }
 
 TEST_CASE("expose writeErrors[].errInfo", "[collection]") {
+
     // A helper for checking that an error document is well-formed according to our requirements:
     auto writeErrors_well_formed = [](const bsoncxx::document::view& reply_view) -> bool {
         if (!reply_view["writeErrors"]) {

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -2813,8 +2813,11 @@ TEST_CASE("Ensure that the WriteConcernError 'errInfo' object is propagated", "[
 }
 
 TEST_CASE("expose writeErrors[].errInfo", "[collection]") {
+    bool insert_succeeded = false;  // this is checked by side-effect in writeErrors_well_formed
+
     // A helper for checking that an error document is well-formed according to our requirements:
-    auto writeErrors_well_formed = [](const bsoncxx::document::view& reply_view) -> bool {
+    auto writeErrors_well_formed =
+        [&insert_succeeded](const bsoncxx::document::view& reply_view) -> bool {
         if (!reply_view["writeErrors"]) {
             return false;
         }
@@ -2834,6 +2837,8 @@ TEST_CASE("expose writeErrors[].errInfo", "[collection]") {
         if (!errdoc["errInfo"]["details"]) {
             throw std::runtime_error("no \"details\" field in \"writeErrors\"");
         }
+
+        insert_succeeded = true;
 
         return true;
     };
@@ -2899,6 +2904,9 @@ TEST_CASE("expose writeErrors[].errInfo", "[collection]") {
             // An exception was thrown, but of the wrong type:
             CHECK(false);
         }
+
+        // Make sure that our callback was actually triggered and completed successfully:
+        REQUIRE(insert_succeeded);
     }
 }
 


### PR DESCRIPTION
Ensure that the "details" field is included in errInfo on failure.

https://jira.mongodb.org/browse/CXX-2183

Signed-off-by: Jesse Williamson <jesse.williamson@mongodb.com>