### PR TITLE
Update documentation for r3.7.1 release

### DIFF
--- a/docs/content/mongocxx-v3/installation/linux.md
+++ b/docs/content/mongocxx-v3/installation/linux.md
@@ -77,12 +77,12 @@ release tarball.
 
 The [mongocxx releases](https://github.com/mongodb/mongo-cxx-driver/releases)
 page will have links to the release tarball for the version you wish you install.  For
-example, to download version 3.7.0:
+example, to download version 3.7.1:
 
 ```sh
-curl -OL https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.7.0/mongo-cxx-driver-r3.7.0.tar.gz
-tar -xzf mongo-cxx-driver-r3.7.0.tar.gz
-cd mongo-cxx-driver-r3.7.0/build
+curl -OL https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.7.1/mongo-cxx-driver-r3.7.1.tar.gz
+tar -xzf mongo-cxx-driver-r3.7.1.tar.gz
+cd mongo-cxx-driver-r3.7.1/build
 ```
 
 Make sure you change to the `build` directory of whatever source tree you

--- a/docs/content/mongocxx-v3/installation/macos.md
+++ b/docs/content/mongocxx-v3/installation/macos.md
@@ -77,12 +77,12 @@ release tarball.
 
 The [mongocxx releases](https://github.com/mongodb/mongo-cxx-driver/releases)
 page will have links to the release tarball for the version you wish you install.  For
-example, to download version 3.7.0:
+example, to download version 3.7.1:
 
 ```sh
-curl -OL https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.7.0/mongo-cxx-driver-r3.7.0.tar.gz
-tar -xzf mongo-cxx-driver-r3.7.0.tar.gz
-cd mongo-cxx-driver-r3.7.0/build
+curl -OL https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.7.1/mongo-cxx-driver-r3.7.1.tar.gz
+tar -xzf mongo-cxx-driver-r3.7.1.tar.gz
+cd mongo-cxx-driver-r3.7.1/build
 ```
 
 Make sure you change to the `build` directory of whatever source tree you

--- a/docs/content/mongocxx-v3/installation/windows.md
+++ b/docs/content/mongocxx-v3/installation/windows.md
@@ -80,12 +80,12 @@ release tarball.
 
 The [mongocxx releases](https://github.com/mongodb/mongo-cxx-driver/releases)
 page will have links to the release tarball for the version you wish you install.  For
-example, to download version 3.7.0:
+example, to download version 3.7.1:
 
 ```sh
-curl -OL https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.7.0/mongo-cxx-driver-r3.7.0.tar.gz
-tar -xzf mongo-cxx-driver-r3.7.0.tar.gz
-cd mongo-cxx-driver-r3.7.0/build
+curl -OL https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.7.1/mongo-cxx-driver-r3.7.1.tar.gz
+tar -xzf mongo-cxx-driver-r3.7.1.tar.gz
+cd mongo-cxx-driver-r3.7.1/build
 ```
 
 Make sure you change to the `build` directory of whatever source tree you

--- a/etc/apidocmenu.md
+++ b/etc/apidocmenu.md
@@ -21,6 +21,7 @@ Currently, no drivers guarantee API or ABI stability.
 
 | mongocxx                                     |
 | ---------------------------------------------|
+| [mongocxx-3.7.1](../mongocxx-3.7.1)          |
 | [mongocxx-3.7.0](../mongocxx-3.7.0)          |
 | [mongocxx-3.6.7](../mongocxx-3.6.7)          |
 | [mongocxx-3.6.6](../mongocxx-3.6.6)          |

--- a/etc/generate-all-apidocs.pl
+++ b/etc/generate-all-apidocs.pl
@@ -58,6 +58,7 @@ my @DOC_TAGS = qw(
   r3.6.6
   r3.6.7
   r3.7.0
+  r3.7.1
 );
 
 sub main {


### PR DESCRIPTION
Completes the last step of [Generate and Publish Documentation](https://github.com/mongodb/mongo-cxx-driver/blob/6af37f81dfc64d1bcd33b993515a7c50e83654bb/etc/releasing.md#generate-and-publish-documentation)

> Merge the commit containing these changes into the master branch. This may require pushing the commit to a fork of the C++ Driver repository and creating a pull request.