### PR TITLE
CXX-2685 Add 6.0 and 7.0 to EVG server version matrix

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -16,6 +16,7 @@ variables:
 
     mongodb_version:
         version_latest: &version_latest "latest"
+        version_70: &version_70 "7.0"
         version_60: &version_60 "6.0"
         version_50: &version_50 "5.0"
         version_44: &version_44 "4.4"
@@ -1167,6 +1168,14 @@ axes:
             display_name: "Latest"
             variables:
                 mongodb_version: *version_latest
+          - id: "7.0"
+            display_name: "7.0"
+            variables:
+                mongodb_version: *version_70
+          - id: "6.0"
+            display_name: "6.0"
+            variables:
+                mongodb_version: *version_60
           - id: "5.0"
             display_name: "5.0"
             variables:

--- a/examples/mongocxx/mongodb.com/documentation_examples.cpp
+++ b/examples/mongocxx/mongodb.com/documentation_examples.cpp
@@ -1617,7 +1617,7 @@ int main() {
             snapshot_example2(conn);
         }
         if (should_run_client_side_encryption_test() && is_replica_set(conn) &&
-            version_at_least(db, 6)) {
+            version_at_least(db, 7)) {
             queryable_encryption_api(conn);
         }
     } catch (const std::logic_error& e) {

--- a/src/mongocxx/test/client_side_encryption.cpp
+++ b/src/mongocxx/test/client_side_encryption.cpp
@@ -2501,12 +2501,12 @@ TEST_CASE("Create Encrypted Collection", "[client_side_encryption]") {
     }
 
     if (!test_util::newer_than(conn, "7.0")) {
-        std::cerr << "Explicit Encryption tests require MongoDB server 7.0+." << std::endl;
+        WARN("Explicit Encryption tests require MongoDB server 7.0+.");
         return;
     }
 
     if (test_util::get_topology(conn) == "single") {
-        std::cerr << "Explicit Encryption tests must not run against a standalone." << std::endl;
+        WARN("Explicit Encryption tests must not run against a standalone.");
         return;
     }
 


### PR DESCRIPTION
Resolves CXX-2501 and CXX-2685. Verified by [this patch](https://spruce.mongodb.com/version/64b6bea90305b95a1482729c/tasks).

Only changes required was patching documentation example code that was still using 6.0+ as the Queryable Encryption check ([should be 7.0+](https://github.com/mongodb/specifications/blob/c09f979ad296400552a98c9b784197ec648c2096/source/client-side-encryption/client-side-encryption.rst#create-collection-helper), see also CXX-2642). Drive-by cleanup of some noisy warnings due to `std::cerr` instead of `WARN()` in test code.