### PR TITLE
Move mock KMS server creation into separate background task

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -250,6 +250,33 @@ functions:
             set -o pipefail
             ./etc/run-clang-tidy.sh
 
+    "clone_drivers-evergreen-tools":
+      - command: shell.exec
+        params:
+          shell: bash
+          script: |-
+            set -o errexit
+            if [ ! -d "drivers-evergreen-tools" ]; then
+                git clone git@github.com:mongodb-labs/drivers-evergreen-tools.git --depth=1
+            fi
+
+    "run_kms_servers":
+      - command: shell.exec
+        params:
+          background: true
+          shell: bash
+          script: |-
+            set -o errexit
+            echo "Starting mock KMS servers..."
+            cd ./drivers-evergreen-tools/.evergreen/csfle
+            . ./activate_venv.sh
+            python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --port 7999 &
+            python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000 &
+            python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 8001 &
+            python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --port 8002 --require_client_cert &
+            python -u kms_kmip_server.py &
+            echo "Starting mock KMS servers... done."
+
     "compile":
         - command: shell.exec
           params:
@@ -373,11 +400,7 @@ functions:
                       set -o errexit
                   fi
 
-                  # Clone drivers-evergreen-tools if not already present.
                   pushd ../../
-                  if [ ! -d "drivers-evergreen-tools" ]; then
-                      git clone git@github.com:mongodb-labs/drivers-evergreen-tools.git
-                  fi
                   cd drivers-evergreen-tools
                   export DRIVERS_TOOLS=$(pwd)
                   if [ "Windows_NT" == "$OS" ]; then
@@ -416,16 +439,6 @@ functions:
                       register_ca_cert
                       echo "Registering CA certificate for KMS TLS tests... done."
 
-                      # Start mock KMS servers.
-                      echo "Starting mock KMS servers..."
-                      pushd $DRIVERS_TOOLS/.evergreen/csfle
-                      . ./activate_venv.sh
-                      python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000 < /dev/null &
-                      python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 8001 < /dev/null &
-                      trap 'kill $(jobs -p)' EXIT HUP
-                      popd
-                      echo "Starting mock KMS servers... done."
-
                       # Ensure mock KMS servers are running before starting tests.
                       wait_for_kms_server() {
                           for i in $(seq 60); do
@@ -440,8 +453,11 @@ functions:
                           return 1
                       }
                       echo "Waiting for mock KMS servers to start..."
+                      wait_for_kms_server 7999
                       wait_for_kms_server 8000
                       wait_for_kms_server 8001
+                      wait_for_kms_server 8002
+                      wait_for_kms_server 5698
                       echo "Waiting for mock KMS servers to start... done."
                   fi
 
@@ -675,6 +691,8 @@ tasks:
         - func: "compile"
           vars:
               RUN_DISTCHECK: 1
+        - func: "clone_drivers-evergreen-tools"
+        - func: "run_kms_servers"
         - func: "test"
 
     - name: compile_and_test_with_shared_libs_extra_alignment
@@ -685,6 +703,8 @@ tasks:
           vars:
               BSON_EXTRA_ALIGNMENT: 1
         - func: "compile"
+        - func: "clone_drivers-evergreen-tools"
+        - func: "run_kms_servers"
         - func: "test"
 
     - name: compile_with_shared_libs
@@ -722,6 +742,8 @@ tasks:
           vars:
               USE_STATIC_LIBS: 1
               RUN_DISTCHECK: 1
+        - func: "clone_drivers-evergreen-tools"
+        - func: "run_kms_servers"
         - func: "test"
           vars:
               USE_STATIC_LIBS: 1
@@ -736,6 +758,8 @@ tasks:
         - func: "compile"
           vars:
               USE_STATIC_LIBS: 1
+        - func: "clone_drivers-evergreen-tools"
+        - func: "run_kms_servers"
         - func: "test"
           vars:
               USE_STATIC_LIBS: 1
@@ -750,6 +774,8 @@ tasks:
         - func: "compile"
           vars:
               RUN_DISTCHECK: 1
+        - func: "clone_drivers-evergreen-tools"
+        - func: "run_kms_servers"
         - func: "test"
 
     - name: uninstall_check
@@ -902,6 +928,8 @@ tasks:
               AUTH: noauth
         - func: "install_c_driver"
         - func: "compile"
+        - func: "clone_drivers-evergreen-tools"
+        - func: "run_kms_servers"
         - func: "test"
           vars:
               MONGODB_API_VERSION: 1
@@ -915,6 +943,8 @@ tasks:
               AUTH: noauth
         - func: "install_c_driver"
         - func: "compile"
+        - func: "clone_drivers-evergreen-tools"
+        - func: "run_kms_servers"
         - func: "test"
 
 #######################################


### PR DESCRIPTION
### Description

For reasons still unclear to me, Evergreen tasks related to [VS 2015 variants](https://spruce.mongodb.com/variant-history/cxx-driver/windows-2k8-release?selectedCommit=901) began [timing out](https://evergreen.mongodb.com/lobster/evergreen/task/cxx_driver_windows_2k8_release_compile_and_test_with_shared_libs_101c986e9d7d9357f82436e507b16a472397a33f_22_06_06_18_42_32/0/task#bookmarks=0%2C9759&l=1&shareLine=9714) after https://github.com/mongodb/mongo-cxx-driver/pull/863 was merged. I narrowed down the issue to a failure to kill the background mock KMS servers with `trap 'kill $(jobs -p)' EXIT HUP`.

This PR attempts to workaround/address this issue by using a similar pattern [as in the C driver](https://github.com/mongodb/mongo-c-driver/pull/879/files#diff-8fe3ebc712c8b34fee22f7bb419e8617725c3cba3ca8f022fa0c6aeb2d3b195aR559) where the mock KMS servers are owned by a separate background Evergreen task to avoid blocking the primary test-related tasks.