### PR TITLE
Fix rpm-package-build

### DIFF
--- a/.evergreen/build_snapshot_rpm.sh
+++ b/.evergreen/build_snapshot_rpm.sh
@@ -39,7 +39,7 @@ done
 
 package=mongo-cxx-driver
 spec_file=../mongo-cxx-driver.spec
-config=${MOCK_TARGET_CONFIG:=fedora-36-aarch64}
+config=${MOCK_TARGET_CONFIG:=fedora-39-aarch64}
 
 if [ ! -x /usr/bin/rpmbuild -o ! -x /usr/bin/rpmspec ]; then
   echo "Missing the rpmbuild or rpmspec utility from the rpm-build package"

--- a/.mci.yml
+++ b/.mci.yml
@@ -1900,4 +1900,4 @@ buildvariants:
          - name: debian-package-build-mnmlstc
          - name: rpm-package-build
            distros:
-           - rhel82-arm64-small
+           - rhel90-arm64-small


### PR DESCRIPTION
Evergreen patch build: https://spruce.mongodb.com/version/648b66d91e2d17b9b2a8bac2/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

This addresses the problem with Fedora 36 being too old to use with mock. However, because the C++ driver is currently dependent on C driver functions which won't land in a release until 1.24.0, the task is still broken. However, after C driver 1.24.0 gets picked up by Fedora, the task should turn green all on its own.