### PR TITLE
CXX-2661 Add macos-1100 tasks and move ubuntu1404 -> ubuntu2204

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -1796,7 +1796,7 @@ buildvariants:
     #######################################
     #         Mac and Windows             #
     #######################################
-    - name: macos-1014-latest
+    - name: macos-1014-latest # CXX-2661: remove in favor of macos-1100.
       display_name: "MacOS 10.14 Release (Boost) (MongoDB Latest)"
       expansions:
           build_type: "Release"
@@ -1812,7 +1812,7 @@ buildvariants:
           - name: compile_and_test_with_static_libs
           - name: compile_and_test_with_static_libs_extra_alignment
 
-    - name: macos-1014-50
+    - name: macos-1014-50 # CXX-2661: remove in favor of macos-1100.
       display_name: "MacOS 10.14 Release (Boost) (MongoDB 5.0)"
       expansions:
           build_type: "Release"
@@ -1828,7 +1828,7 @@ buildvariants:
           - name: compile_and_test_with_static_libs
           - name: compile_and_test_with_static_libs_extra_alignment
 
-    - name: macos-1014-versioned-api
+    - name: macos-1014-versioned-api # CXX-2661: remove in favor of macos-1100.
       display_name: "MacOS 10.14 Release Versioned API"
       expansions:
           build_type: "Release"
@@ -1838,6 +1838,52 @@ buildvariants:
           mongodb_version: *version_latest
       run_on:
           - macos-1014
+      tasks:
+          - name: test_versioned_api
+          - name: test_versioned_api_accept_version_two
+
+    - name: macos-1100-latest
+      display_name: "MacOS 11.0 Release (Boost) (MongoDB Latest)"
+      expansions:
+          build_type: "Release"
+          extra_path: *macos_extra_path
+          cmake_flags: *macos_cmake_flags
+          poly_flags: *poly_boost_flags
+          mongodb_version: *version_latest
+      run_on:
+          - macos-1100
+      tasks:
+          - name: compile_and_test_with_shared_libs
+          - name: compile_and_test_with_shared_libs_extra_alignment
+          - name: compile_and_test_with_static_libs
+          - name: compile_and_test_with_static_libs_extra_alignment
+
+    - name: macos-1100-50
+      display_name: "MacOS 11.0 Release (Boost) (MongoDB 5.0)"
+      expansions:
+          build_type: "Release"
+          extra_path: *macos_extra_path
+          cmake_flags: *macos_cmake_flags
+          poly_flags: *poly_boost_flags
+          mongodb_version: *version_50
+      run_on:
+          - macos-1100
+      tasks:
+          - name: compile_and_test_with_shared_libs
+          - name: compile_and_test_with_shared_libs_extra_alignment
+          - name: compile_and_test_with_static_libs
+          - name: compile_and_test_with_static_libs_extra_alignment
+
+    - name: macos-1100-versioned-api
+      display_name: "MacOS 11.0 Release Versioned API"
+      expansions:
+          build_type: "Release"
+          extra_path: *macos_extra_path
+          cmake_flags: *macos_cmake_flags
+          poly_flags: *poly_boost_flags
+          mongodb_version: *version_latest
+      run_on:
+          - macos-1100
       tasks:
           - name: test_versioned_api
           - name: test_versioned_api_accept_version_two

--- a/.mci.yml
+++ b/.mci.yml
@@ -1611,8 +1611,8 @@ buildvariants:
         - name: clang-tidy
         - name: compile_without_tests
 
-    - name: ubuntu1404-debug-gcc
-      display_name: "Ubuntu 14.04 Debug (g++ 4.8)"
+    - name: ubuntu2204-debug-gcc
+      display_name: "Ubuntu 22.04 Debug (GCC)"
       expansions:
         build_type: "Debug"
         tar_options: *linux_tar_options
@@ -1620,12 +1620,12 @@ buildvariants:
         mongodb_version: *version_latest
         compiler: g++
       run_on:
-        - ubuntu1404-small
+        - ubuntu2204-small
       tasks:
         - name: compile_without_tests
 
-    - name: ubuntu1404-debug-clang
-      display_name: "Ubuntu 14.04 Debug (clang++ 3.4)"
+    - name: ubuntu2204-debug-clang
+      display_name: "Ubuntu 22.04 Debug (Clang)"
       expansions:
         build_type: "Debug"
         tar_options: *linux_tar_options
@@ -1633,7 +1633,7 @@ buildvariants:
         mongodb_version: *version_latest
         compiler: clang++
       run_on:
-        - ubuntu1404-small
+        - ubuntu2204-small
       tasks:
         - name: compile_without_tests
 

--- a/examples/projects/bsoncxx/cmake-deprecated/shared/CMakeLists.txt
+++ b/examples/projects/bsoncxx/cmake-deprecated/shared/CMakeLists.txt
@@ -40,13 +40,13 @@ find_package(libbsoncxx REQUIRED)
 
 add_executable(hello_bsoncxx ../../hello_bsoncxx.cpp)
 
-# Visual Studio pre 2017 requires boost polyfill.
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    if (CMAKE_CXX_STANDARD LESS 17)
-        find_package(Boost 1.56.0 REQUIRED)
-        target_link_libraries(hello_bsoncxx PRIVATE Boost::boost)
-        target_compile_definitions(hello_bsoncxx PRIVATE BSONCXX_POLY_USE_BOOST=ON)
-    endif ()
+# Deprecated libbsoncxx CMake config does not automatically handle the Boost polyfill dependency.
+include(CheckCXXSymbolExists)
+set(CMAKE_REQUIRED_INCLUDES ${LIBBSONCXX_INCLUDE_DIRS})
+check_cxx_symbol_exists(BSONCXX_POLY_USE_BOOST "bsoncxx/config/config.hpp" NEEDS_BOOST_POLYFILL)
+if (NEEDS_BOOST_POLYFILL)
+    find_package(Boost 1.56.0 REQUIRED)
+    target_link_libraries(hello_bsoncxx PRIVATE Boost::boost)
 endif()
 
 target_include_directories(hello_bsoncxx

--- a/examples/projects/bsoncxx/cmake-deprecated/static/CMakeLists.txt
+++ b/examples/projects/bsoncxx/cmake-deprecated/static/CMakeLists.txt
@@ -40,13 +40,13 @@ find_package(libbsoncxx-static REQUIRED)
 
 add_executable(hello_bsoncxx ../../hello_bsoncxx.cpp)
 
-# Visual Studio pre 2017 requires boost polyfill.
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    if (CMAKE_CXX_STANDARD LESS 17)
-        find_package(Boost 1.56.0 REQUIRED)
-        target_link_libraries(hello_bsoncxx PRIVATE Boost::boost)
-        target_compile_definitions(hello_bsoncxx PRIVATE BSONCXX_POLY_USE_BOOST=ON)
-    endif ()
+# Deprecated libbsoncxx CMake config does not automatically handle the Boost polyfill dependency.
+include(CheckCXXSymbolExists)
+set(CMAKE_REQUIRED_INCLUDES ${LIBBSONCXX_STATIC_INCLUDE_DIRS})
+check_cxx_symbol_exists(BSONCXX_POLY_USE_BOOST "bsoncxx/config/config.hpp" NEEDS_BOOST_POLYFILL)
+if (NEEDS_BOOST_POLYFILL)
+    find_package(Boost 1.56.0 REQUIRED)
+    target_link_libraries(hello_bsoncxx PRIVATE Boost::boost)
 endif()
 
 target_include_directories(hello_bsoncxx

--- a/examples/projects/mongocxx/cmake-deprecated/shared/CMakeLists.txt
+++ b/examples/projects/mongocxx/cmake-deprecated/shared/CMakeLists.txt
@@ -40,13 +40,13 @@ find_package(libmongocxx REQUIRED)
 
 add_executable(hello_mongocxx ../../hello_mongocxx.cpp)
 
-# Visual Studio pre 2017 requires boost polyfill.
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    if (CMAKE_CXX_STANDARD LESS 17)
-        find_package(Boost 1.56.0 REQUIRED)
-        target_link_libraries(hello_mongocxx PRIVATE Boost::boost)
-        target_compile_definitions(hello_mongocxx PRIVATE BSONCXX_POLY_USE_BOOST=ON)
-    endif ()
+# Deprecated libbsoncxx CMake config does not automatically handle the Boost polyfill dependency.
+include(CheckCXXSymbolExists)
+set(CMAKE_REQUIRED_INCLUDES ${LIBMONGOCXX_INCLUDE_DIRS})
+check_cxx_symbol_exists(BSONCXX_POLY_USE_BOOST "bsoncxx/config/config.hpp" NEEDS_BOOST_POLYFILL)
+if (NEEDS_BOOST_POLYFILL)
+    find_package(Boost 1.56.0 REQUIRED)
+    target_link_libraries(hello_mongocxx PRIVATE Boost::boost)
 endif()
 
 target_include_directories(hello_mongocxx

--- a/examples/projects/mongocxx/cmake-deprecated/static/CMakeLists.txt
+++ b/examples/projects/mongocxx/cmake-deprecated/static/CMakeLists.txt
@@ -40,13 +40,13 @@ find_package(libmongocxx-static REQUIRED)
 
 add_executable(hello_mongocxx ../../hello_mongocxx.cpp)
 
-# Visual Studio pre 2017 requires boost polyfill.
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    if (CMAKE_CXX_STANDARD LESS 17)
-        find_package(Boost 1.56.0 REQUIRED)
-        target_link_libraries(hello_mongocxx PRIVATE Boost::boost)
-        target_compile_definitions(hello_mongocxx PRIVATE BSONCXX_POLY_USE_BOOST=ON)
-    endif ()
+# Deprecated libbsoncxx CMake config does not automatically handle the Boost polyfill dependency.
+include(CheckCXXSymbolExists)
+set(CMAKE_REQUIRED_INCLUDES ${LIBMONGOCXX_STATIC_INCLUDE_DIRS})
+check_cxx_symbol_exists(BSONCXX_POLY_USE_BOOST "bsoncxx/config/config.hpp" NEEDS_BOOST_POLYFILL)
+if (NEEDS_BOOST_POLYFILL)
+    find_package(Boost 1.56.0 REQUIRED)
+    target_link_libraries(hello_mongocxx PRIVATE Boost::boost)
 endif()
 
 target_include_directories(hello_mongocxx

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -263,7 +263,7 @@ bool compatible_with_server(const bsoncxx::array::element& requirement) {
             throw e;
         }
 
-        for (const auto kvp : server_params.get_document().view()) {
+        for (const auto& kvp : server_params.get_document().view()) {
             const auto param = kvp.key();
             const auto value = kvp.get_value();
             // If actual parameter is unset or unequal to requirement, skip test.
@@ -954,7 +954,7 @@ void assert_outcome(const array::element& test) {
     if (!test["outcome"])
         return;
 
-    for (const auto outcome : test["outcome"].get_array().value) {
+    for (const auto& outcome : test["outcome"].get_array().value) {
         CAPTURE(to_json(outcome.get_document()));
 
         const auto db_name = outcome["databaseName"].get_string().value;
@@ -1033,7 +1033,7 @@ const std::map<std::pair<mongocxx::stdx::string_view, mongocxx::stdx::string_vie
 void run_tests(mongocxx::stdx::string_view test_description, document::view test) {
     REQUIRE(test["tests"]);
 
-    for (const auto ele : test["tests"].get_array().value) {
+    for (const auto& ele : test["tests"].get_array().value) {
         const auto description = string::to_string(ele["description"].get_string().value);
         SECTION(description) {
             {
@@ -1066,7 +1066,7 @@ void run_tests(mongocxx::stdx::string_view test_description, document::view test
 
             operations::state state;
 
-            for (const auto ops : ele["operations"].get_array().value) {
+            for (const auto& ops : ele["operations"].get_array().value) {
                 const auto ignore_result_and_error = [&]() -> bool {
                     const auto elem = ops["ignoreResultAndError"];
                     return elem && elem.get_bool().value;


### PR DESCRIPTION
## Description

As a first step for CXX-2661, adds macos-1100 equivalent tasks for existing macos-1014 tasks. Removal of old macos-1014 tasks would fully resolve CXX-2661.

Additionally, tasks on ubuntu1404 were moved to ubuntu2204 per distro guidelines, resolving CXX-2657 and ongoing failures in the waterfall.

The Apple Clang compiler on the macos-1100 distro appears to have a new warning enabled, `-Wrange-loop-analysis`, which are also addressed by this PR.

Verified by [this patch](https://spruce.mongodb.com/version/6483715a5623430694937114).

## Boost Polyfill Detection

Example projects were updated to replace Windows-only special handling of the conditional Boost dependency, and instead generically detect the use of the Boost polyfill library via the `CMakeCXXSymbolExists` module to detect the presence of the `BSONCXX_POLY_USE_BOOST` preprocessor macro. This avoids example project build failure when compiling with Boost on MacOS.

Note: this only applies to the example projects using the deprecated CMake project config files, as the newer CMake project config files automatically handles the Boost dependency detection and inclusion (see https://github.com/mongodb/mongo-cxx-driver/pull/968#pullrequestreview-1442349052 for more context).