### PR TITLE
CXX-2492 Add zSeries RHEL 8.3 for Latest

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -1421,6 +1421,25 @@ buildvariants:
       tasks:
           - name: test_mongohouse
 
+    - name: zseries-rhel83-latest
+      display_name: "zSeries RHEL 8.3 (MongoDB Latest)"
+      batchtime: 1440 # 1 day
+      expansions:
+          build_type: "Release"
+          tar_options: *linux_tar_options
+          cmake_flags: *linux_cmake_flags
+          mongodb_version: *version_latest
+          cmake: "cmake"
+          lib_dir: "lib64"
+      run_on:
+          - rhel83-zseries-small
+      tasks:
+          - name: compile_with_shared_libs
+          - name: compile_and_test_with_shared_libs
+          - name: compile_and_test_with_shared_libs_extra_alignment
+          - name: compile_and_test_with_static_libs
+          - name: compile_and_test_with_static_libs_extra_alignment
+
     - name: zseries-rhel83-60
       display_name: "zSeries RHEL 8.3 (MongoDB 6.0)"
       batchtime: 1440 # 1 day


### PR DESCRIPTION
## Description

This PR resolves CXX-2492 and is a followup to https://github.com/mongodb/mongo-cxx-driver/pull/871.

Changes verified by [this patch](https://spruce.mongodb.com/version/6308fa943627e02c58eab150).