### PR TITLE
CXX-2188: Add timeseries unified tests.

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -353,6 +353,8 @@ functions:
                   export UNIFIED_FORMAT_TESTS_PATH=$(pwd)/../data/unified-format
                   export SESSION_UNIFIED_TESTS_PATH="$(pwd)/../data/sessions/unified"
                   export VERSIONED_API_TESTS_PATH=$(pwd)/../data/versioned-api
+                  export TIMESERIES_UNIFIED_TESTS_PATH="$(pwd)/../data/timeseries"
+
                   export MONGODB_API_VERSION="${MONGODB_API_VERSION}"
 
                   if [ "$(uname -m)" == "ppc64le" ]; then

--- a/data/timeseries/test_files.txt
+++ b/data/timeseries/test_files.txt
@@ -1,0 +1,1 @@
+unified/timeseries-collection.json

--- a/data/timeseries/unified/timeseries-collection.json
+++ b/data/timeseries/unified/timeseries-collection.json
@@ -1,0 +1,255 @@
+{
+  "description": "timeseries-collection",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "5.0"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "ts-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "ts-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "createCollection with all options",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "expireAfterSeconds": 604800,
+            "timeseries": {
+              "timeField": "time",
+              "metaField": "meta",
+              "granularity": "minutes"
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "ts-tests",
+            "collectionName": "test"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test"
+                },
+                "databaseName": "ts-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "test",
+                  "expireAfterSeconds": 604800,
+                  "timeseries": {
+                    "timeField": "time",
+                    "metaField": "meta",
+                    "granularity": "minutes"
+                  }
+                },
+                "databaseName": "ts-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "insertMany with duplicate ids",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "expireAfterSeconds": 604800,
+            "timeseries": {
+              "timeField": "time",
+              "metaField": "meta",
+              "granularity": "minutes"
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "ts-tests",
+            "collectionName": "test"
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1,
+                "time": {
+                  "$date": {
+                    "$numberLong": "1552949630482"
+                  }
+                }
+              },
+              {
+                "_id": 1,
+                "time": {
+                  "$date": {
+                    "$numberLong": "1552949630483"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "time": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "time": {
+                "$date": {
+                  "$numberLong": "1552949630482"
+                }
+              }
+            },
+            {
+              "_id": 1,
+              "time": {
+                "$date": {
+                  "$numberLong": "1552949630483"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test"
+                },
+                "databaseName": "ts-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "test",
+                  "expireAfterSeconds": 604800,
+                  "timeseries": {
+                    "timeField": "time",
+                    "metaField": "meta",
+                    "granularity": "minutes"
+                  }
+                },
+                "databaseName": "ts-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "time": {
+                        "$date": {
+                          "$numberLong": "1552949630482"
+                        }
+                      }
+                    },
+                    {
+                      "_id": 1,
+                      "time": {
+                        "$date": {
+                          "$numberLong": "1552949630483"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "filter": {},
+                  "sort": {
+                    "time": 1
+                  }
+                },
+                "databaseName": "ts-tests"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/timeseries/unified/timeseries-collection.yml
+++ b/data/timeseries/unified/timeseries-collection.yml
@@ -1,0 +1,129 @@
+description: "timeseries-collection"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "5.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name ts-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: "createCollection with all options"
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+      - name: createCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+          # expireAfterSeconds should be an int64 (as it is stored on the server).
+          expireAfterSeconds: 604800
+          timeseries: &timeseries0
+            timeField: "time"
+            metaField: "meta"
+            granularity: "minutes"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                drop: *collection0Name
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                create: *collection0Name
+                expireAfterSeconds: 604800
+                timeseries: *timeseries0
+              databaseName: *database0Name
+
+  # Unlike regular collections, time-series collections allow duplicate ids.
+  - description: "insertMany with duplicate ids"
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+      - name: createCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+          # expireAfterSeconds should be an int64 (as it is stored on the server).
+          expireAfterSeconds: 604800
+          timeseries: *timeseries0
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+      - name: insertMany
+        object: *collection0
+        arguments:
+          documents: &docs
+            - {
+                _id: 1,
+                time: {
+                  $date: {
+                    $numberLong: "1552949630482"
+                  }
+                }
+              }
+            - {
+                _id: 1,
+                time: {
+                  $date: {
+                    $numberLong: "1552949630483"
+                  }
+                }
+              }
+      - name: find
+        object: *collection0
+        arguments:
+          filter: {}
+          sort: { time: 1 }
+        expectResult: *docs
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                drop: *collection0Name
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                create: *collection0Name
+                expireAfterSeconds: 604800
+                timeseries: *timeseries0
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents: *docs
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: {}
+                sort: { time: 1 }
+              databaseName: *database0Name

--- a/src/mongocxx/test/CMakeLists.txt
+++ b/src/mongocxx/test/CMakeLists.txt
@@ -276,6 +276,8 @@ set_property(TEST unified_format_spec
   APPEND PROPERTY ENVIRONMENT "CRUD_UNIFIED_TESTS_PATH=${PROJECT_SOURCE_DIR}/../../data/crud/unified")
 set_property(TEST unified_format_spec
   APPEND PROPERTY ENVIRONMENT "VERSIONED_API_TESTS_PATH=${PROJECT_SOURCE_DIR}/../../data/versioned-api")
+set_property(TEST unified_format_spec
+  APPEND PROPERTY ENVIRONMENT "TIMESERIES_UNIFIED_TESTS_PATH=${PROJECT_SOURCE_DIR}/../../data/timeseries")
 
 if (MONGOCXX_ENABLE_SLOW_TESTS)
   set_property(TEST driver

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -915,4 +915,8 @@ TEST_CASE("versioned API spec automated tests", "[unified_format_spec]") {
     CHECK(run_unified_format_tests_in_env_dir("VERSIONED_API_TESTS_PATH"));
 }
 
+TEST_CASE("timeseries spec automated tests", "[unified_format_spec]") {
+    CHECK(run_unified_format_tests_in_env_dir("TIMESERIES_UNIFIED_TESTS_PATH"));
+}
+
 }  // namespace


### PR DESCRIPTION
Adds unified tests for the Time-Series Collection feature.

https://jira.mongodb.org/browse/CXX-2188

Signed-off-by: Jesse Williamson <jesse.williamson@mongodb.com>