### PR TITLE
Use the latest CMake when building examples

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -1011,11 +1011,12 @@ tasks:
           shell: bash
           script: |-
             set -o errexit
-            . .evergreen/find_cmake.sh
             cd examples/add_subdirectory
             [ -d mongo-c-driver ] || git clone --depth 1 https://github.com/mongodb/mongo-c-driver
             rsync -aq --exclude='examples/add_subdirectory' $(readlink -f ../..) .
             [ -d build ] || mkdir build
+            . ./mongo-c-driver/.evergreen/scripts/find-cmake-latest.sh
+            export CMAKE="$(find_cmake_latest)"
             cd build
             $CMAKE ..
             $CMAKE --build . -- -j 8


### PR DESCRIPTION
This fixes the following evergreen build failures that were happening when building the example programs.
![image](https://github.com/mongodb/mongo-cxx-driver/assets/13429210/787efb71-d9d5-448c-8c5d-3458340baac6)
```
[2023/06/13 17:45:14.598] Cloning into 'mongo-c-driver'...
[2023/06/13 17:45:14.598] CMake Error at mongo-c-driver/CMakeLists.txt:1 (cmake_minimum_required):
[2023/06/13 17:45:14.598]   CMake 3.15 or higher is required.  You are running version 3.11.0
[2023/06/13 17:45:14.598] -- Configuring incomplete, errors occurred!
```