### PR TITLE
CXX-2650 Fix limit value in open_download_stream

### DIFF
--- a/src/mongocxx/gridfs/bucket.cpp
+++ b/src/mongocxx/gridfs/bucket.cpp
@@ -372,8 +372,8 @@ downloader bucket::_open_download_stream(const client_session* session,
                                    "expected end to not be greater than the file length"};
         }
         if (file_len >= 0 && end_i64 < file_len) {
-            const int64_t num_chunks =
-                1 + ((end_i64 - start_i64) / static_cast<int64_t>(chunk_size));
+            const int64_t num_chunks = (end_i64 / static_cast<int64_t>(chunk_size)) -
+                                       (start_i64 / static_cast<int64_t>(chunk_size)) + 1;
             chunks_options.limit(num_chunks);
         }
     }

--- a/src/mongocxx/test/gridfs/bucket.cpp
+++ b/src/mongocxx/test/gridfs/bucket.cpp
@@ -938,6 +938,12 @@ TEST_CASE("gridfs::bucket::download_to_stream works", "[gridfs::bucket]") {
                                          static_cast<std::size_t>(end));
             }
 
+            SECTION("across 2 chunks at the end") {
+                const auto start = chunk_size - 1;
+                const auto end = start + chunk_size - 1;
+                check_downloaded_content(static_cast<std::size_t>(start),
+                                         static_cast<std::size_t>(end));
+            }
             SECTION("across 3 chunks") {
                 const auto start = chunk_size / 2;
                 const auto end = start + 2 * chunk_size;


### PR DESCRIPTION
Hello,

Here is a patch to fix the limit value computed to returned the correct number of chunks in a partial download.
Without this patch, a `download::read` on 2 chunks throws an execption because the `chunks` cursor was exhausted.

Cheers