### PR TITLE
Update libmongocrypt and libmongoc dependencies to required commits

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -7,10 +7,10 @@
 #######################################
 variables:
 
-    mongoc_version_default: &mongoc_version_default "1.22.0"
+    mongoc_version_default: &mongoc_version_default "2966c67d"
     mongocrypt_version_default: &mongocrypt_version_default "1.5.2"
 
-    mongoc_version_minimum: &mongoc_version_minimum "1.22.0"
+    mongoc_version_minimum: &mongoc_version_minimum "1.22.1"
     mongocrypt_version_minimum: &mongocrypt_version_minimum "1.5.2"
 
     mongodb_version:


### PR DESCRIPTION
## Description

This PR is a followup to https://github.com/mongodb/mongo-cxx-driver/pull/883.

Despite being chronologically the more recent event, libmongoc release 1.22.0 does not contained the [required changes](https://github.com/mongodb/mongo-c-driver/commit/32be2647814af6fcb3d8a9ec430e17dc8b669462) needed for correct error handling in hint for unacknowledged writes tests introduced in https://github.com/mongodb/mongo-cxx-driver/pull/870.

This PR thus bumps `mongoc_version_default` to [2966c67d](https://github.com/mongodb/mongo-c-driver/commit/2966c67d69bc22c3f68fc4f2b2d2164b7cf5b665), which corresponds to the main branch equivalent of the final commit included in the 1.22.1 release. `mongoc_version_minimum` is bumped to `1.22.1` accordingly and to include the patch that enforces libmongocrypt version 1.5.2 or newer.