### PR TITLE
remove unused var in `Database integration tests`

### DIFF
--- a/src/mongocxx/test/database.cpp
+++ b/src/mongocxx/test/database.cpp
@@ -421,8 +421,6 @@ TEST_CASE("Database integration tests", "[database]") {
     }
 
     SECTION("read_concern is inherited from parent", "[database]") {
-        stdx::string_view collection_name{"collection_read_concern"};
-
         read_concern::level majority = read_concern::level::k_majority;
         read_concern::level local = read_concern::level::k_local;
 


### PR DESCRIPTION
Fixes a compiler error when building `test_driver`:

```
$ cmake --build cmake-build --target test_driver -- -j16
```

Results in:

```
[4/5] Building CXX object src/mongocxx/test/CMakeFiles/test_driver.dir/database.cpp.o
FAILED: src/mongocxx/test/CMakeFiles/test_driver.dir/database.cpp.o 
ccache /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DBSONCXX_TESTING -DMONGOCXX_TESTING -DMONGO_CXX_DRIVER_COMPILING -I/Users/kevin.albertson/code/mongo-cxx-driver-CXX2284/src/third_party/catch/include -I/include -I/Users/kevin.albertson/code/mongo-cxx-driver-CXX2284/src/mongocxx/.. -I/Users/kevin.albertson/code/mongo-cxx-driver-CXX2284/cmake-build/src/mongocxx/.. -I/Users/kevin.albertson/code/mongo-cxx-driver-CXX2284/src/bsoncxx/.. -I/Users/kevin.albertson/code/mongo-cxx-driver-CXX2284/cmake-build/src/bsoncxx/.. -isystem /usr/local/include/libmongoc-1.0 -isystem /usr/local/include/libbson-1.0 -Wall -Wextra -Wconversion -Wnarrowing -pedantic -Werror -O0 -Wno-deprecated-declarations -g -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk -mmacosx-version-min=11.7 -std=c++17 -MD -MT src/mongocxx/test/CMakeFiles/test_driver.dir/database.cpp.o -MF src/mongocxx/test/CMakeFiles/test_driver.dir/database.cpp.o.d -o src/mongocxx/test/CMakeFiles/test_driver.dir/database.cpp.o -c /Users/kevin.albertson/code/mongo-cxx-driver-CXX2284/src/mongocxx/test/database.cpp
/Users/kevin.albertson/code/mongo-cxx-driver-CXX2284/src/mongocxx/test/database.cpp:424:27: error: unused variable 'collection_name' [-Werror,-Wunused-variable]
        stdx::string_view collection_name{"collection_read_concern"};
                          ^
1 error generated.
ninja: build stopped: subcommand failed.
```