### PR TITLE
CXX-2579 use standard directories in main install instructions

### DIFF
--- a/docs/content/mongocxx-v3/configuration.md
+++ b/docs/content/mongocxx-v3/configuration.md
@@ -9,7 +9,7 @@ title = "Configuring the mongocxx driver"
 In the mongocxx driver, most configuration is done via the [connection
 URI](https://docs.mongodb.com/manual/reference/connection-string/).  Some
 additional connection options are possible via the
-[mongocxx::options::client] ({{< api3ref classmongocxx_1_1options_1_1client
+[mongocxx::options::client]({{< api3ref classmongocxx_1_1options_1_1client
 >}}) class.
 
 ## Configuring TLS/SSL
@@ -21,7 +21,7 @@ To enable TLS (SSL), set `tls=true` in the URI:
 By default, mongocxx will verify server certificates against the local
 system CA list.  You can override that either by specifying different settings in
 the connection string, or by creating a
-[mongocxx::options::tls] ({{< api3ref classmongocxx_1_1options_1_1tls >}})
+[mongocxx::options::tls]({{< api3ref classmongocxx_1_1options_1_1tls >}})
 object and passing it to `tls_opts` on mongocxx::options::client.
 
 For example, to use a custom CA or to disable certificate validation,
@@ -109,7 +109,7 @@ See the MongoDB server
 for more information about determining the subject name from the
 certificate.
 
-The PEM file can also be specified using the [mongocxx::options::tls] ({{< api3ref classmongocxx_1_1options_1_1tls >}}) class, see the first "Configuring TLS/SSL" example above.
+The PEM file can also be specified using the [mongocxx::options::tls]({{< api3ref classmongocxx_1_1options_1_1tls >}}) class, see the first "Configuring TLS/SSL" example above.
 
 ### Kerberos (GSSAPI)
 

--- a/docs/content/mongocxx-v3/installation/advanced.md
+++ b/docs/content/mongocxx-v3/installation/advanced.md
@@ -136,3 +136,30 @@ cmake ..                                             \
     -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver    \
     -DCMAKE_INSTALL_RPATH=$HOME/mongo-cxx-driver/lib
 ```
+
+If the C driver is installed to a non-standard directory, specify `CMAKE_PREFIX_PATH` to the install
+path of the C driver:
+
+```sh
+cmake ..                                            \
+    -DCMAKE_BUILD_TYPE=Release                      \
+    -DCMAKE_PREFIX_PATH=$HOME/mongo-c-driver        \
+    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
+```
+
+> *Note* If you need multiple paths in a CMake PATH variable, separate them with a semicolon like
+> this:
+> `-DCMAKE_PREFIX_PATH="/your/cdriver/prefix;/some/other/path"`
+
+### Configuring with `mongocxx` 3.1.x or 3.0.x
+
+Instead of the `-DCMAKE_PREFIX_PATH` option, users must specify the `libmongoc` installation
+directory by using the `-DLIBMONGOC_DIR` and `-DLIBBSON_DIR` options:
+
+```sh
+cmake ..                                            \
+    -DCMAKE_BUILD_TYPE=Release                      \
+    -DLIBMONGOC_DIR=$HOME/mongo-c-driver            \
+    -DLIBBSON_DIR=$HOME/mongo-c-driver              \
+    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
+```

--- a/docs/content/mongocxx-v3/installation/advanced.md
+++ b/docs/content/mongocxx-v3/installation/advanced.md
@@ -36,9 +36,7 @@ users.** A user can enable this behavior with the `-DBUILD_SHARED_LIBS` option:
 ```sh
 cmake ..                                            \
     -DCMAKE_BUILD_TYPE=Release                      \
-    -DBUILD_SHARED_LIBS=OFF                         \
-    -DCMAKE_PREFIX_PATH=$HOME/mongo-c-driver         \
-    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
+    -DBUILD_SHARED_LIBS=OFF
 ```
 
 #### Configuring with `mongocxx` 3.5.0 or newer
@@ -49,9 +47,7 @@ this behavior with the `-DBUILD_SHARED_AND_STATIC_LIBS` option:
 ```sh
 cmake ..                                            \
     -DCMAKE_BUILD_TYPE=Release                      \
-    -DBUILD_SHARED_AND_STATIC_LIBS=ON               \
-    -DCMAKE_PREFIX_PATH=$HOME/mongo-c-driver         \
-    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
+    -DBUILD_SHARED_AND_STATIC_LIBS=ON
 ```
 
 Users have the option to build `mongocxx` as a shared library that has statically linked
@@ -61,9 +57,7 @@ Users have the option to build `mongocxx` as a shared library that has staticall
 ```sh
 cmake ..                                            \
     -DCMAKE_BUILD_TYPE=Release                      \
-    -DBUILD_SHARED_LIBS_WITH_STATIC_MONGOC=ON       \
-    -DCMAKE_PREFIX_PATH=$HOME/mongo-c-driver         \
-    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
+    -DBUILD_SHARED_LIBS_WITH_STATIC_MONGOC=ON
 ```
 
 ### For Windows
@@ -76,9 +70,7 @@ users.** A user can enable this behavior with the `-DBUILD_SHARED_LIBS` option:
 ```sh
 cmake ..                                            \
     -DCMAKE_BUILD_TYPE=Release                      \
-    -DBUILD_SHARED_LIBS=OFF                         \
-    -DCMAKE_PREFIX_PATH=C:\mongo-c-driver           \
-    -DCMAKE_INSTALL_PREFIX=C:\mongo-cxx-driver
+    -DBUILD_SHARED_LIBS=OFF
 ```
 
 #### Configuring with `mongocxx` 3.5.0 or newer
@@ -89,9 +81,7 @@ this behavior with the `-DBUILD_SHARED_AND_STATIC_LIBS` option:
 ```sh
 cmake ..                                            \
     -DCMAKE_BUILD_TYPE=Release                      \
-    -DBUILD_SHARED_AND_STATIC_LIBS=ON               \
-    -DCMAKE_PREFIX_PATH=C:\mongo-c-driver           \
-    -DCMAKE_INSTALL_PREFIX=C:\mongo-cxx-driver
+    -DBUILD_SHARED_AND_STATIC_LIBS=ON
 ```
 
 Users have the option to build `mongocxx` as a shared library that has statically linked
@@ -101,9 +91,7 @@ Users have the option to build `mongocxx` as a shared library that has staticall
 ```sh
 cmake ..                                            \
     -DCMAKE_BUILD_TYPE=Release                      \
-    -DBUILD_SHARED_LIBS_WITH_STATIC_MONGOC=ON       \
-    -DCMAKE_PREFIX_PATH=C:\mongo-c-driver           \
-    -DCMAKE_INSTALL_PREFIX=C:\mongo-cxx-driver
+    -DBUILD_SHARED_LIBS_WITH_STATIC_MONGOC=ON
 ```
 
 ## Disabling tests

--- a/docs/content/mongocxx-v3/installation/advanced.md
+++ b/docs/content/mongocxx-v3/installation/advanced.md
@@ -37,8 +37,8 @@ users.** A user can enable this behavior with the `-DBUILD_SHARED_LIBS` option:
 cmake ..                                            \
     -DCMAKE_BUILD_TYPE=Release                      \
     -DBUILD_SHARED_LIBS=OFF                         \
-    -DCMAKE_PREFIX_PATH=/opt/mongo-c-driver         \
-    -DCMAKE_INSTALL_PREFIX=/opt/mongo-cxx-driver
+    -DCMAKE_PREFIX_PATH=$HOME/mongo-c-driver         \
+    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
 ```
 
 #### Configuring with `mongocxx` 3.5.0 or newer
@@ -50,8 +50,8 @@ this behavior with the `-DBUILD_SHARED_AND_STATIC_LIBS` option:
 cmake ..                                            \
     -DCMAKE_BUILD_TYPE=Release                      \
     -DBUILD_SHARED_AND_STATIC_LIBS=ON               \
-    -DCMAKE_PREFIX_PATH=/opt/mongo-c-driver         \
-    -DCMAKE_INSTALL_PREFIX=/opt/mongo-cxx-driver
+    -DCMAKE_PREFIX_PATH=$HOME/mongo-c-driver         \
+    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
 ```
 
 Users have the option to build `mongocxx` as a shared library that has statically linked
@@ -62,8 +62,8 @@ Users have the option to build `mongocxx` as a shared library that has staticall
 cmake ..                                            \
     -DCMAKE_BUILD_TYPE=Release                      \
     -DBUILD_SHARED_LIBS_WITH_STATIC_MONGOC=ON       \
-    -DCMAKE_PREFIX_PATH=/opt/mongo-c-driver         \
-    -DCMAKE_INSTALL_PREFIX=/opt/mongo-cxx-driver
+    -DCMAKE_PREFIX_PATH=$HOME/mongo-c-driver         \
+    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
 ```
 
 ### For Windows

--- a/docs/content/mongocxx-v3/installation/advanced.md
+++ b/docs/content/mongocxx-v3/installation/advanced.md
@@ -163,3 +163,160 @@ cmake ..                                            \
     -DLIBBSON_DIR=$HOME/mongo-c-driver              \
     -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
 ```
+
+### Fixing the "Library not loaded" error on macOS
+
+Applications linking to a non-standard directory installation may encounter an error loading the C++ driver at runtime. Example:
+
+```sh
+# Tell pkg-config where to find C++ driver installation.
+export PKG_CONFIG_PATH=$HOME/mongo-cxx-driver/lib/pkgconfig
+clang++ app.cpp -std=c++11 $(pkg-config --cflags --libs libmongocxx) -o ./app.out
+./app.out
+# Prints the following error:
+# dyld[3217]: Library not loaded: '@rpath/libmongocxx._noabi.dylib'
+#   Referenced from: '/Users/kevin.albertson/code/app.out'
+#   Reason: tried: '/usr/local/lib/libmongocxx._noabi.dylib' (no such file), '/usr/lib/libmongocxx._noabi.dylib' (no such file)
+# zsh: abort      ./app.out
+```
+
+The default `install name` of the C++ driver on macOS includes `@rpath`:
+```sh
+otool -D $HOME/mongo-cxx-driver/lib/libmongocxx.dylib
+# Prints:
+# /Users/kevin.albertson/mongo-cxx-driver/lib/libmongocxx.dylib:
+# @rpath/libmongocxx._noabi.dylib
+```
+
+Including `@rpath` in the install name allows linking applications to control the list of search paths for the library.
+
+`app.out` includes the load command for `@rpath/libmongocxx._noabi.dylib`. `app.out` does not have entries to substitute for `@rpath`.
+
+There are several ways to consider solving this on macOS:
+
+Pass `DYLD_FALLBACK_LIBRARY_PATH` to the directory containing the C++ driver libraries:
+
+```sh
+DYLD_FALLBACK_LIBRARY_PATH=$HOME/mongo-cxx-driver/lib ./app.out
+# Prints "successfully connected with C++ driver"
+```
+
+Alternatively, the linker option `-Wl,-rpath` can be passed to add entries to substitute for `@rpath`:
+```sh
+# Tell pkg-config where to find C++ driver installation.
+export PKG_CONFIG_PATH=$HOME/mongo-cxx-driver/lib/pkgconfig
+# Pass the linker option -rpath to set an rpath in the final executable.
+clang++ app.cpp -std=c++11 -Wl,-rpath,$HOME/mongo-cxx-driver/lib $(pkg-config --cflags --libs libmongocxx) -o ./app.out
+./app.out
+# Prints "successfully connected with C++ driver"
+```
+
+If building the application with cmake, the [Default RPATH settings](https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling#default-rpath-settings) include the full RPATH to all used libraries in the build tree. However, when installing, cmake will clear the RPATH of these targets so they are installed with an empty RPATH. This may result in a `Library not loaded` error after install.
+
+Example:
+```sh
+# Build application `app` using the C++ driver from a non-standard install.
+cmake \
+    -DCMAKE_PREFIX_PATH=$HOME/mongo-cxx-driver \
+    -DCMAKE_INSTALL_PREFIX=$HOME/app \
+    -DCMAKE_CXX_STANDARD=11 \
+    -Bcmake-build -S.
+cmake --build cmake-build --target app.out
+# Running app.out from build tree includes rpath to C++ driver.
+./cmake-build ./cmake-build/app.out
+# Prints: "successfully connected with C++ driver"
+
+cmake --build cmake-build --target install
+# Running app.out from install tree does not include rpath to C++ driver.
+$HOME/app/bin/app.out
+# Prints "Library not loaded" error.
+```
+
+Consider setting `-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE` so the rpath for the executable is kept in the install target.
+```sh
+# Build application `app` using the C++ driver from a non-standard install.
+# Use CMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE to keep rpath entry on installed app.
+cmake \
+    -DCMAKE_PREFIX_PATH=$HOME/mongo-cxx-driver \
+    -DCMAKE_INSTALL_PREFIX=$HOME/app \
+    -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE \
+    -DCMAKE_CXX_STANDARD=11 \
+    -Bcmake-build -S.
+
+cmake --build cmake-build --target install
+$HOME/app/bin/app.out
+# Prints "successfully connected with C++ driver"
+```
+
+See the cmake documentation for [RPATH handling](https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling) for more information.
+
+### Fixing the "cannot open shared object file" error on Linux
+
+Applications linking to a non-standard directory installation may encounter an error loading the C++ driver at runtime. Example:
+
+```sh
+# Tell pkg-config where to find C++ driver installation.
+export PKG_CONFIG_PATH=$HOME/mongo-cxx-driver/lib/pkgconfig
+g++ -std=c++11 app.cpp $(pkg-config --cflags --libs libmongocxx) -o ./app.out
+./app.out
+# Prints the following error:
+# ./app.out: error while loading shared libraries: libmongocxx.so._noabi: cannot open shared object file: No such file or directory
+```
+
+There are several ways to consider solving this on Linux:
+
+Pass `LD_LIBRARY_PATH` to the directory containing the C++ driver libraries:
+
+```sh
+LD_LIBRARY_PATH=$HOME/mongo-cxx-driver/lib ./app.out
+# Prints "successfully connected with C++ driver"
+```
+
+Alternatively, the linker option `-Wl,-rpath` can be passed to add `rpath` entries:
+```sh
+# Tell pkg-config where to find C++ driver installation.
+export PKG_CONFIG_PATH=$HOME/mongo-cxx-driver/lib/pkgconfig
+# Pass the linker option -rpath to set an rpath in the final executable.
+g++ app.cpp -std=c++11 -Wl,-rpath,$HOME/mongo-cxx-driver/lib $(pkg-config --cflags --libs libmongocxx) -o ./app.out
+./app.out
+# Prints "successfully connected with C++ driver"
+```
+
+If building the application with cmake, the [Default RPATH settings](https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling#default-rpath-settings) include the full RPATH to all used libraries in the build tree. However, when installing, cmake will clear the RPATH of these targets so they are installed with an empty RPATH. This may result in a `Library not loaded` error after install.
+
+Example:
+```sh
+# Build application `app` using the C++ driver from a non-standard install.
+cmake \
+    -DCMAKE_PREFIX_PATH=$HOME/mongo-cxx-driver \
+    -DCMAKE_INSTALL_PREFIX=$HOME/app \
+    -DCMAKE_CXX_STANDARD=11 \
+    -Bcmake-build -S.
+cmake --build cmake-build --target app.out
+# Running app.out from build tree includes rpath to C++ driver.
+./cmake-build ./cmake-build/app.out
+# Prints: "successfully connected with C++ driver"
+
+cmake --build cmake-build --target install
+# Running app.out from install tree does not include rpath to C++ driver.
+$HOME/app/bin/app.out
+# Prints "cannot open shared object file" error.
+```
+
+Consider setting `-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE` so the rpath for the executable is kept in the install target.
+```sh
+# Build application `app` using the C++ driver from a non-standard install.
+# Use CMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE to keep rpath entry on installed app.
+cmake \
+    -DCMAKE_PREFIX_PATH=$HOME/mongo-cxx-driver \
+    -DCMAKE_INSTALL_PREFIX=$HOME/app \
+    -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE \
+    -DCMAKE_CXX_STANDARD=11 \
+    -Bcmake-build -S.
+
+cmake --build cmake-build --target install
+$HOME/app/bin/app.out
+# Prints "successfully connected with C++ driver"
+```
+
+See the cmake documentation for [RPATH handling](https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling) for more information.

--- a/docs/content/mongocxx-v3/installation/advanced.md
+++ b/docs/content/mongocxx-v3/installation/advanced.md
@@ -26,9 +26,7 @@ dependencies as static libraries rather than the typical shared libraries.  Thes
 produce library artifacts that will behave differently.  Ensure you have a complete understanding
 of the implications of the various linking approaches before utilizing these options.
 
-### For Linux and macOS
-
-#### Configuring with `mongocxx` 3.2.x or newer
+### Configuring with `mongocxx` 3.2.x or newer
 
 Users have the option to build `mongocxx` as a static library. **This is not recommended for novice
 users.** A user can enable this behavior with the `-DBUILD_SHARED_LIBS` option:
@@ -39,41 +37,7 @@ cmake ..                                            \
     -DBUILD_SHARED_LIBS=OFF
 ```
 
-#### Configuring with `mongocxx` 3.5.0 or newer
-
-Users have the option to build `mongocxx` as both static and shared libraries. A user can enable
-this behavior with the `-DBUILD_SHARED_AND_STATIC_LIBS` option:
-
-```sh
-cmake ..                                            \
-    -DCMAKE_BUILD_TYPE=Release                      \
-    -DBUILD_SHARED_AND_STATIC_LIBS=ON
-```
-
-Users have the option to build `mongocxx` as a shared library that has statically linked
-`libmongoc`. **This is not recommended for novice users.** A user can enable this behavior with the
-`-DBUILD_SHARED_LIBS_WITH_STATIC_MONGOC` option:
-
-```sh
-cmake ..                                            \
-    -DCMAKE_BUILD_TYPE=Release                      \
-    -DBUILD_SHARED_LIBS_WITH_STATIC_MONGOC=ON
-```
-
-### For Windows
-
-#### Configuring with `mongocxx` 3.2.x or newer
-
-Users have the option to build `mongocxx` as a static library. **This is not recommended for novice
-users.** A user can enable this behavior with the `-DBUILD_SHARED_LIBS` option:
-
-```sh
-cmake ..                                            \
-    -DCMAKE_BUILD_TYPE=Release                      \
-    -DBUILD_SHARED_LIBS=OFF
-```
-
-#### Configuring with `mongocxx` 3.5.0 or newer
+### Configuring with `mongocxx` 3.5.0 or newer
 
 Users have the option to build `mongocxx` as both static and shared libraries. A user can enable
 this behavior with the `-DBUILD_SHARED_AND_STATIC_LIBS` option:

--- a/docs/content/mongocxx-v3/installation/advanced.md
+++ b/docs/content/mongocxx-v3/installation/advanced.md
@@ -115,3 +115,24 @@ cmake .. -DENABLE_TESTS=OFF
 cmake --build .. --target help
 # No test targets are configured.
 ```
+
+## Installing to non-standard directories
+
+To install the C++ driver to a non-standard directory, specify `CMAKE_INSTALL_PREFIX` to the desired
+install path:
+
+```sh
+cmake ..                                            \
+    -DCMAKE_BUILD_TYPE=Release                      \
+    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
+```
+
+Consider also specifying the `-DCMAKE_INSTALL_RPATH=` option to the `lib` directory of the install.
+This may enable libmongocxx.so to locate libbsoncxx.so:
+
+```sh
+cmake ..                                             \
+    -DCMAKE_BUILD_TYPE=Release                       \
+    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver    \
+    -DCMAKE_INSTALL_RPATH=$HOME/mongo-cxx-driver/lib
+```

--- a/docs/content/mongocxx-v3/installation/linux.md
+++ b/docs/content/mongocxx-v3/installation/linux.md
@@ -108,21 +108,21 @@ libbsoncxx.so:
 ```
 cmake ..                                \
     -DCMAKE_BUILD_TYPE=Release          \
-    -DCMAKE_INSTALL_PREFIX=/opt/mongo   \
-    -DCMAKE_INSTALL_RPATH=/opt/mongo/lib
+    -DCMAKE_INSTALL_PREFIX=$HOME/mongo   \
+    -DCMAKE_INSTALL_RPATH=$HOME/mongo/lib
 ```
 
 In the Unix examples that follow, `mongocxx` is customized in these ways:
 
-* `libmongoc` is found in `/opt/mongo-c-driver`.
-* `mongocxx` is to be installed into `/opt/mongo-cxx-driver`.
+* `libmongoc` is found in `$HOME/mongo-c-driver`.
+* `mongocxx` is to be installed into `$HOME/mongo-cxx-driver`.
 
 With those two distinct (arbitrary) install locations, a user would run this `cmake` command:
 ```sh
 cmake ..                                            \
     -DCMAKE_BUILD_TYPE=Release                      \
-    -DCMAKE_PREFIX_PATH=/opt/mongo-c-driver         \
-    -DCMAKE_INSTALL_PREFIX=/opt/mongo-cxx-driver
+    -DCMAKE_PREFIX_PATH=$HOME/mongo-c-driver         \
+    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
 ```
 
 > *Note* If you need multiple paths in a CMake PATH variable, separate them with a semicolon like
@@ -135,8 +135,8 @@ would run the command above with the Boost polyfill option:
 cmake ..                                            \
     -DCMAKE_BUILD_TYPE=Release                      \
     -DBSONCXX_POLY_USE_BOOST=1                      \
-    -DCMAKE_PREFIX_PATH=/opt/mongo-c-driver         \
-    -DCMAKE_INSTALL_PREFIX=/opt/mongo-cxx-driver
+    -DCMAKE_PREFIX_PATH=$HOME/mongo-c-driver         \
+    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
 ```
 
 #### Configuring with `mongocxx` 3.1.x or 3.0.x
@@ -147,9 +147,9 @@ directory by using the `-DLIBMONGOC_DIR` and `-DLIBBSON_DIR` options:
 ```sh
 cmake ..                                            \
     -DCMAKE_BUILD_TYPE=Release                      \
-    -DLIBMONGOC_DIR=/opt/mongo-c-driver             \
-    -DLIBBSON_DIR=/opt/mongo-c-driver               \
-    -DCMAKE_INSTALL_PREFIX=/opt/mongo-cxx-driver
+    -DLIBMONGOC_DIR=$HOME/mongo-c-driver             \
+    -DLIBBSON_DIR=$HOME/mongo-c-driver               \
+    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
 ```
 
 ### Step 5: Build and install the driver
@@ -182,6 +182,6 @@ sudo cmake --build . --target uninstall
 Second, the uninstall script can be called:
 
 ```sh
-sudo /opt/mongo-cxx-driver/share/mongo-cxx-driver/uninstall.sh
+sudo $HOME/mongo-cxx-driver/share/mongo-cxx-driver/uninstall.sh
 ```
 

--- a/docs/content/mongocxx-v3/installation/linux.md
+++ b/docs/content/mongocxx-v3/installation/linux.md
@@ -102,13 +102,14 @@ cmake ..                                \
 ```
 
 If installing to a non-standard directory (i.e., one which the dynamic loader does not search),
-consider specifying the `-DCMAKE_INSTALL_RPATH=` option:
+consider specifying the `-DCMAKE_INSTALL_RPATH=` option. This may enable libmongocxx.so to locate
+libbsoncxx.so:
 
 ```
 cmake ..                                \
     -DCMAKE_BUILD_TYPE=Release          \
     -DCMAKE_INSTALL_PREFIX=/opt/mongo   \
-    -DCMAKE_INSTALL_RPATH=/opt/mongo
+    -DCMAKE_INSTALL_RPATH=/opt/mongo/lib
 ```
 
 In the Unix examples that follow, `mongocxx` is customized in these ways:

--- a/docs/content/mongocxx-v3/installation/linux.md
+++ b/docs/content/mongocxx-v3/installation/linux.md
@@ -140,6 +140,6 @@ sudo cmake --build . --target uninstall
 Second, the uninstall script can be called:
 
 ```sh
-sudo /usr/local/share/mongo-cxx-driver/uninstall.sh
+sudo <install-dir>/share/mongo-cxx-driver/uninstall.sh
 ```
 

--- a/docs/content/mongocxx-v3/installation/linux.md
+++ b/docs/content/mongocxx-v3/installation/linux.md
@@ -101,55 +101,13 @@ cmake ..                                \
     -DCMAKE_INSTALL_PREFIX=/usr/local
 ```
 
-If installing to a non-standard directory (i.e., one which the dynamic loader does not search),
-consider specifying the `-DCMAKE_INSTALL_RPATH=` option. This may enable libmongocxx.so to locate
-libbsoncxx.so:
-
-```
-cmake ..                                \
-    -DCMAKE_BUILD_TYPE=Release          \
-    -DCMAKE_INSTALL_PREFIX=$HOME/mongo   \
-    -DCMAKE_INSTALL_RPATH=$HOME/mongo/lib
-```
-
-In the Unix examples that follow, `mongocxx` is customized in these ways:
-
-* `libmongoc` is found in `$HOME/mongo-c-driver`.
-* `mongocxx` is to be installed into `$HOME/mongo-cxx-driver`.
-
-With those two distinct (arbitrary) install locations, a user would run this `cmake` command:
-```sh
-cmake ..                                            \
-    -DCMAKE_BUILD_TYPE=Release                      \
-    -DCMAKE_PREFIX_PATH=$HOME/mongo-c-driver         \
-    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
-```
-
-> *Note* If you need multiple paths in a CMake PATH variable, separate them with a semicolon like
-> this:
-> `-DCMAKE_PREFIX_PATH="/your/cdriver/prefix;/some/other/path"`
-
 These options can be freely mixed with a C++17 polyfill option. For instance, this is how a user
 would run the command above with the Boost polyfill option:
 ```sh
 cmake ..                                            \
     -DCMAKE_BUILD_TYPE=Release                      \
     -DBSONCXX_POLY_USE_BOOST=1                      \
-    -DCMAKE_PREFIX_PATH=$HOME/mongo-c-driver         \
-    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
-```
-
-#### Configuring with `mongocxx` 3.1.x or 3.0.x
-
-Instead of the `-DCMAKE_PREFIX_PATH` option, users must specify the `libmongoc` installation
-directory by using the `-DLIBMONGOC_DIR` and `-DLIBBSON_DIR` options:
-
-```sh
-cmake ..                                            \
-    -DCMAKE_BUILD_TYPE=Release                      \
-    -DLIBMONGOC_DIR=$HOME/mongo-c-driver             \
-    -DLIBBSON_DIR=$HOME/mongo-c-driver               \
-    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
+    -DCMAKE_INSTALL_PREFIX=/usr/local
 ```
 
 ### Step 5: Build and install the driver
@@ -182,6 +140,6 @@ sudo cmake --build . --target uninstall
 Second, the uninstall script can be called:
 
 ```sh
-sudo $HOME/mongo-cxx-driver/share/mongo-cxx-driver/uninstall.sh
+sudo /usr/local/share/mongo-cxx-driver/uninstall.sh
 ```
 

--- a/docs/content/mongocxx-v3/installation/macos.md
+++ b/docs/content/mongocxx-v3/installation/macos.md
@@ -101,44 +101,13 @@ cmake ..                                \
     -DCMAKE_INSTALL_PREFIX=/usr/local
 ```
 
-In the Unix examples that follow, `mongocxx` is customized in these ways:
-
-* `libmongoc` is found in `$HOME/mongo-c-driver`.
-* `mongocxx` is to be installed into `$HOME/mongo-cxx-driver`.
-
-With those two distinct (arbitrary) install locations, a user would run this `cmake` command:
-```sh
-cmake ..                                            \
-    -DCMAKE_BUILD_TYPE=Release                      \
-    -DCMAKE_PREFIX_PATH=$HOME/mongo-c-driver         \
-    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
-```
-
-> *Note* If you need multiple paths in a CMake PATH variable, separate them with a semicolon like
-> this:
-> `-DCMAKE_PREFIX_PATH="/your/cdriver/prefix;/some/other/path"`
-
 These options can be freely mixed with a C++17 polyfill option. For instance, this is how a user
 would run the command above with the Boost polyfill option:
 ```sh
 cmake ..                                            \
     -DCMAKE_BUILD_TYPE=Release                      \
     -DBSONCXX_POLY_USE_BOOST=1                      \
-    -DCMAKE_PREFIX_PATH=$HOME/mongo-c-driver         \
-    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
-```
-
-#### Configuring with `mongocxx` 3.1.x or 3.0.x
-
-Instead of the `-DCMAKE_PREFIX_PATH` option, users must specify the `libmongoc` installation
-directory by using the `-DLIBMONGOC_DIR` and `-DLIBBSON_DIR` options:
-
-```sh
-cmake ..                                            \
-    -DCMAKE_BUILD_TYPE=Release                      \
-    -DLIBMONGOC_DIR=$HOME/mongo-c-driver             \
-    -DLIBBSON_DIR=$HOME/mongo-c-driver               \
-    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
+    -DCMAKE_INSTALL_PREFIX=/usr/local
 ```
 
 ### Step 5: Build and install the driver
@@ -171,6 +140,6 @@ sudo cmake --build . --target uninstall
 Second, the uninstall script can be called:
 
 ```sh
-sudo $HOME/mongo-cxx-driver/share/mongo-cxx-driver/uninstall.sh
+sudo /usr/local/share/mongo-cxx-driver/uninstall.sh
 ```
 

--- a/docs/content/mongocxx-v3/installation/macos.md
+++ b/docs/content/mongocxx-v3/installation/macos.md
@@ -103,15 +103,15 @@ cmake ..                                \
 
 In the Unix examples that follow, `mongocxx` is customized in these ways:
 
-* `libmongoc` is found in `/opt/mongo-c-driver`.
-* `mongocxx` is to be installed into `/opt/mongo-cxx-driver`.
+* `libmongoc` is found in `$HOME/mongo-c-driver`.
+* `mongocxx` is to be installed into `$HOME/mongo-cxx-driver`.
 
 With those two distinct (arbitrary) install locations, a user would run this `cmake` command:
 ```sh
 cmake ..                                            \
     -DCMAKE_BUILD_TYPE=Release                      \
-    -DCMAKE_PREFIX_PATH=/opt/mongo-c-driver         \
-    -DCMAKE_INSTALL_PREFIX=/opt/mongo-cxx-driver
+    -DCMAKE_PREFIX_PATH=$HOME/mongo-c-driver         \
+    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
 ```
 
 > *Note* If you need multiple paths in a CMake PATH variable, separate them with a semicolon like
@@ -124,8 +124,8 @@ would run the command above with the Boost polyfill option:
 cmake ..                                            \
     -DCMAKE_BUILD_TYPE=Release                      \
     -DBSONCXX_POLY_USE_BOOST=1                      \
-    -DCMAKE_PREFIX_PATH=/opt/mongo-c-driver         \
-    -DCMAKE_INSTALL_PREFIX=/opt/mongo-cxx-driver
+    -DCMAKE_PREFIX_PATH=$HOME/mongo-c-driver         \
+    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
 ```
 
 #### Configuring with `mongocxx` 3.1.x or 3.0.x
@@ -136,9 +136,9 @@ directory by using the `-DLIBMONGOC_DIR` and `-DLIBBSON_DIR` options:
 ```sh
 cmake ..                                            \
     -DCMAKE_BUILD_TYPE=Release                      \
-    -DLIBMONGOC_DIR=/opt/mongo-c-driver             \
-    -DLIBBSON_DIR=/opt/mongo-c-driver               \
-    -DCMAKE_INSTALL_PREFIX=/opt/mongo-cxx-driver
+    -DLIBMONGOC_DIR=$HOME/mongo-c-driver             \
+    -DLIBBSON_DIR=$HOME/mongo-c-driver               \
+    -DCMAKE_INSTALL_PREFIX=$HOME/mongo-cxx-driver
 ```
 
 ### Step 5: Build and install the driver
@@ -171,6 +171,6 @@ sudo cmake --build . --target uninstall
 Second, the uninstall script can be called:
 
 ```sh
-sudo /opt/mongo-cxx-driver/share/mongo-cxx-driver/uninstall.sh
+sudo $HOME/mongo-cxx-driver/share/mongo-cxx-driver/uninstall.sh
 ```
 

--- a/docs/content/mongocxx-v3/installation/macos.md
+++ b/docs/content/mongocxx-v3/installation/macos.md
@@ -140,6 +140,6 @@ sudo cmake --build . --target uninstall
 Second, the uninstall script can be called:
 
 ```sh
-sudo /usr/local/share/mongo-cxx-driver/uninstall.sh
+sudo <install-dir>/share/mongo-cxx-driver/uninstall.sh
 ```
 


### PR DESCRIPTION
# Description

This PR changes the main installation instructions to use standard directories. Installing to non-standard directories, as well as common fixes to failures to load libraries, have been moved to the "Advanced Configuration and Installation Options" instructions.

Documentation can be locally built with `cmake --build cmake-build --target hugo`.

## Use standard install directories in main installation instructions

The error described in CXX-2579 is due to the runtime loader being unable to find the C++ driver libraries.

IMO installing to non-standard directories is not a common enough use case to add to the main installation instructions.

The C driver [Unix install instructions](https://mongoc.org/libmongoc/current/installing.html#preparing-a-build-from-a-git-repository-clone) do not set `CMAKE_INSTALL_PREFIX`.

A section named `Installing to non-standard directories` has been added to the `Advanced Configuration and Installation Options` page.

## Add instructions for fixes to locate shared libraries

To assist users encountering errors locating shared libraries, suggested solutions were added to the "Advanced Configuration and Installation Options".

Solutions for the "Library not loaded" error on macOS were [tested here](https://github.com/kevinAlbs/cxx-bootstrap/blob/51e929c4e8f9a57feecd201ff884e40226cbeed5/investigations/CXX-2579_test_rpath_to_cxxdriver/test-macos.sh).
Solutions for the "cannot open shared object file" error on Linux were [tested here](https://github.com/kevinAlbs/cxx-bootstrap/blob/51e929c4e8f9a57feecd201ff884e40226cbeed5/investigations/CXX-2579_test_rpath_to_cxxdriver/test-linux.sh).

https://www.mikeash.com/pyblog/friday-qa-2009-11-06-linking-and-install-names.html suggests that application is responsible for adding paths to load:

> Starting in 10.5, Apple provides rpath, which is a solution to this. When placed at the front of an install name, this asks the dynamic linker to search a list of locations for the library. That list is embedded in the application, and can therefore be controlled by the application's build process, not the framework's. A single copy of a framework can thus work for multiple purposes.

https://www.dribin.org/dave/blog/archives/2009/11/15/rpath/ also suggests this:
> The linking application now needs to define what the rpath expands out to

## Other improvements
- Replace `/opt/`  with `$HOME` in non-standard directory install instructions. Installing to `/opt` may be more likely to require root permissions.
- Include missing `/lib` in `CMAKE_INSTALL_RPATH` instruction.
- Fix link rendering on configuration page.


