### PR TITLE
CXX-2726 do not override CMAKE_BUILD_TYPE for multi-config generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,10 @@ if(BUILD_VERSION STREQUAL "0.0.0")
     endif()
 endif()
 
-if(NOT CMAKE_BUILD_TYPE)
+get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+
+if(NOT CMAKE_BUILD_TYPE AND NOT isMultiConfig)
+    # Do not override CMAKE_BUILD_TYPE if generator is multi config. CMAKE_BUILD_TYPE is ignored for multi-config generators.
     message(STATUS "No build type selected, default is Release")
     set(CMAKE_BUILD_TYPE "Release")
 endif()

--- a/docs/content/mongocxx-v3/installation/windows.md
+++ b/docs/content/mongocxx-v3/installation/windows.md
@@ -145,7 +145,6 @@ directory by using the `-DLIBMONGOC_DIR` and `-DLIBBSON_DIR` options:
 
 ```sh
 cmake ..                                            \
-    -DCMAKE_BUILD_TYPE=Release                      \
     -DLIBMONGOC_DIR=C:\mongo-c-driver               \
     -DLIBBSON_DIR=C:\mongo-c-driver                 \
     -DCMAKE_INSTALL_PREFIX=C:\mongo-cxx-driver

--- a/docs/content/mongocxx-v3/installation/windows.md
+++ b/docs/content/mongocxx-v3/installation/windows.md
@@ -152,11 +152,11 @@ cmake ..                                            \
 
 ### Step 5: Build and install the driver
 
-Build and install the driver:
+Build and install the driver. Use `--config` to select a build configuration (e.g. `Debug`, `RelWithDebInfo`, `Release`):
 
 ```sh
-cmake --build .
-cmake --build . --target install
+cmake --build . --config RelWithDebInfo
+cmake --build . --target install --config RelWithDebInfo
 ```
 
 The driver can be uninstalled at a later time in one of two ways.  First,


### PR DESCRIPTION
# Summary

- do not override `CMAKE_BUILD_TYPE` for multi-config generator
- remove `CMAKE_BUILD_TYPE` from Windows install instructions
- specify `--config` in Windows install instructions

# Background & Motivation


Configuring on Windows with Visual Studio results in this log output from CMake:

```
-- No build type selected, default is Release
```

The log message is printed when overriding `CMAKE_BUILD_TYPE`. Overriding `CMAKE_BUILD_TYPE` is [ignored for multi-configuration generators](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#build-configurations):

> For multi-configuration generators like Visual Studio, Xcode, and Ninja Multi-Config, the configuration is chosen by the user at build time and CMAKE_BUILD_TYPE is ignored.

This may mislead users to think the build is Release, when it may be Debug. This may result in confusing runtime errors if mixing Debug and Release builds in an application. This PR changes to not override `CMAKE_BUILD_TYPE` for multi-configuration generator.

See CXX-2726 for user reports motivating this change.

---

To configure and build on Windows, the following commands were used:

```
$CMAKE \
    -Thost=x64 -A x64 \
    -DCMAKE_PREFIX_PATH="C:\cygwin\home\Administrator\code\c-bootstrap\install\mongo-c-driver-1.24.2x64" \
	-DCMAKE_INSTALL_PREFIX="./.install" \
	-DBUILD_VERSION=3.9.0-pre \
        -DCMAKE_CXX_STANDARD=17 \
	-S. -B./cmake-build

# To build with default config (resulted in Debug):
$CMAKE --build cmake-build --target mongocxx_shared --parallel 16

# To build with specified config:
$CMAKE --build cmake-build --target mongocxx_shared --parallel 16 --config RelWithDebInfo
```


