### PR TITLE
CXX-2184

### DIFF
--- a/data/crud/unified/aggregate-write-readPreference.json
+++ b/data/crud/unified/aggregate-write-readPreference.json
@@ -1,0 +1,460 @@
+{
+  "description": "aggregate-write-readPreference",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "3.6",
+      "topologies": [
+        "replicaset",
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "_yamlAnchors": {
+    "readConcern": {
+      "level": "local"
+    },
+    "writeConcern": {
+      "w": 1
+    }
+  },
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "uriOptions": {
+          "readConcernLevel": "local",
+          "w": 1
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "db0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0",
+        "collectionOptions": {
+          "readPreference": {
+            "mode": "secondaryPreferred",
+            "maxStalenessSeconds": 600
+          }
+        }
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database0",
+        "collectionName": "coll1"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "db0",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    },
+    {
+      "collectionName": "coll1",
+      "databaseName": "db0",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Aggregate with $out includes read preference for 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0",
+          "serverless": "forbid"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$out": "coll1"
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$out": "coll1"
+                    }
+                  ],
+                  "$readPreference": {
+                    "mode": "secondaryPreferred",
+                    "maxStalenessSeconds": 600
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate with $out omits read preference for pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.4.99",
+          "serverless": "forbid"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$out": "coll1"
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$out": "coll1"
+                    }
+                  ],
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate with $merge includes read preference for 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$merge": {
+                  "into": "coll1"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$merge": {
+                        "into": "coll1"
+                      }
+                    }
+                  ],
+                  "$readPreference": {
+                    "mode": "secondaryPreferred",
+                    "maxStalenessSeconds": 600
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate with $merge omits read preference for pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$merge": {
+                  "into": "coll1"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$merge": {
+                        "into": "coll1"
+                      }
+                    }
+                  ],
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/crud/unified/db-aggregate-write-readPreference.json
+++ b/data/crud/unified/db-aggregate-write-readPreference.json
@@ -1,0 +1,446 @@
+{
+  "description": "db-aggregate-write-readPreference",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "3.6",
+      "topologies": [
+        "replicaset"
+      ],
+      "serverless": "forbid"
+    }
+  ],
+  "_yamlAnchors": {
+    "readConcern": {
+      "level": "local"
+    },
+    "writeConcern": {
+      "w": 1
+    }
+  },
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "uriOptions": {
+          "readConcernLevel": "local",
+          "w": 1
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "db0",
+        "databaseOptions": {
+          "readPreference": {
+            "mode": "secondaryPreferred",
+            "maxStalenessSeconds": 600
+          }
+        }
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "db0",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Database-level aggregate with $out includes read preference for 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0",
+          "serverless": "forbid"
+        }
+      ],
+      "operations": [
+        {
+          "object": "database0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              },
+              {
+                "$addFields": {
+                  "_id": 1
+                }
+              },
+              {
+                "$project": {
+                  "_id": 1
+                }
+              },
+              {
+                "$out": "coll0"
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "pipeline": [
+                    {
+                      "$listLocalSessions": {}
+                    },
+                    {
+                      "$limit": 1
+                    },
+                    {
+                      "$addFields": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$out": "coll0"
+                    }
+                  ],
+                  "$readPreference": {
+                    "mode": "secondaryPreferred",
+                    "maxStalenessSeconds": 600
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Database-level aggregate with $out omits read preference for pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.4.99",
+          "serverless": "forbid"
+        }
+      ],
+      "operations": [
+        {
+          "object": "database0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              },
+              {
+                "$addFields": {
+                  "_id": 1
+                }
+              },
+              {
+                "$project": {
+                  "_id": 1
+                }
+              },
+              {
+                "$out": "coll0"
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "pipeline": [
+                    {
+                      "$listLocalSessions": {}
+                    },
+                    {
+                      "$limit": 1
+                    },
+                    {
+                      "$addFields": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$out": "coll0"
+                    }
+                  ],
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Database-level aggregate with $merge includes read preference for 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "database0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              },
+              {
+                "$addFields": {
+                  "_id": 1
+                }
+              },
+              {
+                "$project": {
+                  "_id": 1
+                }
+              },
+              {
+                "$merge": {
+                  "into": "coll0"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "pipeline": [
+                    {
+                      "$listLocalSessions": {}
+                    },
+                    {
+                      "$limit": 1
+                    },
+                    {
+                      "$addFields": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$merge": {
+                        "into": "coll0"
+                      }
+                    }
+                  ],
+                  "$readPreference": {
+                    "mode": "secondaryPreferred",
+                    "maxStalenessSeconds": 600
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Database-level aggregate with $merge omits read preference for pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "database0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              },
+              {
+                "$addFields": {
+                  "_id": 1
+                }
+              },
+              {
+                "$project": {
+                  "_id": 1
+                }
+              },
+              {
+                "$merge": {
+                  "into": "coll0"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "pipeline": [
+                    {
+                      "$listLocalSessions": {}
+                    },
+                    {
+                      "$limit": 1
+                    },
+                    {
+                      "$addFields": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$merge": {
+                        "into": "coll0"
+                      }
+                    }
+                  ],
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/crud/unified/test_files.txt
+++ b/data/crud/unified/test_files.txt
@@ -1,6 +1,7 @@
 aggregate-let.json
 aggregate-merge.json
 aggregate-out-readConcern.json
+aggregate-write-readPreference.json
 aggregate.json
 bulkWrite-arrayFilters-clientError.json
 bulkWrite-arrayFilters.json
@@ -27,6 +28,7 @@ bulkWrite-updateOne-dots_and_dollars.json
 bulkWrite-updateOne-hint-unacknowledged.json
 bulkWrite-updateOne-let.json
 countDocuments-comment.json
+db-aggregate-write-readPreference.json
 db-aggregate.json
 deleteMany-comment.json
 deleteMany-hint-clientError.json

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -342,18 +342,21 @@ options::server_api create_server_api(document::view object) {
 
 read_preference get_read_preference(const document::element& opts) {
     read_preference rp;
-    auto read_pref = opts["readPreference"];
-    auto doc = read_pref.get_document().value;
-    auto mode = std::string(doc["mode"].get_string().value);
-    if (doc["maxStalenessSeconds"]) {
-        auto max_staleness_seconds = doc["maxStalenessSeconds"].get_int32().value;
-        rp.max_staleness(std::chrono::seconds(max_staleness_seconds));
+
+    const auto read_pref = opts["readPreference"];
+
+    if (const auto mss = read_pref["maxStalenessSeconds"]) {
+        rp.max_staleness(std::chrono::seconds(mss.get_int32().value));
     }
-    if (mode == "secondaryPreferred") {
+
+    const auto mode = read_pref["mode"].get_string().value;
+
+    if (mode.compare("secondaryPreferred") == 0) {
         rp.mode(read_preference::read_mode::k_secondary_preferred);
     } else {
-        FAIL("unhandled readPreference mode: " + mode);
+        FAIL("unhandled readPreference mode: " << mode);
     }
+
     return rp;
 }
 

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -345,8 +345,10 @@ read_preference get_read_preference(const document::element& opts) {
     auto read_pref = opts["readPreference"];
     auto doc = read_pref.get_document().value;
     auto mode = std::string(doc["mode"].get_string().value);
-    auto max_staleness_seconds = doc["maxStalenessSeconds"].get_int32().value;
-    rp.max_staleness(std::chrono::seconds(max_staleness_seconds));
+    if (doc["maxStalenessSeconds"]) {
+        auto max_staleness_seconds = doc["maxStalenessSeconds"].get_int32().value;
+        rp.max_staleness(std::chrono::seconds(max_staleness_seconds));
+    }
     if (mode == "secondaryPreferred") {
         rp.mode(read_preference::read_mode::k_secondary_preferred);
     } else {

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -340,10 +340,22 @@ options::server_api create_server_api(document::view object) {
     return server_api_opts;
 }
 
-write_concern get_write_concern(const document::element& opts) {
-    if (!opts["writeConcern"])
-        return {};
+read_preference get_read_preference(const document::element& opts) {
+    read_preference rp;
+    auto read_pref = opts["readPreference"];
+    auto doc = read_pref.get_document().value;
+    auto mode = std::string(doc["mode"].get_string().value);
+    auto max_staleness_seconds = doc["maxStalenessSeconds"].get_int32().value;
+    rp.max_staleness(std::chrono::seconds(max_staleness_seconds));
+    if (mode == "secondaryPreferred") {
+        rp.mode(read_preference::read_mode::k_secondary_preferred);
+    } else {
+        FAIL("unhandled readPreference mode: " + mode);
+    }
+    return rp;
+}
 
+write_concern get_write_concern(const document::element& opts) {
     auto wc = write_concern{};
     if (auto w = opts["writeConcern"]["w"]) {
         if (w.type() == type::k_utf8) {
@@ -367,9 +379,6 @@ write_concern get_write_concern(const document::element& opts) {
 }
 
 read_concern get_read_concern(const document::element& opts) {
-    if (!opts["readConcern"])
-        return {};
-
     auto rc = read_concern{};
 
     if (auto level = opts["readConcern"]["level"]) {
@@ -384,9 +393,17 @@ void set_common_options(T& t, const document::element& opts) {
     if (!opts)
         return;
 
-    t.read_concern(get_read_concern(opts));
-    t.write_concern(get_write_concern(opts));
-    REQUIRE_FALSE(/* TODO */ opts["readPreference"]);
+    if (opts["readConcern"]) {
+        t.read_concern(get_read_concern(opts));
+    }
+
+    if (opts["writeConcern"]) {
+        t.write_concern(get_write_concern(opts));
+    }
+
+    if (opts["readPreference"]) {
+        t.read_preference(get_read_preference(opts));
+    }
 }
 
 options::gridfs::bucket get_bucket_options(document::view object) {


### PR DESCRIPTION
CXX-2184

Support $merge and $out executing on secondaries

Sync spec test files.

Fix bug in test suite.

Previously:
- read_preference was left out
- read_concern and write_concern were overwritten with empty objects, causing failures from the APM checker.

The fix is to only set these options if they are explicitly stated so in the test spec files.