### PR TITLE
CXX-2492 Add zSeries RHEL 8.3 for 5.0 and 6.0

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -14,11 +14,12 @@ variables:
     mongocrypt_version_minimum: &mongocrypt_version_minimum "1.5.0-rc1" # TODO: set to 1.5.0 once released.
 
     mongodb_version:
-        version_latest: &version_latest latest
-        version_50: &version_50 5.0
-        version_44: &version_44 4.4
-        version_42: &version_42 4.2
-        version_40: &version_40 4.0
+        version_latest: &version_latest "latest"
+        version_60: &version_60 "6.0"
+        version_50: &version_50 "5.0"
+        version_44: &version_44 "4.4"
+        version_42: &version_42 "4.2"
+        version_40: &version_40 "4.0"
 
     ## cmake path variables
     extra_path:
@@ -1294,6 +1295,44 @@ buildvariants:
       run_on: ubuntu1804-test
       tasks:
           - name: test_mongohouse
+
+    - name: zseries-rhel83-60
+      display_name: "zSeries RHEL 8.3 (MongoDB 6.0)"
+      batchtime: 1440 # 1 day
+      expansions:
+          build_type: "Release"
+          tar_options: *linux_tar_options
+          cmake_flags: *linux_cmake_flags
+          mongodb_version: *version_60
+          cmake: "cmake"
+          lib_dir: "lib64"
+      run_on:
+          - rhel83-zseries-small
+      tasks:
+          - name: compile_with_shared_libs
+          - name: compile_and_test_with_shared_libs
+          - name: compile_and_test_with_shared_libs_extra_alignment
+          - name: compile_and_test_with_static_libs
+          - name: compile_and_test_with_static_libs_extra_alignment
+
+    - name: zseries-rhel83-50
+      display_name: "zSeries RHEL 8.3 (MongoDB 5.0)"
+      batchtime: 1440 # 1 day
+      expansions:
+          build_type: "Release"
+          tar_options: *linux_tar_options
+          cmake_flags: *linux_cmake_flags
+          mongodb_version: *version_50
+          cmake: "cmake"
+          lib_dir: "lib64"
+      run_on:
+          - rhel83-zseries-small
+      tasks:
+          - name: compile_with_shared_libs
+          - name: compile_and_test_with_shared_libs
+          - name: compile_and_test_with_shared_libs_extra_alignment
+          - name: compile_and_test_with_static_libs
+          - name: compile_and_test_with_static_libs_extra_alignment
 
     - name: power8-rhel81-latest
       display_name: "ppc64le RHEL 8.1 (MongoDB Latest)"


### PR DESCRIPTION
## Description

This PR _partially_ resolves CXX-2492.

A task to test RHEL 8.3 on zSeries with the latest version of MongoDB is currently blocked on the server team building and releasing the required tarball for RHEL 8.3 on zSeries. Once the required tarball for the latest version of MongoDB is made available, a followup PR will be posted to complete CXX-2492.