### PR TITLE
Fix test_util output for client-side encryption test check

### DIFF
--- a/src/mongocxx/test_util/client_helpers.cpp
+++ b/src/mongocxx/test_util/client_helpers.cpp
@@ -479,24 +479,20 @@ bool should_run_client_side_encryption_test(void) {
                                   "MONGOCXX_TEST_AZURE_CLIENT_ID",
                                   "MONGOCXX_TEST_AZURE_CLIENT_SECRET"};
 
-    // If none of the variables are set, we should skip the tests:
+    std::ostringstream os;
+    os << "Please set environment variables to enable client side encryption tests:\n";
+    std::copy(std::begin(vars), std::end(vars), std::ostream_iterator<const char*>(os, "\n"));
+
     if (std::none_of(std::begin(vars), std::end(vars), std::getenv)) {
-        std::ostringstream os;
-        os << "Skipping tests. Please set environment variables to enable client side encryption "
-              "tests:\n";
-        std::copy(std::begin(vars), std::end(vars), std::ostream_iterator<const char*>(os, "\n"));
+        os << "Skipping client side encryption tests.\n";
+
+        WARN(os.str());
 
         return false;
     }
 
-    // If some, but not all, variables are set, fail:
     if (!std::all_of(std::begin(vars), std::end(vars), std::getenv)) {
-        std::ostringstream os;
-        os << "Failing client side encryption tests, some enviornment variables were not set."
-           << "; "
-           << "Please set the following environment variables to enable client side encryption "
-              "tests:\n";
-        std::copy(std::begin(vars), std::end(vars), std::ostream_iterator<const char*>(os, "\n"));
+        os << "Failing client side encryption tests (some environment variables were not set).\n";
 
         FAIL(os.str());
 


### PR DESCRIPTION
Consolidate output code for client-side encryption test check; make sure correct output is seen in all cases.

Behavior was correct but no output shown for case where no environment variables were set. Now cases where
tests are skipped or failed also show the correct output. Also cleans up the implementation a bit. 
(The test_utils change was introduced in "https://github.com/mongodb/mongo-cxx-driver/pull/848".)

Signed-off-by: Jesse Williamson <jesse.williamson@mongodb.com>