### PR TITLE
CXX-2120 Handle nonexistent document fields

### DIFF
--- a/src/bsoncxx/array/element.cpp
+++ b/src/bsoncxx/array/element.cpp
@@ -31,6 +31,8 @@ element::element(const std::uint8_t* raw,
                  std::uint32_t keylen)
     : document::element(raw, length, offset, keylen) {}
 
+element::element(const stdx::string_view key) : document::element(key) {}
+
 bool BSONCXX_CALL operator==(const element& elem, const types::bson_value::view& v) {
     return elem.get_value() == v;
 }

--- a/src/bsoncxx/array/element.hpp
+++ b/src/bsoncxx/array/element.hpp
@@ -87,6 +87,8 @@ class BSONCXX_API element : private document::element {
                                      std::uint32_t length,
                                      std::uint32_t offset,
                                      std::uint32_t keylen);
+
+    BSONCXX_PRIVATE explicit element(const stdx::string_view key);
 };
 
 ///

--- a/src/bsoncxx/array/view.cpp
+++ b/src/bsoncxx/array/view.cpp
@@ -126,7 +126,7 @@ view::const_iterator view::find(std::uint32_t i) const {
     }
 
     if (!bson_iter_init_find(&iter, &b, key.c_str())) {
-        return cend();
+        return const_iterator(element(key.c_str()));
     }
 
     return const_iterator(element(data(),

--- a/src/bsoncxx/array/view.cpp
+++ b/src/bsoncxx/array/view.cpp
@@ -118,11 +118,11 @@ view::const_iterator view::find(std::uint32_t i) const {
     bson_iter_t iter;
 
     if (!bson_init_static(&b, data(), length())) {
-        return cend();
+        return const_iterator(element(key.c_str()));
     }
 
     if (!bson_iter_init(&iter, &b)) {
-        return cend();
+        return const_iterator(element(key.c_str()));
     }
 
     if (!bson_iter_init_find(&iter, &b, key.c_str())) {

--- a/src/bsoncxx/document/element.cpp
+++ b/src/bsoncxx/document/element.cpp
@@ -42,7 +42,7 @@ element::element(const std::uint8_t* raw,
     : _raw(raw), _length(length), _offset(offset), _keylen(keylen) {}
 
 element::element(const stdx::string_view key)
-    : _key(key), _raw(nullptr), _length(0), _offset(0), _keylen(0) {}
+    : _raw(nullptr), _length(0), _offset(0), _keylen(0), _key(key) {}
 
 const std::uint8_t* element::raw() const {
     return _raw;

--- a/src/bsoncxx/document/element.cpp
+++ b/src/bsoncxx/document/element.cpp
@@ -63,7 +63,7 @@ bsoncxx::type element::type() const {
     if (_raw == nullptr) {
         throw bsoncxx::exception{error_code::k_unset_element,
                                  "cannot return the type of uninitialized element with key \"" +
-                                     std::string(_key.value().data()) + "\""};
+                                     std::string(_key.value_or("(none)").data()) + "\""};
     }
 
     BSONCXX_CITER;
@@ -74,7 +74,7 @@ stdx::string_view element::key() const {
     if (_raw == nullptr) {
         throw bsoncxx::exception{error_code::k_unset_element,
                                  "cannot return the key from an uninitialized element with key \"" +
-                                     std::string(_key.value().data()) + "\""};
+                                     std::string(_key.value_or("(none)").data()) + "\""};
     }
 
     BSONCXX_CITER;
@@ -84,16 +84,16 @@ stdx::string_view element::key() const {
     return stdx::string_view{key};
 }
 
-#define BSONCXX_ENUM(name, val)                                                     \
-    types::b_##name element::get_##name() const {                                   \
-        if (_raw == nullptr) {                                                      \
-            throw bsoncxx::exception{error_code::k_unset_element,                   \
-                                     "cannot get " #name                            \
-                                     " from an uninitialized element with key \"" + \
-                                         std::string(_key.value().data()) + "\""};  \
-        }                                                                           \
-        types::bson_value::view v{_raw, _length, _offset, _keylen};                 \
-        return v.get_##name();                                                      \
+#define BSONCXX_ENUM(name, val)                                                               \
+    types::b_##name element::get_##name() const {                                             \
+        if (_raw == nullptr) {                                                                \
+            throw bsoncxx::exception{error_code::k_unset_element,                             \
+                                     "cannot get " #name                                      \
+                                     " from an uninitialized element with key \"" +           \
+                                         std::string(_key.value_or("(none)").data()) + "\""}; \
+        }                                                                                     \
+        types::bson_value::view v{_raw, _length, _offset, _keylen};                           \
+        return v.get_##name();                                                                \
     }
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
@@ -102,7 +102,7 @@ types::b_string element::get_utf8() const {
     if (_raw == nullptr) {
         throw bsoncxx::exception{error_code::k_unset_element,
                                  "cannot get string from an uninitialized element with key \"" +
-                                     std::string(_key.value().data()) + "\""};
+                                     std::string(_key.value_or("(none)").data()) + "\""};
     }
 
     types::bson_value::view v{_raw, _length, _offset, _keylen};

--- a/src/bsoncxx/document/element.cpp
+++ b/src/bsoncxx/document/element.cpp
@@ -61,9 +61,10 @@ std::uint32_t element::keylen() const {
 
 bsoncxx::type element::type() const {
     if (_raw == nullptr) {
-        throw bsoncxx::exception{error_code::k_unset_element,
-                                 "cannot return the type of uninitialized element with key \"" +
-                                     std::string(_key.value_or("(none)").data()) + "\""};
+        throw bsoncxx::exception{
+            error_code::k_unset_element,
+            "cannot return the type of uninitialized element" +
+                std::string(_key ? " with key \"" + std::string(_key.value().data()) + "\"" : "")};
     }
 
     BSONCXX_CITER;
@@ -72,9 +73,10 @@ bsoncxx::type element::type() const {
 
 stdx::string_view element::key() const {
     if (_raw == nullptr) {
-        throw bsoncxx::exception{error_code::k_unset_element,
-                                 "cannot return the key from an uninitialized element with key \"" +
-                                     std::string(_key.value_or("(none)").data()) + "\""};
+        throw bsoncxx::exception{
+            error_code::k_unset_element,
+            "cannot return the key from an uninitialized element" +
+                std::string(_key ? " with key \"" + std::string(_key.value().data()) + "\"" : "")};
     }
 
     BSONCXX_CITER;
@@ -84,25 +86,27 @@ stdx::string_view element::key() const {
     return stdx::string_view{key};
 }
 
-#define BSONCXX_ENUM(name, val)                                                               \
-    types::b_##name element::get_##name() const {                                             \
-        if (_raw == nullptr) {                                                                \
-            throw bsoncxx::exception{error_code::k_unset_element,                             \
-                                     "cannot get " #name                                      \
-                                     " from an uninitialized element with key \"" +           \
-                                         std::string(_key.value_or("(none)").data()) + "\""}; \
-        }                                                                                     \
-        types::bson_value::view v{_raw, _length, _offset, _keylen};                           \
-        return v.get_##name();                                                                \
+#define BSONCXX_ENUM(name, val)                                                                 \
+    types::b_##name element::get_##name() const {                                               \
+        if (_raw == nullptr) {                                                                  \
+            throw bsoncxx::exception{                                                           \
+                error_code::k_unset_element,                                                    \
+                "cannot get " #name " from an uninitialized element" +                          \
+                    std::string(_key ? " with key \"" + std::string(_key.value().data()) + "\"" \
+                                     : "")};                                                    \
+        }                                                                                       \
+        types::bson_value::view v{_raw, _length, _offset, _keylen};                             \
+        return v.get_##name();                                                                  \
     }
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
 
 types::b_string element::get_utf8() const {
     if (_raw == nullptr) {
-        throw bsoncxx::exception{error_code::k_unset_element,
-                                 "cannot get string from an uninitialized element with key \"" +
-                                     std::string(_key.value_or("(none)").data()) + "\""};
+        throw bsoncxx::exception{
+            error_code::k_unset_element,
+            "cannot get string from an uninitialized element" +
+                std::string(_key ? " with key \"" + std::string(_key.value().data()) + "\"" : "")};
     }
 
     types::bson_value::view v{_raw, _length, _offset, _keylen};

--- a/src/bsoncxx/document/element.cpp
+++ b/src/bsoncxx/document/element.cpp
@@ -41,6 +41,9 @@ element::element(const std::uint8_t* raw,
                  std::uint32_t keylen)
     : _raw(raw), _length(length), _offset(offset), _keylen(keylen) {}
 
+element::element(const stdx::string_view key)
+    : _key(key), _raw(nullptr), _length(0), _offset(0), _keylen(0) {}
+
 const std::uint8_t* element::raw() const {
     return _raw;
 }
@@ -59,7 +62,8 @@ std::uint32_t element::keylen() const {
 bsoncxx::type element::type() const {
     if (_raw == nullptr) {
         throw bsoncxx::exception{error_code::k_unset_element,
-                                 "cannot return the type of uninitialized element"};
+                                 "cannot return the type of uninitialized element with key \"" +
+                                     std::string(_key.value().data()) + "\""};
     }
 
     BSONCXX_CITER;
@@ -69,7 +73,8 @@ bsoncxx::type element::type() const {
 stdx::string_view element::key() const {
     if (_raw == nullptr) {
         throw bsoncxx::exception{error_code::k_unset_element,
-                                 "cannot return the key from an uninitialized element"};
+                                 "cannot return the key from an uninitialized element with key \"" +
+                                     std::string(_key.value().data()) + "\""};
     }
 
     BSONCXX_CITER;
@@ -79,14 +84,16 @@ stdx::string_view element::key() const {
     return stdx::string_view{key};
 }
 
-#define BSONCXX_ENUM(name, val)                                                             \
-    types::b_##name element::get_##name() const {                                           \
-        if (_raw == nullptr) {                                                              \
-            throw bsoncxx::exception{error_code::k_unset_element,                           \
-                                     "cannot get " #name " from an uninitialized element"}; \
-        }                                                                                   \
-        types::bson_value::view v{_raw, _length, _offset, _keylen};                         \
-        return v.get_##name();                                                              \
+#define BSONCXX_ENUM(name, val)                                                     \
+    types::b_##name element::get_##name() const {                                   \
+        if (_raw == nullptr) {                                                      \
+            throw bsoncxx::exception{error_code::k_unset_element,                   \
+                                     "cannot get " #name                            \
+                                     " from an uninitialized element with key \"" + \
+                                         std::string(_key.value().data()) + "\""};  \
+        }                                                                           \
+        types::bson_value::view v{_raw, _length, _offset, _keylen};                 \
+        return v.get_##name();                                                      \
     }
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
@@ -94,7 +101,8 @@ stdx::string_view element::key() const {
 types::b_string element::get_utf8() const {
     if (_raw == nullptr) {
         throw bsoncxx::exception{error_code::k_unset_element,
-                                 "cannot get string from an uninitialized element"};
+                                 "cannot get string from an uninitialized element with key \"" +
+                                     std::string(_key.value().data()) + "\""};
     }
 
     types::bson_value::view v{_raw, _length, _offset, _keylen};

--- a/src/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/document/element.hpp
@@ -412,9 +412,9 @@ class BSONCXX_API element {
     std::uint32_t _length;
     std::uint32_t _offset;
     std::uint32_t _keylen;
-    // _key will only exist when a process attempts to find a key in the BSON but is unsuccessful.
+    // _key will only exist when a caller attempts to find a key in the BSON but is unsuccessful.
     // The key is stored for a more helpful error message if the user tries to access the value of
-    // the key that does not exist.
+    // a key that does not exist.
     stdx::optional<stdx::string_view> _key;
 };
 

--- a/src/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/document/element.hpp
@@ -17,6 +17,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 
 #include <bsoncxx/config/prelude.hpp>
@@ -401,6 +402,9 @@ class BSONCXX_API element {
                                      std::uint32_t offset,
                                      std::uint32_t keylen);
 
+    // Construct an invalid element with a key. Useful for exceptions.
+    BSONCXX_PRIVATE explicit element(const stdx::string_view key);
+
     friend class view;
     friend class array::element;
 
@@ -408,6 +412,10 @@ class BSONCXX_API element {
     std::uint32_t _length;
     std::uint32_t _offset;
     std::uint32_t _keylen;
+    // _key will only exist when a process attempts to find a key in the BSON but is unsuccessful.
+    // The key is stored for a more helpful error message if the user tries to access the value of
+    // the key that does not exist.
+    stdx::optional<stdx::string_view> _key;
 };
 
 ///

--- a/src/bsoncxx/document/view.cpp
+++ b/src/bsoncxx/document/view.cpp
@@ -112,7 +112,8 @@ view::const_iterator view::end() const {
 view::const_iterator view::find(stdx::string_view key) const {
     bson_t b;
     if (!bson_init_static(&b, _data, _length)) {
-        return cend();
+        // return invalid element with key to provide more helpful exception message.
+        return const_iterator(element(key));
     }
 
     bson_iter_t iter;

--- a/src/bsoncxx/document/view.cpp
+++ b/src/bsoncxx/document/view.cpp
@@ -131,7 +131,9 @@ view::const_iterator view::find(stdx::string_view key) const {
     }
 
     if (!bson_iter_init_find_w_len(&iter, &b, key.data(), static_cast<int>(key.size()))) {
-        return cend();
+        // returning `cend()` returns an element without a key or value.
+        // return invalid element with key to provide more helpful exception
+        return const_iterator(element(key));
     }
 
     return const_iterator(element(

--- a/src/bsoncxx/test/bson_types.cpp
+++ b/src/bsoncxx/test/bson_types.cpp
@@ -366,4 +366,15 @@ TEST_CASE("bson_value::view with inequality for non-value and value",
     b_int64 int64_val{100};
     REQUIRE(int64_val != bson_value::view{b_int64{200}});
 }
+
+TEST_CASE("get_string from uninitialized element throws an exception", "") {
+    using bsoncxx::builder::basic::kvp;
+    using bsoncxx::builder::basic::make_document;
+    bsoncxx::document::value doc = make_document(kvp("foo", "bar"));
+
+    REQUIRE_THROWS_WITH(
+        doc["doesnotexist"].get_string().value,
+        Catch::Contains(
+            "cannot get string from an uninitialized element: unset document::element"));
+}
 }  // namespace

--- a/src/bsoncxx/test/bson_types.cpp
+++ b/src/bsoncxx/test/bson_types.cpp
@@ -379,5 +379,15 @@ TEST_CASE("get_string from uninitialized element throws an exception", "") {
     REQUIRE_THROWS_WITH(doc["alsodoesnotexist"].get_value(),
                         Catch::Contains("cannot return the type of uninitialized element with key "
                                         "\"alsodoesnotexist\": unset document::element"));
+
+    // Ensure a non-existing element evaluates to false.
+    REQUIRE(!doc["doesnotexist"]);
+    // Ensure finding a non-existing element results in an end iterator.
+    REQUIRE(doc.find("doesnotexist") == doc.cend());
+    // Ensure getting a key from a non-existing element results in an exception.
+    REQUIRE_THROWS_WITH(
+        doc["doesnotexist"].key(),
+        Catch::Contains("cannot return the key from an uninitialized element with key "
+                        "\"doesnotexist\": unset document::element"));
 }
 }  // namespace

--- a/src/bsoncxx/test/bson_types.cpp
+++ b/src/bsoncxx/test/bson_types.cpp
@@ -372,9 +372,12 @@ TEST_CASE("get_string from uninitialized element throws an exception", "") {
     using bsoncxx::builder::basic::make_document;
     bsoncxx::document::value doc = make_document(kvp("foo", "bar"));
 
-    REQUIRE_THROWS_WITH(
-        doc["doesnotexist"].get_string().value,
-        Catch::Contains(
-            "cannot get string from an uninitialized element: unset document::element"));
+    REQUIRE_THROWS_WITH(doc["doesnotexist"].get_string().value,
+                        Catch::Contains("cannot get string from an uninitialized element with key "
+                                        "\"doesnotexist\": unset document::element"));
+
+    REQUIRE_THROWS_WITH(doc["alsodoesnotexist"].get_value(),
+                        Catch::Contains("cannot return the type of uninitialized element with key "
+                                        "\"alsodoesnotexist\": unset document::element"));
 }
 }  // namespace

--- a/src/bsoncxx/test/bson_types.cpp
+++ b/src/bsoncxx/test/bson_types.cpp
@@ -367,7 +367,7 @@ TEST_CASE("bson_value::view with inequality for non-value and value",
     REQUIRE(int64_val != bson_value::view{b_int64{200}});
 }
 
-TEST_CASE("get_string from uninitialized element throws an exception", "") {
+TEST_CASE("document uninitialized element throws exceptions", "") {
     using bsoncxx::builder::basic::kvp;
     using bsoncxx::builder::basic::make_document;
     bsoncxx::document::value doc = make_document(kvp("foo", "bar"));
@@ -389,5 +389,24 @@ TEST_CASE("get_string from uninitialized element throws an exception", "") {
         doc["doesnotexist"].key(),
         Catch::Contains("cannot return the key from an uninitialized element with key "
                         "\"doesnotexist\": unset document::element"));
+}
+
+TEST_CASE("array uninitialized element throws exceptions", "") {
+    using bsoncxx::builder::basic::kvp;
+    using bsoncxx::builder::basic::make_array;
+    bsoncxx::array::value arr = make_array("a", "b", "c");
+
+    REQUIRE_THROWS_WITH(arr.view()[3].get_string().value,
+                        Catch::Contains("cannot get string from an uninitialized element with key "
+                                        "\"3\": unset document::element"));
+    // Ensure a non-existing element evaluates to false.
+    REQUIRE(!arr.view()[3]);
+    // Ensure finding a non-existing element results in an end iterator.
+    REQUIRE(arr.view().find(3) == arr.view().cend());
+    // Ensure getting a key from a non-existing element results in an exception.
+    REQUIRE_THROWS_WITH(
+        arr.view()[3].key(),
+        Catch::Contains("cannot return the key from an uninitialized element with key "
+                        "\"3\": unset document::element"));
 }
 }  // namespace


### PR DESCRIPTION
# Summary
This pull request will include the name of the nonexistent key in the exception message thrown when the value is attempted to get fetched.

# Background
Prior to this PR, when the user would attempt to fetch the value of a nonexistent key, such as
```
auto some_message = doc["sceret"].get_string().value;
```
the error message would be as follows:
```
cannot get string from an uninitialized element: unset document::element"
```
This is unhelpful and quite frustrating for the user as it doesn't provide any information as to what key was uninitialized. If the user has a bunch of `get_string()` or `get_value()` calls across their process, it would be tedious to have to go through each one to figure out where exactly the program failed.

# Getting the Key
It's important to remember that the exception above is not thrown when a nonexistent field is accessed with `doc["sceret"]`, but rather when the value of that nonexistent field is attempted to be accessed (`get_#name()` or `get_value()`). This is because we still want the user to be able to conveniently check for existence, such as 
```
if (doc["some_field"]) {
    // some_field exists
}
```
So, getting the nonexistent key from the `operator[]` function is not an option.

The other half of this problem is that when a nonexistent key is passed through to the `operator[]` function, a "null" value is *not* attached to that key or added to the BSON data structure. It would just go away. Because of this, there was no existing way to get the faulty key though the `get_#name()` or `get_value()` functions as it wasn't stored anywhere, it's a completely separate function call than the `operator[]` call.

The solution to this problem was adding an `stdx::optional<stdx::string_view> _key` member variable to the `element` class. Where the `operator[]` call would attempt to find the nonexistent key before and return an iterator to a completely empty element, we now return an iterator to an element with only the optional `_key` field set. Now when the class attempts to get the value of a field and sees that it is nullptr (`_raw == nullptr`) we can access `_key` to include the key in the exception thrown.

# What's New
- Added `stdx::optional<stdx::string_view> _key` to the `element` class
- Overloaded `element` constructor to take in a `key` and set all other `element` fields to `nullptr` or 0
- Changed exception messages to include `_key`
- Test case that calls both `get_string()` and `get_value()`