### PR TITLE
Update mongocrypt and mongoc dependencies to latest releases

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -7,11 +7,11 @@
 #######################################
 variables:
 
-    mongoc_version_default: &mongoc_version_default "32be2647" # Accept string arguments for queryType and "index_type"
-    mongocrypt_version_default: &mongocrypt_version_default "638b8090" # Update use of removed API
+    mongoc_version_default: &mongoc_version_default "1.22.0"
+    mongocrypt_version_default: &mongocrypt_version_default "1.5.2"
 
-    mongoc_version_minimum: &mongoc_version_minimum "db7e894bc" # TODO: set to 1.22.0 once released.
-    mongocrypt_version_minimum: &mongocrypt_version_minimum "1.5.0-rc1" # TODO: set to 1.5.0 once released.
+    mongoc_version_minimum: &mongoc_version_minimum "1.22.0"
+    mongocrypt_version_minimum: &mongocrypt_version_minimum "1.5.2"
 
     mongodb_version:
         version_latest: &version_latest "latest"


### PR DESCRIPTION
## Description

Updates the Evergreen config file to use latest releases of libmongoc and libmongocrypt, resolving some TODO comments.

The libmongocrypt dependency is updated to 1.5.2 instead of 1.5.0 to include the bugfix for `RewrapManyDataKey`.