### PR TITLE
CXX-2415 Support setting tag set list with array

### DIFF
--- a/src/bsoncxx/array/view.hpp
+++ b/src/bsoncxx/array/view.hpp
@@ -128,6 +128,9 @@ class BSONCXX_API view {
     ///
     bool empty() const;
 
+    ///
+    /// Conversion operator unwrapping a document::view
+    ///
     operator document::view() const;
 
     ///

--- a/src/mongocxx/read_preference.cpp
+++ b/src/mongocxx/read_preference.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/stdx/make_unique.hpp>
+#include <bsoncxx/types.hpp>
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/private/conversions.hh>
@@ -71,8 +72,15 @@ read_preference& read_preference::mode(read_mode mode) {
     return *this;
 }
 
-read_preference& read_preference::tags(bsoncxx::document::view_or_value tags) {
-    libbson::scoped_bson_t scoped_bson_tags(std::move(tags));
+read_preference& read_preference::tags(bsoncxx::document::view_or_value tag_set_list) {
+    libbson::scoped_bson_t scoped_bson_tags(std::move(tag_set_list));
+    libmongoc::read_prefs_set_tags(_impl->read_preference_t, scoped_bson_tags.bson());
+
+    return *this;
+}
+
+read_preference& read_preference::tags(bsoncxx::array::view_or_value tag_set_list) {
+    libbson::scoped_bson_t scoped_bson_tags(bsoncxx::document::view(tag_set_list.view()));
     libmongoc::read_prefs_set_tags(_impl->read_preference_t, scoped_bson_tags.bson());
 
     return *this;

--- a/src/mongocxx/read_preference.hpp
+++ b/src/mongocxx/read_preference.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <string>
 
+#include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/options/transaction.hpp>
@@ -177,25 +178,39 @@ class MONGOCXX_API read_preference {
     read_mode mode() const;
 
     ///
-    /// Sets or updates the tags for this read_preference.
+    /// Sets or updates the tag set list for this read_preference.
     ///
     /// @param tags
-    ///   Document representing the tags.
+    ///   Document representing the tag set list.
     ///
-    /// @see https://docs.mongodb.com/manual/core/read-preference/#tag-sets
+    /// @see https://www.mongodb.com/docs/manual/core/read-preference-tags/
     ///
     /// @return
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    read_preference& tags(bsoncxx::document::view_or_value tags);
+    read_preference& tags(bsoncxx::document::view_or_value tag_set_list);
 
     ///
-    /// Returns the current tags for this read_preference.
+    /// Sets or updates the tag set list for this read_preference.
     ///
-    /// @return The optionally set current tags.
+    /// @param tags
+    ///   Array of tag sets.
     ///
-    /// @see https://docs.mongodb.com/manual/core/read-preference/#tag-sets
+    /// @see https://www.mongodb.com/docs/manual/core/read-preference-tags/
+    ///
+    /// @return
+    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   method chaining.
+    ///
+    read_preference& tags(bsoncxx::array::view_or_value tag_set_list);
+
+    ///
+    /// Sets or updates the tag set list for this read_preference.
+    ///
+    /// @return The optionally set current tag set list.
+    ///
+    /// @see https://www.mongodb.com/docs/manual/core/read-preference-tags/
     ///
     stdx::optional<bsoncxx::document::view> tags() const;
 


### PR DESCRIPTION
## Description

This PR resolves CXX-2415.

Despite [Read Preference Tags](https://www.mongodb.com/docs/manual/core/read-preference-tags/) being specified as an _array_ of tag sets (aka a tag set list), the C++ Driver does not provide an interface to directly set the tag set list as an array, requiring the user to manually convert a `bsoncxx` array into a document to use the [BSON document overload](https://github.com/eramongodb/mongo-cxx-driver/blob/2f4ca28d9962dab9974806633706e47eeac555a7/src/mongocxx/read_preference.hpp#L179) as a workaround. This PR adds an overload that accepts a `bsoncxx::array::view_or_value` to improve the user experience.

This PR also updates the documentation to be more accurate and consistent when referring to "tag set lists". It also updates tests to correctly set the tag set list as a BSON _array_ of documents `[{key: value, ...}, ...]` according to spec.

This PR also adds missing documentation for the conversion operator from `bsoncxx::array::view` -> `bsoncxx::document::view`.