### PR TITLE
CXX-2530 add missing Debian 10, 11 and Ubuntu 20.04 build variants

### DIFF
--- a/.evergreen/find_cmake.sh
+++ b/.evergreen/find_cmake.sh
@@ -11,19 +11,33 @@ find_cmake ()
     CMAKE="/Applications/Cmake.app/Contents/bin/cmake"
   elif [ -f "/opt/cmake/bin/cmake" ]; then
     CMAKE="/opt/cmake/bin/cmake"
-  elif command -v cmake 2>/dev/null; then
+  elif [ -z "$IGNORE_SYSTEM_CMAKE" ] && command -v cmake 2>/dev/null; then
      CMAKE=cmake
   elif uname -a | grep -iq 'x86_64 GNU/Linux'; then
+     if [ -f "$(pwd)/cmake-3.11.0/bin/cmake" ]; then
+      CMAKE="$(pwd)/cmake-3.11.0/bin/cmake"
+      return 0
+     fi
      curl --retry 5 https://cmake.org/files/v3.11/cmake-3.11.0-Linux-x86_64.tar.gz -sS --max-time 120 --fail --output cmake.tar.gz
      mkdir cmake-3.11.0
      tar xzf cmake.tar.gz -C cmake-3.11.0 --strip-components=1
      CMAKE=$(pwd)/cmake-3.11.0/bin/cmake
   elif [ -f "/cygdrive/c/cmake/bin/cmake" ]; then
-    CMAKE=/cygdrive/c/cmake/bin/cmake
-  else
-     # If cmake unavailable, create a BUILD ticket.
-     echo "cmake not available"
-     return 1
+     CMAKE="/cygdrive/c/cmake/bin/cmake"
+  fi
+  if [ -z "$CMAKE" -o -z "$( $CMAKE --version 2>/dev/null )" ]; then
+     # Some images have no cmake yet, or a broken cmake (see: BUILD-8570)
+     echo "-- MAKE CMAKE --"
+     CMAKE_INSTALL_DIR=$(readlink -f cmake-install)
+     curl --retry 5 https://cmake.org/files/v3.11/cmake-3.11.0.tar.gz -sS --max-time 120 --fail --output cmake.tar.gz
+     tar xzf cmake.tar.gz
+     cd cmake-3.11.0
+     ./bootstrap --prefix="${CMAKE_INSTALL_DIR}"
+     make -j8
+     make install
+     cd ..
+     CMAKE="${CMAKE_INSTALL_DIR}/bin/cmake"
+     echo "-- DONE MAKING CMAKE --"
   fi
 }
 

--- a/.mci.yml
+++ b/.mci.yml
@@ -1060,6 +1060,132 @@ buildvariants:
     #######################################
     #         Linux Buildvariants         #
     #######################################
+    - name: debian11-release-latest
+      display_name: "Debian 11 Release (MongoDB Latest)"
+      expansions:
+          build_type: "Release"
+          tar_options: *linux_tar_options
+          extra_path: *linux_extra_path
+          cmake_flags: *linux_cmake_flags
+          mongodb_version: *version_latest
+      run_on:
+          - debian11-large
+      tasks:
+          - name: compile_and_test_with_shared_libs
+          - name: compile_and_test_with_shared_libs_extra_alignment
+          - name: compile_and_test_with_static_libs
+          - name: compile_and_test_with_static_libs_extra_alignment
+          - name: compile_and_test_with_shared_libs_replica_set
+          - name: build_example_with_add_subdirectory
+            distros:
+            - debian11-large
+          - name: uninstall_check
+
+    - name: debian11-release-50
+      display_name: "Debian 11 Release (MongoDB 5.0)"
+      expansions:
+          build_type: "Release"
+          tar_options: *linux_tar_options
+          extra_path: *linux_extra_path
+          cmake_flags: *linux_cmake_flags
+          mongodb_version: *version_50
+      run_on:
+          - debian11-large
+      tasks:
+          - name: compile_and_test_with_shared_libs
+          - name: compile_and_test_with_shared_libs_extra_alignment
+          - name: compile_and_test_with_static_libs
+          - name: compile_and_test_with_static_libs_extra_alignment
+          - name: compile_and_test_with_shared_libs_replica_set
+          - name: build_example_with_add_subdirectory
+            distros:
+            - debian11-large
+          - name: uninstall_check
+
+    - name: debian10-release-latest
+      display_name: "Debian 10 Release (MongoDB Latest)"
+      expansions:
+          build_type: "Release"
+          tar_options: *linux_tar_options
+          extra_path: *linux_extra_path
+          cmake_flags: *linux_cmake_flags
+          mongodb_version: *version_latest
+      run_on:
+          - debian10-large
+      tasks:
+          - name: compile_and_test_with_shared_libs
+          - name: compile_and_test_with_shared_libs_extra_alignment
+          - name: compile_and_test_with_static_libs
+          - name: compile_and_test_with_static_libs_extra_alignment
+          - name: compile_and_test_with_shared_libs_replica_set
+          - name: build_example_with_add_subdirectory
+            distros:
+            - debian10-large
+          - name: uninstall_check
+
+    - name: debian10-release-50
+      display_name: "Debian 10 Release (MongoDB 5.0)"
+      expansions:
+          build_type: "Release"
+          tar_options: *linux_tar_options
+          extra_path: *linux_extra_path
+          cmake_flags: *linux_cmake_flags
+          mongodb_version: *version_50
+      run_on:
+          - debian10-large
+      tasks:
+          - name: compile_and_test_with_shared_libs
+          - name: compile_and_test_with_shared_libs_extra_alignment
+          - name: compile_and_test_with_static_libs
+          - name: compile_and_test_with_static_libs_extra_alignment
+          - name: compile_and_test_with_shared_libs_replica_set
+          - name: build_example_with_add_subdirectory
+            distros:
+            - debian10-large
+          - name: uninstall_check
+
+    - name: ubuntu2004-release-latest
+      display_name: "Ubuntu 20.04 Release (MongoDB Latest)"
+      expansions:
+          build_type: "Release"
+          tar_options: *linux_tar_options
+          extra_path: *linux_extra_path
+          cmake_flags: *linux_cmake_flags
+          mongodb_version: *version_latest
+      run_on:
+          - ubuntu2004-large
+      tasks:
+          - name: compile_and_test_with_shared_libs
+          - name: compile_and_test_with_shared_libs_extra_alignment
+          - name: compile_and_test_with_static_libs
+          - name: compile_and_test_with_static_libs_extra_alignment
+          - name: compile_and_test_with_shared_libs_replica_set
+          - name: build_example_with_add_subdirectory
+            distros:
+            - ubuntu2004-large
+          - name: uninstall_check
+
+    - name: ubuntu2004-release-50
+      display_name: "Ubuntu 20.04 Release (MongoDB 5.0)"
+      expansions:
+          build_type: "Release"
+          tar_options: *linux_tar_options
+          extra_path: *linux_extra_path
+          cmake_flags: *linux_cmake_flags
+          mongodb_version: *version_50
+      run_on:
+          - ubuntu2004-large
+      tasks:
+          - name: compile_and_test_with_shared_libs
+          - name: compile_and_test_with_shared_libs_extra_alignment
+          - name: compile_and_test_with_static_libs
+          - name: compile_and_test_with_static_libs_extra_alignment
+          - name: compile_and_test_with_shared_libs_replica_set
+          - name: build_example_with_add_subdirectory
+            distros:
+            - ubuntu2004-large
+          - name: uninstall_check
+
     - name: ubuntu1804-release-latest
       display_name: "Ubuntu 18.04 Release (MongoDB Latest)"
       expansions:

--- a/docs/content/mongocxx-v3/installation/_index.md
+++ b/docs/content/mongocxx-v3/installation/_index.md
@@ -14,17 +14,8 @@ title = "Installing the mongocxx driver"
 - [CMake](https://cmake.org) 3.2 or later
 - [boost](https://www.boost.org) headers (optional)
 
-We currently test the driver on the following platforms:
-
-- Linux with clang 3.8 and 6.0, GCC 5.4 and 7.5
-- macOS with Apple clang 11.0 using Boost 1.70.0
-- Windows with Visual Studio 2015 using Boost 1.60.0 and Visual Studio 2017
-
-Versions older than the ones listed may not work and are not
-supported; use them at your own risk.
-
-Versions newer than the ones listed above should work; if you
-have problems, please file a bug report via
+If you encounter build failures or other problems with a platform configuration
+that meets the above prerequisites, please file a bug report via
 [JIRA](https://jira.mongodb.org/browse/CXX/).
 
 ## Installation


### PR DESCRIPTION
Evergreen patch build: https://spruce.mongodb.com/version/6307b35a5623437b34e1f3a2/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

The main thing to focus on in the patch build is the new build variants.