### PR TITLE
Queryable Encryption in Public Technical Preview

### DIFF
--- a/src/mongocxx/options/auto_encryption.hpp
+++ b/src/mongocxx/options/auto_encryption.hpp
@@ -244,6 +244,9 @@ class MONGOCXX_API auto_encryption {
     /// an encryptedFields obtained from the server. It protects against a
     /// malicious server advertising a false encryptedFields.
     ///
+    /// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used
+    /// in production and is subject to backwards breaking changes.
+    ///
     /// @param encrypted_fields_map
     ///   The mapping of which fields to encrypt.
     ///
@@ -258,6 +261,9 @@ class MONGOCXX_API auto_encryption {
 
     ///
     /// Get encrypted fields map
+    ///
+    /// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used
+    /// in production and is subject to backwards breaking changes.
     ///
     /// @return
     ///   An optional document containing the encrypted fields map
@@ -290,6 +296,9 @@ class MONGOCXX_API auto_encryption {
     /// Query analysis is disabled when the 'bypassQueryAnalysis'
     /// option is true. Default is 'false' (i.e. query analysis is enabled).
     ///
+    /// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used
+    /// in production and is subject to backwards breaking changes.
+    ///
     /// @param should_bypass
     ///   Whether or not to bypass query analysis.
     ///
@@ -302,6 +311,9 @@ class MONGOCXX_API auto_encryption {
 
     ///
     /// Gets a boolean specifying whether or not query analysis is bypassed.
+    ///
+    /// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used
+    /// in production and is subject to backwards breaking changes.
     ///
     /// @return
     ///   A boolean specifying whether query analysis is bypassed.

--- a/src/mongocxx/options/encrypt.hpp
+++ b/src/mongocxx/options/encrypt.hpp
@@ -103,10 +103,16 @@ class MONGOCXX_API encrypt {
     /// queryType only applies when algorithm is "Indexed" or "RangePreview".
     /// It is an error to set queryType when algorithm is not "Indexed" or "RangePreview".
     ///
+    /// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used
+    /// in production and is subject to backwards breaking changes.
+    ///
     enum class encryption_query_type : std::uint8_t { k_equality };
 
     ///
     /// Sets the algorithm to use for encryption.
+    ///
+    /// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used
+    /// in production and is subject to backwards breaking changes.
     ///
     /// @param algorithm
     ///   An algorithm, either deterministic, random, indexed, or unindexed to use for encryption.
@@ -123,6 +129,9 @@ class MONGOCXX_API encrypt {
     ///
     /// Gets the current algorithm.
     ///
+    /// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used
+    /// in production and is subject to backwards breaking changes.
+    ///
     /// @return
     ///   An optional algorithm.
     ///
@@ -133,6 +142,9 @@ class MONGOCXX_API encrypt {
     /// contentionFactor only applies when algorithm is "Indexed" or "RangePreview".
     /// It is an error to set contentionFactor when algorithm is not "Indexed".
     ///
+    /// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used
+    /// in production and is subject to backwards breaking changes.
+    ///
     /// @param contention_factor
     ///   An integer specifiying the desired contention factor.
     ///
@@ -140,6 +152,9 @@ class MONGOCXX_API encrypt {
 
     ///
     /// Gets the current contention factor.
+    ///
+    /// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used
+    /// in production and is subject to backwards breaking changes.
     ///
     /// @return
     ///   An optional contention factor.

--- a/src/mongocxx/options/encrypt.hpp
+++ b/src/mongocxx/options/encrypt.hpp
@@ -115,6 +115,7 @@ class MONGOCXX_API encrypt {
     ///
     /// Sets the algorithm to use for encryption.
     ///
+    /// Indexed and Unindexed are used for Queryable Encryption.
     /// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used
     /// in production and is subject to backwards breaking changes.
     ///

--- a/src/mongocxx/options/encrypt.hpp
+++ b/src/mongocxx/options/encrypt.hpp
@@ -77,6 +77,10 @@ class MONGOCXX_API encrypt {
     /// Determines which AEAD_AES_256_CBC algorithm to use with HMAC_SHA_512 when
     /// encrypting data.
     ///
+    /// Indexed and Unindexed are used for Queryable Encryption.
+    /// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used
+    /// in production and is subject to backwards breaking changes.
+    ///
     enum class encryption_algorithm : std::uint8_t {
         ///
         /// Use deterministic encryption.

--- a/src/mongocxx/options/encrypt.hpp
+++ b/src/mongocxx/options/encrypt.hpp
@@ -129,6 +129,7 @@ class MONGOCXX_API encrypt {
     ///
     /// Gets the current algorithm.
     ///
+    /// Indexed and Unindexed are used for Queryable Encryption.
     /// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used
     /// in production and is subject to backwards breaking changes.
     ///
@@ -142,6 +143,7 @@ class MONGOCXX_API encrypt {
     /// contentionFactor only applies when algorithm is "Indexed" or "RangePreview".
     /// It is an error to set contentionFactor when algorithm is not "Indexed".
     ///
+    /// Indexed and Unindexed are used for Queryable Encryption.
     /// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used
     /// in production and is subject to backwards breaking changes.
     ///

--- a/src/mongocxx/options/encrypt.hpp
+++ b/src/mongocxx/options/encrypt.hpp
@@ -148,7 +148,7 @@ class MONGOCXX_API encrypt {
     /// contentionFactor only applies when algorithm is "Indexed" or "RangePreview".
     /// It is an error to set contentionFactor when algorithm is not "Indexed".
     ///
-    /// Indexed and Unindexed are used for Queryable Encryption.
+    /// The contention factor is used for Queryable Encryption.
     /// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used
     /// in production and is subject to backwards breaking changes.
     ///

--- a/src/mongocxx/options/encrypt.hpp
+++ b/src/mongocxx/options/encrypt.hpp
@@ -175,6 +175,10 @@ class MONGOCXX_API encrypt {
     /// query_type only applies when algorithm is "Indexed" or "RangePreview".
     /// It is an error to set query_type when algorithm is not "Indexed" or "RangePreview".
     ///
+    /// QueryType is used for Queryable Encryption.
+    /// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used
+    /// in production and is subject to backwards breaking changes.
+    ///
     encrypt& query_type(encryption_query_type query_type);
 
     ///
@@ -182,6 +186,10 @@ class MONGOCXX_API encrypt {
     ///
     /// @return
     ///   A query type.
+    ///
+    /// QueryType is used for Queryable Encryption.
+    /// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used
+    /// in production and is subject to backwards breaking changes.
     ///
     const stdx::optional<encryption_query_type>& query_type() const;
 


### PR DESCRIPTION
Queryable Encryption in Public Technical Preview

CXX-2523

Queryable Encryption is in Public Technical Preview.

Queryable Encryption should not be used in production and is subject to
backwards breaking changes.