### PR TITLE
CXX-2629 Remove requirement to set `/Zc:__cplusplus` in MSVC flags

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -43,11 +43,7 @@ variables:
         ubsan_cmake_flags: &ubsan_cmake_flags -DCMAKE_C_FLAGS="-Wall -Wextra -Wno-attributes -Werror -Wno-missing-field-initializers $ignore_deprecated" -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -DCMAKE_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=0 -fsanitize=undefined -fsanitize-blacklist=$(pwd)/etc/ubsan.ignorelist -fno-sanitize-recover=undefined -O1 -g -fno-omit-frame-pointer -Wall -Wextra -Wconversion -Wnarrowing -pedantic -Werror $ignore_deprecated"
         msvc2015_cmake_flags: &msvc2015_cmake_flags -DBOOST_ROOT=c:/local/boost_1_60_0
         msvc2015_generator: &msvc2015_generator Visual Studio 14 2015 Win64
-        # The VS option /Zc:__cplusplus is necessary to build with VS2017's
-        # native C++17 support. __cplusplus should indicate the standard of C++
-        # the compiler supports. VS2017 erroneously reports it as 199711L
-        # (instead of 201703L) without this option.
-        msvc2017_cmake_flags: &msvc2017_cmake_flags -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS="/Zc:__cplusplus"
+        msvc2017_cmake_flags: &msvc2017_cmake_flags -DCMAKE_CXX_STANDARD=17
         msvc2017_generator: &msvc2017_generator Visual Studio 15 2017 Win64
         code_coverage_cmake_flags: &code_coverage_cmake_flags -DENABLE_CODE_COVERAGE=ON
 

--- a/.mci.yml
+++ b/.mci.yml
@@ -47,9 +47,7 @@ variables:
         # native C++17 support. __cplusplus should indicate the standard of C++
         # the compiler supports. VS2017 erroneously reports it as 199711L
         # (instead of 201703L) without this option.
-        # The VS option /EHsc is necessary to opt into C++ standard exception unwinding.
-        # Without this option, some destructors may not be called in tests (CXX-2054).
-        msvc2017_cmake_flags: &msvc2017_cmake_flags -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS="/Zc:__cplusplus /EHsc"
+        msvc2017_cmake_flags: &msvc2017_cmake_flags -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS="/Zc:__cplusplus"
         msvc2017_generator: &msvc2017_generator Visual Studio 15 2017 Win64
         code_coverage_cmake_flags: &code_coverage_cmake_flags -DENABLE_CODE_COVERAGE=ON
 

--- a/docs/content/mongocxx-v3/installation/windows.md
+++ b/docs/content/mongocxx-v3/installation/windows.md
@@ -109,21 +109,33 @@ The example above assumes:
 * `libmongoc` is found in `C:\mongo-c-driver`.
 * `mongocxx` is to be installed into `C:\mongo-cxx-driver`.
 
-For building with Visual Studio 2017 (without a C++17 polyfill), it is necessary to configure with
-an additional option, `/Zc:__cplusplus` to opt into the correct definition of `__cplusplus`
-([problem described here](https://blogs.msdn.microsoft.com/vcblog/2018/04/09/msvc-now-correctly-reports-__cplusplus/)):
+To build with Visual Studio 2017 without a C++17 polyfill, configure as follows:
 
 ```sh
 'C:\Program Files (x86)\CMake\bin\cmake.exe' .. \
     -G "Visual Studio 15 2017 Win64"            \
     -DCMAKE_CXX_STANDARD=17                     \
-    -DCMAKE_CXX_FLAGS="/Zc:__cplusplus"         \
     -DCMAKE_PREFIX_PATH=C:\mongo-c-driver       \
     -DCMAKE_INSTALL_PREFIX=C:\mongo-cxx-driver  \
 ```
 
 For details on how to install libmongoc for Windows, see the
 [mongoc Windows installation instructions](http://mongoc.org/libmongoc/current/installing.html#building-windows).
+
+#### Configuring with `mongocxx` 3.7.0 and older
+
+To build versions 3.7.0 and older without a C++17 polyfill, it is necessary to configure with additional options:
+- `/Zc:__cplusplus` to opt into the correct definition of `__cplusplus` ([problem described here](https://blogs.msdn.microsoft.com/vcblog/2018/04/09/msvc-now-correctly-reports-__cplusplus/))
+- `/EHsc` to enable recommended [exception handling behavior](https://learn.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-170).
+
+```sh
+'C:\Program Files (x86)\CMake\bin\cmake.exe' .. \
+    -G "Visual Studio 15 2017 Win64"            \
+    -DCMAKE_CXX_STANDARD=17                     \
+    -DCMAKE_CXX_FLAGS="/Zc:__cplusplus /EHsc"   \
+    -DCMAKE_PREFIX_PATH=C:\mongo-c-driver       \
+    -DCMAKE_INSTALL_PREFIX=C:\mongo-cxx-driver  \
+```
 
 #### Configuring with `mongocxx` 3.1.x or 3.0.x
 

--- a/examples/projects/bsoncxx/cmake-deprecated/shared/CMakeLists.txt
+++ b/examples/projects/bsoncxx/cmake-deprecated/shared/CMakeLists.txt
@@ -46,8 +46,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         find_package(Boost 1.56.0 REQUIRED)
         target_link_libraries(hello_bsoncxx PRIVATE Boost::boost)
         target_compile_definitions(hello_bsoncxx PRIVATE BSONCXX_POLY_USE_BOOST=ON)
-    else ()
-        target_compile_options(hello_bsoncxx PRIVATE /Zc:__cplusplus)
     endif ()
 endif()
 

--- a/examples/projects/bsoncxx/cmake-deprecated/static/CMakeLists.txt
+++ b/examples/projects/bsoncxx/cmake-deprecated/static/CMakeLists.txt
@@ -46,8 +46,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         find_package(Boost 1.56.0 REQUIRED)
         target_link_libraries(hello_bsoncxx PRIVATE Boost::boost)
         target_compile_definitions(hello_bsoncxx PRIVATE BSONCXX_POLY_USE_BOOST=ON)
-    else ()
-        target_compile_options(hello_bsoncxx PRIVATE /Zc:__cplusplus)
     endif ()
 endif()
 

--- a/examples/projects/bsoncxx/cmake/shared/CMakeLists.txt
+++ b/examples/projects/bsoncxx/cmake/shared/CMakeLists.txt
@@ -50,8 +50,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
             target_link_libraries(hello_bsoncxx PRIVATE Boost::boost)
         endif()
         target_compile_definitions(hello_bsoncxx PRIVATE BSONCXX_POLY_USE_BOOST=ON)
-    else ()
-        target_compile_options(hello_bsoncxx PRIVATE /Zc:__cplusplus)
     endif ()
 endif()
 

--- a/examples/projects/bsoncxx/cmake/static/CMakeLists.txt
+++ b/examples/projects/bsoncxx/cmake/static/CMakeLists.txt
@@ -50,8 +50,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
             target_link_libraries(hello_bsoncxx PRIVATE Boost::boost)
         endif()
         target_compile_definitions(hello_bsoncxx PRIVATE BSONCXX_POLY_USE_BOOST=ON)
-    else ()
-        target_compile_options(hello_bsoncxx PRIVATE /Zc:__cplusplus)
     endif ()
 endif()
 

--- a/examples/projects/mongocxx/cmake-deprecated/shared/CMakeLists.txt
+++ b/examples/projects/mongocxx/cmake-deprecated/shared/CMakeLists.txt
@@ -46,8 +46,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         find_package(Boost 1.56.0 REQUIRED)
         target_link_libraries(hello_mongocxx PRIVATE Boost::boost)
         target_compile_definitions(hello_mongocxx PRIVATE BSONCXX_POLY_USE_BOOST=ON)
-    else ()
-        target_compile_options(hello_mongocxx PRIVATE /Zc:__cplusplus)
     endif ()
 endif()
 

--- a/examples/projects/mongocxx/cmake-deprecated/static/CMakeLists.txt
+++ b/examples/projects/mongocxx/cmake-deprecated/static/CMakeLists.txt
@@ -46,8 +46,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         find_package(Boost 1.56.0 REQUIRED)
         target_link_libraries(hello_mongocxx PRIVATE Boost::boost)
         target_compile_definitions(hello_mongocxx PRIVATE BSONCXX_POLY_USE_BOOST=ON)
-    else ()
-        target_compile_options(hello_mongocxx PRIVATE /Zc:__cplusplus)
     endif ()
 endif()
 

--- a/examples/projects/mongocxx/cmake/shared/CMakeLists.txt
+++ b/examples/projects/mongocxx/cmake/shared/CMakeLists.txt
@@ -50,8 +50,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
             target_link_libraries(hello_mongocxx PRIVATE Boost::boost)
         endif()
         target_compile_definitions(hello_mongocxx PRIVATE BSONCXX_POLY_USE_BOOST=ON)
-    else ()
-        target_compile_options(hello_mongocxx PRIVATE /Zc:__cplusplus)
     endif ()
 endif()
 

--- a/examples/projects/mongocxx/cmake/static/CMakeLists.txt
+++ b/examples/projects/mongocxx/cmake/static/CMakeLists.txt
@@ -56,8 +56,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
             target_link_libraries(hello_mongocxx PRIVATE Boost::boost)
         endif()
         target_compile_definitions(hello_mongocxx PRIVATE BSONCXX_POLY_USE_BOOST=ON)
-    else ()
-        target_compile_options(hello_mongocxx PRIVATE /Zc:__cplusplus)
     endif ()
 endif()
 

--- a/src/bsoncxx/stdx/make_unique.hpp
+++ b/src/bsoncxx/stdx/make_unique.hpp
@@ -48,7 +48,7 @@ using ::boost::make_unique;
 BSONCXX_INLINE_NAMESPACE_END
 }  // namespace bsoncxx
 
-#elif __cplusplus >= 201402L
+#elif __cplusplus >= 201402L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201402L)
 
 #include <memory>
 


### PR DESCRIPTION
# Summary
- Remove requirement for /Zc:__cplusplus

# Background & Motivation

The current [documented install instructions](https://mongocxx.org/mongocxx-v3/installation/windows/#:~:text=For%20building%20with%20Visual%20Studio%202017) note:

> For building with Visual Studio 2017 (without a C++17 polyfill), it is necessary to configure with an additional option, /Zc:__cplusplus to opt into the correct definition of `__cplusplus` (problem described here):
> 
> ```
> 'C:\Program Files (x86)\CMake\bin\cmake.exe' .. \
>     -G "Visual Studio 15 2017 Win64"            \
>     -DCMAKE_CXX_STANDARD=17                     \
>     -DCMAKE_CXX_FLAGS="/Zc:__cplusplus"         \
>     -DCMAKE_PREFIX_PATH=C:\mongo-c-driver       \
>     -DCMAKE_INSTALL_PREFIX=C:\mongo-cxx-driver  \
> ```

Setting `CMAKE_CXX_FLAGS` appears to have the side-effect of overwriting the default MSVC flags set by cmake.
For example, if `CMAKE_CXX_FLAGS` is not set, this is the output I get with cmake 3.23.1 on my Windows machine:
```
CMAKE_CXX_FLAGS=/DWIN32 /D_WINDOWS /W3 /GR /EHsc
```

Following the C++ driver instructions results in `CMAKE_CXX_FLAGS` only including `/Zc:__cplusplus`.

Excluding `/EHsc` appears particularly problematic. `/EHsc` is the [documented default](https://learn.microsoft.com/en-us/cpp/cpp/exception-handling-in-visual-cpp?view=msvc-170) for the exception handling model:

> Use an /EH compiler option to specify the exception handling model to use in a C++ project. Standard C++ exception handling (/EHsc) is the default in new C++ projects in Visual Studio.

Not including the `/EHsc` flag results in warnings during compilation:
```
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include\ostream(305,1): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
```

Setting `/EHsc` appears to fix an `Internal compiler error` reported in CXX-2616.

---

https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/ notes:

> The _MSVC_LANG predefined macro continues to report the Standard version switch regardless of the value of /Zc:__cplusplus. _MSVC_LANG is set whether or not the /Zc:__cplusplus option is enabled. When /Zc:__cplusplus is enabled, __cplusplus == _MSVC_LANG.

This PR adds a check for `_MSVC_LANG`, to remove the requirement to pass `/Zc:__cplusplus`. Following the documentation no longer results in omitting the `/EHsc` flag.