### PR TITLE
CXX-2549 fix mixed-content errors over HTTPS

### DIFF
--- a/docs/content/mongocxx-v3/installation/linux.md
+++ b/docs/content/mongocxx-v3/installation/linux.md
@@ -76,7 +76,7 @@ release tarball.
 
 The [mongocxx releases](https://github.com/mongodb/mongo-cxx-driver/releases)
 page will have links to the release tarball for the version you wish you install.  For
-example, to download version 3.6.4:
+example, to download version 3.6.7:
 
 ```sh
 curl -OL https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.6.7/mongo-cxx-driver-r3.6.7.tar.gz

--- a/docs/content/mongocxx-v3/installation/macos.md
+++ b/docs/content/mongocxx-v3/installation/macos.md
@@ -76,7 +76,7 @@ release tarball.
 
 The [mongocxx releases](https://github.com/mongodb/mongo-cxx-driver/releases)
 page will have links to the release tarball for the version you wish you install.  For
-example, to download version 3.6.4:
+example, to download version 3.6.7:
 
 ```sh
 curl -OL https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.6.7/mongo-cxx-driver-r3.6.7.tar.gz

--- a/docs/content/mongocxx-v3/installation/windows.md
+++ b/docs/content/mongocxx-v3/installation/windows.md
@@ -79,7 +79,7 @@ release tarball.
 
 The [mongocxx releases](https://github.com/mongodb/mongo-cxx-driver/releases)
 page will have links to the release tarball for the version you wish you install.  For
-example, to download version 3.6.4:
+example, to download version 3.6.7:
 
 ```sh
 curl -OL https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.6.7/mongo-cxx-driver-r3.6.7.tar.gz

--- a/docs/themes/mongodb/layouts/partials/meta.html
+++ b/docs/themes/mongodb/layouts/partials/meta.html
@@ -3,3 +3,4 @@
 <meta name="description" content="">
 <meta name="author" content="">
 <meta name="keyword" content="">
+<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">


### PR DESCRIPTION
# Summary
- Add the meta tag to enable the `upgrade-insecure-requests` Content Security Policy.
- Fix incorrect version references.

# Background & Motivation
The meta tag resolves mixed-content loading CSS and Javascript files when accessing https://mongocxx.org. https://mongocxx.org has already been updated.