### PR TITLE
CXX-2488 resync types CSFLE test

### DIFF
--- a/data/client_side_encryption/types.json
+++ b/data/client_side_encryption/types.json
@@ -540,7 +540,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot use deterministic encryption for element of type: double"
+            "errorContains": "element of type: double"
           }
         }
       ]
@@ -587,7 +587,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot use deterministic encryption for element of type: decimal"
+            "errorContains": "element of type: decimal"
           }
         }
       ]
@@ -943,7 +943,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot use deterministic encryption for element of type: javascriptWithScope"
+            "errorContains": "element of type: javascriptWithScope"
           }
         }
       ]
@@ -988,7 +988,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot use deterministic encryption for element of type: object"
+            "errorContains": "element of type: object"
           }
         }
       ]
@@ -1643,7 +1643,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot use deterministic encryption for element of type: array"
+            "errorContains": "element of type: array"
           }
         }
       ]
@@ -1688,7 +1688,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot use deterministic encryption for element of type: bool"
+            "errorContains": "element of type: bool"
           }
         }
       ]


### PR DESCRIPTION
# Summary
Resync the error messages in the `types` CSFLE test to https://github.com/mongodb/specifications/commit/6a7158d51b4c41f2f4a9c1293c5e1dceb93ab5c2 to resolve test failures on mongocryptd 6.0.0-alpha. Do not pull in test changes to `expectations` made in [SPEC-1768](https://jira.mongodb.org/browse/SPEC-1768). Updating the test runner for the new which is still an open task for the C++ driver in CXX-2155

# Background & Motivation
The `badQueries` test is not included in C++ driver tests due to CDRIVER-3387. Only the `types` test was resynced.