### PR TITLE
CXX-2670 ensure readConcern is included in aggregate options document

### DIFF
--- a/src/mongocxx/options/aggregate.cpp
+++ b/src/mongocxx/options/aggregate.cpp
@@ -54,6 +54,10 @@ void aggregate::append(bsoncxx::builder::basic::document& builder) const {
         builder.append(kvp("hint", hint->to_value()));
     }
 
+    if (const auto& read_concern = this->read_concern()) {
+        builder.append(kvp("readConcern", read_concern->to_document()));
+    }
+
     if (const auto& write_concern = this->write_concern()) {
         builder.append(kvp("writeConcern", write_concern->to_document()));
     }

--- a/src/mongocxx/test/options/aggregate.cpp
+++ b/src/mongocxx/test/options/aggregate.cpp
@@ -23,26 +23,33 @@
 
 namespace {
 using namespace bsoncxx::builder::basic;
-using namespace mongocxx;
 
 using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_document;
 
 TEST_CASE("aggregate", "[aggregate][option]") {
-    instance::current();
+    mongocxx::instance::current();
 
-    options::aggregate agg;
+    mongocxx::options::aggregate agg;
 
-    auto collation = make_document(kvp("locale", "en_US"));
+    const auto collation = make_document(kvp("locale", "en_US"));
+    const auto comment = make_document(kvp("$comment", "some_comment"));
+    const auto hint = bsoncxx::document::view_or_value(make_document(kvp("_id", 1)));
+    const auto let = make_document(kvp("x", "foo"));
 
-    bsoncxx::document::view_or_value hint{make_document(kvp("_id", 1))};
+    // Avoid error: use of overloaded operator '==' is ambiguous.
+    const auto comment_value = bsoncxx::types::bson_value::view_or_value(comment["$comment"].get_value());
 
     CHECK_OPTIONAL_ARGUMENT(agg, allow_disk_use, true);
     CHECK_OPTIONAL_ARGUMENT(agg, batch_size, 500);
     CHECK_OPTIONAL_ARGUMENT(agg, bypass_document_validation, true);
     CHECK_OPTIONAL_ARGUMENT(agg, collation, collation.view());
-    CHECK_OPTIONAL_ARGUMENT(agg, max_time, std::chrono::milliseconds{1000});
-    CHECK_OPTIONAL_ARGUMENT(agg, read_preference, read_preference{});
+    CHECK_OPTIONAL_ARGUMENT(agg, comment, comment_value);
     CHECK_OPTIONAL_ARGUMENT(agg, hint, hint);
+    CHECK_OPTIONAL_ARGUMENT(agg, let, let.view());
+    CHECK_OPTIONAL_ARGUMENT(agg, max_time, std::chrono::milliseconds{1000});
+    CHECK_OPTIONAL_ARGUMENT(agg, read_concern, mongocxx::read_concern());
+    CHECK_OPTIONAL_ARGUMENT(agg, read_preference, mongocxx::read_preference());
+    CHECK_OPTIONAL_ARGUMENT(agg, write_concern, mongocxx::write_concern());
 }
 }  // namespace

--- a/src/mongocxx/test/options/aggregate.cpp
+++ b/src/mongocxx/test/options/aggregate.cpp
@@ -38,7 +38,8 @@ TEST_CASE("aggregate", "[aggregate][option]") {
     const auto let = make_document(kvp("x", "foo"));
 
     // Avoid error: use of overloaded operator '==' is ambiguous.
-    const auto comment_value = bsoncxx::types::bson_value::view_or_value(comment["$comment"].get_value());
+    const auto comment_value =
+        bsoncxx::types::bson_value::view_or_value(comment["$comment"].get_value());
 
     CHECK_OPTIONAL_ARGUMENT(agg, allow_disk_use, true);
     CHECK_OPTIONAL_ARGUMENT(agg, batch_size, 500);


### PR DESCRIPTION
This PR resolves CXX-2670; see ticket for details. Verified by [this patch](https://spruce.mongodb.com/version/6434475561837d53df609a1d).

Updated tests in src/mongocxx/test/collection_mocked.cpp and src/mongocxx/test/options/aggregate.cpp to ensure all options currently supported by `options::aggregate` are properly tested. Options that were not being properly tested include:

- collation
- comment
- hint
- let
- readConcern
- readPreference
- writeConcern

Only `readConcern` was missing in `mongocxx::options::aggregate::append`.

Other `options` types may require an audit to confirm all their corresponding options are being propertly tested in `collection_mocked.cpp`.