### PR TITLE
Improve documentation and scripts relating to CXX Driver releases

### DIFF
--- a/.evergreen/install_c_driver.sh
+++ b/.evergreen/install_c_driver.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Usage examples:
-# MONGOC_VERSION=1.21.2 MONGOCRYPT_VERSION=1.4.1 ./install.sh
-# PREFIX=/tmp/installdir MONGOC_VERSION=1.21.2 MONGOCRYPT_VERSION=1.4.1 ./install.sh
+# MONGOC_VERSION=1.22.1 MONGOCRYPT_VERSION=1.5.2 ./install.sh
+# PREFIX=/tmp/installdir MONGOC_VERSION=1.22.1 MONGOCRYPT_VERSION=1.5.2 ./install.sh
 
 set -o errexit
 set -o pipefail

--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -86,11 +86,15 @@ ISSUE_TYPE_ID = {'Backport': '10300',
 @click.option('--c-driver-install-dir',
               default=os.getcwd() + '/../mongoc',
               show_default=True,
-              help='When building the C driver, install to this directory')
+              help='When building the C driver and libmongocrypt, install to this directory')
 @click.option('--c-driver-build-ref',
-              default='master',
+              default='1.22.1',
               show_default=True,
               help='When building the C driver, build at this Git reference')
+@click.option('--mongocrypt-build-ref',
+              default='1.5.2',
+              show_default=True,
+              help='When building libmongocrypt, build at this Git reference')
 @click.option('--with-c-driver',
               help='Instead of building the C driver, use the one installed at this path')
 @click.option('--dist-file',
@@ -117,6 +121,7 @@ def release(jira_creds_file,
             remote,
             c_driver_install_dir,
             c_driver_build_ref,
+            mongocrypt_build_ref,
             with_c_driver,
             dist_file,
             skip_distcheck,
@@ -175,8 +180,7 @@ def release(jira_creds_file,
             click.echo('Specified distribution tarball does not exist...exiting!', err=True)
             sys.exit(1)
     else:
-        c_driver_dir = ensure_c_driver(c_driver_install_dir, c_driver_build_ref,
-                                       with_c_driver, quiet)
+        c_driver_dir = ensure_c_driver(c_driver_install_dir, c_driver_build_ref, mongocrypt_build_ref, with_c_driver, quiet)
         if not c_driver_dir:
             click.echo('C driver not built or not found...exiting!', err=True)
             sys.exit(1)
@@ -327,7 +331,7 @@ def check_pre_release(tag_name):
 
     return not bool(release_re.match(tag_name))
 
-def ensure_c_driver(c_driver_install_dir, c_driver_build_ref, with_c_driver, quiet):
+def ensure_c_driver(c_driver_install_dir, c_driver_build_ref, mongocrypt_build_ref, with_c_driver, quiet):
     """
     Ensures that there is a properly installed C driver, returning the location
     of the C driver installation.  If the with_c_driver parameter is set and
@@ -346,9 +350,9 @@ def ensure_c_driver(c_driver_install_dir, c_driver_build_ref, with_c_driver, qui
             click.echo('A required component of the C driver is missing!', err=True)
         return None
 
-    return build_c_driver(c_driver_install_dir, c_driver_build_ref, quiet)
+    return build_c_driver(c_driver_install_dir, c_driver_build_ref, mongocrypt_build_ref, quiet)
 
-def build_c_driver(c_driver_install_dir, c_driver_build_ref, quiet):
+def build_c_driver(c_driver_install_dir, c_driver_build_ref, mongocrypt_build_ref, quiet):
     """
     Build the C driver and install to the specified directory.  If the build is
     successful, then return the directory where the C driver was installed,
@@ -363,9 +367,9 @@ def build_c_driver(c_driver_install_dir, c_driver_build_ref, quiet):
 
     env = os.environ
     env['PREFIX'] = mongoc_prefix
-    if not c_driver_build_ref:
-        c_driver_build_ref = 'master'
-    run_shell_script('MONGOC_VERSION=' + c_driver_build_ref + ' ./.evergreen/install_c_driver.sh', env=env)
+    env['MONGOC_VERSION'] = c_driver_build_ref
+    env['MONGOCRYPT_VERSION'] = mongocrypt_build_ref
+    run_shell_script('./.evergreen/install_c_driver.sh', env=env)
 
     if not quiet:
         click.echo('C Driver build was successful.')

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -7,8 +7,8 @@ Ensure the latest commit has run tests on the Evergreen waterfall.
 
 For a minor release this should be the waterfall tracking the master branch:
 https://evergreen.mongodb.com/waterfall/cxx-driver
-For a patch release this is the waterfall tracking that branch. E.g. if you are releasing 3.6.4, then the waterfall tracking releases/v3.6:
-https://evergreen.mongodb.com/waterfall/cxx-driver-v3.6
+For a patch release this is the waterfall tracking that branch. E.g. if you are releasing 3.7.1, then the waterfall tracking releases/v3.7:
+https://spruce.mongodb.com/commits/cxx-driver-v3.7
 
 If there are test failures, ensure they are at least expected or not introduced by changes in the new release.
 
@@ -37,18 +37,18 @@ pip install -r etc/requirements.txt
 
 ## Tag the release
 
-If doing a minor release (e.g. releasing r3.6.0), stay on the master branch. You will create a new `releases/v3.6` branch later in the instructions.
-If doing a patch release (e.g. releasing r3.6.1), check out the corresponding release branch, which should be `releases/v3.6`.
+If doing a minor release (e.g. releasing r3.8.0), stay on the master branch. You will create a new `releases/v3.8` branch later in the instructions.
+If doing a patch release (e.g. releasing r3.7.1), check out the corresponding release branch, which should be the existing `releases/v3.7` branch.
 
 Create a tag for the commit to serve as the release (or release candidate):
 
 ```
-git tag r3.6.0
+git tag r3.8.0
 ```
 
 ## Run make_release.py
 
-`make_release.py` creates the distribution tarball (e.g. mongo-cxx-driver-r3.6.0.tar.gz), interacts with Jira, and drafts the release on GitHub.
+`make_release.py` creates the distribution tarball (e.g. mongo-cxx-driver-r3.8.0.tar.gz), interacts with Jira, and drafts the release on GitHub.
 
 To see all available options, run with `--help`
 ```
@@ -59,25 +59,33 @@ It requires the following:
 - A GitHub token. Go to the GitHub settings page [Personal Access Tokens](https://github.com/settings/tokens) and create a token. Save the token secret to `mongo-cxx-driver-release/github_token.txt`.
 - Jira OAuth credentials. Ask for these from a team member. Save it to `mongo-cxx-driver-release/jira_creds.txt`.
 
-Run the release script with the git tag created above as an argument.
+Run the release script with the git tag created above as an argument and `--dry-run` to test for unexpected errors.
 ```
-python ./etc/make_release.py r3.6.0
+python ./etc/make_release.py --dry-run r3.8.0
 ```
 
-If all goes well, this should build and test the tarball and draft the GitHub release.
+If all goes well, run the command again without `--dry-run`, which should build and test the tarball and draft the GitHub release.
 
 ### Troubleshooting make_release.py
 If an error occurs, inspect logs the script produces, and troubleshoot as follows:
 - Use `--dry-run` to prevent unrecoverable effects.
 - If building the C driver fails, use an existing C driver build (ensure it is the right version) with `--with-c-driver /path/to/cdriver/install`.
 - Use `--skip-distcheck` to bypass time consuming checks when building the distribution tarball.
-- If the script succeeded at creating the distribution tarball, pass it directly with `--dist-file ./build/mongo-cxx-driver-r3.6.0.tar.gz`.
+- If the script succeeded at creating the distribution tarball, pass it directly with `--dist-file ./build/mongo-cxx-driver-r3.8.0.tar.gz`.
 
 ## Push the tag
-Review the build output and, assuming the distcheck target is successful, push the tag
+Review the build output and, assuming the distcheck target is successful, push the tag:
 
 ```
-git push origin r3.6.0
+git push origin r3.8.0
+```
+
+### Release the Version in GitHub
+
+Review the generated release draft on GitHub, then publish the release:
+
+```
+Edit -> Publish Release
 ```
 
 ## Release the Version in Jira
@@ -90,7 +98,7 @@ After any stable release (i.e. not an alpha, beta, RC, etc. release), check out 
 
 ```
 git checkout releases/stable
-git reset --hard r3.6.0
+git reset --hard r3.8.0
 git push -f origin releases/stable
 ```
 
@@ -100,11 +108,12 @@ Documentation generation must be run after the release tag has been made and pus
 
 - Checkout the master branch.
 - Edit `etc/apidocmenu.md` and add the released version in the `mongocxx` column following the established pattern. If this is a major release (x.y.0), revise the entire document as needed.
-- Edit `docs/content/index.md` and `README.md` to match.
+- Edit `docs/content/_index.md` and `README.md` to match.
 - Edit `etc/generate-all-apidocs.pl` and add the new release version to the `@DOC_TAGS` array, following the established pattern.
 - Edit `docs/content/mongocxx-v3/installation/linux.md`, `docs/content/mongocxx-v3/installation/macos.md` and `docs/content/mongocxx-v3/installation/windows.md` and update `Step 1` to reflect to libmongoc requirements. If the release was not a release candidate, update `Step 3` to reflect the new latest stable version to download.
-- Commit these changes `git commit -am "Prepare to generate r3.6.0 release documentation"`
-- Ensure you have doxygen and hugo installed and up to date.
+- Commit these changes: `git commit -am "Prepare to generate r3.8.0 release documentation"`
+- Merge the commit containing these changes into the master branch. This may require pushing the commit to a fork of the C++ Driver repository and creating a pull request.
+- Ensure you have `doxygen` and `hugo` installed and up to date.
 - Run `git clean -dxf` to clear out all extraneous files.
 - Configure with `cmake` in the `build` directory as you usually would.
 - Build docs locally to test.
@@ -116,29 +125,28 @@ Documentation generation must be run after the release tag has been made and pus
 - If the release was not a release candidate, update symlinks
     - Check out the `gh-pages` branch and git pull the deployed docs.
     - Update the `api/mongocxx-v3` symlink to point to the newly released version. If a major version bump has occurred, revise the symlink structure as needed. Make sure `current` always points to a symlink tracking the latest stable release branch.
-    - Commit and push the symlink change: `git commit -am "Update symlink for r3.6.0"`
+    - Commit and push the symlink change: `git commit -am "Update symlink for r3.8.0"`
 - Wait a few minutes and verify mongocxx.org has updated.
-- Push the updated documentation with `git push origin master`.
 
 ## File a DOCSP ticket if needed
-If the MongoDB manual [driver-server compatibility matrix or language compatibility matrix](https://docs.mongodb.com/drivers/driver-compatibility-reference) should be updated, file a DOCSP ticket. This generally will only apply to a minor release. (See DOCSP-3504 for an example).
+Add a comment to the generated DOCSP ticket describing if the [MongoDB Compatibility Table](https://www.mongodb.com/docs/drivers/cxx/#mongodb-compatibility) or [Language Compatibility Table](https://www.mongodb.com/docs/drivers/cxx/#language-compatibility) should be updated. Generally, only a minor release will require updates. (See DOCSP-3504 for an example.)
 
 ## Announce on Community Forums
 Announce
 Post to https://community.mongodb.com under `Product & Driver Announcements` with the tag `cxx`.
 
-Here is an example announcement of the stable release of 3.5.0:
-https://developer.mongodb.com/community/forums/t/mongodb-c-11-driver-3-5-0-released/2182
+Here is an example announcement of the stable release of 3.7.0:
+https://www.mongodb.com/community/forums/t/mongodb-c-11-driver-3-7-0-released/190601
 
 Here is an example announcement of a release candidate of 3.6.0:
 https://developer.mongodb.com/community/forums/t/mongodb-c-11-driver-3-6-0-rc0-released/6960
 
 ## Branch if necessary
-If doing a new minor release (e.g. a `x.y.0` release), create branch `releases/vx.y`  (e.g `releases/v3.6`).
+If doing a new minor release `x.y` (e.g. a `3.8.0` release), create branch `releases/vx.y`  (e.g `releases/v3.8`).
 
 Push the new branch:
 ```
-git push --set-upstream origin releases/v3.6
+git push --set-upstream origin releases/v3.8
 ```
 
 The new branch should be continuously tested on Evergreen. Create a BUILD ticket to request the build team create new Evergreen project to track the `releases/vx.y` branch (see BUILD-5666 for an example).

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -3,3 +3,4 @@ Click
 GitPython
 PyGithub
 jira
+cryptography


### PR DESCRIPTION
## Description

This PR suggests several improvements to both the documentation and the scripts relating to the process of publishing a new C++ Driver release.

## Minimum required version for C Driver and libmongocrypt

The `install_c_driver.sh` and `etc/make_release.py` scripts were updated to use the minimum required versions for the C Driver and libmongocrypt (as specified in `.mci.yml`).

`etc/make_release.py` was not updated to account for the new `MONGOCRYPT_VERSION` script parameter added as part of https://github.com/mongodb/mongo-cxx-driver/pull/867 in https://github.com/mongodb/mongo-cxx-driver/commit/3581760040f8ca95e5932b2d1cb9ca65ce0a891c. This PR adds a new `--mongocrypt-build-ref` option to the script. `--c-driver-build-ref` and `--mongocrypt-build-ref` now default to `1.22.1` and `1.5.2` respectively rather than `master`. These should be updated alongside the minimum required versions in `.mci.yml` and elsewhere. Alternatively, the release instructions can be updated to explicitly provide the current minimum versions in `.mci.yml` to the script when executing the command (required explicit arguments rather than implicit default arguments).

## etc/requirements.txt

Added the `cryptography` package to the list of required packages in `etc/requirements.txt` to address the following error:

```
AttributeError: module 'jwt.algorithms' has no attribute 'hashes'
```

## Release Instructions

`etc/releasing.md` was updated with clarifications and improvements to the release process:

- All minor and patch versions were updated to describe the expected process for the upcoming minor `3.8.0` and patch `3.7.1` versions.
- Added a new step to ensure the generated GitHub release draft is published.
- Clarified that the documentation changes may require the use of a pull request rather than pushing directly to origin.
- Clarified that the DOCSP ticket to comment on is automatically generated.
- Updated links to the MongoDB Compatibility and Language Compatibility tables.