### PR TITLE
Add StringMaker specialization for bsoncxx::document::value

### DIFF
--- a/src/bsoncxx/test_util/catch.hh
+++ b/src/bsoncxx/test_util/catch.hh
@@ -41,6 +41,13 @@ struct StringMaker<bsoncxx::document::view> {
     }
 };
 
+template <>
+struct StringMaker<bsoncxx::document::value> {
+    static std::string convert(const bsoncxx::document::value& value) {
+        return StringMaker<bsoncxx::document::view>::convert(value.view());
+    }
+};
+
 template <typename T>
 struct StringMaker<stdx::optional<T>> {
     static std::string convert(const bsoncxx::stdx::optional<T>& value) {

--- a/src/bsoncxx/test_util/catch.hh
+++ b/src/bsoncxx/test_util/catch.hh
@@ -58,17 +58,6 @@ struct StringMaker<stdx::optional<bsoncxx::stdx::nullopt_t>> {
         return "{nullopt}";
     }
 };
-
-template <>
-struct StringMaker<stdx::optional<bsoncxx::document::view>> {
-    static std::string convert(const bsoncxx::stdx::optional<bsoncxx::document::view>& value) {
-        if (value) {
-            return StringMaker::convert(value.value());
-        }
-
-        return "{nullopt}";
-    }
-};
 }  // namespace Catch
 
 #include <bsoncxx/config/private/postlude.hh>


### PR DESCRIPTION
## Description

Improve readability of test suite output by supporting pretty-printing of `bsoncxx::document::value` objects.

As a drive-by fix, removed the redundant `StringMaker<stdx::optional<bsoncxx::document::view>>` specialization (handled by `StringMaker<stdx::optional<T>>`) that inadvertently leads to infinite self-recursion when invoked.