### PR TITLE
Inject mongoc source directory for building libmongocrypt

### DIFF
--- a/.evergreen/install_c_driver.sh
+++ b/.evergreen/install_c_driver.sh
@@ -63,6 +63,7 @@ fi
 . .evergreen/find_cmake.sh
 
 cd $DIR
+MONGOC_DIR="$(pwd)"
 
 if [ -f /proc/cpuinfo ]; then
     CONCURRENCY=$(grep -c ^processor /proc/cpuinfo)
@@ -84,6 +85,7 @@ case "$OS" in
     cygwin*)
         GENERATOR=${GENERATOR:-"Visual Studio 14 2015 Win64"}
         CMAKE_BUILD_OPTS="/maxcpucount:$CONCURRENCY"
+        MONGOC_DIR=$(cygpath -m "$MONGOC_DIR")
         ;;
 
     *)
@@ -105,7 +107,9 @@ git clone https://github.com/mongodb/libmongocrypt
 mkdir libmongocrypt/cmake_build
 cd libmongocrypt/cmake_build
 git checkout $MONGOCRYPT_VERSION
-"$CMAKE" -G "$GENERATOR" -DENABLE_SHARED_BSON=ON -DCMAKE_INSTALL_PREFIX="$PREFIX" -DCMAKE_PREFIX_PATH="$PREFIX" -DCMAKE_BUILD_TYPE="Debug" -DENABLE_CLIENT_SIDE_ENCRYPTION=OFF ..
+"$CMAKE" -G "$GENERATOR" -DENABLE_SHARED_BSON=ON -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+    -DCMAKE_PREFIX_PATH="$PREFIX" -DCMAKE_BUILD_TYPE="Debug" \
+    -DMONGOCRYPT_MONGOC_DIR="$MONGOC_DIR" -DENABLE_CLIENT_SIDE_ENCRYPTION=OFF ..
 "$CMAKE" --build . --config Debug -- $CMAKE_BUILD_OPTS
 "$CMAKE" --build . --config Debug --target install
 cd ../../$DIR


### PR DESCRIPTION
Based on mongodb/mongo-c-driver@5b91ef0fadf4d0b536be69d47bb1bd7cfb056f63

The changes in libmongocrypt caused the C driver build to fail, but have not yet affected the C++ driver build (for the `master` branch), since libmongocrypt is pinned to an older commit for now.  However, for the `releases/v3.6` branch the libmongocrypt change is already causing failures.  This change is pre-emptive for `master`, as once the libmongocrypt reference is updated, the failure will be triggered.

Evergreen patch build: https://spruce.mongodb.com/version/62c9b5981e2d171761fc87df/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC