### PR TITLE
FLE 1.0 Shared Library

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -1297,6 +1297,7 @@ buildvariants:
           poly_flags: *poly_std_experimental_flags
           mongodb_version: *version_44
           example_projects_cxx_standard: *std_experimental_cxx_standard
+          use_mongocryptd: true  # crypt_shared is not available for Ubuntu 16.04
       run_on:
           - ubuntu1604-build
       tasks:
@@ -1315,7 +1316,7 @@ buildvariants:
           test_params: *valgrind_test_params
           mongodb_version: *version_latest
           disable_slow_tests: 1
-          use_mongocryptd: true
+          use_mongocryptd: true  # false positives arise from the crypt_shared library
       run_on:
           - ubuntu1804-build
       tasks:

--- a/.mci.yml
+++ b/.mci.yml
@@ -535,7 +535,7 @@ functions:
                       if [ "${use_mongocryptd}" = "ON" ] || [ "${use_mongocryptd}" = "true" ]; then
                           echo "Will run tests using mongocryptd (instead of crypt_shared library)"
                       else
-                          echo "Will run tests using cryptd_shared library (instead of mongocryptd)"
+                          echo "Will run tests using crypt_shared library (instead of mongocryptd)"
                           export CRYPT_SHARED_LIB_PATH="${CRYPT_SHARED_LIB_PATH}"
                           echo "CRYPT_SHARED_LIB_PATH=$CRYPT_SHARED_LIB_PATH"
                       fi

--- a/.mci.yml
+++ b/.mci.yml
@@ -532,7 +532,7 @@ functions:
 
                       ulimit -c unlimited || true
 
-                      if [ "${use_mongocryptd}" = "ON" ] || [ "${use_mongocryptd}" = "true" ]; then
+                      if [ "${use_mongocryptd}" = "true" ]; then
                           echo "Will run tests using mongocryptd (instead of crypt_shared library)"
                       else
                           echo "Will run tests using crypt_shared library (instead of mongocryptd)"

--- a/.mci.yml
+++ b/.mci.yml
@@ -1187,27 +1187,18 @@ buildvariants:
             - debian10-large
           - name: uninstall_check
 
-    - name: ubuntu2004-with-mongocryptd-release-latest
-      display_name: "Ubuntu 20.04 Release with mongocryptd (MongoDB Latest)"
-      expansions:
-          build_type: "Release"
-          tar_options: *linux_tar_options
-          extra_path: *linux_extra_path
-          cmake_flags: *linux_cmake_flags
-          mongodb_version: *version_latest
-          use_mongocryptd: true
-      run_on:
-          - ubuntu2004-large
+    # Add matrix for specification test requirement of mongocryptd:
+    # "Drivers MUST run all tests with mongocryptd on at least one platform for all tested server versions (4.2+)."
+    - matrix_name: "mongocryptd"
+      matrix_spec:
+        os: "ubuntu-1804"
+        mongodb_version: ["4.2", "4.4", "5.0", "latest"]
+      display_name: "${os} (MongoDB ${mongodb_version}) with mongocryptd"
       tasks:
           - name: compile_and_test_with_shared_libs
-          - name: compile_and_test_with_shared_libs_extra_alignment
-          - name: compile_and_test_with_static_libs
-          - name: compile_and_test_with_static_libs_extra_alignment
           - name: compile_and_test_with_shared_libs_replica_set
-          - name: build_example_with_add_subdirectory
-            distros:
-            - ubuntu2004-large
-          - name: uninstall_check
+      expansions:
+        use_mongocryptd: true
 
     - name: ubuntu2004-release-latest
       display_name: "Ubuntu 20.04 Release (MongoDB Latest)"
@@ -1306,7 +1297,6 @@ buildvariants:
           poly_flags: *poly_std_experimental_flags
           mongodb_version: *version_44
           example_projects_cxx_standard: *std_experimental_cxx_standard
-          use_mongocryptd: true
       run_on:
           - ubuntu1604-build
       tasks:
@@ -1325,7 +1315,6 @@ buildvariants:
           test_params: *valgrind_test_params
           mongodb_version: *version_latest
           disable_slow_tests: 1
-          use_mongocryptd: true
       run_on:
           - ubuntu1804-build
       tasks:
@@ -1344,7 +1333,6 @@ buildvariants:
           test_params: *valgrind_test_params
           mongodb_version: *version_50
           disable_slow_tests: 1
-          use_mongocryptd: true
       run_on:
           - ubuntu1804-build
       tasks:

--- a/.mci.yml
+++ b/.mci.yml
@@ -536,6 +536,7 @@ functions:
                           echo "Will run tests using mongocryptd (instead of crypt_shared library)"
                       else
                           echo "Will run tests using crypt_shared library (instead of mongocryptd)"
+                          # Set by run-orchestration.sh in "start_mongod".
                           export CRYPT_SHARED_LIB_PATH="${CRYPT_SHARED_LIB_PATH}"
                           echo "CRYPT_SHARED_LIB_PATH=$CRYPT_SHARED_LIB_PATH"
                       fi

--- a/.mci.yml
+++ b/.mci.yml
@@ -164,7 +164,7 @@ functions:
                 ./src/mongocxx/test/test_mongohouse_specs
 
     "start_mongod":
-        command: shell.exec
+      - command: shell.exec
         params:
             shell: bash
             working_dir: "."
@@ -198,6 +198,10 @@ functions:
 
                 cd ../
                 pwd
+      - command: expansions.update
+        params:
+          type: setup
+          file: drivers-evergreen-tools/mo-expansion.yml
 
 
     "stop_mongod":
@@ -527,6 +531,14 @@ functions:
                       fi
 
                       ulimit -c unlimited || true
+
+                      if [ "${use_mongocryptd}" = "ON" ] || [ "${use_mongocryptd}" = "true" ]; then
+                          echo "Will run tests using mongocryptd (instead of crypted_shared library)"
+                      else
+                          echo "Will run tests using cryptd_shared library (instead of mongocryptd)"
+                          export CRYPT_SHARED_LIB_PATH="${CRYPT_SHARED_LIB_PATH}"
+                          echo "CRYPT_SHARED_LIB_PATH=$CRYPT_SHARED_LIB_PATH"
+                      fi
 
                       # Run tests and examples 1-by-1 with "test_params" so we can run them with valgrind.
                       ${test_params} ./src/bsoncxx/test/test_bson
@@ -1174,6 +1186,28 @@ buildvariants:
             - debian10-large
           - name: uninstall_check
 
+    - name: ubuntu2004-with-mongocryptd-release-latest
+      display_name: "Ubuntu 20.04 Release with mongocryptd (MongoDB Latest)"
+      expansions:
+          build_type: "Release"
+          tar_options: *linux_tar_options
+          extra_path: *linux_extra_path
+          cmake_flags: *linux_cmake_flags
+          mongodb_version: *version_latest
+          use_mongocryptd: true
+      run_on:
+          - ubuntu2004-large
+      tasks:
+          - name: compile_and_test_with_shared_libs
+          - name: compile_and_test_with_shared_libs_extra_alignment
+          - name: compile_and_test_with_static_libs
+          - name: compile_and_test_with_static_libs_extra_alignment
+          - name: compile_and_test_with_shared_libs_replica_set
+          - name: build_example_with_add_subdirectory
+            distros:
+            - ubuntu2004-large
+          - name: uninstall_check
+
     - name: ubuntu2004-release-latest
       display_name: "Ubuntu 20.04 Release (MongoDB Latest)"
       expansions:
@@ -1271,6 +1305,7 @@ buildvariants:
           poly_flags: *poly_std_experimental_flags
           mongodb_version: *version_44
           example_projects_cxx_standard: *std_experimental_cxx_standard
+          use_mongocryptd: true
       run_on:
           - ubuntu1604-build
       tasks:
@@ -1289,6 +1324,7 @@ buildvariants:
           test_params: *valgrind_test_params
           mongodb_version: *version_latest
           disable_slow_tests: 1
+          use_mongocryptd: true
       run_on:
           - ubuntu1804-build
       tasks:
@@ -1307,6 +1343,7 @@ buildvariants:
           test_params: *valgrind_test_params
           mongodb_version: *version_50
           disable_slow_tests: 1
+          use_mongocryptd: true
       run_on:
           - ubuntu1804-build
       tasks:

--- a/.mci.yml
+++ b/.mci.yml
@@ -1315,6 +1315,7 @@ buildvariants:
           test_params: *valgrind_test_params
           mongodb_version: *version_latest
           disable_slow_tests: 1
+          use_mongocryptd: true
       run_on:
           - ubuntu1804-build
       tasks:
@@ -1333,6 +1334,7 @@ buildvariants:
           test_params: *valgrind_test_params
           mongodb_version: *version_50
           disable_slow_tests: 1
+          use_mongocryptd: true
       run_on:
           - ubuntu1804-build
       tasks:

--- a/.mci.yml
+++ b/.mci.yml
@@ -533,7 +533,7 @@ functions:
                       ulimit -c unlimited || true
 
                       if [ "${use_mongocryptd}" = "ON" ] || [ "${use_mongocryptd}" = "true" ]; then
-                          echo "Will run tests using mongocryptd (instead of crypted_shared library)"
+                          echo "Will run tests using mongocryptd (instead of crypt_shared library)"
                       else
                           echo "Will run tests using cryptd_shared library (instead of mongocryptd)"
                           export CRYPT_SHARED_LIB_PATH="${CRYPT_SHARED_LIB_PATH}"

--- a/src/mongocxx/options/auto_encryption.hpp
+++ b/src/mongocxx/options/auto_encryption.hpp
@@ -334,6 +334,33 @@ class MONGOCXX_API auto_encryption {
     /// - mongocryptdSpawnArgs: array[strings], options passed to mongocryptd
     ///   when spawing. Defaults to ["--idleShutdownTimeoutSecs=60"].
     ///
+    /// - cryptSharedLibPath - Set a filepath string referring to a crypt_shared library file. Unset
+    ///   by default. If not set (the default), libmongocrypt will attempt to load crypt_shared
+    ///   using the host system’s default dynamic-library-search system.
+    ///
+    ///   If set, the given path should identify the crypt_shared dynamic library file itself, not
+    ///   the directory that contains it.
+    ///
+    ///   If the given path is a relative path and the first path component is $ORIGIN, the $ORIGIN
+    ///   component will be replaced with the absolute path to the directory containing the
+    ///   libmongocrypt library in use by the application.
+    ///
+    ///   Note No other RPATH/RUNPATH-style substitutions are available.
+    ///   If the given path is a relative path, the path will be resolved relative to the working
+    ///   directory of the operating system process.
+    ///
+    ///   If this option is set and libmongocrypt fails to load crypt_shared from the given
+    ///   filepath, libmongocrypt will fail to initialize and will not attempt to search for
+    ///   crypt_shared in any other locations.
+    ///
+    /// - cryptSharedLibRequired - If set to true, and libmongocrypt fails to load a crypt_shared
+    ///   library, initialization of auto-encryption will fail immediately and will not attempt to
+    ///   spawn mongocryptd.
+    ///
+    ///   If set to false (the default), cryptSharedLibPath is not set, and libmongocrypt fails to
+    ///   load crypt_shared, then libmongocrypt will proceed without crypt_shared and fall back to
+    ///   using mongocryptd.
+    ///
     /// @param extra
     ///   The extra options to set.
     ///

--- a/src/mongocxx/test/client_side_encryption.cpp
+++ b/src/mongocxx/test/client_side_encryption.cpp
@@ -234,15 +234,12 @@ void _add_cse_opts(options::client_encryption* opts,
 options::client crypt_shared_opts(options::client opts = {}) {
     const auto shared_lib_path = std::getenv("CRYPT_SHARED_LIB_PATH");
     if (shared_lib_path) {
-        auto extra = make_document(kvp("cryptSharedLibPath", shared_lib_path),
-                                   kvp("cryptSharedLibRequired", true));
-
-        options::auto_encryption auto_encrypt_opts{};
-        auto_encrypt_opts.kms_providers(_make_kms_doc());
-        auto_encrypt_opts.key_vault_namespace({"keyvault", "datakeys"});
-        auto_encrypt_opts.extra_options({std::move(extra)});
-
-        opts.auto_encryption_opts(std::move(auto_encrypt_opts));
+        opts.auto_encryption_opts(
+            options::auto_encryption()
+                .kms_providers(_make_kms_doc())
+                .key_vault_namespace({"keyvault", "datakeys"})
+                .extra_options(make_document(kvp("cryptSharedLibPath", shared_lib_path),
+                                             kvp("cryptSharedLibRequired", true))));
     }
     return opts;
 }

--- a/src/mongocxx/test/client_side_encryption.cpp
+++ b/src/mongocxx/test/client_side_encryption.cpp
@@ -1565,7 +1565,7 @@ void bypass_mongocrypt_via_shared_library(const std::string& shared_lib_path,
     // 2. Use client_encrypted to insert the document {"unencrypted": "test"} into db.coll.
     // Expect this to succeed.
     auto coll = client_encrypted["db"]["coll"];
-    coll.insert_one(make_document(kvp("encrypted", "test")));
+    coll.insert_one(make_document(kvp("unencrypted", "test")));
 
     // 3. Validate that mongocryptd was not spawned. Create a MongoClient to localhost:27021 (or
     // whatever was passed via --port) with serverSelectionTimeoutMS=1000. Run a handshake

--- a/src/mongocxx/test/client_side_encryption.cpp
+++ b/src/mongocxx/test/client_side_encryption.cpp
@@ -231,20 +231,6 @@ void _add_cse_opts(options::client_encryption* opts,
     opts->key_vault_namespace({"keyvault", "datakeys"});
 }
 
-options::client crypt_shared_opts() {
-    options::client opts;
-    const auto shared_lib_path = std::getenv("CRYPT_SHARED_LIB_PATH");
-    if (shared_lib_path) {
-        opts.auto_encryption_opts(
-            options::auto_encryption()
-                .kms_providers(_make_kms_doc())
-                .key_vault_namespace({"keyvault", "datakeys"})
-                .extra_options(make_document(kvp("cryptSharedLibPath", shared_lib_path),
-                                             kvp("cryptSharedLibRequired", true))));
-    }
-    return opts;
-}
-
 template <typename Callable>
 void run_datakey_and_double_encryption(Callable create_data_key,
                                        stdx::string_view provider,
@@ -500,13 +486,12 @@ TEST_CASE("Datakey and double encryption", "[client_side_encryption]") {
 
 void run_external_key_vault_test(bool with_external_key_vault) {
     class client external_key_vault_client {
-        uri{"mongodb://fake-user:fake-pwd@localhost:27017"},
-            test_util::add_test_server_api(crypt_shared_opts()),
+        uri{"mongodb://fake-user:fake-pwd@localhost:27017"}, test_util::add_test_server_api(),
     };
 
     // Create a MongoClient without encryption enabled (referred to as client).
     class client client {
-        uri{}, test_util::add_test_server_api(crypt_shared_opts()),
+        uri{}, test_util::add_test_server_api(),
     };
 
     // Using client, drop the collections keyvault.datakeys and db.coll.
@@ -595,7 +580,7 @@ TEST_CASE("External key vault", "[client_side_encryption]") {
     }
 
     class client setup_client {
-        uri{}, test_util::add_test_server_api(crypt_shared_opts()),
+        uri{}, test_util::add_test_server_api(),
     };
 
     if (test_util::get_max_wire_version(setup_client) < 8) {
@@ -617,7 +602,7 @@ TEST_CASE("BSON size limits and batch splitting", "[client_side_encryption]") {
 
     // Create a MongoClient without encryption enabled (referred to as client).
     class client client {
-        uri{}, test_util::add_test_server_api(crypt_shared_opts()),
+        uri{}, test_util::add_test_server_api(),
     };
 
     if (test_util::get_max_wire_version(client) < 8) {
@@ -1129,7 +1114,7 @@ TEST_CASE("Corpus", "[client_side_encryption]") {
     }
 
     class client setup_client {
-        uri{}, test_util::add_test_server_api(crypt_shared_opts()),
+        uri{}, test_util::add_test_server_api(),
     };
 
     if (test_util::get_max_wire_version(setup_client) < 8) {
@@ -1258,7 +1243,7 @@ TEST_CASE("Custom endpoint", "[client_side_encryption]") {
     }
 
     class client setup_client {
-        uri{}, test_util::add_test_server_api(crypt_shared_opts()),
+        uri{}, test_util::add_test_server_api(),
     };
 
     if (test_util::get_max_wire_version(setup_client) < 8) {
@@ -1932,7 +1917,7 @@ TEST_CASE("KMS TLS Options Tests", "[client_side_encryption][!mayfail]") {
         return;
     }
 
-    auto setup_client = client(uri(), test_util::add_test_server_api(crypt_shared_opts()));
+    auto setup_client = client(uri(), test_util::add_test_server_api());
 
     // Support for detailed certificate verify failure messages required by this test are only
     // available in libmongoc 1.20.0 and newer (CDRIVER-3927).
@@ -2516,7 +2501,7 @@ TEST_CASE("Unique Index on keyAltNames", "[client_side_encryption]") {
     }
 
     // 1. Create a MongoClient object (referred to as client).
-    mongocxx::client client{mongocxx::uri{}, test_util::add_test_server_api(crypt_shared_opts())};
+    mongocxx::client client{mongocxx::uri{}, test_util::add_test_server_api()};
 
     // 2. Using client, drop the collection keyvault.datakeys.
     client["keyvault"]["datakeys"].drop();
@@ -2671,7 +2656,7 @@ TEST_CASE("Custom Key Material Test", "[client_side_encryption]") {
     }
 
     // 1. Create a MongoClient object (referred to as client).
-    mongocxx::client client{mongocxx::uri{}, test_util::add_test_server_api(crypt_shared_opts())};
+    mongocxx::client client{mongocxx::uri{}, test_util::add_test_server_api()};
 
     // 2. Using client, drop the collection keyvault.datakeys.
     client["keyvault"]["datakeys"].drop();

--- a/src/mongocxx/test/client_side_encryption.cpp
+++ b/src/mongocxx/test/client_side_encryption.cpp
@@ -192,9 +192,8 @@ void _add_client_encrypted_opts(options::client* client_opts,
 
     const auto shared_lib_path = std::getenv("CRYPT_SHARED_LIB_PATH");
     if (shared_lib_path) {
-        auto extra = make_document(kvp("cryptSharedLibPath", shared_lib_path),
-                                   kvp("cryptSharedLibRequired", true));
-        auto_encrypt_opts.extra_options({std::move(extra)});
+        auto_encrypt_opts.extra_options(make_document(kvp("cryptSharedLibPath", shared_lib_path),
+                                                      kvp("cryptSharedLibRequired", true)));
     } else if (bypass_spawn || mongocryptd_path) {
         auto cmd = bsoncxx::builder::basic::document{};
 

--- a/src/mongocxx/test/client_side_encryption.cpp
+++ b/src/mongocxx/test/client_side_encryption.cpp
@@ -231,7 +231,8 @@ void _add_cse_opts(options::client_encryption* opts,
     opts->key_vault_namespace({"keyvault", "datakeys"});
 }
 
-options::client crypt_shared_opts(options::client opts = {}) {
+options::client crypt_shared_opts() {
+    options::client opts;
     const auto shared_lib_path = std::getenv("CRYPT_SHARED_LIB_PATH");
     if (shared_lib_path) {
         opts.auto_encryption_opts(
@@ -668,7 +669,7 @@ TEST_CASE("BSON size limits and batch splitting", "[client_side_encryption]") {
     client_encrypted_opts.apm_opts(apm_opts);
 
     class client client_encrypted {
-        uri{}, test_util::add_test_server_api(crypt_shared_opts(client_encrypted_opts)),
+        uri{}, test_util::add_test_server_api(client_encrypted_opts)
     };
 
     // Using client_encrypted perform the following operations:
@@ -803,7 +804,7 @@ TEST_CASE("Views are prohibited", "[client_side_encryption]") {
     options::client opts;
     _add_client_encrypted_opts(&opts, {}, _make_kms_doc(), _make_tls_opts());
     class client client_encrypted {
-        uri{}, test_util::add_test_server_api(crypt_shared_opts(opts)),
+        uri{}, test_util::add_test_server_api(opts)
     };
 
     // Using client_encrypted, attempt to insert a document into db.view.
@@ -1751,7 +1752,7 @@ TEST_CASE("KMS TLS expired certificate", "[client_side_encryption]") {
     options::client client_opts;
 
     class client setup_client {
-        uri{}, test_util::add_test_server_api(crypt_shared_opts(client_opts)),
+        uri{}, test_util::add_test_server_api(client_opts)
     };
 
     // Support for detailed certificate verify failure messages required by this test are only
@@ -1815,7 +1816,7 @@ TEST_CASE("KMS TLS wrong host certificate", "[client_side_encryption]") {
     options::client client_opts;
 
     class client setup_client {
-        uri{}, test_util::add_test_server_api(crypt_shared_opts(client_opts)),
+        uri{}, test_util::add_test_server_api(client_opts)
     };
 
     // Support for detailed certificate verify failure messages required by this test are only


### PR DESCRIPTION
CXX-2433
CXX-2596
CXX-2608

* Test mongocryptd is not spawned when shared library is loaded
* Drivers MUST run all tests with mongocryptd on at least one platform
for all tested server versions (4.2+).
* Drivers MUST run all tests with crypt_shared_ on at least one platform
for all tested server versions (4.2+). For server versions < 6.0,
drivers MUST test with the latest major release of crypt_shared_
(currently 6.0). Using the latest major release of crypt_shared_ is
supported with older server versions.