### PR TITLE
CXX-2464 Use count instead of collStats for estimatedDocumentCount

### DIFF
--- a/.evergreen/install_c_driver.sh
+++ b/.evergreen/install_c_driver.sh
@@ -32,7 +32,7 @@ echo "About to install C driver ($VERSION) into $PREFIX"
 
 LIB=mongo-c-driver
 rm -rf $(echo $LIB*)
-curl -o $LIB.zip -L https://github.com/mongodb/$LIB/archive/$VERSION.zip
+curl -sS -o $LIB.zip -L https://github.com/mongodb/$LIB/archive/$VERSION.zip
 unzip -q $LIB.zip
 DIR=$(echo $LIB-*)
 
@@ -45,7 +45,7 @@ else
     # Otherwise, use the tag name of the latest release to construct a prerelease version string.
 
     # Extract "tag_name" from latest Github release.
-    BUILD_VERSION=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/mongodb/mongo-c-driver/releases/latest | jq -r ".tag_name")
+    BUILD_VERSION=$(curl -sS -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/mongodb/mongo-c-driver/releases/latest | jq -r ".tag_name")
 
     # Assert the tag name is a SemVer string.
     test $(echo $BUILD_VERSION | grep -P "$SEMVER_REGEX")

--- a/.evergreen/install_c_driver.sh
+++ b/.evergreen/install_c_driver.sh
@@ -31,18 +31,33 @@ CMAKE_ARGS="
 echo "About to install C driver ($VERSION) into $PREFIX"
 
 LIB=mongo-c-driver
-if [ -n "$(echo "${VERSION}" | grep '^[a-z]' )" ]; then
-    rm -rf $LIB
-    # Must be http as rhel55 has https issues
-    curl -o $LIB.tgz -L http://s3.amazonaws.com/mciuploads/$LIB/$VERSION/$LIB-latest.tar.gz
-    tar --extract --file $LIB.tgz
-    rm -rf $LIB
-    DIR=$(echo $LIB-*)
+rm -rf $(echo $LIB*)
+curl -o $LIB.zip -L https://github.com/mongodb/$LIB/archive/$VERSION.zip
+unzip -q $LIB.zip
+DIR=$(echo $LIB-*)
+
+# RegEx pattern to match SemVer strings. See https://semver.org/.
+SEMVER_REGEX="^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+if [ $(echo "$VERSION" | grep -P "$SEMVER_REGEX") ]; then
+    # If $VERSION is already SemVer compliant, use as-is.
+    CMAKE_ARGS="$CMAKE_ARGS -DBUILD_VERSION=$BUILD_VERSION"
 else
-    DIR=$LIB-${VERSION}
-    rm -rf $LIB.tgz $DIR
-    curl -o $LIB.tgz -L https://github.com/mongodb/$LIB/releases/download/${VERSION}/$LIB-${VERSION}.tar.gz
-    tar --extract --file $LIB.tgz
+    # Otherwise, use the tag name of the latest release to construct a prerelease version string.
+
+    # Extract "tag_name" from latest Github release.
+    BUILD_VERSION=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/mongodb/mongo-c-driver/releases/latest | jq -r ".tag_name")
+
+    # Assert the tag name is a SemVer string.
+    test $(echo $BUILD_VERSION | grep -P "$SEMVER_REGEX")
+
+    # Bump to the next minor version, e.g. 1.0.1 -> 1.1.0.
+    BUILD_VERSION=$(echo $BUILD_VERSION | perl -pe "$(printf 's/%s/$+{major} . "." . ($+{minor}+1) . ".0"/e' $SEMVER_REGEX)")
+
+    # Append a prerelease tag, e.g. 1.1.0-pre+<version>.
+    BUILD_VERSION=$(printf "%s-pre+%s" $BUILD_VERSION $VERSION)
+
+    # Use the constructed prerelease build version when building the C driver.
+    CMAKE_ARGS="$CMAKE_ARGS -DBUILD_VERSION=$BUILD_VERSION"
 fi
 
 . .evergreen/find_cmake.sh

--- a/.evergreen/install_c_driver.sh
+++ b/.evergreen/install_c_driver.sh
@@ -38,20 +38,20 @@ DIR=$(echo $LIB-*)
 
 # RegEx pattern to match SemVer strings. See https://semver.org/.
 SEMVER_REGEX="^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
-if [ $(echo "$VERSION" | grep -P "$SEMVER_REGEX") ]; then
+if [ $(echo "$VERSION" | perl -ne "$(printf 'exit 1 unless /%s/' $SEMVER_REGEX)") ]; then
     # If $VERSION is already SemVer compliant, use as-is.
     CMAKE_ARGS="$CMAKE_ARGS -DBUILD_VERSION=$BUILD_VERSION"
 else
     # Otherwise, use the tag name of the latest release to construct a prerelease version string.
 
     # Extract "tag_name" from latest Github release.
-    BUILD_VERSION=$(curl -sS -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/mongodb/mongo-c-driver/releases/latest | jq -r ".tag_name")
+    BUILD_VERSION=$(curl -sS -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/mongodb/mongo-c-driver/releases/latest | perl -ne 'print for /"tag_name": "(.+)"/')
 
-    # Assert the tag name is a SemVer string.
-    test $(echo $BUILD_VERSION | grep -P "$SEMVER_REGEX")
+    # Assert the tag name is a SemVer string via errexit.
+    echo $BUILD_VERSION | perl -ne "$(printf 'exit 1 unless /%s/' $SEMVER_REGEX)"
 
     # Bump to the next minor version, e.g. 1.0.1 -> 1.1.0.
-    BUILD_VERSION=$(echo $BUILD_VERSION | perl -pe "$(printf 's/%s/$+{major} . "." . ($+{minor}+1) . ".0"/e' $SEMVER_REGEX)")
+    BUILD_VERSION=$(echo $BUILD_VERSION | perl -ne "$(printf '/%s/; print $+{major} . "." . ($+{minor}+1) . ".0"' $SEMVER_REGEX)")
 
     # Append a prerelease tag, e.g. 1.1.0-pre+<version>.
     BUILD_VERSION=$(printf "%s-pre+%s" $BUILD_VERSION $VERSION)

--- a/.mci.yml
+++ b/.mci.yml
@@ -1340,7 +1340,7 @@ buildvariants:
           tar_options: *linux_tar_options
           cmake_flags: *linux_cmake_flags
           mongodb_version: *version_latest
-          mongoc_version: "1.19.0"
+          mongoc_version: "db7e894bc" # TODO: set to 1.22.0 once released.
       run_on:
           - ubuntu1804-build
       tasks:

--- a/data/crud/unified/estimatedDocumentCount.json
+++ b/data/crud/unified/estimatedDocumentCount.json
@@ -34,6 +34,13 @@
         "database": "database0",
         "collectionName": "coll1"
       }
+    },
+    {
+      "collection": {
+        "id": "collection0View",
+        "database": "database0",
+        "collectionName": "coll0view"
+      }
     }
   ],
   "initialData": [
@@ -58,288 +65,7 @@
   ],
   "tests": [
     {
-      "description": "estimatedDocumentCount uses $collStats on 4.9.0 or greater",
-      "runOnRequirements": [
-        {
-          "minServerVersion": "4.9.0"
-        }
-      ],
-      "operations": [
-        {
-          "name": "estimatedDocumentCount",
-          "object": "collection0",
-          "expectResult": 3
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client0",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "aggregate": "coll0",
-                  "pipeline": [
-                    {
-                      "$collStats": {
-                        "count": {}
-                      }
-                    },
-                    {
-                      "$group": {
-                        "_id": 1,
-                        "n": {
-                          "$sum": "$count"
-                        }
-                      }
-                    }
-                  ]
-                },
-                "commandName": "aggregate",
-                "databaseName": "edc-tests"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "estimatedDocumentCount with maxTimeMS on 4.9.0 or greater",
-      "runOnRequirements": [
-        {
-          "minServerVersion": "4.9.0"
-        }
-      ],
-      "operations": [
-        {
-          "name": "estimatedDocumentCount",
-          "object": "collection0",
-          "arguments": {
-            "maxTimeMS": 6000
-          },
-          "expectResult": 3
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client0",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "aggregate": "coll0",
-                  "pipeline": [
-                    {
-                      "$collStats": {
-                        "count": {}
-                      }
-                    },
-                    {
-                      "$group": {
-                        "_id": 1,
-                        "n": {
-                          "$sum": "$count"
-                        }
-                      }
-                    }
-                  ],
-                  "maxTimeMS": 6000
-                },
-                "commandName": "aggregate",
-                "databaseName": "edc-tests"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "estimatedDocumentCount on non-existent collection on 4.9.0 or greater",
-      "runOnRequirements": [
-        {
-          "minServerVersion": "4.9.0"
-        }
-      ],
-      "operations": [
-        {
-          "name": "estimatedDocumentCount",
-          "object": "collection1",
-          "expectResult": 0
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client0",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "aggregate": "coll1",
-                  "pipeline": [
-                    {
-                      "$collStats": {
-                        "count": {}
-                      }
-                    },
-                    {
-                      "$group": {
-                        "_id": 1,
-                        "n": {
-                          "$sum": "$count"
-                        }
-                      }
-                    }
-                  ]
-                },
-                "commandName": "aggregate",
-                "databaseName": "edc-tests"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "estimatedDocumentCount errors correctly on 4.9.0 or greater--command error",
-      "runOnRequirements": [
-        {
-          "minServerVersion": "4.9.0"
-        }
-      ],
-      "operations": [
-        {
-          "name": "failPoint",
-          "object": "testRunner",
-          "arguments": {
-            "client": "client0",
-            "failPoint": {
-              "configureFailPoint": "failCommand",
-              "mode": {
-                "times": 1
-              },
-              "data": {
-                "failCommands": [
-                  "aggregate"
-                ],
-                "errorCode": 8
-              }
-            }
-          }
-        },
-        {
-          "name": "estimatedDocumentCount",
-          "object": "collection0",
-          "expectError": {
-            "errorCode": 8
-          }
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client0",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "aggregate": "coll0",
-                  "pipeline": [
-                    {
-                      "$collStats": {
-                        "count": {}
-                      }
-                    },
-                    {
-                      "$group": {
-                        "_id": 1,
-                        "n": {
-                          "$sum": "$count"
-                        }
-                      }
-                    }
-                  ]
-                },
-                "commandName": "aggregate",
-                "databaseName": "edc-tests"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "estimatedDocumentCount errors correctly on 4.9.0 or greater--socket error",
-      "runOnRequirements": [
-        {
-          "minServerVersion": "4.9.0"
-        }
-      ],
-      "operations": [
-        {
-          "name": "failPoint",
-          "object": "testRunner",
-          "arguments": {
-            "client": "client0",
-            "failPoint": {
-              "configureFailPoint": "failCommand",
-              "mode": {
-                "times": 1
-              },
-              "data": {
-                "failCommands": [
-                  "aggregate"
-                ],
-                "closeConnection": true
-              }
-            }
-          }
-        },
-        {
-          "name": "estimatedDocumentCount",
-          "object": "collection0",
-          "expectError": {
-            "isError": true
-          }
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client0",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "aggregate": "coll0",
-                  "pipeline": [
-                    {
-                      "$collStats": {
-                        "count": {}
-                      }
-                    },
-                    {
-                      "$group": {
-                        "_id": 1,
-                        "n": {
-                          "$sum": "$count"
-                        }
-                      }
-                    }
-                  ]
-                },
-                "commandName": "aggregate",
-                "databaseName": "edc-tests"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "estimatedDocumentCount uses count on less than 4.9.0",
-      "runOnRequirements": [
-        {
-          "maxServerVersion": "4.8.99"
-        }
-      ],
+      "description": "estimatedDocumentCount always uses count",
       "operations": [
         {
           "name": "estimatedDocumentCount",
@@ -365,12 +91,7 @@
       ]
     },
     {
-      "description": "estimatedDocumentCount with maxTimeMS on less than 4.9.0",
-      "runOnRequirements": [
-        {
-          "maxServerVersion": "4.8.99"
-        }
-      ],
+      "description": "estimatedDocumentCount with maxTimeMS",
       "operations": [
         {
           "name": "estimatedDocumentCount",
@@ -400,12 +121,7 @@
       ]
     },
     {
-      "description": "estimatedDocumentCount on non-existent collection on less than 4.9.0",
-      "runOnRequirements": [
-        {
-          "maxServerVersion": "4.8.99"
-        }
-      ],
+      "description": "estimatedDocumentCount on non-existent collection",
       "operations": [
         {
           "name": "estimatedDocumentCount",
@@ -431,11 +147,10 @@
       ]
     },
     {
-      "description": "estimatedDocumentCount errors correctly on less than 4.9.0--command error",
+      "description": "estimatedDocumentCount errors correctly--command error",
       "runOnRequirements": [
         {
           "minServerVersion": "4.0.0",
-          "maxServerVersion": "4.8.99",
           "topologies": [
             "single",
             "replicaset"
@@ -443,7 +158,6 @@
         },
         {
           "minServerVersion": "4.2.0",
-          "maxServerVersion": "4.8.99",
           "topologies": [
             "sharded"
           ]
@@ -495,11 +209,10 @@
       ]
     },
     {
-      "description": "estimatedDocumentCount errors correctly on less than 4.9.0--socket error",
+      "description": "estimatedDocumentCount errors correctly--socket error",
       "runOnRequirements": [
         {
           "minServerVersion": "4.0.0",
-          "maxServerVersion": "4.8.99",
           "topologies": [
             "single",
             "replicaset"
@@ -507,7 +220,6 @@
         },
         {
           "minServerVersion": "4.2.0",
-          "maxServerVersion": "4.8.99",
           "topologies": [
             "sharded"
           ]
@@ -557,7 +269,89 @@
           ]
         }
       ]
+    },
+    {
+      "description": "estimatedDocumentCount works correctly on views",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.4.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "coll0view"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "coll0view",
+            "viewOn": "coll0",
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection0View",
+          "expectResult": 2
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "coll0view"
+                },
+                "commandName": "drop",
+                "databaseName": "edc-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "coll0view",
+                  "viewOn": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    }
+                  ]
+                },
+                "commandName": "create",
+                "databaseName": "edc-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "count": "coll0view"
+                },
+                "commandName": "count",
+                "databaseName": "edc-tests"
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }
-

--- a/data/mongohouse/estimatedDocumentCount.json
+++ b/data/mongohouse/estimatedDocumentCount.json
@@ -16,7 +16,9 @@
           "command_started_event": {
             "command": {
               "count": "driverdata"
-            }
+            },
+            "command_name": "count",
+            "database_name": "test"
           }
         }
       ]

--- a/data/retryable-reads/estimatedDocumentCount-serverErrors.json
+++ b/data/retryable-reads/estimatedDocumentCount-serverErrors.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "4.0",
-      "maxServerVersion": "4.8.99",
       "topology": [
         "single",
         "replicaset"
@@ -10,7 +9,6 @@
     },
     {
       "minServerVersion": "4.1.7",
-      "maxServerVersion": "4.8.99",
       "topology": [
         "sharded"
       ]
@@ -110,7 +108,7 @@
       ]
     },
     {
-      "description": "EstimatedDocumentCount succeeds after NotMaster",
+      "description": "EstimatedDocumentCount succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -150,7 +148,7 @@
       ]
     },
     {
-      "description": "EstimatedDocumentCount succeeds after NotMasterNoSlaveOk",
+      "description": "EstimatedDocumentCount succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -190,7 +188,7 @@
       ]
     },
     {
-      "description": "EstimatedDocumentCount succeeds after NotMasterOrSecondary",
+      "description": "EstimatedDocumentCount succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -470,7 +468,7 @@
       ]
     },
     {
-      "description": "EstimatedDocumentCount fails after two NotMaster errors",
+      "description": "EstimatedDocumentCount fails after two NotWritablePrimary errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -510,7 +508,7 @@
       ]
     },
     {
-      "description": "EstimatedDocumentCount fails after NotMaster when retryReads is false",
+      "description": "EstimatedDocumentCount fails after NotWritablePrimary when retryReads is false",
       "clientOptions": {
         "retryReads": false
       },

--- a/data/retryable-reads/estimatedDocumentCount.json
+++ b/data/retryable-reads/estimatedDocumentCount.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "4.0",
-      "maxServerVersion": "4.8.99",
       "topology": [
         "single",
         "replicaset"
@@ -10,7 +9,6 @@
     },
     {
       "minServerVersion": "4.1.7",
-      "maxServerVersion": "4.8.99",
       "topology": [
         "sharded"
       ]

--- a/data/retryable-reads/test_files.txt
+++ b/data/retryable-reads/test_files.txt
@@ -15,8 +15,8 @@ distinct.json
 distinct-serverErrors.json
 estimatedDocumentCount-4.9.json
 estimatedDocumentCount-serverErrors-4.9.json
-estimatedDocumentCount-pre4.9.json
-estimatedDocumentCount-serverErrors-pre4.9.json
+estimatedDocumentCount.json
+estimatedDocumentCount-serverErrors.json
 find.json
 findOne.json
 findOne-serverErrors.json

--- a/data/versioned-api/crud-api-version-1-strict.json
+++ b/data/versioned-api/crud-api-version-1-strict.json
@@ -1,6 +1,6 @@
 {
   "description": "CRUD Api Version 1 (strict)",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "4.9"
@@ -141,6 +141,11 @@
     },
     {
       "description": "aggregate on database appends declared API version",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "aggregate",
@@ -608,6 +613,15 @@
     },
     {
       "description": "estimatedDocumentCount appends declared API version",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0.9",
+          "maxServerVersion": "5.0.99"
+        },
+        {
+          "minServerVersion": "5.3.2"
+        }
+      ],
       "operations": [
         {
           "name": "estimatedDocumentCount",
@@ -622,22 +636,7 @@
             {
               "commandStartedEvent": {
                 "command": {
-                  "aggregate": "test",
-                  "pipeline": [
-                    {
-                      "$collStats": {
-                        "count": {}
-                      }
-                    },
-                    {
-                      "$group": {
-                        "_id": 1,
-                        "n": {
-                          "$sum": "$count"
-                        }
-                      }
-                    }
-                  ],
+                  "count": "test",
                   "apiVersion": "1",
                   "apiStrict": true,
                   "apiDeprecationErrors": {

--- a/data/versioned-api/crud-api-version-1.json
+++ b/data/versioned-api/crud-api-version-1.json
@@ -1,6 +1,6 @@
 {
   "description": "CRUD Api Version 1",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "4.9"
@@ -141,6 +141,11 @@
     },
     {
       "description": "aggregate on database appends declared API version",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "aggregate",
@@ -599,7 +604,16 @@
       ]
     },
     {
-      "description": "estimatedDocumentCount appends declared API version on 4.9.0 or greater",
+      "description": "estimatedDocumentCount appends declared API version",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0.9",
+          "maxServerVersion": "5.0.99"
+        },
+        {
+          "minServerVersion": "5.3.2"
+        }
+      ],
       "operations": [
         {
           "name": "estimatedDocumentCount",
@@ -614,22 +628,7 @@
             {
               "commandStartedEvent": {
                 "command": {
-                  "aggregate": "test",
-                  "pipeline": [
-                    {
-                      "$collStats": {
-                        "count": {}
-                      }
-                    },
-                    {
-                      "$group": {
-                        "_id": 1,
-                        "n": {
-                          "$sum": "$count"
-                        }
-                      }
-                    }
-                  ],
+                  "count": "test",
                   "apiVersion": "1",
                   "apiStrict": {
                     "$$unsetOrMatches": false

--- a/src/mongocxx/collection.hpp
+++ b/src/mongocxx/collection.hpp
@@ -415,6 +415,12 @@ class MONGOCXX_API collection {
     ///
     /// @note For a fast count of the total documents in a collection, see
     /// estimated_document_count().
+    ///
+    /// @note Due to an oversight in MongoDB server versions 5.0.0 through 5.0.7, the `count`
+    /// command was not included in Stable API v1. Users of the Stable API with
+    /// estimatedDocumentCount are recommended to upgrade their server version to 5.0.8 or newer, or
+    /// set `apiStrict: false` to avoid encountering errors.
+    ///
     /// @see mongocxx::estimated_document_count
     ///
     std::int64_t count_documents(bsoncxx::document::view_or_value filter,
@@ -434,6 +440,13 @@ class MONGOCXX_API collection {
     ///
     /// @throws mongocxx::query_exception if the count operation fails.
     ///
+    /// @note Due to an oversight in MongoDB server versions 5.0.0 through 5.0.7, the `count`
+    /// command was not included in Stable API v1. Users of the Stable API with
+    /// estimatedDocumentCount are recommended to upgrade their server version to 5.0.8 or newer, or
+    /// set `apiStrict: false` to avoid encountering errors.
+    ///
+    /// @see mongocxx::estimated_document_count
+    ///
     std::int64_t count_documents(const client_session& session,
                                  bsoncxx::document::view_or_value filter,
                                  const options::count& options = options::count());
@@ -452,6 +465,9 @@ class MONGOCXX_API collection {
     /// @return The count of the documents that matched the filter.
     ///
     /// @throws mongocxx::query_exception if the count operation fails.
+    ///
+    /// @note This function is implemented in terms of the count server command. See:
+    /// https://www.mongodb.com/docs/manual/reference/command/count/#behavior for more information.
     ///
     /// @see mongocxx::count_documents
     ///

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -2337,10 +2337,10 @@ TEST_CASE("read_concern is inherited from parent", "[collection]") {
     }
 }
 
-void find_index_and_validate(
-    collection& coll,
-    stdx::string_view index_name,
-    const std::function<void(bsoncxx::document::view)>& validate = [](bsoncxx::document::view) {}) {
+void find_index_and_validate(collection& coll,
+                             stdx::string_view index_name,
+                             const std::function<void(bsoncxx::document::view)>& validate =
+                                 [](bsoncxx::document::view) {}) {
     auto cursor = coll.list_indexes();
 
     for (auto&& index : cursor) {

--- a/src/mongocxx/test/spec/unified_tests/operations.cpp
+++ b/src/mongocxx/test/spec/unified_tests/operations.cpp
@@ -1408,18 +1408,27 @@ document::value operations::run(entity::map& entity_map,
         auto coll_name = string::to_string(op["arguments"]["collection"].get_string().value);
         auto& db = entity_map.get_database(object);
         auto opts = builder::basic::document{};
-        if (op["arguments"]["timeseries"]) {
-            opts.append(builder::basic::kvp("timeseries",
-                                            op["arguments"]["timeseries"].get_document().view()));
+        const auto arguments = op["arguments"];
+        if (const auto timeseries = arguments["timeseries"]) {
+            opts.append(builder::basic::kvp("timeseries", timeseries.get_document().view()));
         }
-        if (op["arguments"]["expireAfterSeconds"]) {
-            opts.append(builder::basic::kvp(
-                "expireAfterSeconds", op["arguments"]["expireAfterSeconds"].get_int32().value));
+        if (const auto eas = arguments["expireAfterSeconds"]) {
+            opts.append(builder::basic::kvp("expireAfterSeconds", eas.get_int32().value));
         }
-        if (op["arguments"]["session"]) {
-            auto session_name = string::to_string(op["arguments"]["session"].get_string().value);
-            auto& session = entity_map.get_client_session(session_name);
-            db.create_collection(session, coll_name, opts.view());
+        {
+            const auto view_on = arguments["viewOn"];
+            const auto pipeline = arguments["pipeline"];
+
+            // Both fields must be present as a pair.
+            if (view_on && pipeline) {
+                opts.append(builder::basic::kvp("viewOn", view_on.get_string().value));
+                opts.append(builder::basic::kvp("pipeline", pipeline.get_array().value));
+            }
+        }
+        if (const auto session = arguments["session"]) {
+            const auto session_name = string::to_string(session.get_string().value);
+            const auto& client_session = entity_map.get_client_session(session_name);
+            db.create_collection(client_session, coll_name, opts.view());
         } else {
             db.create_collection(coll_name, opts.view());
         }

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -108,7 +108,7 @@ bool is_compatible_version(Range1 range1, Range2 range2, ignore_patch ip) {
     }
 
     // Compatible major, minor and patch ignored.
-    if (range1[0] < range2[1]) {
+    if (range1[0] < range2[0]) {
         return true;
     }
 

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -97,10 +97,38 @@ std::vector<int> get_version(bsoncxx::document::element doc) {
     return get_version(string::to_string(doc.get_string().value));
 }
 
+// Toggle ignoring patch number when comparing version strings.
+enum struct ignore_patch { no, yes };
+
+template <typename Range1, typename Range2>
+bool is_compatible_version(Range1 range1, Range2 range2, ignore_patch ip) {
+    // Incompatible major.
+    if (range1[0] > range2[0]) {
+        return false;
+    }
+
+    // Compatible major, minor and patch ignored.
+    if (range1[0] < range2[1]) {
+        return true;
+    }
+
+    // Compatible major, incompatible minor.
+    if (range1[1] > range2[1]) {
+        return false;
+    }
+
+    // Compatible major, compatible minor, patch ignored.
+    if (ip == ignore_patch::yes) {
+        return true;
+    }
+
+    // Compatible major, compatible minor, and compatible patch.
+    return range1[1] < range2[1] || range1[2] <= range2[2];
+}
+
 template <typename Range1, typename Range2>
 bool is_compatible_version(Range1 range1, Range2 range2) {
-    // only compare major and minor in version of the form "<int>.<int>.<int>", i.e., [0:2)
-    return range1[0] < range2[0] || (range1[0] == range2[0] && range1[1] <= range2[1]);
+    return is_compatible_version(range1, range2, ignore_patch::no);
 }
 
 bool equals_server_topology(const document::element& topologies) {
@@ -511,7 +539,8 @@ bool is_compatible_schema_version(document::view test_spec) {
         // Test files are considered compatible with a test runner if their schemaVersion is less
         // than or equal to a supported version in the test runner, given the same major version
         // component.
-        return test_schema_version[0] == v[0] && is_compatible_version(test_schema_version, v);
+        return test_schema_version[0] == v[0] &&
+               is_compatible_version(test_schema_version, v, ignore_patch::yes);
     };
     return std::any_of(std::begin(schema_versions), std::end(schema_versions), compat);
 }

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -123,7 +123,7 @@ bool is_compatible_version(Range1 range1, Range2 range2, ignore_patch ip) {
     }
 
     // Compatible major, compatible minor, and compatible patch.
-    return range1[1] < range2[1] || range1[2] <= range2[2];
+    return range1[2] <= range2[2];
 }
 
 template <typename Range1, typename Range2>

--- a/src/mongocxx/test/spec/util.cpp
+++ b/src/mongocxx/test/spec/util.cpp
@@ -450,12 +450,12 @@ void run_tests_in_suite(std::string ev, test_runner cb, std::set<std::string> un
 
     std::string test_file;
     while (std::getline(test_files, test_file)) {
-        if (unsupported_tests.find(test_file) != unsupported_tests.end()) {
-            WARN("Skipping unsupported test file: " << test_file);
-            continue;
-        }
         SECTION(test_file) {
-            cb(path + "/" + test_file);
+            if (unsupported_tests.find(test_file) != unsupported_tests.end()) {
+                WARN("Skipping unsupported test file: " << test_file);
+            } else {
+                cb(path + "/" + test_file);
+            }
         }
     }
 }


### PR DESCRIPTION
### Description

This PR resolves CXX-2464, which is unblocked by CDRIVER-4309.

In addition to updating the spec test files, the C++ unified test runner had to be updated to handle the `viewOn` and `pipeline` argument fields to `createCollection`, which were previously being ignored.

### Version String Comparison

The unified test runner used the same comparison logic for server version strings and JSON schema version strings. However, server version string comparison _must not_ ignore patch numbers, whereas JSON schema version string comparison _must_ ignore patch numbers. This PR includes a drive-by fix to version string comparison in the test runner to correctly distinguish between the two cases.

### Unsupported Test Files

As a drive-by improvement, the warning indicating an unsupported test file is being skipped was moved into the test section of the test file being skipped to avoid redundant duplication of skip warnings in the test output.

For example, before the change, the following block was printed repeatedly over 50 times with varying subsets of skipped test files in each block. More often than not, all files were included, exacerbating the test output noise. Only the first three test files in a given block is included here for brevity:

```
-------------------------------------------------------------------------------
retryable reads spec tests
-------------------------------------------------------------------------------
.src/mongocxx/test/spec/retryable-reads.cpp:122
...............................................................................

.src/mongocxx/test/spec/util.cpp:454: warning:
  Skipping unsupported test file: count.json

.src/mongocxx/test/spec/util.cpp:454: warning:
  Skipping unsupported test file: count-serverErrors.json

.src/mongocxx/test/spec/util.cpp:454: warning:
  Skipping unsupported test file: gridfs-downloadByName.json
  
...

-------------------------------------------------------------------------------
retryable reads spec tests
-------------------------------------------------------------------------------
.src/mongocxx/test/spec/retryable-reads.cpp:122
...............................................................................

.src/mongocxx/test/spec/util.cpp:454: warning:
  Skipping unsupported test file: count.json

.src/mongocxx/test/spec/util.cpp:454: warning:
  Skipping unsupported test file: count-serverErrors.json

.src/mongocxx/test/spec/util.cpp:454: warning:
  Skipping unsupported test file: gridfs-downloadByName.json
  
...
```

After the change, each unsupported test file emits a single warning, _once only_, for the whole test run, dramatically reducing the length of the test output:

```
-------------------------------------------------------------------------------
retryable reads spec tests
  count.json
-------------------------------------------------------------------------------
./src/mongocxx/test/spec/util.cpp:453
...............................................................................

./src/mongocxx/test/spec/util.cpp:455: warning:
  Skipping unsupported test file: count.json

-------------------------------------------------------------------------------
retryable reads spec tests
  count-serverErrors.json
-------------------------------------------------------------------------------
./src/mongocxx/test/spec/util.cpp:453
...............................................................................

./src/mongocxx/test/spec/util.cpp:455: warning:
  Skipping unsupported test file: count-serverErrors.json

-------------------------------------------------------------------------------
retryable reads spec tests
  gridfs-downloadByName.json
-------------------------------------------------------------------------------
./src/mongocxx/test/spec/util.cpp:453
...............................................................................

./src/mongocxx/test/spec/util.cpp:455: warning:
  Skipping unsupported test file: gridfs-downloadByName.json

...
```

### Add support for pinning mongo-c-driver version to commit hash

Added support for pinning the mongo-c-driver repository by arbitrary Git blobs (branch, tag, or commit hash) instead of being limited to branch/tag names. This allows pinning to arbitrary commits (i.e. latest commit in mongo-c-driver) without being required to create a corresponding tag in the mongo-c-driver repo.

If the requested version string does not comply with SemVer (e.g. a branch name such as `master` or a commit hash), the mongo-c-driver `BUILD_VERSION` is derived by obtaining the tag name of the latest mongo-c-driver release (which is assumed to be a SemVer string) and bumping the minor version number), where "latest" is as defined by [the GitHub API](https://docs.github.com/en/rest/releases/releases#get-the-latest-release). e.g. if the latest release is `1.21.1` (as it is at time of writing), `BUILD_VERSION` is set to `1.22.0-pre-<version>` where `<version>` is `$VERSION` (which may be a branch, tag name, commit hash, etc.).