### PR TITLE
CXX-2582 revise tutorial

### DIFF
--- a/docs/content/mongocxx-v3/tutorial.md
+++ b/docs/content/mongocxx-v3/tutorial.md
@@ -57,8 +57,8 @@ line in above expands to this:
 
 ```sh
 c++ --std=c++11 <input>.cpp
-  -I/usr/local/include/mongocxx/v_noabi -I/usr/local/include/libmongoc-1.0 \
-  -I/usr/local/include/bsoncxx/v_noabi -I/usr/local/include/libbson-1.0 \
+  -I/usr/local/include/mongocxx/v_noabi \
+  -I/usr/local/include/bsoncxx/v_noabi \
   -L/usr/local/lib -lmongocxx -lbsoncxx
 ```
 

--- a/docs/content/mongocxx-v3/tutorial.md
+++ b/docs/content/mongocxx-v3/tutorial.md
@@ -244,7 +244,7 @@ To insert multiple documents to the collection, use a
 The following example will add multiple documents of the form:
 
 ```json
-{ "i" : value }
+{ "i" : "<value>" }
 ```
 
 Create the documents in a loop and add to the documents list:
@@ -445,7 +445,7 @@ index key specification document contains the fields to index and the
 index type for each field:
 
 ```json
-{ "index1": "<type>", "index2": <type> }
+{ "index1": "<type>", "index2": "<type>" }
 ```
 
 - For an ascending index type, specify 1 for `<type>`.

--- a/docs/content/mongocxx-v3/tutorial.md
+++ b/docs/content/mongocxx-v3/tutorial.md
@@ -7,6 +7,9 @@ title = "Tutorial for mongocxx"
   parent="mongocxx3"
 +++
 
+See the full code for this tutorial in
+[tutorial.cpp](https://github.com/mongodb/mongo-cxx-driver/blob/master/examples/mongocxx/tutorial.cpp).
+
 ## Prerequisites
 
 - A [mongod](https://docs.mongodb.com/manual/reference/program/mongod/)
@@ -20,22 +23,17 @@ title = "Tutorial for mongocxx"
 #include <cstdint>
 #include <iostream>
 #include <vector>
+
+#include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/json.hpp>
 #include <mongocxx/client.hpp>
+#include <mongocxx/instance.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/uri.hpp>
-#include <mongocxx/instance.hpp>
-#include <bsoncxx/builder/stream/helpers.hpp>
-#include <bsoncxx/builder/stream/document.hpp>
-#include <bsoncxx/builder/stream/array.hpp>
 
-
-using bsoncxx::builder::stream::close_array;
-using bsoncxx::builder::stream::close_document;
-using bsoncxx::builder::stream::document;
-using bsoncxx::builder::stream::finalize;
-using bsoncxx::builder::stream::open_array;
-using bsoncxx::builder::stream::open_document;
+using bsoncxx::builder::basic::kvp;
+using bsoncxx::builder::basic::make_array;
+using bsoncxx::builder::basic::make_document;
 ```
 
 ## Compiling
@@ -110,7 +108,7 @@ first store data.
 The following example accesses the `mydb` database:
 
 ```c++
-mongocxx::database db = client["mydb"];
+auto db = client["mydb"];
 ```
 
 ## Access a Collection
@@ -129,7 +127,7 @@ the following statement accesses the collection named `test` in the
 `mydb` database:
 
 ```c++
-mongocxx::collection coll = db["test"];
+auto collection = db["test"];
 ```
 
 ## Create a Document
@@ -145,7 +143,7 @@ Basic builder: `bsoncxx::builder::basic`
   A more conventional document builder that involves calling methods on
   a builder instance.
 
-This guide only briefly describes the stream builder.
+This guide only briefly describes the basic builder.
 
 For example, consider the following JSON document:
 
@@ -154,7 +152,7 @@ For example, consider the following JSON document:
    "name" : "MongoDB",
    "type" : "database",
    "count" : 1,
-   "versions": [ "v3.2", "v3.0", "v2.6" ],
+   "versions": [ "v6.0", "v5.0", "v4.4", "v4.2", "v4.0", "v3.6" ],
    "info" : {
                "x" : 203,
                "y" : 102
@@ -162,28 +160,17 @@ For example, consider the following JSON document:
 }
 ```
 
-Using the stream builder interface, you can construct this document
+Using the basic builder interface, you can construct this document
 as follows:
 
 ```c++
-auto builder = bsoncxx::builder::stream::document{};
-bsoncxx::document::value doc_value = builder
-  << "name" << "MongoDB"
-  << "type" << "database"
-  << "count" << 1
-  << "versions" << bsoncxx::builder::stream::open_array
-    << "v3.2" << "v3.0" << "v2.6"
-  << close_array
-  << "info" << bsoncxx::builder::stream::open_document
-    << "x" << 203
-    << "y" << 102
-  << bsoncxx::builder::stream::close_document
-  << bsoncxx::builder::stream::finalize;
+auto doc_value = make_document(
+    kvp("name", "MongoDB"),
+    kvp("type", "database"),
+    kvp("count", 1),
+    kvp("versions", make_array("v6.0", "v5.0", "v4.4", "v4.2", "v4.0", "v3.6")),
+    kvp("info", make_document(kvp("x", 203), kvp("y", 102))));
 ```
-
-Use `bsoncxx::builder::stream::finalize` to obtain a
-[`bsoncxx::document::value`]({{< api3ref classbsoncxx_1_1document_1_1value >}})
-instance.
 
 This `bsoncxx::document::value` type is a read-only object owning
 its own memory. To use it, you must obtain a
@@ -191,7 +178,7 @@ its own memory. To use it, you must obtain a
 the `view()` method:
 
 ```c++
-bsoncxx::document::view view = doc_value.view();
+auto doc_view = doc_value.view();
 ```
 
 You can access fields within this document view using `operator[]`,
@@ -201,12 +188,10 @@ instance. For example, the following will extract the `name` field whose
 value is a string:
 
 ```c++
-bsoncxx::document::element element = view["name"];
-if(element.type() != bsoncxx::type::k_string) {
-  // Error
-}
-// For the versions older than 3.7.0, use get_utf8 instead of get_string
-std::string name = element.get_string().value.to_string();
+auto element = doc_view["name"];
+assert(element.type() == bsoncxx::type::k_string);
+auto name = element.get_string().value; // For C++ driver version < 3.7.0, use get_utf8()
+assert(0 == name.compare("MongoDB"));
 ```
 
 If the value in the `name` field is not a string and you do not
@@ -220,11 +205,20 @@ throw an instance of
 
 To insert a single document into the collection, use a
 [`mongocxx::collection`]({{< api3ref classmongocxx_1_1collection >}})
-instance's `insert_one()` method:
+instance's `insert_one()` method to insert `{ "i": 0 }`:
 
 ```c++
-bsoncxx::stdx::optional<mongocxx::result::insert_one> result =
- restaurants.insert_one(doc);
+auto insert_one_result = collection.insert_one(make_document(kvp("i", 0)));
+```
+
+`insert_one_result` is an optional [`mongocxx::result::insert_one`]({{< api3ref
+classmongocxx_1_1result_1_1insert_one >}}). In this example, `insert_one_result`
+is expected to be set. The default behavior for write operations is to wait for
+a reply from the server. This may be overriden by setting an unacknowledged
+[`mongocxx::write_concern`]({{< api3ref classmongocxx_1_1write__concern >}}).
+
+```c++
+assert(insert_one_result);  // Acknowledged writes return results.
 ```
 
 If you do not specify a top-level `_id` field in the document,
@@ -235,33 +229,32 @@ returned
 [`mongocxx::result::insert_one`]({{< api3ref classmongocxx_1_1result_1_1insert__one >}})
 instance.
 
+```c++
+auto doc_id = insert_one_result->inserted_id();
+assert(doc_id.type() == bsoncxx::type::k_oid);
+```
+
 ### Insert Multiple Documents
 
 To insert multiple documents to the collection, use a
 [`mongocxx::collection`]({{< api3ref classmongocxx_1_1collection >}}) instance's
 `insert_many()` method, which takes a list of documents to insert.
 
-The following example will add multiple documents of the form:
-
-```json
-{ "i" : "<value>" }
-```
-
-Create the documents in a loop and add to the documents list:
+The following example inserts the documents `{ "i": 1 }` and `{ "i": 2 }`.
+Create the documents and add to the documents list:
 
 ```c++
 std::vector<bsoncxx::document::value> documents;
-for(int i = 0; i < 100; i++) {
-    documents.push_back(
-      bsoncxx::builder::stream::document{} << "i" << i << finalize);
-}
+documents.push_back(make_document(kvp("i", 1)));
+documents.push_back(make_document(kvp("i", 2)));
 ```
 
 To insert these documents to the collection, pass the list of documents
 to the `insert_many()` method.
 
 ```c++
-collection.insert_many(documents);
+auto insert_many_result = collection.insert_many(documents);
+assert(insert_many_result);  // Acknowledged writes return results.
 ```
 
 If you do not specify a top-level `_id` field in each document,
@@ -271,6 +264,13 @@ You can obtain this value using the `inserted_ids()` method of the
 returned
 [`mongocxx::result::insert_many`]({{< api3ref classmongocxx_1_1result_1_1insert__many >}})
 instance.
+
+```c++
+auto doc0_id = insert_many_result->inserted_ids().at(0);
+auto doc1_id = insert_many_result->inserted_ids().at(1);
+assert(doc0_id.type() == bsoncxx::type::k_oid);
+assert(doc1_id.type() == bsoncxx::type::k_oid);
+```
 
 ## Query the Collection
 
@@ -292,41 +292,43 @@ To return a single document in the collection, use the `find_one()`
 method without any parameters.
 
 ```c++
-bsoncxx::stdx::optional<bsoncxx::document::value> maybe_result =
-  collection.find_one({});
-if(maybe_result) {
-  // Do something with *maybe_result;
+auto find_one_result = collection.find_one({});
+if (find_one_result) {
+    // Do something with *find_one_result
 }
+assert(find_one_result);
 ```
 
 ### Find All Documents in a Collection
 
 ```c++
-mongocxx::cursor cursor = collection.find({});
-for(auto doc : cursor) {
-  std::cout << bsoncxx::to_json(doc) << "\n";
+auto cursor_all = collection.find({});
+for (auto doc : cursor_all) {
+    // Do something with doc
+    assert(doc["_id"].type() == bsoncxx::type::k_oid);
 }
 ```
 
-### Specify a Query Filter
+### Print All Documents in a Collection
 
-#### Get A Single Document That Matches a Filter
-
-To find the first document where the field `i` has the value `71`,
-pass the document `{"i": 71}` to specify the equality condition:
+The [`bsoncxx::to_json`]({{< api3ref namespacebsoncxx>}}) function to converts a BSON document to a JSON string.
 
 ```c++
-bsoncxx::stdx::optional<bsoncxx::document::value> maybe_result =
-  collection.find_one(document{} << "i" << 71 << finalize);
-if(maybe_result) {
-  std::cout << bsoncxx::to_json(*maybe_result) << "\n";
+auto cursor_all = collection.find({});
+std::cout << "collection " << collection.name()
+          << " contains these documents:" << std::endl;
+for (auto doc : cursor_all) {
+    std::cout << bsoncxx::to_json(doc, bsoncxx::ExtendedJsonMode::k_relaxed) << std::endl;
 }
+std::cout << std::endl;
 ```
 
-The example prints one document:
-
-```json
-{ "_id" : { "$oid" : "5755e19b38c96f1fb25667a8" },  "i" : 71 }
+The above example prints output resembling the following:
+```
+collection test contains these documents:
+{ "_id" : { "$oid" : "6409edb48c37f371c70f03a1" }, "i" : 0 }
+{ "_id" : { "$oid" : "6409edb48c37f371c70f03a2" }, "i" : 1 }
+{ "_id" : { "$oid" : "6409edb48c37f371c70f03a3" }, "i" : 2 }
 ```
 
 The `_id` element has been added automatically by MongoDB to your
@@ -334,19 +336,30 @@ document and your value will differ from that shown. MongoDB reserves
 field names that start with an underscore (`_`) and the dollar sign
 (`$`) for internal use.
 
-#### Get All Documents That Match a Filter
+### Specify a Query Filter
 
-The following example returns and prints all documents where
-`50 < "i" <= 100`:
+#### Get A Single Document That Matches a Filter
+
+To find the first document where the field `i` has the value `0`,
+pass the document `{"i": 0}` to specify the equality condition:
 
 ```c++
-mongocxx::cursor cursor = collection.find(
-  document{} << "i" << open_document <<
-    "$gt" << 50 <<
-    "$lte" << 100
-  << close_document << finalize);
-for(auto doc : cursor) {
-  std::cout << bsoncxx::to_json(doc) << "\n";
+auto find_one_filtered_result = collection.find_one(make_document(kvp("i", 0)));
+if (find_one_filtered_result) {
+    // Do something with *find_one_filtered_result
+}
+```
+
+#### Get All Documents That Match a Filter
+
+The following example gets all documents where `0 < "i" <= 2`:
+
+```c++
+auto cursor_filtered =
+    collection.find(make_document(kvp("i", make_document(kvp("$gt", 0), kvp("$lte", 2)))));
+for (auto doc : cursor_filtered) {
+    // Do something with doc
+    assert(doc["_id"].type() == bsoncxx::type::k_oid);
 }
 ```
 
@@ -365,12 +378,14 @@ documents modified by the update.
 To update at most one document, use the `update_one()` method.
 
 The following example updates the first document that matches the filter
-`{ "i": 10 }` and sets the value of `i` to `110`:
+`{ "i": 0 }` and sets the value of `foo` to `bar`:
 
 ```c++
-collection.update_one(document{} << "i" << 10 << finalize,
-                      document{} << "$set" << open_document <<
-                        "i" << 110 << close_document << finalize);
+auto update_one_result =
+    collection.update_one(make_document(kvp("i", 0)),
+                          make_document(kvp("$set", make_document(kvp("foo", "bar")))));
+assert(update_one_result);  // Acknowledged writes return results.
+assert(update_one_result->modified_count() == 1);
 ```
 
 
@@ -379,20 +394,15 @@ collection.update_one(document{} << "i" << 10 << finalize,
 To update all documents matching a filter, use the `update_many()`
 method.
 
-The following example increments the value of `i` by `100` where
-`i` is less than `100`:
+The following example sets the value of `foo` to `buzz` where
+`i` is greater than `0`:
 
 ```c++
-bsoncxx::stdx::optional<mongocxx::result::update> result =
- collection.update_many(
-  document{} << "i" << open_document <<
-    "$lt" << 100 << close_document << finalize,
-  document{} << "$inc" << open_document <<
-    "i" << 100 << close_document << finalize);
-
-if(result) {
-  std::cout << result->modified_count() << "\n";
-}
+auto update_many_result =
+    collection.update_many(make_document(kvp("i", make_document(kvp("$gt", 0)))),
+                            make_document(kvp("$set", make_document(kvp("foo", "buzz")))));
+assert(update_many_result);  // Acknowledged writes return results.
+assert(update_many_result->modified_count() == 2);
 ```
 
 ## Delete Documents
@@ -410,10 +420,12 @@ To delete at most a single document that matches a filter, use the
 `delete_one()` method.
 
 For example, to delete a document that matches the filter
-`{ "i": 110 }`:
+`{ "i": 0 }`:
 
 ```c++
-collection.delete_one(document{} << "i" << 110 << finalize);
+auto delete_one_result = collection.delete_one(make_document(kvp("i", 0)));
+assert(delete_one_result);  // Acknowledged writes return results.
+assert(delete_one_result->deleted_count() == 1);
 ```
 
 ### Delete All Documents That Match a Filter
@@ -421,18 +433,13 @@ collection.delete_one(document{} << "i" << 110 << finalize);
 To delete all documents matching a filter, use a collection's
 `delete_many()` method.
 
-The following example deletes all documents where `i` is greater or
-equal to `100`:
+The following example deletes all documents where `i` is greater than `0`:
 
 ```c++
-bsoncxx::stdx::optional<mongocxx::result::delete_result> result =
- collection.delete_many(
-  document{} << "i" << open_document <<
-    "$gte" << 100 << close_document << finalize);
-
-if(result) {
-  std::cout << result->deleted_count() << "\n";
-}
+auto delete_many_result =
+    collection.delete_many(make_document(kvp("i", make_document(kvp("$gt", 0)))));
+assert(delete_many_result);  // Acknowledged writes return results.
+assert(delete_many_result->deleted_count() == 2);
 ```
 
 ## Create Indexes
@@ -454,6 +461,6 @@ index type for each field:
 The following example creates an ascending index on the `i` field:
 
 ```c++
-auto index_specification = document{} << "i" << 1 << finalize;
+auto index_specification = make_document(kvp("i", 1));
 collection.create_index(std::move(index_specification));
 ```

--- a/docs/content/mongocxx-v3/tutorial.md
+++ b/docs/content/mongocxx-v3/tutorial.md
@@ -311,7 +311,7 @@ for (auto doc : cursor_all) {
 
 ### Print All Documents in a Collection
 
-The [`bsoncxx::to_json`]({{< api3ref namespacebsoncxx>}}) function to converts a BSON document to a JSON string.
+The [`bsoncxx::to_json`]({{< api3ref namespacebsoncxx>}}) function converts a BSON document to a JSON string.
 
 ```c++
 auto cursor_all = collection.find({});

--- a/examples/mongocxx/CMakeLists.txt
+++ b/examples/mongocxx/CMakeLists.txt
@@ -45,6 +45,7 @@ set(MONGOCXX_EXAMPLES
     remove.cpp
     server_side_field_level_encryption_enforcement.cpp
     tailable_cursor.cpp
+    tutorial.cpp
     update.cpp
     view_or_value_variant.cpp
     with_transaction.cpp

--- a/examples/mongocxx/inserted_id.cpp
+++ b/examples/mongocxx/inserted_id.cpp
@@ -36,10 +36,6 @@ int main(int, char**) {
     try {
         auto result = collection.insert_one(make_document(kvp("test", 1)));
 
-        // Currently, result will always be true (or an exception will be
-        // thrown).  Eventually, unacknowledged writes will give a false
-        // result. See https://jira.mongodb.org/browse/CXX-894
-
         if (!result) {
             std::cout << "Unacknowledged write. No id available." << std::endl;
             return EXIT_SUCCESS;

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -39,11 +39,11 @@ int main() {
     mongocxx::uri uri("mongodb://localhost:27017");
     mongocxx::client client(uri);
 
-    mongocxx::database db = client["mydb"];
-    mongocxx::collection collection = db["test"];
+    auto db = client["mydb"];
+    auto collection = db["test"];
 
     auto builder = bsoncxx::builder::stream::document{};
-    bsoncxx::document::value doc_value =
+    auto doc_value =
         builder << "name"
                 << "MongoDB"
                 << "type"
@@ -54,15 +54,15 @@ int main() {
                 << 203 << "y" << 102 << bsoncxx::builder::stream::close_document
                 << bsoncxx::builder::stream::finalize;
 
-    bsoncxx::document::view view = doc_value.view();
+    auto view = doc_value.view();
 
-    bsoncxx::document::element element = view["name"];
+    auto element = view["name"];
     if (element.type() != bsoncxx::type::k_string) {
         // Error
     }
-    bsoncxx::stdx::string_view name = element.get_string().value;
+    auto name = element.get_string().value;
 
-    bsoncxx::stdx::optional<mongocxx::result::insert_one> result = collection.insert_one(view);
+    auto result = collection.insert_one(view);
 
     std::vector<bsoncxx::document::value> documents;
     for (int i = 0; i < 100; i++) {
@@ -71,25 +71,23 @@ int main() {
 
     collection.insert_many(documents);
 
-    bsoncxx::stdx::optional<bsoncxx::document::value> maybe_result = collection.find_one({});
+    auto maybe_result = collection.find_one({});
     if (maybe_result) {
         // Do something with *maybe_result;
     }
 
-    mongocxx::cursor cursor = collection.find({});
+    auto cursor = collection.find({});
     for (auto doc : cursor) {
         std::cout << bsoncxx::to_json(doc) << "\n";
     }
 
-    bsoncxx::stdx::optional<bsoncxx::document::value> maybe_result =
-        collection.find_one(document{} << "i" << 71 << finalize);
+    auto maybe_result = collection.find_one(document{} << "i" << 71 << finalize);
     if (maybe_result) {
         std::cout << bsoncxx::to_json(*maybe_result) << "\n";
     }
 
-    mongocxx::cursor cursor =
-        collection.find(document{} << "i" << open_document << "$gt" << 50 << "$lte" << 100
-                                   << close_document << finalize);
+    auto cursor = collection.find(document{} << "i" << open_document << "$gt" << 50 << "$lte" << 100
+                                             << close_document << finalize);
     for (auto doc : cursor) {
         std::cout << bsoncxx::to_json(doc) << "\n";
     }
@@ -98,7 +96,7 @@ int main() {
         document{} << "i" << 10 << finalize,
         document{} << "$set" << open_document << "i" << 110 << close_document << finalize);
 
-    bsoncxx::stdx::optional<mongocxx::result::update> result = collection.update_many(
+    auto result = collection.update_many(
         document{} << "i" << open_document << "$lt" << 100 << close_document << finalize,
         document{} << "$inc" << open_document << "i" << 100 << close_document << finalize);
 
@@ -108,8 +106,8 @@ int main() {
 
     collection.delete_one(document{} << "i" << 110 << finalize);
 
-    bsoncxx::stdx::optional<mongocxx::result::delete_result> result = collection.delete_many(
-        document{} << "i" << open_document << "$gte" << 100 << close_document << finalize);
+    auto result = collection.delete_many(document{} << "i" << open_document << "$gte" << 100
+                                                    << close_document << finalize);
 
     if (result) {
         std::cout << result->deleted_count() << "\n";

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -60,7 +60,7 @@ int main() {
     if (element.type() != bsoncxx::type::k_string) {
         // Error
     }
-    std::string name = element.get_string().value.to_string();
+    bsoncxx::stdx::string_view name = element.get_string().value;
 
     bsoncxx::stdx::optional<mongocxx::result::insert_one> result = collection.insert_one(doc);
 

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -1,0 +1,120 @@
+// Compile with: c++ --std=c++11 tutorial.cpp $(pkg-config --cflags --libs libmongocxx)
+
+#ifdef NDEBUG
+#undef assert
+#define assert(stmt)                                                                         \
+    do {                                                                                     \
+        if (!(stmt)) {                                                                       \
+            std::cerr << "Assert on line " << __LINE__ << " failed: " << #stmt << std::endl; \
+            abort();                                                                         \
+        }                                                                                    \
+    } while (0)
+#endif
+
+// The following is a formatted copy from the tutorial https://mongocxx.org/mongocxx-v3/tutorial/.
+// It does not currently compiled. TODO: fix.
+
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+#include <bsoncxx/builder/stream/array.hpp>
+#include <bsoncxx/builder/stream/document.hpp>
+#include <bsoncxx/builder/stream/helpers.hpp>
+#include <bsoncxx/json.hpp>
+#include <mongocxx/client.hpp>
+#include <mongocxx/instance.hpp>
+#include <mongocxx/stdx.hpp>
+#include <mongocxx/uri.hpp>
+
+using bsoncxx::builder::stream::close_array;
+using bsoncxx::builder::stream::close_document;
+using bsoncxx::builder::stream::document;
+using bsoncxx::builder::stream::finalize;
+using bsoncxx::builder::stream::open_array;
+using bsoncxx::builder::stream::open_document;
+
+int main() {
+    mongocxx::instance instance{};  // This should be done only once.
+    mongocxx::uri uri("mongodb://localhost:27017");
+    mongocxx::client client(uri);
+
+    mongocxx::database db = client["mydb"];
+    mongocxx::collection coll = db["test"];
+
+    auto builder = bsoncxx::builder::stream::document{};
+    bsoncxx::document::value doc_value =
+        builder << "name"
+                << "MongoDB"
+                << "type"
+                << "database"
+                << "count" << 1 << "versions" << bsoncxx::builder::stream::open_array << "v3.2"
+                << "v3.0"
+                << "v2.6" << close_array << "info" << bsoncxx::builder::stream::open_document << "x"
+                << 203 << "y" << 102 << bsoncxx::builder::stream::close_document
+                << bsoncxx::builder::stream::finalize;
+
+    bsoncxx::document::view view = doc_value.view();
+
+    bsoncxx::document::element element = view["name"];
+    if (element.type() != bsoncxx::type::k_string) {
+        // Error
+    }
+    std::string name = element.get_string().value.to_string();
+
+    bsoncxx::stdx::optional<mongocxx::result::insert_one> result = restaurants.insert_one(doc);
+
+    std::vector<bsoncxx::document::value> documents;
+    for (int i = 0; i < 100; i++) {
+        documents.push_back(bsoncxx::builder::stream::document{} << "i" << i << finalize);
+    }
+
+    collection.insert_many(documents);
+
+    bsoncxx::stdx::optional<bsoncxx::document::value> maybe_result = collection.find_one({});
+    if (maybe_result) {
+        // Do something with *maybe_result;
+    }
+
+    mongocxx::cursor cursor = collection.find({});
+    for (auto doc : cursor) {
+        std::cout << bsoncxx::to_json(doc) << "\n";
+    }
+
+    bsoncxx::stdx::optional<bsoncxx::document::value> maybe_result =
+        collection.find_one(document{} << "i" << 71 << finalize);
+    if (maybe_result) {
+        std::cout << bsoncxx::to_json(*maybe_result) << "\n";
+    }
+
+    mongocxx::cursor cursor =
+        collection.find(document{} << "i" << open_document << "$gt" << 50 << "$lte" << 100
+                                   << close_document << finalize);
+    for (auto doc : cursor) {
+        std::cout << bsoncxx::to_json(doc) << "\n";
+    }
+
+    collection.update_one(
+        document{} << "i" << 10 << finalize,
+        document{} << "$set" << open_document << "i" << 110 << close_document << finalize);
+
+    bsoncxx::stdx::optional<mongocxx::result::update> result = collection.update_many(
+        document{} << "i" << open_document << "$lt" << 100 << close_document << finalize,
+        document{} << "$inc" << open_document << "i" << 100 << close_document << finalize);
+
+    if (result) {
+        std::cout << result->modified_count() << "\n";
+    }
+
+    collection.delete_one(document{} << "i" << 110 << finalize);
+
+    bsoncxx::stdx::optional<mongocxx::result::delete_result> result = collection.delete_many(
+        document{} << "i" << open_document << "$gte" << 100 << close_document << finalize);
+
+    if (result) {
+        std::cout << result->deleted_count() << "\n";
+    }
+
+    auto index_specification = document{} << "i" << 1 << finalize;
+    collection.create_index(std::move(index_specification));
+}

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -67,7 +67,8 @@ int main() {
 
     // Insert One Document
     {
-        auto insert_one_result = collection.insert_one(view);
+        auto insert_one_result = collection.insert_one(document{} << "hello"
+                                                                  << "world" << finalize);
         // Acknowledged writes return a result.
         assert(insert_one_result);
         auto doc_id = insert_one_result->inserted_id();

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -94,6 +94,17 @@ int main() {
         }
     }
 
+    // Print All Documents in a Collection
+    {
+        auto cursor_all = collection.find({});
+        std::cout << "collection " << collection.name()
+                  << " contains these documents:" << std::endl;
+        for (auto doc : cursor_all) {
+            std::cout << bsoncxx::to_json(doc, bsoncxx::ExtendedJsonMode::k_relaxed) << std::endl;
+        }
+        std::cout << std::endl;
+    }
+
     // Get A Single Document That Matches a Filter
     {
         auto find_one_filtered_result = collection.find_one(make_document(kvp("i", 0)));

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -56,8 +56,7 @@ int main() {
     // Insert One Document
     {
         auto insert_one_result = collection.insert_one(make_document(kvp("hello", "world")));
-        // Acknowledged writes return a result.
-        assert(insert_one_result);
+        assert(insert_one_result);  // Acknowledged writes return results.
         auto doc_id = insert_one_result->inserted_id();
         assert(doc_id.type() == bsoncxx::type::k_oid);
     }
@@ -70,7 +69,7 @@ int main() {
         }
 
         auto insert_many_result = collection.insert_many(documents);
-        assert(insert_many_result);
+        assert(insert_many_result);  // Acknowledged writes return results.
         auto doc0_id = insert_many_result->inserted_ids().at(0);
         auto doc1_id = insert_many_result->inserted_ids().at(1);
         assert(doc0_id.type() == bsoncxx::type::k_oid);
@@ -122,10 +121,8 @@ int main() {
         auto update_many_result =
             collection.update_many(make_document(kvp("i", make_document(kvp("$lt", 3)))),
                                    make_document(kvp("$inc", make_document(kvp("i", 1)))));
-
-        if (update_many_result) {
-            std::cout << update_many_result->modified_count() << "\n";
-        }
+        assert(update_many_result);  // Acknowledged writes return results.
+        std::cout << update_many_result->modified_count() << "\n";
     }
 
     // Delete a Single Document
@@ -135,10 +132,8 @@ int main() {
     {
         auto delete_many_result =
             collection.delete_many(make_document(kvp("i", make_document(kvp("$gte", 3)))));
-
-        if (delete_many_result) {
-            std::cout << delete_many_result->deleted_count() << "\n";
-        }
+        assert(delete_many_result);  // Acknowledged writes return results.
+        std::cout << delete_many_result->deleted_count() << "\n";
     }
 
     // Create Indexes

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -12,7 +12,6 @@
 #endif
 
 // The following is a formatted copy from the tutorial https://mongocxx.org/mongocxx-v3/tutorial/.
-// It does not currently compiled. TODO: fix.
 
 #include <cstdint>
 #include <iostream>

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -40,7 +40,7 @@ int main() {
     mongocxx::client client(uri);
 
     mongocxx::database db = client["mydb"];
-    mongocxx::collection coll = db["test"];
+    mongocxx::collection collection = db["test"];
 
     auto builder = bsoncxx::builder::stream::document{};
     bsoncxx::document::value doc_value =

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -39,11 +39,12 @@ int main() {
 
     // Create a Document
     {
-        auto doc_value = make_document(kvp("name", "MongoDB"),
-                                       kvp("type", "database"),
-                                       kvp("count", 1),
-                                       kvp("versions", make_array("v3.2", "v3.0", "v2.6")),
-                                       kvp("info", make_document(kvp("x", 203), kvp("y", 102))));
+        auto doc_value = make_document(
+            kvp("name", "MongoDB"),
+            kvp("type", "database"),
+            kvp("count", 1),
+            kvp("versions", make_array("v6.0", "v5.0", "v4.4", "v4.2", "v4.0", "v3.6")),
+            kvp("info", make_document(kvp("x", 203), kvp("y", 102))));
 
         auto doc_view = doc_value.view();
 
@@ -112,8 +113,11 @@ int main() {
 
     // Update a Single Document
     {
-        collection.update_one(make_document(kvp("i", 3)),
-                              make_document(kvp("$set", make_document(kvp("i", 10)))));
+        auto update_one_result = collection.update_one(
+            make_document(kvp("i", 3)), make_document(kvp("$set", make_document(kvp("i", 10)))));
+        assert(update_one_result);  // Acknowledged writes return results.
+        std::cout << "update_one_result->modified_count() = " << update_one_result->modified_count()
+                  << std::endl;
     }
 
     // Update Multiple Documents

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -62,7 +62,7 @@ int main() {
     }
     bsoncxx::stdx::string_view name = element.get_string().value;
 
-    bsoncxx::stdx::optional<mongocxx::result::insert_one> result = collection.insert_one(doc);
+    bsoncxx::stdx::optional<mongocxx::result::insert_one> result = collection.insert_one(view);
 
     std::vector<bsoncxx::document::value> documents;
     for (int i = 0; i < 100; i++) {

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -143,4 +143,7 @@ int main() {
         auto index_specification = make_document(kvp("i", 1));
         collection.create_index(std::move(index_specification));
     }
+
+    // Drop collection to clean up.
+    collection.drop();
 }

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -80,7 +80,7 @@ int main() {
     {
         auto find_one_result = collection.find_one({});
         if (find_one_result) {
-            // Do something with *find_one_result;
+            // Do something with *find_one_result
         }
         assert(find_one_result);
     }
@@ -89,7 +89,8 @@ int main() {
     {
         auto cursor_all = collection.find({});
         for (auto doc : cursor_all) {
-            std::cout << bsoncxx::to_json(doc) << "\n";
+            // Do something with doc
+            assert(doc["_id"].type() == bsoncxx::type::k_oid);
         }
     }
 
@@ -97,7 +98,7 @@ int main() {
     {
         auto find_one_filtered_result = collection.find_one(make_document(kvp("i", 0)));
         if (find_one_filtered_result) {
-            std::cout << bsoncxx::to_json(*find_one_filtered_result) << "\n";
+            // Do something with *find_one_filtered_result
         }
     }
 
@@ -106,7 +107,8 @@ int main() {
         auto cursor_filtered =
             collection.find(make_document(kvp("i", make_document(kvp("$gt", 0), kvp("$lte", 2)))));
         for (auto doc : cursor_filtered) {
-            std::cout << bsoncxx::to_json(doc) << "\n";
+            // Do something with doc
+            assert(doc["_id"].type() == bsoncxx::type::k_oid);
         }
     }
 
@@ -116,8 +118,7 @@ int main() {
             collection.update_one(make_document(kvp("i", 0)),
                                   make_document(kvp("$set", make_document(kvp("foo", "bar")))));
         assert(update_one_result);  // Acknowledged writes return results.
-        std::cout << "update_one_result->modified_count() = " << update_one_result->modified_count()
-                  << std::endl;
+        assert(update_one_result->modified_count() == 1);
     }
 
     // Update Multiple Documents
@@ -126,7 +127,7 @@ int main() {
             collection.update_many(make_document(kvp("i", make_document(kvp("$gt", 0)))),
                                    make_document(kvp("$set", make_document(kvp("foo", "buzz")))));
         assert(update_many_result);  // Acknowledged writes return results.
-        std::cout << update_many_result->modified_count() << "\n";
+        assert(update_many_result->modified_count() == 2);
     }
 
     // Delete a Single Document
@@ -141,7 +142,7 @@ int main() {
         auto delete_many_result =
             collection.delete_many(make_document(kvp("i", make_document(kvp("$gt", 0)))));
         assert(delete_many_result);  // Acknowledged writes return results.
-        std::cout << delete_many_result->deleted_count() << "\n";
+        assert(delete_many_result->deleted_count() == 2);
     }
 
     // Create Indexes

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -63,13 +63,19 @@ int main() {
     auto name = element.get_string().value;
 
     auto insert_one_result = collection.insert_one(view);
+    // Acknowledged writes return a result.
+    assert(insert_one_result);
+    auto doc_id = insert_one_result->inserted_id();
 
     std::vector<bsoncxx::document::value> documents;
     for (int i = 0; i < 100; i++) {
         documents.push_back(bsoncxx::builder::stream::document{} << "i" << i << finalize);
     }
 
-    collection.insert_many(documents);
+    auto insert_many_result = collection.insert_many(documents);
+    assert(insert_many_result);
+    auto doc0_id = insert_many_result->inserted_ids().at(0);
+    auto doc1_id = insert_many_result->inserted_ids().at(1);
 
     auto find_one_result = collection.find_one({});
     if (find_one_result) {

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -42,84 +42,118 @@ int main() {
     auto db = client["mydb"];
     auto collection = db["test"];
 
-    auto builder = bsoncxx::builder::stream::document{};
-    auto doc_value =
-        builder << "name"
-                << "MongoDB"
-                << "type"
-                << "database"
-                << "count" << 1 << "versions" << bsoncxx::builder::stream::open_array << "v3.2"
-                << "v3.0"
-                << "v2.6" << close_array << "info" << bsoncxx::builder::stream::open_document << "x"
-                << 203 << "y" << 102 << bsoncxx::builder::stream::close_document
-                << bsoncxx::builder::stream::finalize;
+    // Create a Document
+    {
+        auto builder = bsoncxx::builder::stream::document{};
+        auto doc_value =
+            builder << "name"
+                    << "MongoDB"
+                    << "type"
+                    << "database"
+                    << "count" << 1 << "versions" << bsoncxx::builder::stream::open_array << "v3.2"
+                    << "v3.0"
+                    << "v2.6" << close_array << "info" << bsoncxx::builder::stream::open_document
+                    << "x" << 203 << "y" << 102 << bsoncxx::builder::stream::close_document
+                    << bsoncxx::builder::stream::finalize;
 
-    auto view = doc_value.view();
+        auto view = doc_value.view();
 
-    auto element = view["name"];
-    if (element.type() != bsoncxx::type::k_string) {
-        // Error
-    }
-    auto name = element.get_string().value;
-
-    auto insert_one_result = collection.insert_one(view);
-    // Acknowledged writes return a result.
-    assert(insert_one_result);
-    auto doc_id = insert_one_result->inserted_id();
-
-    std::vector<bsoncxx::document::value> documents;
-    for (int i = 0; i < 100; i++) {
-        documents.push_back(bsoncxx::builder::stream::document{} << "i" << i << finalize);
+        auto element = view["name"];
+        if (element.type() != bsoncxx::type::k_string) {
+            // Error
+        }
+        auto name = element.get_string().value;
     }
 
-    auto insert_many_result = collection.insert_many(documents);
-    assert(insert_many_result);
-    auto doc0_id = insert_many_result->inserted_ids().at(0);
-    auto doc1_id = insert_many_result->inserted_ids().at(1);
-
-    auto find_one_result = collection.find_one({});
-    if (find_one_result) {
-        // Do something with *find_one_result;
+    // Insert One Document
+    {
+        auto insert_one_result = collection.insert_one(view);
+        // Acknowledged writes return a result.
+        assert(insert_one_result);
+        auto doc_id = insert_one_result->inserted_id();
     }
 
-    auto cursor_all = collection.find({});
-    for (auto doc : cursor_all) {
-        std::cout << bsoncxx::to_json(doc) << "\n";
+    // Insert Multiple Documents
+    {
+        std::vector<bsoncxx::document::value> documents;
+        for (int i = 0; i < 100; i++) {
+            documents.push_back(bsoncxx::builder::stream::document{} << "i" << i << finalize);
+        }
+
+        auto insert_many_result = collection.insert_many(documents);
+        assert(insert_many_result);
+        auto doc0_id = insert_many_result->inserted_ids().at(0);
+        auto doc1_id = insert_many_result->inserted_ids().at(1);
     }
 
-    auto find_one_filtered_result = collection.find_one(document{} << "i" << 71 << finalize);
-    if (find_one_filtered_result) {
-        std::cout << bsoncxx::to_json(*find_one_filtered_result) << "\n";
+    // Find a Single Document in a Collection
+    {
+        auto find_one_result = collection.find_one({});
+        if (find_one_result) {
+            // Do something with *find_one_result;
+        }
     }
 
-    auto cursor_filtered =
-        collection.find(document{} << "i" << open_document << "$gt" << 50 << "$lte" << 100
-                                   << close_document << finalize);
-    for (auto doc : cursor_filtered) {
-        std::cout << bsoncxx::to_json(doc) << "\n";
+    // Find All Documents in a Collection
+    {
+        auto cursor_all = collection.find({});
+        for (auto doc : cursor_all) {
+            std::cout << bsoncxx::to_json(doc) << "\n";
+        }
     }
 
-    collection.update_one(
-        document{} << "i" << 10 << finalize,
-        document{} << "$set" << open_document << "i" << 110 << close_document << finalize);
-
-    auto update_many_result = collection.update_many(
-        document{} << "i" << open_document << "$lt" << 100 << close_document << finalize,
-        document{} << "$inc" << open_document << "i" << 100 << close_document << finalize);
-
-    if (update_many_result) {
-        std::cout << update_many_result->modified_count() << "\n";
+    // Get A Single Document That Matches a Filter
+    {
+        auto find_one_filtered_result = collection.find_one(document{} << "i" << 71 << finalize);
+        if (find_one_filtered_result) {
+            std::cout << bsoncxx::to_json(*find_one_filtered_result) << "\n";
+        }
     }
 
-    collection.delete_one(document{} << "i" << 110 << finalize);
-
-    auto delete_many_result = collection.delete_many(
-        document{} << "i" << open_document << "$gte" << 100 << close_document << finalize);
-
-    if (delete_many_result) {
-        std::cout << delete_many_result->deleted_count() << "\n";
+    // Get All Documents That Match a Filter
+    {
+        auto cursor_filtered =
+            collection.find(document{} << "i" << open_document << "$gt" << 50 << "$lte" << 100
+                                       << close_document << finalize);
+        for (auto doc : cursor_filtered) {
+            std::cout << bsoncxx::to_json(doc) << "\n";
+        }
     }
 
-    auto index_specification = document{} << "i" << 1 << finalize;
-    collection.create_index(std::move(index_specification));
+    // Update a Single Document
+    {
+        collection.update_one(
+            document{} << "i" << 10 << finalize,
+            document{} << "$set" << open_document << "i" << 110 << close_document << finalize);
+    }
+
+    // Update Multiple Documents
+    {
+        auto update_many_result = collection.update_many(
+            document{} << "i" << open_document << "$lt" << 100 << close_document << finalize,
+            document{} << "$inc" << open_document << "i" << 100 << close_document << finalize);
+
+        if (update_many_result) {
+            std::cout << update_many_result->modified_count() << "\n";
+        }
+    }
+
+    // Delete a Single Document
+    { collection.delete_one(document{} << "i" << 110 << finalize); }
+
+    // Delete All Documents That Match a Filter
+    {
+        auto delete_many_result = collection.delete_many(
+            document{} << "i" << open_document << "$gte" << 100 << close_document << finalize);
+
+        if (delete_many_result) {
+            std::cout << delete_many_result->deleted_count() << "\n";
+        }
+    }
+
+    // Create Indexes
+    {
+        auto index_specification = document{} << "i" << 1 << finalize;
+        collection.create_index(std::move(index_specification));
+    }
 }

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -1,6 +1,6 @@
 // Compile with: c++ --std=c++11 tutorial.cpp $(pkg-config --cflags --libs libmongocxx)
 
-#ifdef NDEBUG
+#if defined(NDEBUG) || !defined(assert)
 #undef assert
 #define assert(stmt)                                                                         \
     do {                                                                                     \

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -62,7 +62,7 @@ int main() {
     }
     std::string name = element.get_string().value.to_string();
 
-    bsoncxx::stdx::optional<mongocxx::result::insert_one> result = restaurants.insert_one(doc);
+    bsoncxx::stdx::optional<mongocxx::result::insert_one> result = collection.insert_one(doc);
 
     std::vector<bsoncxx::document::value> documents;
     for (int i = 0; i < 100; i++) {

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -49,7 +49,7 @@ int main() {
         auto doc_view = doc_value.view();
 
         auto element = doc_view["name"];
-        assert(element.type() != bsoncxx::type::k_string);
+        assert(element.type() == bsoncxx::type::k_string);
         auto name = element.get_string().value;
         assert(0 == name.compare("MongoDB"));
     }

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -18,21 +18,16 @@
 #include <iostream>
 #include <vector>
 
-#include <bsoncxx/builder/stream/array.hpp>
-#include <bsoncxx/builder/stream/document.hpp>
-#include <bsoncxx/builder/stream/helpers.hpp>
+#include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/json.hpp>
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/uri.hpp>
 
-using bsoncxx::builder::stream::close_array;
-using bsoncxx::builder::stream::close_document;
-using bsoncxx::builder::stream::document;
-using bsoncxx::builder::stream::finalize;
-using bsoncxx::builder::stream::open_array;
-using bsoncxx::builder::stream::open_document;
+using bsoncxx::builder::basic::kvp;
+using bsoncxx::builder::basic::make_array;
+using bsoncxx::builder::basic::make_document;
 
 int main() {
     mongocxx::instance instance{};  // This should be done only once.
@@ -44,17 +39,11 @@ int main() {
 
     // Create a Document
     {
-        auto builder = bsoncxx::builder::stream::document{};
-        auto doc_value =
-            builder << "name"
-                    << "MongoDB"
-                    << "type"
-                    << "database"
-                    << "count" << 1 << "versions" << bsoncxx::builder::stream::open_array << "v3.2"
-                    << "v3.0"
-                    << "v2.6" << close_array << "info" << bsoncxx::builder::stream::open_document
-                    << "x" << 203 << "y" << 102 << bsoncxx::builder::stream::close_document
-                    << bsoncxx::builder::stream::finalize;
+        auto doc_value = make_document(kvp("name", "MongoDB"),
+                                       kvp("type", "database"),
+                                       kvp("count", 1),
+                                       kvp("versions", make_array("v3.2", "v3.0", "v2.6")),
+                                       kvp("info", make_document(kvp("x", 203), kvp("y", 102))));
 
         auto view = doc_value.view();
 
@@ -67,8 +56,7 @@ int main() {
 
     // Insert One Document
     {
-        auto insert_one_result = collection.insert_one(document{} << "hello"
-                                                                  << "world" << finalize);
+        auto insert_one_result = collection.insert_one(make_document(kvp("hello", "world")));
         // Acknowledged writes return a result.
         assert(insert_one_result);
         auto doc_id = insert_one_result->inserted_id();
@@ -78,7 +66,7 @@ int main() {
     {
         std::vector<bsoncxx::document::value> documents;
         for (int i = 0; i < 100; i++) {
-            documents.push_back(bsoncxx::builder::stream::document{} << "i" << i << finalize);
+            documents.push_back(make_document(kvp("i", i)));
         }
 
         auto insert_many_result = collection.insert_many(documents);
@@ -105,7 +93,7 @@ int main() {
 
     // Get A Single Document That Matches a Filter
     {
-        auto find_one_filtered_result = collection.find_one(document{} << "i" << 71 << finalize);
+        auto find_one_filtered_result = collection.find_one(make_document(kvp("i", 71)));
         if (find_one_filtered_result) {
             std::cout << bsoncxx::to_json(*find_one_filtered_result) << "\n";
         }
@@ -113,9 +101,8 @@ int main() {
 
     // Get All Documents That Match a Filter
     {
-        auto cursor_filtered =
-            collection.find(document{} << "i" << open_document << "$gt" << 50 << "$lte" << 100
-                                       << close_document << finalize);
+        auto cursor_filtered = collection.find(
+            make_document(kvp("i", make_document(kvp("$gt", 50), kvp("$lte", 100)))));
         for (auto doc : cursor_filtered) {
             std::cout << bsoncxx::to_json(doc) << "\n";
         }
@@ -123,16 +110,15 @@ int main() {
 
     // Update a Single Document
     {
-        collection.update_one(
-            document{} << "i" << 10 << finalize,
-            document{} << "$set" << open_document << "i" << 110 << close_document << finalize);
+        collection.update_one(make_document(kvp("i", 10)),
+                              make_document(kvp("$set", make_document(kvp("i", 110)))));
     }
 
     // Update Multiple Documents
     {
-        auto update_many_result = collection.update_many(
-            document{} << "i" << open_document << "$lt" << 100 << close_document << finalize,
-            document{} << "$inc" << open_document << "i" << 100 << close_document << finalize);
+        auto update_many_result =
+            collection.update_many(make_document(kvp("i", make_document(kvp("$lt", 100)))),
+                                   make_document(kvp("$inc", make_document(kvp("i", 100)))));
 
         if (update_many_result) {
             std::cout << update_many_result->modified_count() << "\n";
@@ -140,12 +126,12 @@ int main() {
     }
 
     // Delete a Single Document
-    { collection.delete_one(document{} << "i" << 110 << finalize); }
+    { collection.delete_one(make_document(kvp("i", 110))); }
 
     // Delete All Documents That Match a Filter
     {
-        auto delete_many_result = collection.delete_many(
-            document{} << "i" << open_document << "$gte" << 100 << close_document << finalize);
+        auto delete_many_result =
+            collection.delete_many(make_document(kvp("i", make_document(kvp("$gte", 100)))));
 
         if (delete_many_result) {
             std::cout << delete_many_result->deleted_count() << "\n";
@@ -154,7 +140,7 @@ int main() {
 
     // Create Indexes
     {
-        auto index_specification = document{} << "i" << 1 << finalize;
+        auto index_specification = make_document(kvp("i", 1));
         collection.create_index(std::move(index_specification));
     }
 }

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -62,7 +62,7 @@ int main() {
     }
     auto name = element.get_string().value;
 
-    auto result = collection.insert_one(view);
+    auto insert_one_result = collection.insert_one(view);
 
     std::vector<bsoncxx::document::value> documents;
     for (int i = 0; i < 100; i++) {
@@ -71,24 +71,25 @@ int main() {
 
     collection.insert_many(documents);
 
-    auto maybe_result = collection.find_one({});
-    if (maybe_result) {
-        // Do something with *maybe_result;
+    auto find_one_result = collection.find_one({});
+    if (find_one_result) {
+        // Do something with *find_one_result;
     }
 
-    auto cursor = collection.find({});
-    for (auto doc : cursor) {
+    auto cursor_all = collection.find({});
+    for (auto doc : cursor_all) {
         std::cout << bsoncxx::to_json(doc) << "\n";
     }
 
-    auto maybe_result = collection.find_one(document{} << "i" << 71 << finalize);
-    if (maybe_result) {
-        std::cout << bsoncxx::to_json(*maybe_result) << "\n";
+    auto find_one_filtered_result = collection.find_one(document{} << "i" << 71 << finalize);
+    if (find_one_filtered_result) {
+        std::cout << bsoncxx::to_json(*find_one_filtered_result) << "\n";
     }
 
-    auto cursor = collection.find(document{} << "i" << open_document << "$gt" << 50 << "$lte" << 100
-                                             << close_document << finalize);
-    for (auto doc : cursor) {
+    auto cursor_filtered =
+        collection.find(document{} << "i" << open_document << "$gt" << 50 << "$lte" << 100
+                                   << close_document << finalize);
+    for (auto doc : cursor_filtered) {
         std::cout << bsoncxx::to_json(doc) << "\n";
     }
 
@@ -96,21 +97,21 @@ int main() {
         document{} << "i" << 10 << finalize,
         document{} << "$set" << open_document << "i" << 110 << close_document << finalize);
 
-    auto result = collection.update_many(
+    auto update_many_result = collection.update_many(
         document{} << "i" << open_document << "$lt" << 100 << close_document << finalize,
         document{} << "$inc" << open_document << "i" << 100 << close_document << finalize);
 
-    if (result) {
-        std::cout << result->modified_count() << "\n";
+    if (update_many_result) {
+        std::cout << update_many_result->modified_count() << "\n";
     }
 
     collection.delete_one(document{} << "i" << 110 << finalize);
 
-    auto result = collection.delete_many(document{} << "i" << open_document << "$gte" << 100
-                                                    << close_document << finalize);
+    auto delete_many_result = collection.delete_many(
+        document{} << "i" << open_document << "$gte" << 100 << close_document << finalize);
 
-    if (result) {
-        std::cout << result->deleted_count() << "\n";
+    if (delete_many_result) {
+        std::cout << delete_many_result->deleted_count() << "\n";
     }
 
     auto index_specification = document{} << "i" << 1 << finalize;

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -48,7 +48,7 @@ int main() {
         auto doc_view = doc_value.view();
         auto element = doc_view["name"];
         assert(element.type() == bsoncxx::type::k_string);
-        auto name = element.get_string().value;
+        auto name = element.get_string().value;  // For C++ driver version < 3.7.0, use get_utf8()
         assert(0 == name.compare("MongoDB"));
     }
 

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -46,7 +46,6 @@ int main() {
             kvp("info", make_document(kvp("x", 203), kvp("y", 102))));
 
         auto doc_view = doc_value.view();
-
         auto element = doc_view["name"];
         assert(element.type() == bsoncxx::type::k_string);
         auto name = element.get_string().value;

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -45,9 +45,9 @@ int main() {
                                        kvp("versions", make_array("v3.2", "v3.0", "v2.6")),
                                        kvp("info", make_document(kvp("x", 203), kvp("y", 102))));
 
-        auto view = doc_value.view();
+        auto doc_view = doc_value.view();
 
-        auto element = view["name"];
+        auto element = doc_view["name"];
         if (element.type() != bsoncxx::type::k_string) {
             // Error
         }

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -1,16 +1,5 @@
 // Compile with: c++ --std=c++11 tutorial.cpp $(pkg-config --cflags --libs libmongocxx)
 
-#if defined(NDEBUG) || !defined(assert)
-#undef assert
-#define assert(stmt)                                                                         \
-    do {                                                                                     \
-        if (!(stmt)) {                                                                       \
-            std::cerr << "Assert on line " << __LINE__ << " failed: " << #stmt << std::endl; \
-            abort();                                                                         \
-        }                                                                                    \
-    } while (0)
-#endif
-
 // The following is a formatted copy from the tutorial https://mongocxx.org/mongocxx-v3/tutorial/.
 
 #include <cstdint>
@@ -23,6 +12,19 @@
 #include <mongocxx/instance.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/uri.hpp>
+
+// Redefine assert after including headers. Release builds may undefine the assert macro and result
+// in -Wunused-variable warnings.
+#if defined(NDEBUG) || !defined(assert)
+#undef assert
+#define assert(stmt)                                                                         \
+    do {                                                                                     \
+        if (!(stmt)) {                                                                       \
+            std::cerr << "Assert on line " << __LINE__ << " failed: " << #stmt << std::endl; \
+            abort();                                                                         \
+        }                                                                                    \
+    } while (0)
+#endif
 
 using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_array;

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -48,10 +48,9 @@ int main() {
         auto doc_view = doc_value.view();
 
         auto element = doc_view["name"];
-        if (element.type() != bsoncxx::type::k_string) {
-            // Error
-        }
+        assert(element.type() != bsoncxx::type::k_string);
         auto name = element.get_string().value;
+        assert(0 == name.compare("MongoDB"));
     }
 
     // Insert One Document
@@ -60,6 +59,7 @@ int main() {
         // Acknowledged writes return a result.
         assert(insert_one_result);
         auto doc_id = insert_one_result->inserted_id();
+        assert(doc_id.type() == bsoncxx::type::k_oid);
     }
 
     // Insert Multiple Documents
@@ -73,6 +73,8 @@ int main() {
         assert(insert_many_result);
         auto doc0_id = insert_many_result->inserted_ids().at(0);
         auto doc1_id = insert_many_result->inserted_ids().at(1);
+        assert(doc0_id.type() == bsoncxx::type::k_oid);
+        assert(doc1_id.type() == bsoncxx::type::k_oid);
     }
 
     // Find a Single Document in a Collection
@@ -81,6 +83,7 @@ int main() {
         if (find_one_result) {
             // Do something with *find_one_result;
         }
+        assert(find_one_result);
     }
 
     // Find All Documents in a Collection

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -65,7 +65,7 @@ int main() {
     // Insert Multiple Documents
     {
         std::vector<bsoncxx::document::value> documents;
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < 5; i++) {
             documents.push_back(make_document(kvp("i", i)));
         }
 
@@ -93,7 +93,7 @@ int main() {
 
     // Get A Single Document That Matches a Filter
     {
-        auto find_one_filtered_result = collection.find_one(make_document(kvp("i", 71)));
+        auto find_one_filtered_result = collection.find_one(make_document(kvp("i", 3)));
         if (find_one_filtered_result) {
             std::cout << bsoncxx::to_json(*find_one_filtered_result) << "\n";
         }
@@ -101,8 +101,8 @@ int main() {
 
     // Get All Documents That Match a Filter
     {
-        auto cursor_filtered = collection.find(
-            make_document(kvp("i", make_document(kvp("$gt", 50), kvp("$lte", 100)))));
+        auto cursor_filtered =
+            collection.find(make_document(kvp("i", make_document(kvp("$gt", 50), kvp("$lte", 3)))));
         for (auto doc : cursor_filtered) {
             std::cout << bsoncxx::to_json(doc) << "\n";
         }
@@ -110,15 +110,15 @@ int main() {
 
     // Update a Single Document
     {
-        collection.update_one(make_document(kvp("i", 10)),
-                              make_document(kvp("$set", make_document(kvp("i", 110)))));
+        collection.update_one(make_document(kvp("i", 3)),
+                              make_document(kvp("$set", make_document(kvp("i", 10)))));
     }
 
     // Update Multiple Documents
     {
         auto update_many_result =
-            collection.update_many(make_document(kvp("i", make_document(kvp("$lt", 100)))),
-                                   make_document(kvp("$inc", make_document(kvp("i", 100)))));
+            collection.update_many(make_document(kvp("i", make_document(kvp("$lt", 3)))),
+                                   make_document(kvp("$inc", make_document(kvp("i", 1)))));
 
         if (update_many_result) {
             std::cout << update_many_result->modified_count() << "\n";
@@ -131,7 +131,7 @@ int main() {
     // Delete All Documents That Match a Filter
     {
         auto delete_many_result =
-            collection.delete_many(make_document(kvp("i", make_document(kvp("$gte", 100)))));
+            collection.delete_many(make_document(kvp("i", make_document(kvp("$gte", 3)))));
 
         if (delete_many_result) {
             std::cout << delete_many_result->deleted_count() << "\n";


### PR DESCRIPTION
# Summary

- Add `tutorial.cpp` with code snippets from `tutorial.md`.
- Satisfy requests from CXX-2582
    - e1f0d6e80337889000161bac6568a76414725dad add an example of getting inserted IDs.
    - c33534f4f905bb63999c4434c0175f0e61f67b9f renames `coll` to `collection`.
    - 9d28594e64768167405590ef856f744e08ab33fc distinguishes result variables to make examples easier to copy-paste.
- Make several changes to `tutorial.cpp`. Notably:
    - 69f1e757ed67654d094a461de45a5dfa357ad1c0 fixes a compile error.
    - 40113e6c455775864fc44813d8866a554f1cc04b simplifies the examples to use only three documents.
    - 60da85a9d31a30fabead3d28e308f7e1f11cf6e8 replaces prints with assertions.
- Apply updates from `tutorial.cpp` to `tutorial.md`.

# Background & Motivation

Adding `tutorial.cpp` with assertions is intended to make it easier to verify correctness of tutorial code snippets.

Changes were applied to `tutorial.cpp` in separate commits. Commit messages describe some of the rationale.

Documentation can be built locally with `cmake --build cmake-build --target hugo` and viewed with `open ./build/hugo/mongocxx-v3/tutorial/index.html`.

Evergreen appears to not be receiving GitHub checks at the moment. [Here](https://spruce.mongodb.com/version/640a04cdc9ec440498f9971f/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) is an Evergreen patch build with these changes.
