### PR TITLE
CXX-2284 Append platform data to handshake

### DIFF
--- a/src/mongocxx/config/CMakeLists.txt
+++ b/src/mongocxx/config/CMakeLists.txt
@@ -24,6 +24,18 @@ configure_file(
     ${CMAKE_CURRENT_BINARY_DIR}/config.hpp
 )
 
+if (DEFINED CMAKE_CXX_COMPILER_ID)
+    set (MONGOCXX_COMPILER_ID "${CMAKE_CXX_COMPILER_ID}")
+else ()
+    set (MONGOCXX_COMPILER_ID "Unknown")
+endif ()
+
+if (DEFINED CMAKE_CXX_COMPILER_VERSION)
+    set (MONGOCXX_COMPILER_VERSION "${CMAKE_CXX_COMPILER_VERSION}")
+else ()
+    set (MONGOCXX_COMPILER_VERSION "Unknown")
+endif ()
+
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/private/config.hh.in
     ${CMAKE_CURRENT_BINARY_DIR}/private/config.hh

--- a/src/mongocxx/config/private/config.hh.in
+++ b/src/mongocxx/config/private/config.hh.in
@@ -13,3 +13,5 @@
 // limitations under the License.
 
 #cmakedefine MONGOCXX_ENABLE_SSL
+#cmakedefine MONGOCXX_COMPILER_ID "${MONGOCXX_COMPILER_ID}"
+#cmakedefine MONGOCXX_COMPILER_VERSION "${MONGOCXX_COMPILER_VERSION}"

--- a/src/mongocxx/instance.cpp
+++ b/src/mongocxx/instance.cpp
@@ -96,8 +96,15 @@ class instance::impl {
         // mongoc_handshake_data_append does not add a delimitter, so include the " / " in the
         // argument for consistency with the driver_name, and driver_version.
         std::stringstream platform;
+        long stdcxx = __cplusplus;
+#ifdef _MSVC_LANG
+        // Prefer _MSVC_LANG to report the supported C++ standard with MSVC.
+        // The __cplusplus macro may be incorrect. See:
+        // https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
+        stdcxx = _MSVC_LANG;
+#endif
         platform << "CXX=" << MONGOCXX_COMPILER_ID << " " << MONGOCXX_COMPILER_VERSION << " "
-                 << "stdcxx=" << __cplusplus << " / ";
+                 << "stdcxx=" << stdcxx << " / ";
         libmongoc::handshake_data_append(
             "mongocxx", MONGOCXX_VERSION_STRING, platform.str().c_str());
     }

--- a/src/mongocxx/instance.cpp
+++ b/src/mongocxx/instance.cpp
@@ -91,6 +91,10 @@ class instance::impl {
         } else {
             libmongoc::log_set_handler(null_log_handler, nullptr);
         }
+
+        // Despite the name, mongoc_handshake_data_append *prepends* the platform string.
+        // mongoc_handshake_data_append does not add a delimitter, so include the " / " in the
+        // argument for consistency with the driver_name, and driver_version.
         std::stringstream platform;
         platform << "CXX=" << MONGOCXX_COMPILER_ID << " " << MONGOCXX_COMPILER_VERSION << " / ";
         libmongoc::handshake_data_append(

--- a/src/mongocxx/instance.cpp
+++ b/src/mongocxx/instance.cpp
@@ -96,7 +96,8 @@ class instance::impl {
         // mongoc_handshake_data_append does not add a delimitter, so include the " / " in the
         // argument for consistency with the driver_name, and driver_version.
         std::stringstream platform;
-        platform << "CXX=" << MONGOCXX_COMPILER_ID << " " << MONGOCXX_COMPILER_VERSION << " / ";
+        platform << "CXX=" << MONGOCXX_COMPILER_ID << " " << MONGOCXX_COMPILER_VERSION << " "
+                 << "stdcxx=" << __cplusplus << " / ";
         libmongoc::handshake_data_append(
             "mongocxx", MONGOCXX_VERSION_STRING, platform.str().c_str());
     }

--- a/src/mongocxx/instance.cpp
+++ b/src/mongocxx/instance.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <atomic>
+#include <sstream>
 #include <type_traits>
 #include <utility>
 
@@ -90,7 +91,10 @@ class instance::impl {
         } else {
             libmongoc::log_set_handler(null_log_handler, nullptr);
         }
-        libmongoc::handshake_data_append("mongocxx", MONGOCXX_VERSION_STRING, NULL);
+        std::stringstream platform;
+        platform << "CXX=" << MONGOCXX_COMPILER_ID << " " << MONGOCXX_COMPILER_VERSION << " / ";
+        libmongoc::handshake_data_append(
+            "mongocxx", MONGOCXX_VERSION_STRING, platform.str().c_str());
     }
 
     ~impl() {


### PR DESCRIPTION
# Summary

- Prepend compiler ID, compiler version, and C++ standard to the [Handshake platform string](https://github.com/mongodb/specifications/blob/9319b1a8cb4e7909871e893e24919ecabc00495b/source/mongodb-handshake/handshake.rst#client-platform)

# Background & Motivation

The [Handshake](https://github.com/mongodb/specifications/blob/9319b1a8cb4e7909871e893e24919ecabc00495b/source/mongodb-handshake/handshake.rst) is the first command performed upon establishing the connection to MongoDB.
The Handshake includes metadata in the `client` field, so a client can identify itself. The Handshake metadata appears in `mongod` logs.

Here is a formatted log from `mongod` from a C++ driver connection before this change:
```json
{
    "t": {
        "$date": "2022-12-21T12:02:28.088-05:00"
    },
    "s": "I",
    "c": "NETWORK",
    "id": 51800,
    "ctx": "conn11",
    "msg": "client metadata",
    "attr": {
        "remote": "127.0.0.1:59363",
        "client": "conn11",
        "doc": {
            "driver": {
                "name": "mongoc / mongocxx",
                "version": "1.23.1 / 3.7.1-pre"
            },
            "os": {
                "type": "Darwin",
                "name": "macOS",
                "version": "20.6.0",
                "architecture": "x86_64"
            },
            "platform": "cfg=0x0200d68a65 posix=200112 stdc=201710 CC=clang 13.0.0 (clang-1300.0.29.30) CFLAGS=\"\" LDFLAGS=\"\""
        }
    }
}
```

The `platform` only includes information from the C driver. After this change, the `platform` field includes the C++ compiler ID and version in the prefix:
```json
{
    "t": {
        "$date": "2023-01-03T09:15:05.013-05:00"
    },
    "s": "I",
    "c": "NETWORK",
    "id": 51800,
    "ctx": "conn12",
    "msg": "client metadata",
    "attr": {
        "remote": "127.0.0.1:59806",
        "client": "conn12",
        "doc": {
            "driver": {
                "name": "mongoc / mongocxx",
                "version": "1.23.1 / 3.7.1-pre"
            },
            "os": {
                "type": "Darwin",
                "name": "macOS",
                "version": "20.6.0",
                "architecture": "x86_64"
            },
            "platform": "CXX=AppleClang 13.0.0.13000029 stdcxx=201703 / cfg=0x0200d68a65 posix=200112 stdc=201710 CC=clang 13.0.0 (clang-1300.0.29.30) CFLAGS=\"\" LDFLAGS=\"\""
        }
    }
}
```

cmake is used to determine the compiler ID and version. The C driver uses macros to determine the compiler ID and version, and [falls back to values set by cmake](https://github.com/mongodb/mongo-c-driver/blob/f827e2fad19d11e579b33f155ced7adf29b500f7/src/libmongoc/src/mongoc/mongoc-handshake-compiler-private.h#L61-L62). I see no reason to use macros instead of cmake to determine the compiler type and version for the C++ driver. The C driver may have preferred macros for consistent values between cmake and the [now removed autotools build](https://jira.mongodb.org/browse/CDRIVER-1349). But I am not sure.

[A patch build](https://spruce.mongodb.com/version/63a469ee1e2d1712b0728f4c) was run to determine all `MONGOCXX_COMPILER_ID` and `MONGOCXX_COMPILER_VERSION` for tested variants. The following table is the unique values:

| MONGOCXX_COMPILER_ID   | MONGOCXX_COMPILER_VERSION   |
|------------------------|-----------------------------|
| GNU                    | 8.3.1                       |
| AppleClang             | 11.0.0.11000033             |
| GNU                    | 8.3.0                       |
| GNU                    | 9.4.0                       |
| GNU                    | 7.5.0                       |
| GNU                    | 10.2.1                      |
| Clang                  | 6.0.0                       |
| GNU                    | 5.4.0                       |
| MSVC                   | 19.16.27043.0               |
| MSVC                   | 19.0.24223.0                |