### PR TITLE
CXX-2700 Add search index management e2e testing against Atlas

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -1148,7 +1148,6 @@ tasks:
             working_dir: mongo-cxx-driver
             script: |
               export MONGODB_URI=${MONGODB_URI}
-              export FUNCTION_NAME=${LAMBDA_STACK_NAME}-$(git rev-parse --short HEAD)
 
               if [ -n "${lib_dir}" ]; then
                   export LD_LIBRARY_PATH=$(pwd)/../mongoc/${lib_dir}/

--- a/.mci.yml
+++ b/.mci.yml
@@ -312,7 +312,11 @@ functions:
             if [ ! -d "drivers-evergreen-tools" ]; then
                 git clone git@github.com:mongodb-labs/drivers-evergreen-tools.git --depth=1
             fi
-
+            echo "DRIVERS_TOOLS: $(pwd)/drivers-evergreen-tools" > det-expansion.yml
+      # Set DRIVERS_TOOLS expansion.
+      - command: expansions.update
+        params:
+          file: det-expansion.yml
     "run_kms_servers":
       - command: shell.exec
         params:
@@ -1134,6 +1138,57 @@ tasks:
         - func: "run_kms_servers"
         - func: "test"
 
+    - name: test_search_index_helpers
+      commands:
+        - func: "install_c_driver"
+        - func: "compile"
+        - command: shell.exec
+          params:
+            shell: bash
+            working_dir: mongo-cxx-driver
+            script: |
+              export MONGODB_URI=${MONGODB_URI}
+              export FUNCTION_NAME=${LAMBDA_STACK_NAME}-$(git rev-parse --short HEAD)
+
+              if [ -n "${lib_dir}" ]; then
+                  export LD_LIBRARY_PATH=$(pwd)/../mongoc/${lib_dir}/
+                else
+                  export LD_LIBRARY_PATH=$(pwd)/../mongoc/lib/
+              fi
+
+              ./build/src/mongocxx/test/test_driver "atlas search indexes prose tests"
+
+task_groups:
+  - name: test_atlas_task_group_search_indexes
+    setup_group:
+      - func: "setup"
+      - func: "clone_drivers-evergreen-tools"
+      - command: subprocess.exec
+        params:
+          working_dir: mongo-cxx-driver
+          binary: bash
+          add_expansions_to_env: true
+          env:
+            MONGODB_VERSION: '7.0'
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
+      - command: expansions.update
+        # Expected to set MONGODB_URI expansion.
+        params:
+          file: mongo-cxx-driver/atlas-expansion.yml
+    teardown_group:
+      - command: subprocess.exec
+        params:
+          working_dir: mongo-cxx-driver
+          binary: bash
+          add_expansions_to_env: true
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown-atlas-cluster.sh
+    setup_group_can_fail_task: true
+    setup_group_timeout_secs: 1800
+    tasks:
+      - test_search_index_helpers
+
 #######################################
 #           MongoDB Version Matrix    #
 #######################################
@@ -1623,6 +1678,7 @@ buildvariants:
       tasks:
         - name: clang-tidy
         - name: compile_without_tests
+        - name: test_atlas_task_group_search_indexes
 
     - name: ubuntu2204-debug-gcc
       display_name: "Ubuntu 22.04 Debug (GCC)"

--- a/data/index-management/createSearchIndex.json
+++ b/data/index-management/createSearchIndex.json
@@ -54,7 +54,8 @@
             }
           },
           "expectError": {
-            "isError": true
+            "isError": true,
+            "errorContains": "Search index commands are only supported with Atlas"
           }
         }
       ],
@@ -100,7 +101,8 @@
             }
           },
           "expectError": {
-            "isError": true
+            "isError": true,
+            "errorContains": "Search index commands are only supported with Atlas"
           }
         }
       ],

--- a/data/index-management/createSearchIndexes.json
+++ b/data/index-management/createSearchIndexes.json
@@ -48,7 +48,8 @@
             "models": []
           },
           "expectError": {
-            "isError": true
+            "isError": true,
+            "errorContains": "Search index commands are only supported with Atlas"
           }
         }
       ],
@@ -87,7 +88,8 @@
             ]
           },
           "expectError": {
-            "isError": true
+            "isError": true,
+            "errorContains": "Search index commands are only supported with Atlas"
           }
         }
       ],
@@ -135,7 +137,8 @@
             ]
           },
           "expectError": {
-            "isError": true
+            "isError": true,
+            "errorContains": "Search index commands are only supported with Atlas"
           }
         }
       ],

--- a/data/index-management/dropSearchIndex.json
+++ b/data/index-management/dropSearchIndex.json
@@ -48,7 +48,8 @@
             "name": "test index"
           },
           "expectError": {
-            "isError": true
+            "isError": true,
+            "errorContains": "Search index commands are only supported with Atlas"
           }
         }
       ],

--- a/data/index-management/listSearchIndexes.json
+++ b/data/index-management/listSearchIndexes.json
@@ -45,7 +45,8 @@
           "name": "listSearchIndexes",
           "object": "collection0",
           "expectError": {
-            "isError": true
+            "isError": true,
+            "errorContains": "Search index commands are only supported with Atlas"
           }
         }
       ],
@@ -79,7 +80,8 @@
             "name": "test index"
           },
           "expectError": {
-            "isError": true
+            "isError": true,
+            "errorContains": "Search index commands are only supported with Atlas"
           }
         }
       ],
@@ -119,7 +121,8 @@
             }
           },
           "expectError": {
-            "isError": true
+            "isError": true,
+            "errorContains": "Search index commands are only supported with Atlas"
           }
         }
       ],

--- a/data/index-management/updateSearchIndex.json
+++ b/data/index-management/updateSearchIndex.json
@@ -49,7 +49,8 @@
             "definition": {}
           },
           "expectError": {
-            "isError": true
+            "isError": true,
+            "errorContains": "Search index commands are only supported with Atlas"
           }
         }
       ],

--- a/src/mongocxx/private/search_index_view.hh
+++ b/src/mongocxx/private/search_index_view.hh
@@ -137,6 +137,14 @@ class search_index_view::impl {
         bool result = libmongoc::collection_write_command_with_opts(
             _coll, command_bson.bson(), opts_bson.bson(), reply.bson_for_init(), &error);
 
+        const uint32_t serverErrorNamespaceNotFound = 26;
+        if (error.domain == MONGOC_ERROR_QUERY && error.code == serverErrorNamespaceNotFound) {
+            // Ignore NamespaceNotFound error.
+            // NamespaceNotFound server error code is documented in server code:
+            // https://github.com/mongodb/mongo/blob/07e852967e936adbc255518ebaa9c116937becc4/src/mongo/base/error_codes.yml#L64
+            return;
+        }
+
         if (!result) {
             throw_exception<operation_exception>(reply.steal(), error);
         }

--- a/src/mongocxx/search_index_view.cpp
+++ b/src/mongocxx/search_index_view.cpp
@@ -65,23 +65,24 @@ std::string search_index_view::create_one(const client_session& session,
     return _get_impl().create_one(&session, model);
 }
 
-std::vector<bsoncxx::string::view_or_value> search_index_view::create_many(
+std::vector<std::string> search_index_view::create_many(
     const std::vector<search_index_model>& models) {
     auto response = _get_impl().create_many(nullptr, models);
     return _create_many_helper(response["indexesCreated"].get_array().value);
 }
 
-std::vector<bsoncxx::string::view_or_value> search_index_view::create_many(
+std::vector<std::string> search_index_view::create_many(
     const client_session& session, const std::vector<search_index_model>& models) {
     auto response = _get_impl().create_many(&session, models);
     return _create_many_helper(response["indexesCreated"].get_array().value);
 }
 
-std::vector<bsoncxx::string::view_or_value> search_index_view::_create_many_helper(
+std::vector<std::string> search_index_view::_create_many_helper(
     bsoncxx::array::view created_indexes) {
-    std::vector<bsoncxx::string::view_or_value> search_index_names;
+    std::vector<std::string> search_index_names;
     for (auto&& index : created_indexes) {
-        search_index_names.push_back(index.get_document().value["name"].get_string().value);
+        search_index_names.push_back(
+            bsoncxx::string::to_string(index.get_document().value["name"].get_string().value));
     }
     return search_index_names;
 }

--- a/src/mongocxx/search_index_view.cpp
+++ b/src/mongocxx/search_index_view.cpp
@@ -45,6 +45,15 @@ cursor search_index_view::list(const client_session& session,
     return _get_impl().list(&session, name, options);
 }
 
+std::string search_index_view::create_one(bsoncxx::document::view_or_value definition) {
+    return create_one(search_index_model(definition));
+}
+
+std::string search_index_view::create_one(const client_session& session,
+                                          bsoncxx::document::view_or_value definition) {
+    return create_one(session, search_index_model(definition));
+}
+
 std::string search_index_view::create_one(bsoncxx::string::view_or_value name,
                                           bsoncxx::document::view_or_value definition) {
     return create_one(search_index_model(name, definition));

--- a/src/mongocxx/search_index_view.hpp
+++ b/src/mongocxx/search_index_view.hpp
@@ -151,8 +151,7 @@ class MONGOCXX_API search_index_view {
     ///
     /// @return The names of the created indexes.
     ///
-    std::vector<bsoncxx::string::view_or_value> create_many(
-        const std::vector<search_index_model>& models);
+    std::vector<std::string> create_many(const std::vector<search_index_model>& models);
 
     ///
     /// Creates multiple search indexes in the collection.
@@ -164,8 +163,8 @@ class MONGOCXX_API search_index_view {
     ///
     /// @return The names of the created indexes.
     ///
-    std::vector<bsoncxx::string::view_or_value> create_many(
-        const client_session& session, const std::vector<search_index_model>& models);
+    std::vector<std::string> create_many(const client_session& session,
+                                         const std::vector<search_index_model>& models);
 
     ///
     /// @}
@@ -232,7 +231,7 @@ class MONGOCXX_API search_index_view {
 
     MONGOCXX_PRIVATE search_index_view(void* coll, void* client);
 
-    MONGOCXX_PRIVATE std::vector<bsoncxx::string::view_or_value> _create_many_helper(
+    MONGOCXX_PRIVATE std::vector<std::string> _create_many_helper(
         bsoncxx::array::view created_indexes);
 
     MONGOCXX_PRIVATE const impl& _get_impl() const;

--- a/src/mongocxx/search_index_view.hpp
+++ b/src/mongocxx/search_index_view.hpp
@@ -89,6 +89,27 @@ class MONGOCXX_API search_index_view {
     ///
     /// This is a convenience method for creating a single search index.
     ///
+    /// @param definition
+    ///    The document describing the search index to be created.
+    ///
+    /// @return The name of the created search index.
+    ///
+    std::string create_one(bsoncxx::document::view_or_value definition);
+
+    ///
+    /// This is a convenience method for creating a single search index.
+    ///
+    /// @param definition
+    ///    The document describing the search index to be created.
+    ///
+    /// @return The name of the created search index.
+    ///
+    std::string create_one(const client_session& session,
+                           bsoncxx::document::view_or_value definition);
+
+    ///
+    /// This is a convenience method for creating a single search index.
+    ///
     /// @param name
     ///    The name of the search index to create.
     /// @param definition

--- a/src/mongocxx/search_index_view.hpp
+++ b/src/mongocxx/search_index_view.hpp
@@ -87,7 +87,7 @@ class MONGOCXX_API search_index_view {
     ///
     /// @{
     ///
-    /// This is a convenience method for creating a single search index.
+    /// This is a convenience method for creating a single search index with a default name.
     ///
     /// @param definition
     ///    The document describing the search index to be created.
@@ -97,7 +97,7 @@ class MONGOCXX_API search_index_view {
     std::string create_one(bsoncxx::document::view_or_value definition);
 
     ///
-    /// This is a convenience method for creating a single search index.
+    /// This is a convenience method for creating a single search index with a default name.
     ///
     /// @param definition
     ///    The document describing the search index to be created.

--- a/src/mongocxx/test/CMakeLists.txt
+++ b/src/mongocxx/test/CMakeLists.txt
@@ -68,6 +68,7 @@ set(test_driver_sources
     result/insert_one.cpp
     result/replace_one.cpp
     result/update.cpp
+    search_index_view.cpp
     sdam-monitoring.cpp
     spec/initial_dns_seedlist_discovery.cpp
     spec/monitoring.cpp
@@ -337,6 +338,7 @@ set_dist_list (src_mongocxx_test_DIST
    result/insert_one.cpp
    result/replace_one.cpp
    result/update.cpp
+   search_index_view.cpp
    sdam-monitoring.cpp
    spec/client_side_encryption.cpp
    spec/command_monitoring.cpp

--- a/src/mongocxx/test/search_index_view.cpp
+++ b/src/mongocxx/test/search_index_view.cpp
@@ -1,1 +1,210 @@
+#include <chrono>
+#include <thread>
+
+#include <bsoncxx/builder/basic/document.hpp>
+#include <bsoncxx/builder/basic/kvp.hpp>
+#include <bsoncxx/oid.hpp>
+#include <bsoncxx/test_util/catch.hh>
+#include <mongocxx/client.hpp>
+#include <mongocxx/cursor.hpp>
+#include <mongocxx/instance.hpp>
 #include <mongocxx/search_index_view.hpp>
+#include <mongocxx/test_util/client_helpers.hh>
+
+namespace {
+using bsoncxx::builder::basic::kvp;
+using bsoncxx::builder::basic::make_document;
+using namespace mongocxx;
+
+bool does_search_index_exist_on_cursor(cursor& c, search_index_model& model, bool with_status) {
+    for (auto&& doc : c) {
+        // check the name, that the index is queryable, and that the definition matches.
+        if (doc["name"].get_string().value == *model.name() && doc["queryable"].get_bool().value &&
+            doc["latestDefinition"].get_document().view() == model.definition())
+            // additional check needed if we also need to check the status
+            if (with_status &&
+                bsoncxx::string::to_string(doc["status"].get_string().value) == "READY") {
+                return true;
+            } else if (!with_status) {
+                return true;
+            }
+    }
+    return false;
+}
+
+void wait_for_search_index(search_index_view& siv,
+                           search_index_model& model,
+                           bool to_exist,
+                           bool with_status) {
+    auto c = siv.list();
+    while (does_search_index_exist_on_cursor(c, model, with_status) == !to_exist) {
+        std::this_thread::sleep_for(std::chrono::seconds(5));
+        c = siv.list();
+    }
+}
+
+TEST_CASE("atlas search indexes prose tests", "") {
+    instance::current();
+
+    // TODO: have evergreen set this env variable
+    auto uri_getenv = std::getenv("ATLAS_SEARCH_INDEXES_URI");
+    if (!uri_getenv) {
+        WARN("Skipping - Test requires the environment variable: ATLAS_SEARCH_INDEXES_URI");
+        return;
+    }
+
+    client mongodb_client{uri{uri_getenv}};
+    // TODO: have evergreen get the name of the cluster created and insert here (cluster name is
+    // generated in setup-atlas-cluster so I guess we could modify setup-atlas-cluster and hardcode
+    // it)
+    database db = mongodb_client["dbx-cxx-lambda-cd9542cb"];
+
+    SECTION("create one with name and definition") {
+        // use a randomly generated collection name as there's a server side limitation that
+        // prevents multiple search indexes with the same name, definition and collection name
+        // from being created.
+        bsoncxx::oid id;
+        db.create_collection(id.to_string());
+        collection coll = db[id.to_string()];
+        auto siv = coll.search_indexes();
+        // {
+        //   name: 'test-search-index',
+        //   definition : {
+        //     mappings : { dynamic: false }
+        //   }
+        // }
+        auto name = "test-search-index";
+        auto definition = make_document(kvp("mappings", make_document(kvp("dynamic", false))));
+        auto model = search_index_model(name, definition.view());
+
+        REQUIRE(siv.create_one(name, definition.view()) == "test-search-index");
+
+        wait_for_search_index(siv, model, true, false);
+
+        std::cout << "create one with name and definition SUCCESS" << std::endl;
+    }
+
+    SECTION("create one with model") {
+        bsoncxx::oid id;
+        db.create_collection(id.to_string());
+        collection coll = db[id.to_string()];
+        auto siv = coll.search_indexes();
+        // {
+        //   name: 'test-search-index',
+        //   definition : {
+        //     mappings : { dynamic: false }
+        //   }
+        // }
+        auto name = "test-search-index";
+        auto definition = make_document(kvp("mappings", make_document(kvp("dynamic", false))));
+        auto model = search_index_model(name, definition.view());
+
+        REQUIRE(siv.create_one(model) == "test-search-index");
+
+        wait_for_search_index(siv, model, true, false);
+
+        std::cout << "create one with model SUCCESS" << std::endl;
+    }
+
+    SECTION("create many") {
+        bsoncxx::oid id;
+        db.create_collection(id.to_string());
+        collection coll = db[id.to_string()];
+        auto siv = coll.search_indexes();
+        // {
+        //   name: 'test-search-index-1',
+        //   definition : {
+        //     mappings : { dynamic: false }
+        //   }
+        // }
+        auto name1 = "test-search-index-1";
+        auto definition1 = make_document(kvp("mappings", make_document(kvp("dynamic", false))));
+        auto model1 = search_index_model(name1, definition1.view());
+
+        // {
+        //   name: 'test-search-index-2',
+        //   definition : {
+        //     mappings : { dynamic: false }
+        //   }
+        // }
+        auto name2 = "test-search-index-2";
+        auto definition2 = make_document(kvp("mappings", make_document(kvp("dynamic", false))));
+        auto model2 = search_index_model(name2, definition2.view());
+
+        std::vector<search_index_model> models = {model1, model2};
+
+        std::vector<std::string> result = siv.create_many(models);
+        std::vector<std::string> expected = {"test-search-index-1", "test-search-index-2"};
+        REQUIRE(result == expected);
+
+        wait_for_search_index(siv, model1, true, false);
+        wait_for_search_index(siv, model2, true, false);
+
+        std::cout << "create many SUCCESS" << std::endl;
+    }
+
+    SECTION("drop one") {
+        bsoncxx::oid id;
+        db.create_collection(id.to_string());
+        collection coll = db[id.to_string()];
+        auto siv = coll.search_indexes();
+        // {
+        //   name: 'test-search-index',
+        //   definition : {
+        //     mappings : { dynamic: false }
+        //   }
+        // }
+        auto name = "test-search-index";
+        auto definition = make_document(kvp("mappings", make_document(kvp("dynamic", false))));
+        auto model = search_index_model(name, definition.view());
+
+        REQUIRE(siv.create_one(model) == "test-search-index");
+
+        wait_for_search_index(siv, model, true, false);
+
+        siv.drop_one(name);
+
+        wait_for_search_index(siv, model, false, false);
+
+        std::cout << "drop one SUCCESS" << std::endl;
+    }
+
+    SECTION("update one") {
+        bsoncxx::oid id;
+        db.create_collection(id.to_string());
+        collection coll = db[id.to_string()];
+        auto siv = coll.search_indexes();
+        // {
+        //   name: 'test-search-index',
+        //   definition : {
+        //     mappings : { dynamic: false }
+        //   }
+        // }
+        auto name = "test-search-index";
+        auto definition = make_document(kvp("mappings", make_document(kvp("dynamic", false))));
+        auto model = search_index_model(name, definition.view());
+
+        REQUIRE(siv.create_one(model) == "test-search-index");
+
+        wait_for_search_index(siv, model, true, false);
+
+        // definition : {
+        //   mappings : { dynamic: true }
+        // }
+        auto new_definition = make_document(kvp("mappings", make_document(kvp("dynamic", true))));
+        auto new_model = search_index_model(name, new_definition.view());
+        siv.update_one(name, new_definition.view());
+
+        wait_for_search_index(siv, new_model, true, true);
+
+        std::cout << "update one SUCCESS" << std::endl;
+    }
+
+    // SECTION("drop one suppress namespace not found") {
+    //     bsoncxx::oid id;
+    //     collection coll;
+    //     coll.rename("fake-collection");
+    //     coll.search_indexes().drop_one("apples");
+    // }
+}
+}  // namespace

--- a/src/mongocxx/test/search_index_view.cpp
+++ b/src/mongocxx/test/search_index_view.cpp
@@ -220,6 +220,8 @@ TEST_CASE("atlas search indexes prose tests", "") {
         bsoncxx::oid id;
         auto coll = db[id.to_string()];
         coll.search_indexes().drop_one("apples");
+
+        std::cout << "drop one supress namespace not found SUCCESS" << std::endl;
     }
 }
 }  // namespace

--- a/src/mongocxx/test/search_index_view.cpp
+++ b/src/mongocxx/test/search_index_view.cpp
@@ -216,10 +216,10 @@ TEST_CASE("atlas search indexes prose tests", "") {
         std::cout << "update one SUCCESS" << std::endl;
     }
 
-    // SECTION("drop one suppress namespace not found") {
-    //     bsoncxx::oid id;
-    //     auto coll = db[id.to_string()];
-    //     coll.search_indexes().drop_one("apples");
-    // }
+    SECTION("drop one suppress namespace not found") {
+        bsoncxx::oid id;
+        auto coll = db[id.to_string()];
+        coll.search_indexes().drop_one("apples");
+    }
 }
 }  // namespace

--- a/src/mongocxx/test/search_index_view.cpp
+++ b/src/mongocxx/test/search_index_view.cpp
@@ -52,18 +52,15 @@ bool wait_for_search_index(search_index_view& siv,
 TEST_CASE("atlas search indexes prose tests", "") {
     instance::current();
 
-    // TODO: have evergreen set this env variable
-    auto uri_getenv = std::getenv("ATLAS_SEARCH_INDEXES_URI");
+    auto uri_getenv = std::getenv("MONGODB_URI");
     if (!uri_getenv) {
-        WARN("Skipping - Test requires the environment variable: ATLAS_SEARCH_INDEXES_URI");
+        WARN("Skipping - Test requires the environment variable: MONGODB_URI");
         return;
     }
 
     client mongodb_client{uri{uri_getenv}};
-    // TODO: have evergreen get the name of the cluster created and insert here (cluster name is
-    // generated in setup-atlas-cluster so I guess we could modify setup-atlas-cluster and hardcode
-    // it)
-    database db = mongodb_client["dbx-cxx-lambda-cd9542cb"];
+
+    database db = mongodb_client[std::getenv("FUNCTION_NAME")];
 
     SECTION("create one with name and definition") {
         // use a randomly generated collection name as there's a server side limitation that

--- a/src/mongocxx/test/search_index_view.cpp
+++ b/src/mongocxx/test/search_index_view.cpp
@@ -20,7 +20,7 @@ bool does_search_index_exist_on_cursor(cursor& c, search_index_model& model, boo
     for (auto&& doc : c) {
         // check the name, that the index is queryable, and that the definition matches.
         if (doc["name"].get_string().value == *model.name() && doc["queryable"].get_bool().value &&
-            doc["latestDefinition"].get_document().view() == model.definition())
+            doc["latestDefinition"].get_document().view() == model.definition()) {
             // additional check needed if we also need to check the status
             if (with_status &&
                 bsoncxx::string::to_string(doc["status"].get_string().value) == "READY") {
@@ -28,6 +28,7 @@ bool does_search_index_exist_on_cursor(cursor& c, search_index_model& model, boo
             } else if (!with_status) {
                 return true;
             }
+        }
     }
     return false;
 }

--- a/src/mongocxx/test/search_index_view.cpp
+++ b/src/mongocxx/test/search_index_view.cpp
@@ -21,11 +21,9 @@ bool does_search_index_exist_on_cursor(cursor& c, search_index_model& model, boo
         // check the name, that the index is queryable, and that the definition matches.
         if (doc["name"].get_string().value == *model.name() && doc["queryable"].get_bool().value &&
             doc["latestDefinition"].get_document().view() == model.definition()) {
-            // additional check needed if we also need to check the status
-            if (with_status &&
-                bsoncxx::string::to_string(doc["status"].get_string().value) == "READY") {
-                return true;
-            } else if (!with_status) {
+            // optional addition check needed if with_status is set
+            if (!with_status || (with_status && bsoncxx::string::to_string(
+                                                    doc["status"].get_string().value) == "READY")) {
                 return true;
             }
         }

--- a/src/mongocxx/test/spec/unified_tests/operations.cpp
+++ b/src/mongocxx/test/spec/unified_tests/operations.cpp
@@ -1821,8 +1821,7 @@ document::value create_search_indexes(collection& coll, document::view operation
         models.push_back(model);
     }
 
-    std::vector<bsoncxx::string::view_or_value> created_indexes =
-        coll.search_indexes().create_many(models);
+    std::vector<std::string> created_indexes = coll.search_indexes().create_many(models);
 
     builder::basic::array result;
     for (auto s : created_indexes) {


### PR DESCRIPTION
# Summary
This PR will add 5 prose tests that will test search index management against a live Atlas cluster, modify the existing Evergreen config to automatically run these tests in the CI pipeline, and make small changes to the existing spec tests to sync with the [drivers ticket](https://github.com/mongodb/specifications/pull/1442).

# Background
[This](https://github.com/mongodb/specifications/pull/1442) ticket (mainly the changes made in the README) gives the vast majority of context needed to understand what prose tests should be added, why they should be added, and how to run them in Evergreen.

# How to Test Locally
Being that running the prose tests could take around 20 minutes in total, there was not a lot of emphasis placed on making them easy to run locally. However, if you do wish to run them locally, here are the steps that you'll have to take:
1. Spawn an Atlas cluster. The easiest way to do this is by running the `setup-atlas-cluster.sh` script in `drivers-evergreen-tools/.evergreen/atlas`. You'll need to `export` some of the environment variables mentioned in the comments of the script, they can be found on the Evergreen variables page. Spawning the cluster can take 7-10 minutes.
2. Export the `MONGODB_URI` environment variable as the cluster URI (printed to `atlas-expansion.yml` by the script)
3. Compile and run the tests. The test name is `atlas search indexes prose tests`. This will take 5-10 minutes.
4. Teardown the cluster using `teardown-atlas-cluster.sh`. You'll need some environment variables for this one too, it's all mentioned in the comments of the script.

# Evergreen
We chose to use a task group to run the search index prose tests. What's unique about task groups is that they have a `setup_group` and a `teardown_group`, which are commands that will run before the tasks attached to the group are run (setup) and after they are run (teardown). Both the setup commands and the teardown commands will run regardless of the outcome of the actual tests. This is important in this use case because we need to ensure that the Atlas cluster gets torn down even if the tests don't pass. Failure to teardown the Atlas cluster is inefficient and will cause problems the next time that we try to spawn an Atlas cluster. 

# What's New
- Minor changes to the spec tests
- Added another overload to `create_one` that only takes in a definition (see comment for explanation)
- Added 5 prose tests in `test/search_index_view.cpp`
- Updated Evergreen config to automatically spawn a cluster, run the tests, and teardown the cluster