### PR TITLE
CXX-2172 Support AWS temporary credentials

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -285,6 +285,20 @@ functions:
     "run_kms_servers":
       - command: shell.exec
         params:
+          shell: bash
+          script: |-
+            set -o errexit
+            echo "Preparing CSFLE venv environment..."
+            cd ./drivers-evergreen-tools/.evergreen/csfle
+            # This function ensures future invocations of activate_venv.sh conducted in
+            # parallel do not race to setup a venv environment; it has already been prepared.
+            # This primarily addresses the situation where the "test" and "run_kms_servers"
+            # functions invoke 'activate_venv.sh' simultaneously.
+            . ./activate_venv.sh
+            deactivate
+            echo "Preparing CSFLE venv environment... done."
+      - command: shell.exec
+        params:
           background: true
           shell: bash
           script: |-
@@ -420,6 +434,30 @@ functions:
                       # export environment variables for encryption tests
                       set +o errexit
 
+                      # Avoid printing credentials in logs.
+                      set +o xtrace
+
+                      echo "Setting temporary credentials..."
+                      pushd "$DRIVERS_TOOLS/.evergreen/csfle"
+                      export AWS_SECRET_ACCESS_KEY="${cse_aws_secret_access_key}"
+                      export AWS_ACCESS_KEY_ID="${cse_aws_access_key_id}"
+                      export AWS_DEFAULT_REGION="us-east-1"
+                      echo "Running activate_venv.sh..."
+                      . ./activate_venv.sh
+                      echo "Running activate_venv.sh... done."
+                      echo "Running set-temp-creds.sh..."
+                      PYTHON="$(type -P python)" . ./set-temp-creds.sh
+                      echo "Running set-temp-creds.sh... done."
+                      deactivate
+                      popd
+                      echo "Setting temporary credentials... done."
+
+                      # Ensure temporary credentials were properly set.
+                      if [ -z "$CSFLE_AWS_TEMP_ACCESS_KEY_ID" ]; then
+                        echo "Failed to set temporary credentials!"
+                        exit 1
+                      fi
+
                       if [ "Windows_NT" == "$OS"]; then
                           export MONGOCXX_TEST_CSFLE_TLS_CA_FILE=$DRIVERS_TOOLS\.evergreen\x509gen\ca.pem
                           export MONGOCXX_TEST_CSFLE_TLS_CERTIFICATE_KEY_FILE=$DRIVERS_TOOLS\.evergreen\x509gen\client.pem
@@ -428,6 +466,9 @@ functions:
                           export MONGOCXX_TEST_CSFLE_TLS_CERTIFICATE_KEY_FILE=$DRIVERS_TOOLS/.evergreen/x509gen/client.pem
                       fi
 
+                      export MONGOCXX_TEST_AWS_TEMP_ACCESS_KEY_ID="$CSFLE_AWS_TEMP_ACCESS_KEY_ID"
+                      export MONGOCXX_TEST_AWS_TEMP_SECRET_ACCESS_KEY="$CSFLE_AWS_TEMP_SECRET_ACCESS_KEY"
+                      export MONGOCXX_TEST_AWS_TEMP_SESSION_TOKEN="$CSFLE_AWS_TEMP_SESSION_TOKEN"
                       export MONGOCXX_TEST_AWS_SECRET_ACCESS_KEY="${cse_aws_secret_access_key}"
                       export MONGOCXX_TEST_AWS_ACCESS_KEY_ID="${cse_aws_access_key_id}"
                       export MONGOCXX_TEST_AZURE_TENANT_ID="${cse_azure_tenant_id}"

--- a/.mci.yml
+++ b/.mci.yml
@@ -378,16 +378,16 @@ functions:
                   set -o pipefail
 
                   # Grabs the mongocryptd path
-                  cd ../
+                  pushd ..
                   export MONGOCRYPTD_PATH=$(pwd)/
                   if [ "Windows_NT" == "$OS" ]; then
                      export MONGOCRYPTD_PATH=$(cygpath -m $MONGOCRYPTD_PATH)
                   fi
-                  cd mongo-cxx-driver
+                  popd # ..
 
                   export PATH="${extra_path}:$PATH"
 
-                  cd build
+                  pushd build
                   export PREFIX=$(pwd)/../../mongoc
 
                   # Use PATH / LD_LIBRARY_PATH / DYLD_LIBRARY_PATH to inform the tests where to find
@@ -420,13 +420,12 @@ functions:
 
                   export MONGODB_API_VERSION="${MONGODB_API_VERSION}"
 
-                  pushd ../../
-                  cd drivers-evergreen-tools
+                  pushd ../../drivers-evergreen-tools
                   export DRIVERS_TOOLS=$(pwd)
                   if [ "Windows_NT" == "$OS" ]; then
                       export DRIVERS_TOOLS=$(cygpath -m $DRIVERS_TOOLS)
                   fi
-                  popd
+                  popd # ../../drivers-evergreen-tools
 
                   if [ "$(uname -m)" == "ppc64le" ]; then
                       echo "Skipping CSFLE test setup (CDRIVER-4246/CXX-2423)"
@@ -449,7 +448,7 @@ functions:
                       PYTHON="$(type -P python)" . ./set-temp-creds.sh
                       echo "Running set-temp-creds.sh... done."
                       deactivate
-                      popd
+                      popd # "$DRIVERS_TOOLS/.evergreen/csfle"
                       echo "Setting temporary credentials... done."
 
                       # Ensure temporary credentials were properly set.
@@ -598,7 +597,8 @@ functions:
                       fi
                   fi
 
-                  cd ..
+                  popd # ./build
+
                   export CMAKE_PREFIX_PATH=$PREFIX:$(pwd)/build/install
                   if [ -n "${lib_dir}" ]; then
                      export PKG_CONFIG_PATH=$PREFIX/${lib_dir}/pkgconfig:$(pwd)/build/install/${lib_dir}/pkgconfig

--- a/data/client_side_encryption/awsTemporary.json
+++ b/data/client_side_encryption/awsTemporary.json
@@ -1,0 +1,225 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.1.10"
+    }
+  ],
+  "database_name": "default",
+  "collection_name": "default",
+  "data": [],
+  "json_schema": {
+    "properties": {
+      "encrypted_w_altname": {
+        "encrypt": {
+          "keyId": "/altname",
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+        }
+      },
+      "encrypted_string": {
+        "encrypt": {
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                "subType": "04"
+              }
+            }
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+        }
+      },
+      "random": {
+        "encrypt": {
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                "subType": "04"
+              }
+            }
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+        }
+      },
+      "encrypted_string_equivalent": {
+        "encrypt": {
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                "subType": "04"
+              }
+            }
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+        }
+      }
+    },
+    "bsonType": "object"
+  },
+  "key_vault_data": [
+    {
+      "status": 1,
+      "_id": {
+        "$binary": {
+          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+          "subType": "04"
+        }
+      },
+      "masterKey": {
+        "provider": "aws",
+        "key": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
+        "region": "us-east-1"
+      },
+      "updateDate": {
+        "$date": {
+          "$numberLong": "1552949630483"
+        }
+      },
+      "keyMaterial": {
+        "$binary": {
+          "base64": "AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gEqnsxXlR51T5EbEVezUqqKAAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDHa4jo6yp0Z18KgbUgIBEIB74sKxWtV8/YHje5lv5THTl0HIbhSwM6EqRlmBiFFatmEWaeMk4tO4xBX65eq670I5TWPSLMzpp8ncGHMmvHqRajNBnmFtbYxN3E3/WjxmdbOOe+OXpnGJPcGsftc7cB2shRfA4lICPnE26+oVNXT6p0Lo20nY5XC7jyCO",
+          "subType": "00"
+        }
+      },
+      "creationDate": {
+        "$date": {
+          "$numberLong": "1552949630483"
+        }
+      },
+      "keyAltNames": [
+        "altname",
+        "another_altname"
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Insert a document with auto encryption using the AWS provider with temporary credentials",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "awsTemporary": {}
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "encrypted_string": "string0"
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "default"
+              }
+            },
+            "command_name": "listCollections"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "datakeys",
+              "filter": {
+                "$or": [
+                  {
+                    "_id": {
+                      "$in": [
+                        {
+                          "$binary": {
+                            "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                            "subType": "04"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "keyAltNames": {
+                      "$in": []
+                    }
+                  }
+                ]
+              },
+              "$db": "keyvault"
+            },
+            "command_name": "find"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default",
+              "documents": [
+                {
+                  "_id": 1,
+                  "encrypted_string": {
+                    "$binary": {
+                      "base64": "AQAAAAAAAAAAAAAAAAAAAAACwj+3zkv2VM+aTfk60RqhXq6a/77WlLwu/BxXFkL7EppGsju/m8f0x5kBDD3EZTtGALGXlym5jnpZAoSIkswHoA==",
+                      "subType": "06"
+                    }
+                  }
+                }
+              ],
+              "ordered": true
+            },
+            "command_name": "insert"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "encrypted_string": {
+                "$binary": {
+                  "base64": "AQAAAAAAAAAAAAAAAAAAAAACwj+3zkv2VM+aTfk60RqhXq6a/77WlLwu/BxXFkL7EppGsju/m8f0x5kBDD3EZTtGALGXlym5jnpZAoSIkswHoA==",
+                  "subType": "06"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Insert with invalid temporary credentials",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "awsTemporaryNoSessionToken": {}
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "encrypted_string": "string0"
+            }
+          },
+          "result": {
+            "errorContains": "security token"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/data/client_side_encryption/test_files.txt
+++ b/data/client_side_encryption/test_files.txt
@@ -1,4 +1,5 @@
 aggregate.json
+awsTemporary.json
 azureKMS.json
 badQueries.json
 badSchema.json

--- a/src/mongocxx/test/spec/client_side_encryption.cpp
+++ b/src/mongocxx/test/spec/client_side_encryption.cpp
@@ -96,6 +96,31 @@ void add_auto_encryption_opts(document::view test, options::client* client_opts)
                 }));
             }
 
+            if (providers["awsTemporary"]) {
+                kms_doc.append(kvp("aws", [](sub_document subdoc) {
+                    subdoc.append(
+                        kvp("secretAccessKey",
+                            test_util::getenv_or_fail("MONGOCXX_TEST_AWS_TEMP_SECRET_ACCESS_KEY")));
+                    subdoc.append(
+                        kvp("accessKeyId",
+                            test_util::getenv_or_fail("MONGOCXX_TEST_AWS_TEMP_ACCESS_KEY_ID")));
+                    subdoc.append(
+                        kvp("sessionToken",
+                            test_util::getenv_or_fail("MONGOCXX_TEST_AWS_TEMP_SESSION_TOKEN")));
+                }));
+            }
+
+            if (providers["awsTemporaryNoSessionToken"]) {
+                kms_doc.append(kvp("aws", [](sub_document subdoc) {
+                    subdoc.append(
+                        kvp("secretAccessKey",
+                            test_util::getenv_or_fail("MONGOCXX_TEST_AWS_TEMP_SECRET_ACCESS_KEY")));
+                    subdoc.append(
+                        kvp("accessKeyId",
+                            test_util::getenv_or_fail("MONGOCXX_TEST_AWS_TEMP_ACCESS_KEY_ID")));
+                }));
+            }
+
             // Add gcp credentials (from the enviornment):
             if (providers["gcp"]) {
                 kms_doc.append(kvp("gcp", [](sub_document subdoc) {


### PR DESCRIPTION
## Description

This PR address CXX-2172.

No changes were necessary to the C++ Driver interface to support AWS temp creds.

The CSE legacy unified test runner was updated to support the new `awsTemporary` and `awsTemporaryNoSessionToken` KMS providers used to test AWS temp creds by the new `awsTemporary.json` test file.

The Evergreen config file was updated to support the generation of AWS temp creds as the new `MONGOCXX_TEST_AWS_TEMP_*` environment variables using the same pattern as applied in https://github.com/mongodb/mongo-c-driver/pull/1109.

Changes were verified by [this patch](https://spruce.mongodb.com/version/63376bace3c3315b40d5dd12). Failures on PowerPC and zSeries RHEL variants appear to be due to unrelated issues with Python package dependencies and will be addressed separately.