### PR TITLE
CXX-2517 Use C Driver scripts to install libmongoc and libmongocrypt

### DIFF
--- a/.evergreen/install_c_driver.sh
+++ b/.evergreen/install_c_driver.sh
@@ -27,7 +27,7 @@ else
   mongoc_install_idir="${mongoc_dir}"
 fi
 : "${mongoc_idir:?}"
-: "${mongoc_install_idir}"
+: "${mongoc_install_idir:?}"
 
 echo "libmongoc version: ${mongoc_version}"
 echo "libmongocrypt version: ${mongocrypt_version}"

--- a/.evergreen/install_c_driver.sh
+++ b/.evergreen/install_c_driver.sh
@@ -4,6 +4,7 @@ set -o errexit
 set -o pipefail
 
 declare -r mongoc_version="${mongoc_version:-"${mongoc_version_default:?"missing mongoc version"}"}"
+: "${mongoc_version:?}"
 
 # Usage:
 #   to_windows_path "./some/unix/style/path"

--- a/.evergreen/install_c_driver.sh
+++ b/.evergreen/install_c_driver.sh
@@ -30,7 +30,6 @@ fi
 : "${mongoc_install_idir:?}"
 
 echo "libmongoc version: ${mongoc_version}"
-echo "libmongocrypt version: ${mongocrypt_version}"
 
 echo "Installing C Driver into ${mongoc_dir}..."
 

--- a/.evergreen/install_c_driver.sh
+++ b/.evergreen/install_c_driver.sh
@@ -1,151 +1,133 @@
-#!/bin/bash
-# Usage examples:
-# MONGOC_VERSION=1.22.1 MONGOCRYPT_VERSION=1.5.2 ./install.sh
-# PREFIX=/tmp/installdir MONGOC_VERSION=1.22.1 MONGOCRYPT_VERSION=1.5.2 ./install.sh
+#!/usr/bin/env bash
 
 set -o errexit
 set -o pipefail
 
-export PREFIX=$(pwd)/../mongoc/
-if [ "Windows_NT" == "$OS" ]; then
-  PREFIX=$(cygpath -m "$PREFIX")
-fi
-export CMAKE=${cmake}
-export GENERATOR="${generator}"
-if [ "1" == "${BSON_EXTRA_ALIGNMENT}" ]; then
-  echo "Building C driver with BSON extra alignment"
-fi
-MONGOC_VERSION=${mongoc_version}
-MONGOCRYPT_VERSION=${mongocrypt_version}
-if [[ -z $MONGOC_VERSION ]]; then
-  MONGOC_VERSION=${mongoc_version_default}
-fi
-if [[ -z $MONGOCRYPT_VERSION ]]; then
-  MONGOCRYPT_VERSION=${mongocrypt_version_default}
-fi
+declare -r mongoc_version="${mongoc_version:-"${mongoc_version_default:?"missing mongoc version"}"}"
 
-print_usage() {
-  echo "usage: MONGOC_VERSION=<version> MONGOCRYPT_VERSION=<version> ./install.sh"
+# Usage:
+#   to_windows_path "./some/unix/style/path"
+#   to_windows_path "/some/unix/style/path"
+to_windows_path() {
+  cygpath -aw "${1:?"to_windows_path requires a path to convert"}"
 }
 
-if [[ -z $MONGOC_VERSION ]]; then
-  print_usage
-  exit 2
-fi
-if [[ -z $MONGOCRYPT_VERSION ]]; then
-  print_usage
-  exit 2
-fi
+declare mongoc_dir
+mongoc_dir="$(pwd)/mongoc"
 
-VERSION=$MONGOC_VERSION
-PREFIX=${PREFIX:-$(pwd)"/../mongoc/"}
-OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-
-if [ "$BSON_EXTRA_ALIGNMENT" = "1" ]; then
-  ENABLE_EXTRA_ALIGNMENT="ON"
+# "i" for "(platform-)independent".
+declare mongoc_idir mongoc_install_idir
+if [[ "${OSTYPE:?}" == "cygwin" ]]; then
+  # CMake requires Windows paths for configuration variables on Windows.
+  mongoc_idir="$(to_windows_path "${mongoc_dir}")"
+  mongoc_install_idir="$(to_windows_path "${mongoc_dir}")"
 else
-  ENABLE_EXTRA_ALIGNMENT="OFF"
+  mongoc_idir="${mongoc_dir}"
+  mongoc_install_idir="${mongoc_dir}"
 fi
-CMAKE_ARGS="
-  -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF -DENABLE_SHM_COUNTERS=OFF
-  -DENABLE_TESTS=OFF -DENABLE_EXAMPLES=OFF -DENABLE_STATIC=ON
-  -DENABLE_EXTRA_ALIGNMENT=${ENABLE_EXTRA_ALIGNMENT} -DCMAKE_MACOSX_RPATH=ON
-  -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_PREFIX_PATH=$PREFIX"
+: "${mongoc_idir:?}"
+: "${mongoc_install_idir}"
 
-echo "About to install C driver ($VERSION) into $PREFIX"
+echo "libmongoc version: ${mongoc_version}"
+echo "libmongocrypt version: ${mongocrypt_version}"
 
-LIB=mongo-c-driver
-rm -rf $(echo $LIB*)
-curl -sS -o $LIB.tar.gz -L https://api.github.com/repos/mongodb/$LIB/tarball/$VERSION
-tar xzf $LIB.tar.gz
-DIR=$(echo mongodb-$LIB-*)
+echo "Installing C Driver into ${mongoc_dir}..."
 
+# Download tarball from GitHub and extract into ${mongoc_dir}.
+rm -rf "${mongoc_dir}"
+mkdir "${mongoc_dir}"
+curl -sS -o mongo-c-driver.tar.gz -L "https://api.github.com/repos/mongodb/mongo-c-driver/tarball/${mongoc_version}"
+tar xzf mongo-c-driver.tar.gz --directory "${mongoc_dir}" --strip-components=1
+
+# C Driver needs VERSION_CURRENT to compute BUILD_VERSION.
 # RegEx pattern to match SemVer strings. See https://semver.org/.
-SEMVER_REGEX="^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
-if [ $(echo "$VERSION" | perl -ne "$(printf 'exit 1 unless /%s/' $SEMVER_REGEX)") ]; then
+declare -r semver_regex="^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+if echo "${mongoc_version}" | perl -ne "$(printf 'exit 1 unless /%s/' "${semver_regex}")"; then
   # If $VERSION is already SemVer compliant, use as-is.
-  CMAKE_ARGS="$CMAKE_ARGS -DBUILD_VERSION=$BUILD_VERSION"
+  echo "${mongoc_version}" >|"${mongoc_dir}/VERSION_CURRENT"
 else
   # Otherwise, use the tag name of the latest release to construct a prerelease version string.
 
   # Extract "tag_name" from latest Github release.
-  BUILD_VERSION=$(curl -sS -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/mongodb/mongo-c-driver/releases/latest | perl -ne 'print for /"tag_name": "(.+)"/')
+  declare build_version
+  build_version=$(curl -sS -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/mongodb/mongo-c-driver/releases/latest | perl -ne 'print for /"tag_name": "(.+)"/')
 
   # Assert the tag name is a SemVer string via errexit.
-  echo $BUILD_VERSION | perl -ne "$(printf 'exit 1 unless /%s/' $SEMVER_REGEX)"
+  echo "${build_version}" | perl -ne "$(printf 'exit 1 unless /%s/' "${semver_regex}")"
 
   # Bump to the next minor version, e.g. 1.0.1 -> 1.1.0.
-  BUILD_VERSION=$(echo $BUILD_VERSION | perl -ne "$(printf '/%s/; print $+{major} . "." . ($+{minor}+1) . ".0"' $SEMVER_REGEX)")
+  build_version="$(echo "${build_version}" | perl -ne "$(printf '/%s/; print $+{major} . "." . ($+{minor}+1) . ".0"' "${semver_regex}")")"
 
   # Append a prerelease tag, e.g. 1.1.0-pre+<version>.
-  BUILD_VERSION=$(printf "%s-pre+%s" $BUILD_VERSION $VERSION)
+  build_version="$(printf "%s-pre+%s" "${build_version}" "${mongoc_version}")"
 
   # Use the constructed prerelease build version when building the C driver.
-  CMAKE_ARGS="$CMAKE_ARGS -DBUILD_VERSION=$BUILD_VERSION"
+  echo "${build_version}" >|"${mongoc_dir}/VERSION_CURRENT"
 fi
 
-. .evergreen/find_cmake.sh
+# shellcheck source=/dev/null
+. "${mongoc_dir}/.evergreen/scripts/find-cmake-latest.sh"
+declare cmake_binary
+cmake_binary="$(find_cmake_latest)"
+command -v "${cmake_binary:?}"
 
-cd $DIR
-MONGOC_DIR="$(pwd)"
+# Install libmongocrypt.
+"${mongoc_dir}/.evergreen/scripts/compile-libmongocrypt.sh" "${cmake_binary}" "${mongoc_idir}" "${mongoc_install_idir}"
 
-if [ -f /proc/cpuinfo ]; then
-  CONCURRENCY=$(grep -c ^processor /proc/cpuinfo)
-elif which sysctl; then
-  CONCURRENCY=$(sysctl -n hw.logicalcpu)
+if [[ "${OSTYPE}" == darwin* ]]; then
+  # MacOS does not have nproc.
+  nproc() {
+    sysctl -n hw.logicalcpu
+  }
+fi
+
+# Default CMake generator to use if not already provided.
+declare cmake_generator
+if [[ "${OSTYPE:?}" == "cygwin" ]]; then
+  cmake_generator=${generator:-"Visual Studio 14 2015 Win64"}
 else
-  echo "$0: can't figure out what value of -j to pass to 'make'" >&2
-  exit 1
+  cmake_generator=${generator:-"Unix Makefiles"}
 fi
+: "${cmake_generator:?}"
 
-export CFLAGS="-fPIC"
+declare -a configure_flags=(
+  "-DCMAKE_BUILD_TYPE=Debug"
+  "-DCMAKE_INSTALL_PREFIX=${mongoc_install_idir}"
+  "-DCMAKE_PREFIX_PATH=${mongoc_idir}"
+  "-DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF"
+  "-DENABLE_CLIENT_SIDE_ENCRYPTION=ON"
+  "-DENABLE_EXAMPLES=OFF"
+  "-DENABLE_SHM_COUNTERS=OFF"
+  "-DENABLE_STATIC=ON"
+  "-DENABLE_TESTS=OFF"
+)
 
-case "$OS" in
-darwin | linux)
-  GENERATOR=${GENERATOR:-"Unix Makefiles"}
-  CMAKE_BUILD_OPTS="-j $CONCURRENCY"
+declare -a compile_flags
+
+case "${OSTYPE:?}" in
+cygwin)
+  compile_flags+=("/maxcpucount:$(nproc)")
   ;;
-
-cygwin*)
-  GENERATOR=${GENERATOR:-"Visual Studio 14 2015 Win64"}
-  CMAKE_BUILD_OPTS="/maxcpucount:$CONCURRENCY"
-  MONGOC_DIR=$(cygpath -m "$MONGOC_DIR")
+darwin*)
+  configure_flags+=("-DCMAKE_C_FLAGS=-fPIC")
+  configure_flags+=("-DCMAKE_MACOSX_RPATH=ON")
+  compile_flags+=("-j" "$(nproc)")
   ;;
-
 *)
-  echo "$0: unsupported platform '$OS'" >&2
-  exit 2
+  configure_flags+=("-DCMAKE_C_FLAGS=-fPIC")
+  compile_flags+=("-j" "$(nproc)")
   ;;
 esac
 
-# build libbson
-mkdir cmake_build
-cd cmake_build
-"$CMAKE" -G "$GENERATOR" -DCMAKE_BUILD_TYPE="Debug" -DENABLE_MONGOC=OFF $CMAKE_ARGS ..
-"$CMAKE" --build . --config Debug -- $CMAKE_BUILD_OPTS
-"$CMAKE" --build . --config Debug --target install
-cd ../../
+if [[ "${BSON_EXTRA_ALIGNMENT}" == "1" ]]; then
+  echo "Building C Driver with ENABLE_EXTRA_ALIGNMENT=ON"
+  configure_flags+=("-DENABLE_EXTRA_ALIGNMENT=ON")
+else
+  configure_flags+=("-DENABLE_EXTRA_ALIGNMENT=OFF")
+fi
 
-# fetch and build libmongocrypt
-git clone https://github.com/mongodb/libmongocrypt
-mkdir libmongocrypt/cmake_build
-cd libmongocrypt/cmake_build
-git checkout $MONGOCRYPT_VERSION
-"$CMAKE" -G "$GENERATOR" -DENABLE_SHARED_BSON=ON -DCMAKE_INSTALL_PREFIX="$PREFIX" \
-  -DCMAKE_PREFIX_PATH="$PREFIX" -DCMAKE_BUILD_TYPE="Debug" \
-  -DMONGOCRYPT_MONGOC_DIR="$MONGOC_DIR" -DENABLE_CLIENT_SIDE_ENCRYPTION=OFF ..
-"$CMAKE" --build . --config Debug -- $CMAKE_BUILD_OPTS
-"$CMAKE" --build . --config Debug --target install
-cd ../../$DIR
+# Install libmongoc.
+"${cmake_binary}" -S "${mongoc_idir}" -B "${mongoc_idir}" -G "${cmake_generator}" "${configure_flags[@]}"
+"${cmake_binary}" --build "${mongoc_idir}" --config Debug --target install -- "${compile_flags[@]}"
 
-# build libmongoc
-cd cmake_build
-"$CMAKE" -G "$GENERATOR" -DCMAKE_BUILD_TYPE="Debug" -DENABLE_MONGOC=ON -DENABLE_CLIENT_SIDE_ENCRYPTION=ON $CMAKE_ARGS ..
-"$CMAKE" --build . --config Debug -- $CMAKE_BUILD_OPTS
-"$CMAKE" --build . --config Debug --target install
-cd ../
-
-echo "Done installing"
-
-cd ..
-ls -l ..
+echo "Installing C Driver into ${mongoc_dir}... done."

--- a/.evergreen/install_c_driver.sh
+++ b/.evergreen/install_c_driver.sh
@@ -6,6 +6,24 @@
 set -o errexit
 set -o pipefail
 
+export PREFIX=$(pwd)/../mongoc/
+if [ "Windows_NT" == "$OS" ]; then
+  PREFIX=$(cygpath -m "$PREFIX")
+fi
+export CMAKE=${cmake}
+export GENERATOR="${generator}"
+if [ "1" == "${BSON_EXTRA_ALIGNMENT}" ]; then
+  echo "Building C driver with BSON extra alignment"
+fi
+MONGOC_VERSION=${mongoc_version}
+MONGOCRYPT_VERSION=${mongocrypt_version}
+if [[ -z $MONGOC_VERSION ]]; then
+  MONGOC_VERSION=${mongoc_version_default}
+fi
+if [[ -z $MONGOCRYPT_VERSION ]]; then
+  MONGOCRYPT_VERSION=${mongocrypt_version_default}
+fi
+
 print_usage() {
   echo "usage: MONGOC_VERSION=<version> MONGOCRYPT_VERSION=<version> ./install.sh"
 }

--- a/.mci.yml
+++ b/.mci.yml
@@ -7,14 +7,14 @@
 #######################################
 variables:
 
-    mongoc_version_default: &mongoc_version_default "2966c67d"
-    mongocrypt_version_default: &mongocrypt_version_default "1.5.2"
+    mongoc_version_default: &mongoc_version_default "9ef1cc99" # TODO: update to 1.24.0 once released.
+    mongocrypt_version_default: &mongocrypt_version_default "1.7.0"
 
     # If updating mongoc_version_minimum, also update:
     # - the default value of --c-driver-build-ref in etc/make_release.py
     # - LIBMONGOC_REQUIRED_VERSION in src/mongocxx/CMakeLists.txt
-    mongoc_version_minimum: &mongoc_version_minimum "1.22.1"
-    mongocrypt_version_minimum: &mongocrypt_version_minimum "1.5.2"
+    mongoc_version_minimum: &mongoc_version_minimum "9ef1cc99" # TODO: update to 1.24.0 once released.
+    mongocrypt_version_minimum: &mongocrypt_version_minimum "1.7.0"
 
     mongodb_version:
         version_latest: &version_latest "latest"

--- a/.mci.yml
+++ b/.mci.yml
@@ -229,27 +229,8 @@ functions:
         params:
             shell: bash
             working_dir: "mongo-cxx-driver"
-            script: |
-                    set -o errexit
-                    set -o pipefail
-                    export PREFIX=$(pwd)/../mongoc/
-                    if [ "Windows_NT" == "$OS" ]; then
-                        PREFIX=$(cygpath -m "$PREFIX")
-                    fi
-                    export CMAKE=${cmake}
-                    export GENERATOR="${generator}"
-                    if [ "1" == "${BSON_EXTRA_ALIGNMENT}" ]; then
-                        echo "Building C driver with BSON extra alignment"
-                    fi
-                    MONGOC_VERSION=${mongoc_version}
-                    MONGOCRYPT_VERSION=${mongocrypt_version}
-                    if [[ -z $MONGOC_VERSION ]]; then
-                      MONGOC_VERSION=${mongoc_version_default}
-                    fi
-                    if [[ -z $MONGOCRYPT_VERSION ]]; then
-                      MONGOCRYPT_VERSION=${mongocrypt_version_default}
-                    fi
-                    BSON_EXTRA_ALIGNMENT=${BSON_EXTRA_ALIGNMENT} MONGOC_VERSION=$MONGOC_VERSION MONGOCRYPT_VERSION=$MONGOCRYPT_VERSION ./.evergreen/install_c_driver.sh
+            add_expansions_to_env: true
+            script: .evergreen/install_c_driver.sh
 
     "lint":
         - command: shell.exec

--- a/.mci.yml
+++ b/.mci.yml
@@ -8,13 +8,11 @@
 variables:
 
     mongoc_version_default: &mongoc_version_default "9ef1cc99" # TODO: update to 1.24.0 once released.
-    mongocrypt_version_default: &mongocrypt_version_default "1.7.0"
 
     # If updating mongoc_version_minimum, also update:
     # - the default value of --c-driver-build-ref in etc/make_release.py
     # - LIBMONGOC_REQUIRED_VERSION in src/mongocxx/CMakeLists.txt
     mongoc_version_minimum: &mongoc_version_minimum "9ef1cc99" # TODO: update to 1.24.0 once released.
-    mongocrypt_version_minimum: &mongocrypt_version_minimum "1.7.0"
 
     mongodb_version:
         version_latest: &version_latest "latest"
@@ -223,14 +221,11 @@ functions:
           updates:
             - key: mongoc_version_default
               value: *mongoc_version_default
-            - key: mongocrypt_version_default
-              value: *mongocrypt_version_default
       - command: shell.exec
         params:
             shell: bash
-            working_dir: "mongo-cxx-driver"
             add_expansions_to_env: true
-            script: .evergreen/install_c_driver.sh
+            script: mongo-cxx-driver/.evergreen/install_c_driver.sh
 
     "lint":
         - command: shell.exec
@@ -1592,7 +1587,6 @@ buildvariants:
           cmake_flags: *linux_cmake_flags
           mongodb_version: *version_latest
           mongoc_version: *mongoc_version_minimum
-          mongocrypt_version: *mongocrypt_version_minimum
       run_on:
           - ubuntu1804-build
       tasks:


### PR DESCRIPTION
## Description

This PR unblocks CXX-2517 and other CXX Driver work that depend on libmongocrypt 1.7.0. Verified by [this patch](https://spruce.mongodb.com/version/642d80740305b96c2d9a1f10).

## Minimum C Driver Version

The minimum C Driver version was bumped to the current latest commit (https://github.com/mongodb/mongo-c-driver/commit/9ef1cc99517a6fb89cc59d34ac6c5999d044b8e1) in anticipation of upcoming CXX-2517 work. The minimum C Driver version should eventually be updated to be 1.24.0 once it is released (documented as a TODO comment).

## EVG Config

The `add_expansions_to_env` parameter is used to simplify the `install_c_driver` EVG function by removing redundant (re)definitions of EVG expansions as environment variables. The EVG function can now invoke the script directly without additional setup required.

## Building libmongocrypt and libmongoc

The `install_c_driver.sh` script was refactored to use the new C Driver [compile-libmongocrypt.sh script](https://github.com/mongodb/mongo-c-driver/blob/9ef1cc99517a6fb89cc59d34ac6c5999d044b8e1/.evergreen/scripts/compile-libmongocrypt.sh) (introduced in https://github.com/mongodb/mongo-c-driver/commit/c7e43c15bb13b69f832ac283320466f092d19137) to satisfy the libmongocrypt dependency. This allowed deferring the libbson and libmongocrypt compile-and-install routine to `compile-libmongocrypt.sh`.

This also allowed removal of specifying minimum libmongocrypt version in the CXX Driver. Instead, the CXX Driver now transitively depends on the C Driver's minimum libmongocrypt version as defined within `compile-libmongocrypt.sh`. This required slightly modifying the `install_c_driver.sh` script to generate a `VERSION_CURRENT` file that is required when building libbson via libmongocrypt to specify/determine the `BUILD_VERSION`.

This refactor also uses the C Driver's `find-cmake-latest.sh` script to obtain a newer CMake version to satisfy libmongocrypt's CMake 3.12 requirement. This also allows the CXX Driver to use newer versions of C++ and corresponding compilers (i.e. VS 2019 and newer).