### PR TITLE
CXX-2344 CXX-2394 Bump minimum libmongoc version to f14370ea

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -7,12 +7,12 @@
 #######################################
 variables:
 
-    mongoc_version_default: &mongoc_version_default "11e31e3e" # TODO: update to 1.24.0 once released.
+    mongoc_version_default: &mongoc_version_default "f14370ea" # TODO: update to 1.24.0 once released.
 
     # If updating mongoc_version_minimum, also update:
     # - the default value of --c-driver-build-ref in etc/make_release.py
     # - LIBMONGOC_REQUIRED_VERSION in src/mongocxx/CMakeLists.txt
-    mongoc_version_minimum: &mongoc_version_minimum "11e31e3e" # TODO: update to 1.24.0 once released.
+    mongoc_version_minimum: &mongoc_version_minimum "f14370ea" # TODO: update to 1.24.0 once released.
 
     mongodb_version:
         version_latest: &version_latest "latest"

--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -84,7 +84,7 @@ ISSUE_TYPE_ID = {'Backport': '10300',
               show_default=True,
               help='The remote reference which points to the mongodb/mongo-cxx-driver repo')
 @click.option('--c-driver-build-ref',
-              default='11e31e3e',
+              default='f14370ea',
               show_default=True,
               help='When building the C driver, build at this Git reference')
 @click.option('--with-c-driver',


### PR DESCRIPTION
Both CXX-2344 and CXX-2394 are resolved by https://github.com/mongodb/mongo-c-driver/pull/1256. This PR bumps the minimum libmongoc version to the corresponding commit (https://github.com/mongodb/mongo-c-driver/commit/f14370ea8130a645080dc6f78342f53b25ddb339) to document this dependency and resolution.