### PR TITLE
CXX-2642 update C driver and QE tests for QEv2 collection creation

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -7,12 +7,12 @@
 #######################################
 variables:
 
-    mongoc_version_default: &mongoc_version_default "11e31e3e" # TODO: update to 1.24.0 once released.
+    mongoc_version_default: &mongoc_version_default "cf45741cef8a26b77ae8dda557e49af311a6d66d" # TODO: update to 1.24.0 once released.
 
     # If updating mongoc_version_minimum, also update:
     # - the default value of --c-driver-build-ref in etc/make_release.py
     # - LIBMONGOC_REQUIRED_VERSION in src/mongocxx/CMakeLists.txt
-    mongoc_version_minimum: &mongoc_version_minimum "11e31e3e" # TODO: update to 1.24.0 once released.
+    mongoc_version_minimum: &mongoc_version_minimum "cf45741cef8a26b77ae8dda557e49af311a6d66d" # TODO: update to 1.24.0 once released.
 
     mongodb_version:
         version_latest: &version_latest "latest"

--- a/data/client_side_encryption/explicit-encryption/encryptedFields.json
+++ b/data/client_side_encryption/explicit-encryption/encryptedFields.json
@@ -1,7 +1,4 @@
 {
-  "escCollection": "enxcol_.default.esc",
-  "eccCollection": "enxcol_.default.ecc",
-  "ecocCollection": "enxcol_.default.ecoc",
   "fields": [
     {
       "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-BypassQueryAnalysis.json
+++ b/data/client_side_encryption/legacy/fle2v2-BypassQueryAnalysis.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Compact.json
+++ b/data/client_side_encryption/legacy/fle2v2-Compact.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-CreateCollection-OldServer.json
+++ b/data/client_side_encryption/legacy/fle2v2-CreateCollection-OldServer.json
@@ -1,0 +1,62 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "6.0.0",
+      "maxServerVersion": "6.3.99",
+      "topology": [
+        "replicaset",
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "database_name": "default",
+  "collection_name": "default",
+  "tests": [
+    {
+      "description": "driver returns an error if creating a QEv2 collection on unsupported server",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                      "subType": "04"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          },
+          "result": {
+            "errorContains": "Driver support of Queryable Encryption is incompatible with server. Upgrade server to use Queryable Encryption."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/data/client_side_encryption/legacy/fle2v2-CreateCollection.json
+++ b/data/client_side_encryption/legacy/fle2v2-CreateCollection.json
@@ -22,9 +22,6 @@
           },
           "encryptedFieldsMap": {
             "default.encryptedCollection": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -65,7 +62,7 @@
           }
         },
         {
-          "name": "assertCollectionExists",
+          "name": "assertCollectionNotExists",
           "object": "testRunner",
           "arguments": {
             "database": "default",
@@ -111,15 +108,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
@@ -153,21 +141,6 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.ecc",
-              "clusteredIndex": {
-                "key": {
-                  "_id": 1
-                },
-                "unique": true
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "create": "enxcol_.encryptedCollection.ecoc",
               "clusteredIndex": {
                 "key": {
@@ -185,9 +158,9 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": "enxcol_.encryptedCollection.esc",
-                "eccCollection": "enxcol_.encryptedCollection.ecc",
-                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
+                "escCollection": null,
+                "ecocCollection": null,
+                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -243,12 +216,6 @@
                       "subType": "04",
                       "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
                     }
-                  },
-                  "queries": {
-                    "queryType": "equality",
-                    "contention": {
-                      "$numberLong": "0"
-                    }
                   }
                 }
               ]
@@ -280,7 +247,7 @@
           }
         },
         {
-          "name": "assertCollectionExists",
+          "name": "assertCollectionNotExists",
           "object": "testRunner",
           "arguments": {
             "database": "default",
@@ -326,15 +293,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
@@ -368,21 +326,6 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.ecc",
-              "clusteredIndex": {
-                "key": {
-                  "_id": 1
-                },
-                "unique": true
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "create": "enxcol_.encryptedCollection.ecoc",
               "clusteredIndex": {
                 "key": {
@@ -400,6 +343,9 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
+                "escCollection": null,
+                "ecocCollection": null,
+                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -408,12 +354,6 @@
                       "$binary": {
                         "subType": "04",
                         "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
-                      }
-                    },
-                    "queries": {
-                      "queryType": "equality",
-                      "contention": {
-                        "$numberLong": "0"
                       }
                     }
                   }
@@ -461,12 +401,6 @@
                       "subType": "04",
                       "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
                     }
-                  },
-                  "queries": {
-                    "queryType": "equality",
-                    "contention": {
-                      "$numberLong": "0"
-                    }
                   }
                 }
               ]
@@ -498,7 +432,7 @@
           }
         },
         {
-          "name": "assertCollectionExists",
+          "name": "assertCollectionNotExists",
           "object": "testRunner",
           "arguments": {
             "database": "default",
@@ -535,14 +469,6 @@
           "object": "database",
           "arguments": {
             "collection": "encryptedCollection"
-          }
-        },
-        {
-          "name": "assertCollectionNotExists",
-          "object": "testRunner",
-          "arguments": {
-            "database": "default",
-            "collection": "enxcol_.encryptedCollection.ecc"
           }
         },
         {
@@ -584,15 +510,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
@@ -612,21 +529,6 @@
           "command_started_event": {
             "command": {
               "create": "enxcol_.encryptedCollection.esc",
-              "clusteredIndex": {
-                "key": {
-                  "_id": 1
-                },
-                "unique": true
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "create": "enxcol_.encryptedCollection.ecc",
               "clusteredIndex": {
                 "key": {
                   "_id": 1
@@ -667,12 +569,6 @@
                         "subType": "04",
                         "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
                       }
-                    },
-                    "queries": {
-                      "queryType": "equality",
-                      "contention": {
-                        "$numberLong": "0"
-                      }
                     }
                   }
                 ]
@@ -711,15 +607,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
@@ -732,235 +619,6 @@
               "drop": "encryptedCollection"
             },
             "command_name": "drop",
-            "database_name": "default"
-          }
-        }
-      ]
-    },
-    {
-      "description": "encryptedFieldsMap with cyclic entries does not loop",
-      "clientOptions": {
-        "autoEncryptOpts": {
-          "kmsProviders": {
-            "aws": {}
-          },
-          "encryptedFieldsMap": {
-            "default.encryptedCollection": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
-              "fields": [
-                {
-                  "path": "firstName",
-                  "bsonType": "string",
-                  "keyId": {
-                    "$binary": {
-                      "subType": "04",
-                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
-                    }
-                  }
-                }
-              ]
-            },
-            "default.encryptedCollection.esc": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
-              "fields": [
-                {
-                  "path": "firstName",
-                  "bsonType": "string",
-                  "keyId": {
-                    "$binary": {
-                      "subType": "04",
-                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        }
-      },
-      "operations": [
-        {
-          "name": "dropCollection",
-          "object": "database",
-          "arguments": {
-            "collection": "encryptedCollection"
-          }
-        },
-        {
-          "name": "createCollection",
-          "object": "database",
-          "arguments": {
-            "collection": "encryptedCollection"
-          }
-        },
-        {
-          "name": "assertCollectionExists",
-          "object": "testRunner",
-          "arguments": {
-            "database": "default",
-            "collection": "enxcol_.encryptedCollection.esc"
-          }
-        },
-        {
-          "name": "assertCollectionExists",
-          "object": "testRunner",
-          "arguments": {
-            "database": "default",
-            "collection": "enxcol_.encryptedCollection.ecc"
-          }
-        },
-        {
-          "name": "assertCollectionExists",
-          "object": "testRunner",
-          "arguments": {
-            "database": "default",
-            "collection": "enxcol_.encryptedCollection.ecoc"
-          }
-        },
-        {
-          "name": "assertCollectionExists",
-          "object": "testRunner",
-          "arguments": {
-            "database": "default",
-            "collection": "encryptedCollection"
-          }
-        },
-        {
-          "name": "assertIndexExists",
-          "object": "testRunner",
-          "arguments": {
-            "database": "default",
-            "collection": "encryptedCollection",
-            "index": "__safeContent___1"
-          }
-        }
-      ],
-      "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "drop": "enxcol_.encryptedCollection.esc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "drop": "enxcol_.encryptedCollection.ecoc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "create": "enxcol_.encryptedCollection.esc",
-              "clusteredIndex": {
-                "key": {
-                  "_id": 1
-                },
-                "unique": true
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "create": "enxcol_.encryptedCollection.ecc",
-              "clusteredIndex": {
-                "key": {
-                  "_id": 1
-                },
-                "unique": true
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "create": "enxcol_.encryptedCollection.ecoc",
-              "clusteredIndex": {
-                "key": {
-                  "_id": 1
-                },
-                "unique": true
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "create": "encryptedCollection",
-              "encryptedFields": {
-                "escCollection": "enxcol_.encryptedCollection.esc",
-                "eccCollection": "enxcol_.encryptedCollection.ecc",
-                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
-                "fields": [
-                  {
-                    "path": "firstName",
-                    "bsonType": "string",
-                    "keyId": {
-                      "$binary": {
-                        "subType": "04",
-                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
-                      }
-                    }
-                  }
-                ]
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "createIndexes": "encryptedCollection",
-              "indexes": [
-                {
-                  "name": "__safeContent___1",
-                  "key": {
-                    "__safeContent__": 1
-                  }
-                }
-              ]
-            },
-            "command_name": "createIndexes",
             "database_name": "default"
           }
         }
@@ -975,9 +633,6 @@
           },
           "encryptedFieldsMap": {
             "default.encryptedCollection": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1060,9 +715,6 @@
           },
           "encryptedFieldsMap": {
             "default.encryptedCollection": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1103,7 +755,7 @@
           }
         },
         {
-          "name": "assertCollectionExists",
+          "name": "assertCollectionNotExists",
           "object": "testRunner",
           "arguments": {
             "database": "default",
@@ -1149,15 +801,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
@@ -1191,21 +834,6 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.ecc",
-              "clusteredIndex": {
-                "key": {
-                  "_id": 1
-                },
-                "unique": true
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "create": "enxcol_.encryptedCollection.ecoc",
               "clusteredIndex": {
                 "key": {
@@ -1223,9 +851,9 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": "enxcol_.encryptedCollection.esc",
-                "eccCollection": "enxcol_.encryptedCollection.ecc",
-                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
+                "escCollection": null,
+                "ecocCollection": null,
+                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -1279,9 +907,6 @@
           "arguments": {
             "collection": "encryptedCollection",
             "encryptedFields": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1303,9 +928,6 @@
           "arguments": {
             "collection": "encryptedCollection",
             "encryptedFields": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1330,7 +952,7 @@
           }
         },
         {
-          "name": "assertCollectionExists",
+          "name": "assertCollectionNotExists",
           "object": "testRunner",
           "arguments": {
             "database": "default",
@@ -1376,15 +998,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
@@ -1418,21 +1031,6 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.ecc",
-              "clusteredIndex": {
-                "key": {
-                  "_id": 1
-                },
-                "unique": true
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "create": "enxcol_.encryptedCollection.ecoc",
               "clusteredIndex": {
                 "key": {
@@ -1450,9 +1048,9 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": "enxcol_.encryptedCollection.esc",
-                "eccCollection": "enxcol_.encryptedCollection.ecc",
-                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
+                "escCollection": null,
+                "ecocCollection": null,
+                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -1511,9 +1109,6 @@
           },
           "encryptedFieldsMap": {
             "default.encryptedCollection": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1544,15 +1139,6 @@
           "command_started_event": {
             "command": {
               "drop": "enxcol_.encryptedCollection.esc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1595,9 +1181,6 @@
           "arguments": {
             "collection": "encryptedCollection",
             "encryptedFields": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1619,9 +1202,6 @@
           "arguments": {
             "collection": "encryptedCollection",
             "encryptedFields": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1646,7 +1226,7 @@
           }
         },
         {
-          "name": "assertCollectionExists",
+          "name": "assertCollectionNotExists",
           "object": "testRunner",
           "arguments": {
             "database": "default",
@@ -1684,9 +1264,6 @@
           "arguments": {
             "collection": "encryptedCollection",
             "encryptedFields": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1715,14 +1292,6 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "enxcol_.encryptedCollection.ecc"
-          }
-        },
-        {
-          "name": "assertCollectionNotExists",
-          "object": "testRunner",
-          "arguments": {
-            "database": "default",
             "collection": "enxcol_.encryptedCollection.ecoc"
           }
         },
@@ -1740,15 +1309,6 @@
           "command_started_event": {
             "command": {
               "drop": "enxcol_.encryptedCollection.esc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1790,21 +1350,6 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.ecc",
-              "clusteredIndex": {
-                "key": {
-                  "_id": 1
-                },
-                "unique": true
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "create": "enxcol_.encryptedCollection.ecoc",
               "clusteredIndex": {
                 "key": {
@@ -1822,9 +1367,9 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": "enxcol_.encryptedCollection.esc",
-                "eccCollection": "enxcol_.encryptedCollection.ecc",
-                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
+                "escCollection": null,
+                "ecocCollection": null,
+                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -1876,15 +1421,6 @@
           "command_started_event": {
             "command": {
               "drop": "enxcol_.encryptedCollection.esc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1927,9 +1463,6 @@
           "arguments": {
             "collection": "encryptedCollection",
             "encryptedFields": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1951,9 +1484,6 @@
           "arguments": {
             "collection": "encryptedCollection",
             "encryptedFields": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1978,7 +1508,7 @@
           }
         },
         {
-          "name": "assertCollectionExists",
+          "name": "assertCollectionNotExists",
           "object": "testRunner",
           "arguments": {
             "database": "default",
@@ -2030,14 +1560,6 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "enxcol_.encryptedCollection.ecc"
-          }
-        },
-        {
-          "name": "assertCollectionNotExists",
-          "object": "testRunner",
-          "arguments": {
-            "database": "default",
             "collection": "enxcol_.encryptedCollection.ecoc"
           }
         },
@@ -2055,15 +1577,6 @@
           "command_started_event": {
             "command": {
               "drop": "enxcol_.encryptedCollection.esc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -2105,21 +1618,6 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.ecc",
-              "clusteredIndex": {
-                "key": {
-                  "_id": 1
-                },
-                "unique": true
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "create": "enxcol_.encryptedCollection.ecoc",
               "clusteredIndex": {
                 "key": {
@@ -2137,9 +1635,9 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": "enxcol_.encryptedCollection.esc",
-                "eccCollection": "enxcol_.encryptedCollection.ecc",
-                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
+                "escCollection": null,
+                "ecocCollection": null,
+                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -2211,15 +1709,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
@@ -2233,6 +1722,53 @@
             },
             "command_name": "drop",
             "database_name": "default"
+          }
+        }
+      ]
+    },
+    {
+      "description": "encryptedFields are consulted for metadata collection names",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "invalid_esc_name",
+              "ecocCollection": "invalid_ecoc_name",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          },
+          "result": {
+            "errorContains": "Encrypted State Collection name should follow"
           }
         }
       ]

--- a/data/client_side_encryption/legacy/fle2v2-Delete.json
+++ b/data/client_side_encryption/legacy/fle2v2-Delete.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -179,9 +176,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -240,9 +234,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-EncryptedFields-vs-EncryptedFieldsMap.json
+++ b/data/client_side_encryption/legacy/fle2v2-EncryptedFields-vs-EncryptedFieldsMap.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -95,9 +92,6 @@
           },
           "encryptedFieldsMap": {
             "default.default": {
-              "escCollection": "enxcol_.default.esc",
-              "eccCollection": "enxcol_.default.ecc",
-              "ecocCollection": "enxcol_.default.ecoc",
               "fields": []
             }
           }

--- a/data/client_side_encryption/legacy/fle2v2-EncryptedFields-vs-jsonSchema.json
+++ b/data/client_side_encryption/legacy/fle2v2-EncryptedFields-vs-jsonSchema.json
@@ -18,9 +18,6 @@
     "bsonType": "object"
   },
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -186,9 +183,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -242,9 +236,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-EncryptedFieldsMap-defaults.json
+++ b/data/client_side_encryption/legacy/fle2v2-EncryptedFieldsMap-defaults.json
@@ -74,9 +74,7 @@
                 },
                 "schema": {
                   "default.default": {
-                    "fields": [],
-                    "escCollection": "enxcol_.default.esc",
-                    "ecocCollection": "enxcol_.default.ecoc"
+                    "fields": []
                   }
                 }
               },

--- a/data/client_side_encryption/legacy/fle2v2-FindOneAndUpdate.json
+++ b/data/client_side_encryption/legacy/fle2v2-FindOneAndUpdate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -186,9 +183,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -247,9 +241,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -428,9 +419,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -491,9 +479,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-InsertFind-Indexed.json
+++ b/data/client_side_encryption/legacy/fle2v2-InsertFind-Indexed.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -182,9 +179,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -238,9 +232,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-InsertFind-Unindexed.json
+++ b/data/client_side_encryption/legacy/fle2v2-InsertFind-Unindexed.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-MissingKey.json
+++ b/data/client_side_encryption/legacy/fle2v2-MissingKey.json
@@ -23,9 +23,6 @@
     }
   ],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Date-Aggregate.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Date-Aggregate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -216,9 +213,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -274,9 +268,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -338,9 +329,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Date-Correctness.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Date-Correctness.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Date-Delete.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Date-Delete.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -205,9 +202,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -263,9 +257,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -327,9 +318,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Date-FindOneAndUpdate.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Date-FindOneAndUpdate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -220,9 +217,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -278,9 +272,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -344,9 +335,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Date-InsertFind.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Date-InsertFind.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -212,9 +209,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -270,9 +264,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -329,9 +320,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Date-Update.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Date-Update.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -216,9 +213,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -274,9 +268,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -346,9 +337,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Decimal-Aggregate.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Decimal-Aggregate.json
@@ -12,9 +12,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -196,9 +193,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -244,9 +238,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -298,9 +289,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Decimal-Correctness.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Decimal-Correctness.json
@@ -12,9 +12,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Decimal-Delete.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Decimal-Delete.json
@@ -12,9 +12,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -187,9 +184,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -235,9 +229,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -289,9 +280,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.json
@@ -12,9 +12,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -198,9 +195,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -246,9 +240,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -302,9 +293,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Decimal-InsertFind.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Decimal-InsertFind.json
@@ -12,9 +12,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -192,9 +189,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -240,9 +234,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -289,9 +280,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Decimal-Update.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Decimal-Update.json
@@ -12,9 +12,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -196,9 +193,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -244,9 +238,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -306,9 +297,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-Aggregate.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-Aggregate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -207,9 +204,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -264,9 +258,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -327,9 +318,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-Correctness.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-Correctness.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-Delete.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-Delete.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -198,9 +195,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -255,9 +249,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -318,9 +309,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -209,9 +206,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -266,9 +260,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -331,9 +322,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-InsertFind.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-InsertFind.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -203,9 +200,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -260,9 +254,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -318,9 +309,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-Update.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-Update.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -207,9 +204,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -264,9 +258,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -335,9 +326,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Double-Aggregate.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Double-Aggregate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -198,9 +195,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -246,9 +240,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -300,9 +291,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Double-Correctness.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Double-Correctness.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Double-Delete.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Double-Delete.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -189,9 +186,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -237,9 +231,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -291,9 +282,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Double-FindOneAndUpdate.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Double-FindOneAndUpdate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -200,9 +197,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -248,9 +242,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -304,9 +295,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Double-InsertFind.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Double-InsertFind.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -194,9 +191,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -242,9 +236,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -291,9 +282,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Double-Update.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Double-Update.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -198,9 +195,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -246,9 +240,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -308,9 +299,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-Aggregate.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-Aggregate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -207,9 +204,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -264,9 +258,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -327,9 +318,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-Correctness.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-Correctness.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-Delete.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-Delete.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -198,9 +195,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -255,9 +249,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -318,9 +309,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -209,9 +206,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -266,9 +260,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -331,9 +322,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-InsertFind.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-InsertFind.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -203,9 +200,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -260,9 +254,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -318,9 +309,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-Update.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-Update.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -207,9 +204,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -264,9 +258,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -335,9 +326,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Int-Aggregate.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Int-Aggregate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -204,9 +201,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -258,9 +252,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -318,9 +309,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Int-Correctness.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Int-Correctness.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Int-Delete.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Int-Delete.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -195,9 +192,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -249,9 +243,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -309,9 +300,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Int-FindOneAndUpdate.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Int-FindOneAndUpdate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -206,9 +203,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -260,9 +254,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -322,9 +313,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Int-InsertFind.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Int-InsertFind.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -200,9 +197,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -254,9 +248,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -309,9 +300,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Int-Update.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Int-Update.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -204,9 +201,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -258,9 +252,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -326,9 +317,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Long-Aggregate.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Long-Aggregate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -204,9 +201,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -258,9 +252,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -318,9 +309,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Long-Correctness.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Long-Correctness.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Long-Delete.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Long-Delete.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -195,9 +192,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -249,9 +243,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -309,9 +300,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Long-FindOneAndUpdate.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Long-FindOneAndUpdate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -206,9 +203,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -260,9 +254,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -322,9 +313,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Long-InsertFind.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Long-InsertFind.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -200,9 +197,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -254,9 +248,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -309,9 +300,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-Long-Update.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-Long-Update.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -204,9 +201,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -258,9 +252,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -326,9 +317,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Range-WrongType.json
+++ b/data/client_side_encryption/legacy/fle2v2-Range-WrongType.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-Update.json
+++ b/data/client_side_encryption/legacy/fle2v2-Update.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -186,9 +183,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -251,9 +245,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -432,9 +423,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {
@@ -499,9 +487,6 @@
                 "type": 1,
                 "schema": {
                   "default.default": {
-                    "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
-                    "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
                         "keyId": {

--- a/data/client_side_encryption/legacy/fle2v2-validatorAndPartialFieldExpression.json
+++ b/data/client_side_encryption/legacy/fle2v2-validatorAndPartialFieldExpression.json
@@ -1,0 +1,504 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "7.0.0",
+      "serverless": "forbid",
+      "topology": [
+        "replicaset",
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "database_name": "default",
+  "collection_name": "default",
+  "data": [],
+  "tests": [
+    {
+      "description": "create with a validator on an unencrypted field is OK",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "fields": [
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedIndexed",
+                  "bsonType": "string",
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                },
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedUnindexed",
+                  "bsonType": "string"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "validator": {
+              "unencrypted_string": "foo"
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        }
+      ]
+    },
+    {
+      "description": "create with a validator on an encrypted field is an error",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "fields": [
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedIndexed",
+                  "bsonType": "string",
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                },
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedUnindexed",
+                  "bsonType": "string"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "validator": {
+              "encryptedIndexed": "foo"
+            }
+          },
+          "result": {
+            "errorContains": "Comparison to encrypted fields not supported"
+          }
+        }
+      ]
+    },
+    {
+      "description": "collMod with a validator on an unencrypted field is OK",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "fields": [
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedIndexed",
+                  "bsonType": "string",
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                },
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedUnindexed",
+                  "bsonType": "string"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "collMod": "encryptedCollection",
+              "validator": {
+                "unencrypted_string": "foo"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "collMod with a validator on an encrypted field is an error",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "fields": [
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedIndexed",
+                  "bsonType": "string",
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                },
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedUnindexed",
+                  "bsonType": "string"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "collMod": "encryptedCollection",
+              "validator": {
+                "encryptedIndexed": "foo"
+              }
+            }
+          },
+          "result": {
+            "errorContains": "Comparison to encrypted fields not supported"
+          }
+        }
+      ]
+    },
+    {
+      "description": "createIndexes with a partialFilterExpression on an unencrypted field is OK",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "fields": [
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedIndexed",
+                  "bsonType": "string",
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                },
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedUnindexed",
+                  "bsonType": "string"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "name",
+                  "key": {
+                    "name": 1
+                  },
+                  "partialFilterExpression": {
+                    "unencrypted_string": "foo"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "name"
+          }
+        }
+      ]
+    },
+    {
+      "description": "createIndexes with a partialFilterExpression on an encrypted field is an error",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "fields": [
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedIndexed",
+                  "bsonType": "string",
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                },
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedUnindexed",
+                  "bsonType": "string"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "name",
+                  "key": {
+                    "name": 1
+                  },
+                  "partialFilterExpression": {
+                    "encryptedIndexed": "foo"
+                  }
+                }
+              ]
+            }
+          },
+          "result": {
+            "errorContains": "Comparison to encrypted fields not supported"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -84,7 +84,7 @@ ISSUE_TYPE_ID = {'Backport': '10300',
               show_default=True,
               help='The remote reference which points to the mongodb/mongo-cxx-driver repo')
 @click.option('--c-driver-build-ref',
-              default='11e31e3e',
+              default='cf45741cef8a26b77ae8dda557e49af311a6d66d',
               show_default=True,
               help='When building the C driver, build at this Git reference')
 @click.option('--with-c-driver',


### PR DESCRIPTION
# Summary

This PR updates the C++ driver's test dependency of the C driver and updates tests.

- update C driver dependency to commit https://github.com/mongodb/mongo-c-driver/commit/cf45741cef8a26b77ae8dda557e49af311a6d66d to include CDRIVER-4563.
- sync `fle2v2-*` and `encryptedFields.json` to specifications commit https://github.com/mongodb/specifications/commit/aa28f787718eb4306ce7ff8e5a87bd46bb0a2c05 to include updated `fle2v2-*` tests.

Verified by this change: https://spruce.mongodb.com/version/646293f40ae606539b7e0cc3/

# Background & Motivation

The changes in DRIVERS-2524 are done in the C driver and do not required C++ driver changes.
