### PR TITLE
improve output of Catch2 exception string matchers

### DIFF
--- a/src/third_party/catch/include/helpers.hpp
+++ b/src/third_party/catch/include/helpers.hpp
@@ -37,7 +37,7 @@ public:
     }
 
     std::string describe() const override {
-        return std::string("mongocxx::exception contains message: \"") + expected_msg + "\"";
+        return std::string("mongocxx::exception was expected to contain the message: \"") + expected_msg + "\"";
     }
 };
 } // namespace test_util


### PR DESCRIPTION
Our current Catch2 exception helper says that an exception "contains" a message, when it was actually 
/expected/ to contain that message. This fixes the output to not be misleading.

https://jira.mongodb.org/browse/CXX-2470

Signed-off-by: Jesse Williamson <jesse.williamson@mongodb.com>