### PR TITLE
Add GCC diagnostic guards

### DIFF
--- a/src/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/document/value.hpp
@@ -234,7 +234,9 @@ class BSONCXX_API value {
 #if defined(__GNUC__) && (__cplusplus >= 201709L)
 // Silence false positive with g++ 10.2.1 on Debian 11.
 #pragma GCC diagnostic push
+#if !defined(__has_warning) || __has_warning("-Wmaybe-uninitialized")
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 #endif
 BSONCXX_INLINE document::view value::view() const noexcept {
     return document::view{static_cast<uint8_t*>(_data.get()), _length};

--- a/src/bsoncxx/private/libbson.hh
+++ b/src/bsoncxx/private/libbson.hh
@@ -19,7 +19,9 @@
 #pragma clang diagnostic ignored "-Wconversion"
 #elif defined(__GNUC__)
 #pragma GCC diagnostic push
+#if !defined(__has_warning) || __has_warning("-Wconversion")
 #pragma GCC diagnostic ignored "-Wconversion"
+#endif
 #elif (_MSC_VER)
 // TODO: CXX-1366 Disable MSVC warnings for libbson
 #endif

--- a/src/bsoncxx/types.hpp
+++ b/src/bsoncxx/types.hpp
@@ -18,7 +18,9 @@
 #pragma clang diagnostic ignored "-Wfloat-equal"
 #elif defined(__GNUC__)
 #pragma GCC diagnostic push
+#if !defined(__has_warning) || __has_warning("-Wfloat-equal")
 #pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
 #endif
 
 #include <chrono>

--- a/src/mongocxx/options/private/transaction.hh
+++ b/src/mongocxx/options/private/transaction.hh
@@ -107,7 +107,9 @@ class transaction::impl {
 #if defined(__GNUC__) && (__cplusplus >= 201709L)
 // Silence false positive with g++ 10.2.1 on Debian 11.
 #pragma GCC diagnostic push
+#if !defined(__has_warning) || __has_warning("-Wmaybe-uninitialized")
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 #endif
             return {};
 #if defined(__GNUC__) && (__cplusplus >= 201709L)

--- a/src/mongocxx/private/libmongoc.cpp
+++ b/src/mongocxx/private/libmongoc.cpp
@@ -25,7 +25,9 @@ namespace libmongoc {
 #if defined(__GNUC__) && (__GNUC__ >= 6) && !defined(__clang__)
 // See libmongoc.hh for details on this diagnostic suppression
 #pragma GCC diagnostic push
+#if !defined(__has_warning) || __has_warning("-Wignored-attributes")
 #pragma GCC diagnostic ignored "-Wignored-attributes"
+#endif
 #endif
 
 #define MONGOCXX_LIBMONGOC_SYMBOL(name)               \

--- a/src/mongocxx/private/libmongoc.hh
+++ b/src/mongocxx/private/libmongoc.hh
@@ -19,7 +19,9 @@
 #pragma clang diagnostic ignored "-Wconversion"
 #elif defined(__GNUC__)
 #pragma GCC diagnostic push
+#if !defined(__has_warning) || __has_warning("-Wconversion")
 #pragma GCC diagnostic ignored "-Wconversion"
+#endif
 #elif (_MSC_VER)
 // TODO: CXX-1366 Disable MSVC warnings for libmongoc
 #endif
@@ -51,7 +53,9 @@ namespace libmongoc {
 // and considers them part of the type, and then emits a silly
 // diagnostic stating that the attribute was ignored.
 #pragma GCC diagnostic push
+#if !defined(__has_warning) || __has_warning("-Wignored-attributes")
 #pragma GCC diagnostic ignored "-Wignored-attributes"
+#endif
 #endif
 
 #define MONGOCXX_LIBMONGOC_SYMBOL(name) \

--- a/src/third_party/catch/include/catch.hpp
+++ b/src/third_party/catch/include/catch.hpp
@@ -39,11 +39,17 @@
      // Because REQUIREs trigger GCC's -Wparentheses, and because still
      // supported version of g++ have only buggy support for _Pragmas,
      // Wparentheses have to be suppressed globally.
+#if !defined(__has_warning) || __has_warning("-Wparantheses")
 #    pragma GCC diagnostic ignored "-Wparentheses" // See #674 for details
+#endif
 
 #    pragma GCC diagnostic push
+#if !defined(__has_warning) || __has_warning("-Wunused-variable")
 #    pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
+#if !defined(__has_warning) || __has_warning("-Wpadded")
 #    pragma GCC diagnostic ignored "-Wpadded"
+#endif
 #endif
 // end catch_suppress_warnings.h
 #if defined(CATCH_CONFIG_MAIN) || defined(CATCH_CONFIG_RUNNER)
@@ -10877,7 +10883,9 @@ namespace Catch {
 // that.
 #if defined(__GNUC__)
 #    pragma GCC diagnostic push
+#if !defined(__has_warning) || __has_warning("-Wmissing-field-initializers")
 #    pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
 #endif
 
     static char* altStackMem = nullptr;


### PR DESCRIPTION
Building mongo-cxx-driver with the GitHub Actions ubuntu-22.04 image yields the following error during compilation:

```
error: unknown warning group '-Wmaybe-uninitialized', ignored
  [-Werror,-Wunknown-pragmas]
                    #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
```

To alleviate this issue, I've added __has_warning guards to all GCC diagnostic ignore pragmas. This resolves the compilation issue.