### PR TITLE
Ensure unified test runner tests against primary in replica sets

### DIFF
--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -254,17 +254,13 @@ std::string uri_options_to_string(document::view object) {
 }
 
 std::string get_hostnames(document::view object) {
-    const auto default_uri = std::string{"localhost:27017"};
-
-    // Spec: This [useMultipleMongoses] option has no effect for non-sharded topologies.
-    if (!test_util::is_sharded_cluster()) {
-        return default_uri;
-    }
-
+    // Spec: [useMultipleMongoses] option has no effect for non-sharded topologies.
     // Spec: If true and the topology is a sharded cluster, the test runner MUST assert that this
     // MongoClient connects to multiple mongos hosts (e.g. by inspecting the connection string).
-    if (!object["useMultipleMongoses"] || !object["useMultipleMongoses"].get_bool())
-        return default_uri;
+    if (!test_util::is_sharded_cluster() || !object["useMultipleMongoses"] ||
+        !object["useMultipleMongoses"].get_bool()) {
+        return test_util::is_replica_set() ? test_util::get_primary() : "localhost:27017";
+    }
 
     // from: https://docs.mongodb.com/manual/reference/config-database/#config.shards
     // If the shard is a replica set, the host field displays the name of the replica set, then a

--- a/src/mongocxx/test_util/client_helpers.cpp
+++ b/src/mongocxx/test_util/client_helpers.cpp
@@ -259,6 +259,14 @@ bool is_sharded_cluster(const client& client) {
     return msg.get_string().value.compare("isdbgrid") == 0;
 }
 
+std::string get_primary(const client& client) {
+    auto reply = get_is_master(client);
+    if (const auto primary = reply["primary"]) {
+        return string::to_string(primary.get_string().value);
+    }
+    return {};
+}
+
 std::string get_hosts(const client& client) {
     auto shards = get_shards(client);
     if (shards)

--- a/src/mongocxx/test_util/client_helpers.hh
+++ b/src/mongocxx/test_util/client_helpers.hh
@@ -110,6 +110,11 @@ bool is_replica_set(const client& client = {uri{}, add_test_server_api()});
 bool is_sharded_cluster(const client& client = {uri{}, add_test_server_api()});
 
 ///
+/// Returns the hostname of the primary in a replica set.
+///
+std::string get_primary(const client& client = {uri{}, add_test_server_api()});
+
+///
 /// Returns "standalone", "replicaset", or "sharded".
 ///
 std::string get_topology(const client& client = {uri{}, add_test_server_api()});


### PR DESCRIPTION
## Description

This PR ensures the unified test runner runs commands against the _primary_ in a replica set. This should address flaky tests on Evergreen involving replica sets that occasionally fail due to the server running on `27017` not being the primary as expected.