### PR TITLE
CXX-2584 update min libmongoc version in cmake

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -10,7 +10,7 @@ variables:
     mongoc_version_default: &mongoc_version_default "2966c67d"
     mongocrypt_version_default: &mongocrypt_version_default "1.5.2"
 
-    # If updating mongoc_version_minimum and mongocrypt_version_minimum, also update:
+    # If updating mongoc_version_minimum, also update:
     # - the default value of --c-driver-build-ref in etc/make_release.py
     # - LIBMONGOC_REQUIRED_VERSION in src/mongocxx/CMakeLists.txt
     mongoc_version_minimum: &mongoc_version_minimum "1.22.1"

--- a/.mci.yml
+++ b/.mci.yml
@@ -10,6 +10,9 @@ variables:
     mongoc_version_default: &mongoc_version_default "2966c67d"
     mongocrypt_version_default: &mongocrypt_version_default "1.5.2"
 
+    # If updating mongoc_version_minimum and mongocrypt_version_minimum, also update:
+    # - the default value of --c-driver-build-ref in etc/make_release.py
+    # - LIBMONGOC_REQUIRED_VERSION in src/mongocxx/CMakeLists.txt
     mongoc_version_minimum: &mongoc_version_minimum "1.22.1"
     mongocrypt_version_minimum: &mongocrypt_version_minimum "1.5.2"
 

--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -87,9 +87,6 @@ ISSUE_TYPE_ID = {'Backport': '10300',
               default=os.getcwd() + '/../mongoc',
               show_default=True,
               help='When building the C driver and libmongocrypt, install to this directory')
-# If updating the default value of --c-driver-build-ref, also update:
-# - LIBMONGOC_REQUIRED_VERSION in src/mongocxx/CMakeLists.txt
-# - mongoc_version_minimum in .mci.yml
 @click.option('--c-driver-build-ref',
               default='1.22.1',
               show_default=True,

--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -87,6 +87,9 @@ ISSUE_TYPE_ID = {'Backport': '10300',
               default=os.getcwd() + '/../mongoc',
               show_default=True,
               help='When building the C driver and libmongocrypt, install to this directory')
+# If updating the default value of --c-driver-build-ref, also update:
+# - LIBMONGOC_REQUIRED_VERSION in src/mongocxx/CMakeLists.txt
+# - mongoc_version_minimum in .mci.yml
 @click.option('--c-driver-build-ref',
               default='1.22.1',
               show_default=True,

--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -29,9 +29,6 @@ message ("mongocxx version: ${MONGOCXX_VERSION}")
 set(MONGOCXX_INLINE_NAMESPACE "v${MONGOCXX_ABI_VERSION}")
 set(MONGOCXX_HEADER_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}/mongocxx/${MONGOCXX_INLINE_NAMESPACE}" CACHE INTERNAL "")
 
-# If updating LIBMONGOC_REQUIRED_VERSION also update:
-# - the default value of --c-driver-build-ref in etc/make_release.py
-# - mongoc_version_minimum in .mci.yml
 set(LIBMONGOC_REQUIRED_VERSION 1.22.1)
 set(LIBMONGOC_REQUIRED_ABI_VERSION 1.0)
 

--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -29,7 +29,10 @@ message ("mongocxx version: ${MONGOCXX_VERSION}")
 set(MONGOCXX_INLINE_NAMESPACE "v${MONGOCXX_ABI_VERSION}")
 set(MONGOCXX_HEADER_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}/mongocxx/${MONGOCXX_INLINE_NAMESPACE}" CACHE INTERNAL "")
 
-set(LIBMONGOC_REQUIRED_VERSION 1.19.0)
+# If updating LIBMONGOC_REQUIRED_VERSION also update:
+# - the default value of --c-driver-build-ref in etc/make_release.py
+# - mongoc_version_minimum in .mci.yml
+set(LIBMONGOC_REQUIRED_VERSION 1.22.1)
 set(LIBMONGOC_REQUIRED_ABI_VERSION 1.0)
 
 set(mongocxx_pkg_dep "")


### PR DESCRIPTION
# Summary
- Update the minimum libmongoc version check in cmake scripts.

# Background & Motivation
The required libmongoc dependency was increased to 1.22.1 in https://github.com/mongodb/mongo-cxx-driver/pull/884.