### PR TITLE
CXX-2599 add prose test and upgrade C test dependency

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -7,12 +7,12 @@
 #######################################
 variables:
 
-    mongoc_version_default: &mongoc_version_default "f14370ea" # TODO: update to 1.24.0 once released.
+    mongoc_version_default: &mongoc_version_default "98995b5d9e31768ae02be265e3debe43ec35cff8" # TODO: update to 1.24.0 once released.
 
     # If updating mongoc_version_minimum, also update:
     # - the default value of --c-driver-build-ref in etc/make_release.py
     # - LIBMONGOC_REQUIRED_VERSION in src/mongocxx/CMakeLists.txt
-    mongoc_version_minimum: &mongoc_version_minimum "f14370ea" # TODO: update to 1.24.0 once released.
+    mongoc_version_minimum: &mongoc_version_minimum "98995b5d9e31768ae02be265e3debe43ec35cff8" # TODO: update to 1.24.0 once released.
 
     mongodb_version:
         version_latest: &version_latest "latest"

--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -84,7 +84,7 @@ ISSUE_TYPE_ID = {'Backport': '10300',
               show_default=True,
               help='The remote reference which points to the mongodb/mongo-cxx-driver repo')
 @click.option('--c-driver-build-ref',
-              default='f14370ea',
+              default='98995b5d9e31768ae02be265e3debe43ec35cff8',
               show_default=True,
               help='When building the C driver, build at this Git reference')
 @click.option('--with-c-driver',

--- a/src/mongocxx/test/client_side_encryption.cpp
+++ b/src/mongocxx/test/client_side_encryption.cpp
@@ -3536,4 +3536,25 @@ TEST_CASE("Range Explicit Encryption", "[client_side_encryption]") {
     }
 }
 
+TEST_CASE("16. Rewrap. Case 2: RewrapManyDataKeyOpts.provider is not optional",
+          "[client_side_encryption]") {
+    instance::current();
+
+    if (!mongocxx::test_util::should_run_client_side_encryption_test()) {
+        return;
+    }
+
+    auto keyvault_client = mongocxx::client(mongocxx::uri(), test_util::add_test_server_api());
+    auto ce_opts = mongocxx::options::client_encryption();
+    ce_opts.key_vault_client(&keyvault_client);
+    ce_opts.key_vault_namespace({"keyvault", "datakeys"});
+    ce_opts.kms_providers(_make_kms_doc(true /* include_external */));
+
+    auto clientEncryption = mongocxx::client_encryption(ce_opts);
+    REQUIRE_THROWS_WITH(
+        clientEncryption.rewrap_many_datakey(
+            make_document(), mongocxx::options::rewrap_many_datakey().master_key(make_document())),
+        Catch::Contains("expected 'provider' to be set to identify type of 'master_key'"));
+}
+
 }  // namespace


### PR DESCRIPTION
# Summary

- update C driver test dependency to https://github.com/mongodb/mongo-c-driver/commit/98995b5d9e31768ae02be265e3debe43ec35cff8
- add prose test specified in DRIVERS-2441

# Background & Motivation

See https://github.com/mongodb/mongo-c-driver/pull/1259 for the corresponding C driver changes.