### PR TITLE
Add a comment about renamed element method to docs

### DIFF
--- a/docs/content/mongocxx-v3/tutorial.md
+++ b/docs/content/mongocxx-v3/tutorial.md
@@ -205,7 +205,7 @@ bsoncxx::document::element element = view["name"];
 if(element.type() != bsoncxx::type::k_string) {
   // Error
 }
-// For the previous versions of 3.7.0, use get_utf8 instead of get_string
+// For the versions older than 3.7.0, use get_utf8 instead of get_string
 std::string name = element.get_string().value.to_string();
 ```
 

--- a/docs/content/mongocxx-v3/tutorial.md
+++ b/docs/content/mongocxx-v3/tutorial.md
@@ -205,6 +205,7 @@ bsoncxx::document::element element = view["name"];
 if(element.type() != bsoncxx::type::k_string) {
   // Error
 }
+// For the previous versions of 3.7.0, use get_utf8 instead of get_string
 std::string name = element.get_string().value.to_string();
 ```
 


### PR DESCRIPTION
According to the ticket [here](https://jira.mongodb.org/browse/CXX-1817?jql=text%20~%20%22get_string%22), element method get_utf8 renamed into get_string, and merged in with version 3.7.0. But the documentation tutorial leads users to use get_string and it is somewhat time consuming to understand which one to use for earlier-version-users of 3.7. A simple comment may help readers about this.