### PR TITLE
Update release documentation

### DIFF
--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -47,6 +47,7 @@ import click # pip install Click
 from git import Repo # pip install GitPython
 from github import Github # pip install PyGithub
 from jira import JIRA # pip install jira
+import oauthlib.oauth1
 
 if sys.version_info < (3, 0, 0):
     raise RuntimeError("This script requires Python 3 or higher")
@@ -425,6 +426,11 @@ def read_jira_oauth_creds(jira_creds_file):
             oauth_dict['consumer_key'] = creds_match.group(3)
             # Fix the double-backslash created by the decode() call above
             oauth_dict['key_cert'] = creds_match.group(4).replace("\\n", "\n")
+            # Use signature algorithm `SIGNATURE_RSA` to override `jira` default of `SIGNATURE_HMAC_SHA1`.
+            # `jira` 3.5.1 changed the default signature algorithm to `SIGNATURE_HMAC_SHA1`.
+            # MongoDB Jira servers do not appear to support `SIGNATURE_HMAC_SHA1`. Using `SIGNATURE_HMAC_SHA1` results in `signature_method_rejected`` error.
+            # See https://github.com/pycontribs/jira/pull/1664
+            oauth_dict["signature_method"] = oauthlib.oauth1.SIGNATURE_RSA
 
     return oauth_dict
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -213,13 +213,13 @@ If this is a stable release, update the [mongo-cxx-driver](https://github.com/Ho
 Example:
 `brew bump-formula-pr mongo-cxx-driver --url https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.7.3/mongo-cxx-driver-r3.7.3.tar.gz`
 
-## File a DOCSP ticket if needed
+## Comment on the generated DOCSP ticket
 
-Add a comment to the generated DOCSP ticket describing if the
+Minor releases generate a DOCSP ticket. Add a comment to the generated DOCSP ticket describing if the
 [MongoDB Compatibility Table](https://www.mongodb.com/docs/drivers/cxx/#mongodb-compatibility)
 or [Language Compatibility Table](https://www.mongodb.com/docs/drivers/cxx/#language-compatibility)
 should be updated. Generally, only a minor release will require updates.
-(See DOCSP-3504 for an example.)
+(See [DOCSP-30876](https://jira.mongodb.org/browse/DOCSP-30876) for an example.)
 
 ## Announce on Community Forums
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -167,7 +167,7 @@ pushed.
 
 - Checkout the master branch.
 - Edit `etc/apidocmenu.md` and add the released version in the `mongocxx` column
-  following the established pattern. If this is a major release (x.y.0), revise
+  following the established pattern. If this is a minor release (x.y.0), revise
   the entire document as needed.
 - Edit `docs/content/_index.md` and `README.md` to match.
 - Edit `etc/generate-all-apidocs.pl` and add the new release version to the

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -2,5 +2,8 @@
 Click
 GitPython
 PyGithub
-jira
+# Pin `jira` to apply fix of https://github.com/pycontribs/jira/commit/010223289eb66663aaafb70447397038efb2d40d.
+# This avoids the `signature_method_rejected` error described in https://github.com/pycontribs/jira/pull/1643.
+# TODO: replace the following line with `jira` once there is a release of `jira` containing the fix.
+git+https://github.com/pycontribs/jira.git@010223289eb66663aaafb70447397038efb2d40d
 cryptography


### PR DESCRIPTION
# Summary

- fdbc24ff3 pin to `jira` commit and use `SIGNATURE_RSA`
- 014f7c58c clarify DOCSP ticket is generated
- c4a9fdac9 replace "major" with "minor"

# Background & Motivation

Pinning to `jira` commit was motivated by an observed error attempting the release:

```
% python ./etc/make_release.py --jira-creds-file ~/.secrets/jira_creds.txt --github-token-file ~/.secrets/github_token.txt --dry-run r3.8.0
[...]
jira.exceptions.JIRAError: JiraError HTTP 400 url: https://jira.mongodb.org/rest/api/2/serverInfo
        text: oauth_problem=signature_method_rejected

        response headers = {'Date': 'Wed, 21 Jun 2023 14:07:11 GMT', 'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8', 'Content-Length': '39', 'Connection': 'keep-alive', 'WWW-Authenticate': 'OAuth realm="https%3A%2F%2Fjira.mongodb.org", oauth_problem="signature_method_rejected"', 'Content-Security-Policy': 'sandbox'}
        response text = oauth_problem=signature_method_rejected
```

I think the cause of the issue is the `jira` package [changed the default signature method](https://github.com/pycontribs/jira/pull/1643) from SIGNATURE_RSA to SIGNATURE_HMAC_SHA1 in version 3.5.1. This can alternatively be worked around this by installing an older version of the `jira` package: `pip install jira==3.5.0`. I opted to pin to an unreleased commit of `jira`: https://github.com/pycontribs/jira/pull/1664 which includes an option to override the signature method to resolve this issue.

https://github.com/pycontribs/jira/pull/1664 notes:

> The problem is that some Jira servers don't accept SIGNATURE_HMAC_SHA1 and there's currently no way for the user to choose which method to use.

Filed [ITSYSENG-7270](https://jira.mongodb.org/browse/ITSYSENG-7270) to request `SIGNATURE_HMAC_SHA1` be accepted by MongoDB Jira servers.