### PR TITLE
CXX-2162 Use DET hygienic scripts for Python binary selection and venv creation

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -293,11 +293,11 @@ functions:
             set -o errexit
             echo "Preparing CSFLE venv environment..."
             cd ./drivers-evergreen-tools/.evergreen/csfle
-            # This function ensures future invocations of activate_venv.sh conducted in
+            # This function ensures future invocations of activate-kmstlsvenv.sh conducted in
             # parallel do not race to setup a venv environment; it has already been prepared.
             # This primarily addresses the situation where the "test" and "run_kms_servers"
-            # functions invoke 'activate_venv.sh' simultaneously.
-            . ./activate_venv.sh
+            # functions invoke 'activate-kmstlsvenv.sh' simultaneously.
+            . ./activate-kmstlsvenv.sh
             deactivate
             echo "Preparing CSFLE venv environment... done."
       - command: shell.exec
@@ -308,7 +308,7 @@ functions:
             set -o errexit
             echo "Starting mock KMS servers..."
             cd ./drivers-evergreen-tools/.evergreen/csfle
-            . ./activate_venv.sh
+            . ./activate-kmstlsvenv.sh
             python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --port 8999 &
             python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 9000 &
             python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 9001 &
@@ -444,11 +444,11 @@ functions:
                       export AWS_SECRET_ACCESS_KEY="${cse_aws_secret_access_key}"
                       export AWS_ACCESS_KEY_ID="${cse_aws_access_key_id}"
                       export AWS_DEFAULT_REGION="us-east-1"
-                      echo "Running activate_venv.sh..."
-                      . ./activate_venv.sh
-                      echo "Running activate_venv.sh... done."
+                      echo "Running activate-kmstlsvenv.sh..."
+                      . ./activate-kmstlsvenv.sh
+                      echo "Running activate-kmstlsvenv.sh... done."
                       echo "Running set-temp-creds.sh..."
-                      PYTHON="$(type -P python)" . ./set-temp-creds.sh
+                      . ./set-temp-creds.sh
                       echo "Running set-temp-creds.sh... done."
                       deactivate
                       popd # "$DRIVERS_TOOLS/.evergreen/csfle"

--- a/.mci.yml
+++ b/.mci.yml
@@ -214,12 +214,10 @@ functions:
                 set -o errexit
                 set -o pipefail
                 cd drivers-evergreen-tools/.evergreen/orchestration
-                if [ -f venv/bin/activate ]; then
-                    . venv/bin/activate
-                elif [ -f venv/Scripts/activate ]; then
-                    . venv/Scripts/activate
+                . ../venv-utils.sh
+                if venvactivate venv; then
+                  mongo-orchestration stop
                 fi
-                mongo-orchestration stop
 
     "install_c_driver":
       - command: expansions.update

--- a/.mci.yml
+++ b/.mci.yml
@@ -451,7 +451,7 @@ functions:
                         exit 1
                       fi
 
-                      if [ "Windows_NT" == "$OS"]; then
+                      if [ "Windows_NT" == "$OS" ]; then
                           export MONGOCXX_TEST_CSFLE_TLS_CA_FILE=$DRIVERS_TOOLS\.evergreen\x509gen\ca.pem
                           export MONGOCXX_TEST_CSFLE_TLS_CERTIFICATE_KEY_FILE=$DRIVERS_TOOLS\.evergreen\x509gen\client.pem
                       else

--- a/.mci.yml
+++ b/.mci.yml
@@ -346,21 +346,14 @@ functions:
                   fi
                   export CMAKE=${cmake}
 
-                  if [ "x$(lsb_release -cs)" = "xtrusty" -a -f /opt/mongodbtoolchain/v2/bin/python ]; then
-                      /opt/mongodbtoolchain/v2/bin/python -m virtualenv venv
-                  elif ! python -m virtualenv venv 2>/dev/null; then
-                      /opt/mongodbtoolchain/v3/bin/python3 -m venv venv
+                  if [ ! -d ../drivers-evergreen-tools ]; then
+                    git clone --depth 1 git@github.com:mongodb-labs/drivers-evergreen-tools.git ../drivers-evergreen-tools
                   fi
+                  . ../drivers-evergreen-tools/.evergreen/find-python3.sh
+                  . ../drivers-evergreen-tools/.evergreen/venv-utils.sh
 
-                  cd venv
-                  if [ -f bin/activate ]; then
-                      . bin/activate
-                      ./bin/pip install GitPython
-                  elif [ -f Scripts/activate ]; then
-                      . Scripts/activate
-                      ./Scripts/pip install GitPython
-                  fi
-                  cd ..
+                  venvcreate "$(find_python3)" venv
+                  python -m pip install GitPython
 
                   export GENERATOR="${generator}"
 

--- a/.mci.yml
+++ b/.mci.yml
@@ -124,7 +124,7 @@ functions:
             shell: bash
             script: |
                 if [ ! -d "drivers-evergreen-tools" ]; then
-                    git clone git@github.com:mongodb-labs/drivers-evergreen-tools.git
+                    git clone git@github.com:eramongodb/drivers-evergreen-tools.git --depth 1 --branch det-scripts
                 fi
                 cd drivers-evergreen-tools
                 export DRIVERS_TOOLS=$(pwd)
@@ -177,7 +177,7 @@ functions:
                 set -o errexit
                 set -o pipefail
                 if [ ! -d "drivers-evergreen-tools" ]; then
-                    git clone git@github.com:mongodb-labs/drivers-evergreen-tools.git
+                    git clone git@github.com:eramongodb/drivers-evergreen-tools.git --depth 1 --branch det-scripts
                 fi
                 cd drivers-evergreen-tools
                 export DRIVERS_TOOLS=$(pwd)
@@ -280,7 +280,7 @@ functions:
           script: |-
             set -o errexit
             if [ ! -d "drivers-evergreen-tools" ]; then
-                git clone git@github.com:mongodb-labs/drivers-evergreen-tools.git --depth=1
+                git clone git@github.com:eramongodb/drivers-evergreen-tools.git --depth 1 --branch det-scripts
             fi
 
     "run_kms_servers":
@@ -345,7 +345,7 @@ functions:
                   export CMAKE=${cmake}
 
                   if [ ! -d ../drivers-evergreen-tools ]; then
-                    git clone --depth 1 git@github.com:mongodb-labs/drivers-evergreen-tools.git ../drivers-evergreen-tools
+                    git clone git@github.com:eramongodb/drivers-evergreen-tools.git ../drivers-evergreen-tools --depth 1 --branch det-scripts
                   fi
                   . ../drivers-evergreen-tools/.evergreen/find-python3.sh
                   . ../drivers-evergreen-tools/.evergreen/venv-utils.sh


### PR DESCRIPTION
This PR addresses CXX-2162, motivated by ongoing task failures due to `ImportError: No module named functools_lru_cache` when evaluating the `start_mongod` Evergreen function.

Verified by [this patch](https://spruce.mongodb.com/version/639cae6de3c3316f6f565e06/tasks), which depends on a custom DET branch with features pending review in https://github.com/mongodb-labs/drivers-evergreen-tools/pull/255. This PR will be moved out of draft status once the DET pull request has been merged.