### PR TITLE
Update r3.8.0 release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Currently, no drivers guarantee API or ABI stability.
 | Family/version       | Stability   | Development         | Purpose                             |
 | -------------------- | ----------- | ------------------- | ----------------------------------- |
 | (repo master branch) | Unstable    | Active development  | New feature development             |
-| mongocxx 3.7.x       | Stable      | Bug fixes only      | Current stable C++ driver release   |
+| mongocxx 3.8.x       | Stable      | Bug fixes only      | Current stable C++ driver release   |
+| mongocxx 3.7.x       | Stable      | None                | Previous stable C++ driver release  |
 | mongocxx 3.6.x       | Stable      | None                | Previous stable C++ driver release  |
 | mongocxx 3.5.x       | Stable      | None                | Previous stable C++ driver release  |
 | mongocxx 3.4.x       | Stable      | None                | Previous stable C++ driver release  |
@@ -49,7 +50,7 @@ Currently, no drivers guarantee API or ABI stability.
 
 ## MongoDB compatibility
 
-Compatibility of each C++ driver version with each MongoDB server is documented in the [MongoDB C++ Driver Documentation](https://www.mongodb.com/docs/drivers/cxx/#mongodb-compatibility).
+Compatibility of each C++ driver version with each MongoDB server is documented in the [MongoDB manual](https://docs.mongodb.com/drivers/cxx#mongodb-compatibility).
 
 ## Bugs and issues
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -21,7 +21,8 @@ Currently, no drivers guarantee API or ABI stability.
 | Family/version       | Stability   | Development         | Purpose                             |
 | -------------------- | ----------- | ------------------- | ----------------------------------- |
 | (repo master branch) | Unstable    | Active development  | New feature development             |
-| mongocxx 3.7.x       | Stable      | Bug fixes only      | Current stable C++ driver release   |
+| mongocxx 3.8.x       | Stable      | Bug fixes only      | Current stable C++ driver release   |
+| mongocxx 3.7.x       | Stable      | None                | Previous stable C++ driver release  |
 | mongocxx 3.6.x       | Stable      | None                | Previous stable C++ driver release  |
 | mongocxx 3.5.x       | Stable      | None                | Previous stable C++ driver release  |
 | mongocxx 3.4.x       | Stable      | None                | Previous stable C++ driver release  |

--- a/docs/content/mongocxx-v3/installation/linux.md
+++ b/docs/content/mongocxx-v3/installation/linux.md
@@ -11,6 +11,7 @@ title = "Linux"
 
 The mongocxx driver builds on top of the MongoDB C driver.
 
+* For mongocxx-3.8.x, libmongoc 1.24.0 or later is required.
 * For mongocxx-3.7.x, libmongoc 1.22.1 or later is required.
 * For mongocxx-3.6.x, libmongoc 1.17.0 or later is required.
 * For mongocxx-3.5.x, libmongoc 1.15.0 or later is required.
@@ -77,12 +78,12 @@ release tarball.
 
 The [mongocxx releases](https://github.com/mongodb/mongo-cxx-driver/releases)
 page will have links to the release tarball for the version you wish you install.  For
-example, to download version 3.7.2:
+example, to download version 3.8.0:
 
 ```sh
-curl -OL https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.7.2/mongo-cxx-driver-r3.7.2.tar.gz
-tar -xzf mongo-cxx-driver-r3.7.2.tar.gz
-cd mongo-cxx-driver-r3.7.2/build
+curl -OL https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.8.0/mongo-cxx-driver-r3.8.0.tar.gz
+tar -xzf mongo-cxx-driver-r3.8.0.tar.gz
+cd mongo-cxx-driver-r3.8.0/build
 ```
 
 Make sure you change to the `build` directory of whatever source tree you

--- a/docs/content/mongocxx-v3/installation/macos.md
+++ b/docs/content/mongocxx-v3/installation/macos.md
@@ -11,6 +11,7 @@ title = "macOS"
 
 The mongocxx driver builds on top of the MongoDB C driver.
 
+* For mongocxx-3.8.x, libmongoc 1.24.0 or later is required.
 * For mongocxx-3.7.x, libmongoc 1.22.1 or later is required.
 * For mongocxx-3.6.x, libmongoc 1.17.0 or later is required.
 * For mongocxx-3.5.x, libmongoc 1.15.0 or later is required.
@@ -77,12 +78,12 @@ release tarball.
 
 The [mongocxx releases](https://github.com/mongodb/mongo-cxx-driver/releases)
 page will have links to the release tarball for the version you wish you install.  For
-example, to download version 3.7.2:
+example, to download version 3.8.0:
 
 ```sh
-curl -OL https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.7.2/mongo-cxx-driver-r3.7.2.tar.gz
-tar -xzf mongo-cxx-driver-r3.7.2.tar.gz
-cd mongo-cxx-driver-r3.7.2/build
+curl -OL https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.8.0/mongo-cxx-driver-r3.8.0.tar.gz
+tar -xzf mongo-cxx-driver-r3.8.0.tar.gz
+cd mongo-cxx-driver-r3.8.0/build
 ```
 
 Make sure you change to the `build` directory of whatever source tree you

--- a/docs/content/mongocxx-v3/installation/windows.md
+++ b/docs/content/mongocxx-v3/installation/windows.md
@@ -11,6 +11,7 @@ title = "Windows"
 
 The mongocxx driver builds on top of the MongoDB C driver.
 
+* For mongocxx-3.8.x, libmongoc 1.24.0 or later is required.
 * For mongocxx-3.7.x, libmongoc 1.22.1 or later is required.
 * For mongocxx-3.6.x, libmongoc 1.17.0 or later is required.
 * For mongocxx-3.5.x, libmongoc 1.15.0 or later is required.
@@ -80,12 +81,12 @@ release tarball.
 
 The [mongocxx releases](https://github.com/mongodb/mongo-cxx-driver/releases)
 page will have links to the release tarball for the version you wish you install.  For
-example, to download version 3.7.2:
+example, to download version 3.8.0:
 
 ```sh
-curl -OL https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.7.2/mongo-cxx-driver-r3.7.2.tar.gz
-tar -xzf mongo-cxx-driver-r3.7.2.tar.gz
-cd mongo-cxx-driver-r3.7.2/build
+curl -OL https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.8.0/mongo-cxx-driver-r3.8.0.tar.gz
+tar -xzf mongo-cxx-driver-r3.8.0.tar.gz
+cd mongo-cxx-driver-r3.8.0/build
 ```
 
 Make sure you change to the `build` directory of whatever source tree you

--- a/etc/apidocmenu.md
+++ b/etc/apidocmenu.md
@@ -8,7 +8,8 @@ Currently, no drivers guarantee API or ABI stability.
 | Family/version       | Stability   | Development         | Purpose                               |
 | -------------------- | ----------- | ------------------- | ------------------------------------- |
 | (repo master branch) | Unstable    | Active development  | New feature development               |
-| mongocxx 3.7.x       | Stable      | Bug fixes only      | Current stable C++ driver release     |
+| mongocxx 3.8.x       | Stable      | Bug fixes only      | Current stable C++ driver release     |
+| mongocxx 3.7.x       | Stable      | None                | Previous stable C++ driver release    |
 | mongocxx 3.6.x       | Stable      | None                | Previous stable C++ driver release    |
 | mongocxx 3.5.x       | Stable      | None                | Previous stable C++ driver release    |
 | mongocxx 3.4.x       | Stable      | None                | Previous stable C++ driver release    |
@@ -21,6 +22,7 @@ Currently, no drivers guarantee API or ABI stability.
 
 | mongocxx                                     |
 | ---------------------------------------------|
+| [mongocxx-3.8.0](../mongocxx-3.8.0)          |
 | [mongocxx-3.7.2](../mongocxx-3.7.2)          |
 | [mongocxx-3.7.1](../mongocxx-3.7.1)          |
 | [mongocxx-3.7.0](../mongocxx-3.7.0)          |
@@ -54,21 +56,7 @@ Currently, no drivers guarantee API or ABI stability.
 
 ## MongoDB compatibility
 
-The following compatibility table specifies the driver version(s)
-recommended for different versions of MongoDB.  The mongocxx series
-is recommended for all new development.
-
-| Family/version | MongoDB 3.0 | MongoDB 3.2 | MongoDB 3.4 | MongoDB 3.6 | MongoDB 4.0 | MongoDB 4.2 | MongoDB 4.4 | MongoDB 5.0 |
-| -------------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- |
-| mongocxx 3.7.x | ✓           | ✓           | ✓           | ✓           | ✓           | ✓           | ✓           | ✓           |
-| mongocxx 3.6.x | ✓           | ✓           | ✓           | ✓           | ✓           | ✓           | ✓           |             |
-| mongocxx 3.5.x | ✓           | ✓           | ✓           | ✓           | ✓           | Partial     |             |             |
-| mongocxx 3.4.x | ✓           | ✓           | ✓           | ✓           | ✓           |             |             |             |
-| mongocxx 3.3.x | ✓           | ✓           | ✓           | ✓           |             |             |             |             |
-| mongocxx 3.2.x | ✓           | ✓           | ✓           | Partial     |             |             |             |             |
-| mongocxx 3.1.x | ✓           | ✓           | ✓           |             |             |             |             |             |
-| mongocxx 3.0.x | ✓           | ✓           |             |             |             |             |             |             |
-
+Compatibility of each C++ driver version with each MongoDB server is documented in the [MongoDB manual](https://docs.mongodb.com/drivers/cxx#mongodb-compatibility).
 
 ## Resources
 

--- a/etc/generate-all-apidocs.pl
+++ b/etc/generate-all-apidocs.pl
@@ -60,6 +60,7 @@ my @DOC_TAGS = qw(
   r3.7.0
   r3.7.1
   r3.7.2
+  r3.8.0
 );
 
 sub main {


### PR DESCRIPTION
# Summary
- Applies documentation changes for r3.8.0 onto the master branch. 

# Background & Motivation

These changes were already applied to the r3.8.0 documentation. Applying to the master branch is noted in the [Generate and Publish Documentation](https://github.com/mongodb/mongo-cxx-driver/blob/2e645d047108e4e30265eb53d00dcd28f903bc42/etc/releasing.md#generate-and-publish-documentation) release step:

> Checkout the master branch. Push the commit containing changes to etc/ and docs/. This may require pushing the commit to a fork of the C++ Driver repository and creating a pull request.