### PR TITLE
Remove redundant to_json causing flaky warnings on zSeries RHEL 8.3

### DIFF
--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -514,7 +514,7 @@ bool add_to_map(const array::element& obj) {
     if (type == "session")      return map.insert(id, create_session(params));
     // clang-format on
 
-    CAPTURE(type, id, to_json(params));
+    CAPTURE(type, id, params);
     FAIL("unrecognized type { " + type + " }");
     return false;
 }


### PR DESCRIPTION
## Description

Evergreen tasks on zSeries RHEL 8.3 are failing due to what appears to be a flaky `-Wmaybe-uninitialized` warning being incorrectly triggered by a call to `to_json(bsoncxx::document::view)` in `add_to_map`. This PR resolves this issue by removing the redundant call to `to_json` and capturing the `params` variable directly, which happens to address the false-positive warning.

Initially, I suspected that the use of an uninitialized data member was being detected, but I could not identify such a data member. Trivial tweaks to `add_to_map` causing the presence or absence of the error suggested this is a false-positive warning.