### PR TITLE
CXX-2580 fix change stream examples

### DIFF
--- a/src/mongocxx/test/CMakeLists.txt
+++ b/src/mongocxx/test/CMakeLists.txt
@@ -95,6 +95,10 @@ add_executable(test_driver
     ${test_driver_sources}
 )
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+target_link_libraries(test_driver Threads::Threads)
+
 add_executable(test_logging
   ${THIRD_PARTY_SOURCE_DIR}/catch/main.cpp
   logging.cpp

--- a/src/mongocxx/test/change_streams.cpp
+++ b/src/mongocxx/test/change_streams.cpp
@@ -445,7 +445,8 @@ TEST_CASE("Documentation Examples", "[min36]") {
     collection events = (*mongodb_client)["streams"]["events"];
     collection inventory = events;  // doc examples use this name
 
-    std::atomic_bool insert_thread_done = false;
+    std::atomic_bool insert_thread_done;
+    insert_thread_done.store(false);
     // Start a thread repeatedly insert documents to generate notifications.
     auto insert_thread = std::thread{[&pool, &insert_thread_done] {
         auto client = pool.acquire();

--- a/src/mongocxx/test/change_streams.cpp
+++ b/src/mongocxx/test/change_streams.cpp
@@ -499,7 +499,7 @@ TEST_CASE("Documentation Examples", "[min36]") {
                 // Server returned no new notifications. Restart iteration to poll server.
                 it = stream.begin();
             }
-            next = *it;
+            next = bsoncxx::document::value(*it);
         }
         // Start Changestream Example 3
         auto resume_token = (*next)["_id"].get_document().value;

--- a/src/mongocxx/test/change_streams.cpp
+++ b/src/mongocxx/test/change_streams.cpp
@@ -447,7 +447,7 @@ TEST_CASE("Documentation Examples", "[min36]") {
 
     std::atomic_bool insert_thread_done;
     insert_thread_done.store(false);
-    // Start a thread repeatedly insert documents to generate notifications.
+    // Start a thread to repeatedly insert documents to generate notifications.
     auto insert_thread = std::thread{[&pool, &insert_thread_done] {
         auto client = pool.acquire();
         auto inventory = (*client)["streams"]["events"];

--- a/src/mongocxx/test/change_streams.cpp
+++ b/src/mongocxx/test/change_streams.cpp
@@ -22,7 +22,9 @@
 #include <mongocxx/collection.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/insert.hpp>
+#include <mongocxx/options/pool.hpp>
 #include <mongocxx/pipeline.hpp>
+#include <mongocxx/pool.hpp>
 #include <mongocxx/private/libbson.hh>
 #include <mongocxx/test_util/client_helpers.hh>
 #include <mongocxx/write_concern.hpp>
@@ -432,13 +434,14 @@ TEST_CASE("Give an invalid pipeline", "[min36]") {
 
 TEST_CASE("Documentation Examples", "[min36]") {
     instance::current();
-    client mongodb_client{uri{}, test_util::add_test_server_api()};
-    if (!test_util::is_replica_set(mongodb_client)) {
+    mongocxx::pool pool{uri{}, options::pool(test_util::add_test_server_api())};
+    auto mongodb_client = pool.acquire();
+    if (!test_util::is_replica_set(*mongodb_client)) {
         WARN("skip: change streams require replica set");
         return;
     }
 
-    collection events = mongodb_client["streams"]["events"];
+    collection events = (*mongodb_client)["streams"]["events"];
     collection inventory = events;  // doc examples use this name
 
     SECTION("Example 1") {

--- a/src/mongocxx/test/change_streams.cpp
+++ b/src/mongocxx/test/change_streams.cpp
@@ -471,7 +471,7 @@ TEST_CASE("Documentation Examples", "[min36]") {
         }
         bsoncxx::document::view next = *it;
         // End Changestream Example 1
-        (void)next;
+        REQUIRE(0 == next["operationType"].get_string().value.compare("insert"));
     }
 
     SECTION("Example 2") {
@@ -486,7 +486,7 @@ TEST_CASE("Documentation Examples", "[min36]") {
         }
         bsoncxx::document::view next = *it;
         // End Changestream Example 2
-        REQUIRE(next["operationType"].get_string().value == "insert");
+        REQUIRE(0 == next["operationType"].get_string().value.compare("insert"));
     }
 
     SECTION("Example 3") {
@@ -512,7 +512,7 @@ TEST_CASE("Documentation Examples", "[min36]") {
             it = stream.begin();
         }
         // End Changestream Example 3
-        REQUIRE((*it)["operationType"].get_string().value == "insert");
+        REQUIRE(0 == (*it)["operationType"].get_string().value.compare("insert"));
     }
 
     SECTION("Example 4") {
@@ -533,7 +533,7 @@ TEST_CASE("Documentation Examples", "[min36]") {
             it = stream.begin();
         }
         // End Changestream Example 4
-        REQUIRE((*it)["operationType"].get_string().value == "insert");
+        REQUIRE(0 == (*it)["operationType"].get_string().value.compare("insert"));
     }
 
     insert_thread_done = true;


### PR DESCRIPTION
# Summary
- Iterate exactly one document in change stream examples.
- Make notifications for change stream examples on a separate thread.

# Background & Motivation

DRIVERS-436 requests examples to use on https://www.mongodb.com/docs/manual/changeStreams/.

The `Changestream Example` code examples in the C++ driver does not match the requested examples in DRIVERS-436.

The examples requested in DRIVERS-436 request iterating one document:

```java
// Start Changestream Example 1
 
MongoCursor<Document> cursor = inventory.watch().iterator();
Document next = cursor.next();
 
// End Changestream Example 1
```

The C++ driver example may print 0, 1, or many documents:

```c++
change_stream stream = inventory.watch();
for (auto& event : stream) {
    std::cout << bsoncxx::to_json(event) << std::endl;
}
```

This has been changed to iterate exactly 1 document:
```c++
// Start Changestream Example 1
change_stream stream = inventory.watch();
auto it = stream.begin();
while (it == stream.end()) {
    // Server returned no new notifications. Restart iteration to poll server.
    it = stream.begin();
}
bsoncxx::document::view next = *it;
// End Changestream Example 1
```

Iterating exactly 1 document requires at least one document be returned to run the example. To do so, a separate thread is started to insert documents. Using a separate thread is also done in the [C# driver here](https://github.com/mongodb/mongo-csharp-driver/blob/3155c5ba513c9ddfbe58cd43386abab22fd3e2dd/tests/MongoDB.Driver.Examples/ChangeStreamExamples.cs#L38-L44).