### PR TITLE
CXX-2637 Remove use of `collStats` and `currentOp`

### DIFF
--- a/data/client_side_encryption/legacy/bypassedCommand.json
+++ b/data/client_side_encryption/legacy/bypassedCommand.json
@@ -78,7 +78,7 @@
       ]
     },
     {
-      "description": "current op is not bypassed",
+      "description": "kill op is not bypassed",
       "clientOptions": {
         "autoEncryptOpts": {
           "kmsProviders": {
@@ -90,14 +90,15 @@
         {
           "name": "runCommand",
           "object": "database",
-          "command_name": "currentOp",
+          "command_name": "killOp",
           "arguments": {
             "command": {
-              "currentOp": 1
+              "killOp": 1,
+              "op": 1234
             }
           },
           "result": {
-            "errorContains": "command not supported for auto encryption: currentOp"
+            "errorContains": "command not supported for auto encryption: killOp"
           }
         }
       ]

--- a/examples/mongocxx/mongodb.com/runcommand_examples.cpp
+++ b/examples/mongocxx/mongodb.com/runcommand_examples.cpp
@@ -33,22 +33,6 @@ void runcommand_examples(mongocxx::database& db) {
             throw std::logic_error("buildInfo command failed in runCommand example 1");
         }
     }
-
-    {
-        using namespace bsoncxx::builder::basic;
-        // drop and recreate dummy data so command succeeds
-        db["restaurants"].drop();
-        db["restaurants"].insert_one(make_document(kvp("name", "Noodle-Sushi")));
-
-        // Start runCommand Example 2
-        using namespace bsoncxx::builder::basic;
-        auto buildInfo = db.run_command(make_document(kvp("collStats", "restaurants")));
-        // End runCommand Example 1
-
-        if (buildInfo.view()["ok"].get_double() != double{1}) {
-            throw std::logic_error("buildInfo command failed in runCommand example 2");
-        }
-    }
 }
 
 int main() {

--- a/src/mongocxx/test/client.cpp
+++ b/src/mongocxx/test/client.cpp
@@ -377,15 +377,9 @@ TEST_CASE("integration tests for client metadata handshake feature") {
 
     auto run_test = [app_name](const client& client) {
         mongocxx::database db = client["admin"];
-        auto current_op = db.run_command(make_document(kvp("currentOp", 1)));
-        auto current_op_view = current_op.view();
-
-        auto in_prog = current_op_view["inprog"].get_array().value;
+        auto cursor = db.aggregate(pipeline().current_op(make_document()));
         bool found_op = false;
-
-        for (auto&& it : in_prog) {
-            auto op_view = it.get_document().view();
-
+        for (auto&& op_view : cursor) {
             if (!op_view["appName"] ||
                 op_view["appName"].get_string().value != stdx::string_view(app_name)) {
                 continue;

--- a/src/mongocxx/test/client.cpp
+++ b/src/mongocxx/test/client.cpp
@@ -389,29 +389,24 @@ TEST_CASE("integration tests for client metadata handshake feature") {
 
             std::string server_version = test_util::get_server_version(client);
 
-            // clientMetadata not returned until 3.5.8.
-            if (test_util::compare_versions(server_version, "3.5.8") >= 0) {
-                REQUIRE(op_view["clientMetadata"]);
-                auto metadata = op_view["clientMetadata"].get_document();
-                auto metadata_view = metadata.view();
+            REQUIRE(op_view["clientMetadata"]);
+            auto metadata = op_view["clientMetadata"].get_document();
+            auto metadata_view = metadata.view();
 
-                REQUIRE(metadata_view["application"]);
-                auto application = metadata_view["application"].get_document();
-                REQUIRE(application.view()["name"].get_string().value ==
-                        stdx::string_view(app_name));
+            REQUIRE(metadata_view["application"]);
+            auto application = metadata_view["application"].get_document();
+            REQUIRE(application.view()["name"].get_string().value == stdx::string_view(app_name));
 
-                REQUIRE(metadata_view["driver"]);
-                auto driver = metadata_view["driver"].get_document();
-                auto driver_view = driver.view();
-                REQUIRE(driver_view["name"].get_string().value ==
-                        stdx::string_view{"mongoc / mongocxx"});
-                auto version =
-                    bsoncxx::string::to_string(driver_view["version"].get_string().value);
-                REQUIRE(version.find(MONGOCXX_VERSION_STRING) != std::string::npos);
+            REQUIRE(metadata_view["driver"]);
+            auto driver = metadata_view["driver"].get_document();
+            auto driver_view = driver.view();
+            REQUIRE(driver_view["name"].get_string().value ==
+                    stdx::string_view{"mongoc / mongocxx"});
+            auto version = bsoncxx::string::to_string(driver_view["version"].get_string().value);
+            REQUIRE(version.find(MONGOCXX_VERSION_STRING) != std::string::npos);
 
-                REQUIRE(metadata_view["os"]);
-                REQUIRE(metadata_view["os"].get_document().view()["type"]);
-            }
+            REQUIRE(metadata_view["os"]);
+            REQUIRE(metadata_view["os"].get_document().view()["type"]);
 
             break;
         }


### PR DESCRIPTION
# Summary

- Remove use of `collStats` and `currentOp`

# Background & Motivation

See DRIVERS-2232:

> collStats and currentOp will produce a deprecation message in 6.0 and are candidates for removal in another major release.

The `runCommand Example 2` example, which used `collStats`, was removed. This example was added for the documentation team in DRIVERS-448. DOCSP-21320 requests removing `runCommand Example 2` from documentation.
