### PR TITLE
Add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 3.9.0 [Unreleased]
+
+### Added 
+
+- Add CMake option `USE_DEFAULT_INSTALL_PATH`.
+- Add API to manage Atlas Search Indexes.
+- Automatically download C driver dependency if not provided.
+
+### Changed
+- Do not build tests as part of `all` target. Configure with `BUILD_TESTING=ON` to build tests.

--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -203,7 +203,9 @@ def release(jira_creds_file,
         # all_issues_closed() has already produced an error message
         sys.exit(1)
 
-    release_notes_text = generate_release_notes(issues, release_version)
+    with open ("CHANGELOG.md", "r") as changelog:
+        changelog_contents = changelog.read()
+    release_notes_text = generate_release_notes(release_version, changelog_contents)
 
     gh_repo = auth_gh.get_repo('mongodb/mongo-cxx-driver')
     gh_release_dict = get_github_releases(gh_repo)
@@ -514,33 +516,7 @@ def all_issues_closed(issues):
 
     return True
 
-def generate_release_notes(issues, release_version):
-    """
-    Produce HTML release notes which can be used as part of the project release
-    announcement.
-    """
-
-    release_notes = '<h1>Release Notes - C++ Driver - Version {}</h1>\n'.format(release_version)
-    release_notes += '<h2>Bug</h2>\n'
-    release_notes += '<ul>\n'
-    bug_filter = lambda i: i.fields.issuetype.id == ISSUE_TYPE_ID['Bug']
-    release_notes += print_issues(list(filter(bug_filter, issues)))
-    release_notes += '</ul>\n'
-    release_notes += '<h2>New Feature</h2>\n'
-    release_notes += '<ul>\n'
-    new_feature_filter = lambda i: i.fields.issuetype.id == ISSUE_TYPE_ID['New Feature']
-    release_notes += print_issues(list(filter(new_feature_filter, issues)))
-    release_notes += '</ul>\n'
-    release_notes += '<h2>Improvement</h2>\n'
-    release_notes += '<ul>\n'
-    improvement_filter = lambda i: i.fields.issuetype.id == ISSUE_TYPE_ID['Improvement']
-    release_notes += print_issues(list(filter(improvement_filter, issues)))
-    release_notes += '</ul>\n'
-
-    return release_notes
-
-
-def generate_release_notes_v2(release_version: str, changelog_contents: str) -> str:
+def generate_release_notes(release_version: str, changelog_contents: str) -> str:
     lines = []
     adding_to_lines = False
     for line in changelog_contents.splitlines(keepends=True):

--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -20,6 +20,7 @@
 Make a release of the C++ Driver, including steps associated with the CXX
 project in Jira, and with the mongodb/mongo-cxx-driver GitHub repository.
 See releasing.md for complete release instructions.
+When editing this file, consider running `test_make_release.py` to validate changes.
 """
 
 # CXX Project ID - 11980
@@ -36,6 +37,7 @@ See releasing.md for complete release instructions.
 # | Task        | 3      |
 # ------------------------
 
+import textwrap
 import re
 from distutils.version import LooseVersion
 import os
@@ -534,6 +536,67 @@ def generate_release_notes(issues, release_version):
     improvement_filter = lambda i: i.fields.issuetype.id == ISSUE_TYPE_ID['Improvement']
     release_notes += print_issues(list(filter(improvement_filter, issues)))
     release_notes += '</ul>\n'
+
+    return release_notes
+
+
+def generate_release_notes_v2(release_version: str, changelog_contents: str) -> str:
+    lines = []
+    adding_to_lines = False
+    for line in changelog_contents.splitlines(keepends=True):
+        # Check for a version title. Example: `## 3.9.0`.
+        match = re.match(r"^## (.*?)\s(.*)$".format(release_version), line)
+        if match:
+            matched_version = match.group(1)
+            if matched_version == release_version:
+                # Found matching version.
+                extra = match.group(2)
+                if extra != "":
+                    raise click.ClickException(
+                        "Unexpected extra characters in CHANGELOG: {}. Is the CHANGELOG updated?".format(extra))
+                if adding_to_lines:
+                    raise click.ClickException(
+                        "Unexpected second changelog entry matching version: {}: {}".format(release_version), line)
+                # Begin adding lines to `lines` list.
+                adding_to_lines = True
+                continue
+            # End adding lines when another title is seen.
+            else:
+                adding_to_lines = False
+                break
+
+        if adding_to_lines:
+            # Reduce title by one.
+            if line.startswith("#"):
+                lines.append(line[1:])
+            else:
+                lines.append(line)
+
+    # Removing beginning empty lines.
+    while len(lines) > 0 and lines[0] == "\n":
+        lines = lines[1:]
+
+    # Remove trailing empty lines.
+    while len(lines) > 0 and lines[-1] == "\n":
+        lines = lines[0:-1]
+
+    if lines == []:
+        raise click.ClickException(
+            "Failed to find changelog contents for {}".format(release_version))
+
+    footer = textwrap.dedent("""
+    ## Feedback
+    To report a bug or request a feature, please open a ticket in the MongoDB issue management tool Jira:
+
+    - [Create an account](https://jira.mongodb.org) and login.
+    - Navigate to the [CXX project](https://jira.mongodb.org/browse/CXX)
+    - Click `Create`.
+    """).lstrip()
+
+    release_notes = "".join(lines) + "\n"
+    release_notes += "See the [full list of changes in Jira](https://jira.mongodb.org/issues/?jql=project%20%3D%20CXX%20AND%20fixVersion%20%3D%20{}).\n\n".format(
+        release_version)
+    release_notes += footer
 
     return release_notes
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -36,13 +36,16 @@ changes cherry-picked onto the release branch. This is indicated by a comment on
 the ticket. Here is an
 [example comment](https://jira.mongodb.com/browse/CXX-2650?focusedCommentId=5271981&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-5271981).
 
-## Audit Jira ticket titles and types for use in release notes
+## Audit Jira ticket titles and types
 
-From the releases page click the "Release Notes" link to see a summary of
-tickets to be included in release notes. Update the ticket type and title as
-appropriate. User-facing issues should generally be either "Bug" or
-"New Feature". Non-user facing issues should generally be "Task" tickets (and
-will be omitted later, so you can ignore them here).
+Update Jira ticket types and titles as appropriate.
+User-facing issues should generally be either "Bug" or "New Feature".
+Non-user facing issues should generally be "Task" tickets.
+
+## Update CHANGELOG.md
+
+Check Jira for tickets closed in this fix version. Consider updating CHANGELOG.md
+with notable changes not already mentioned.
 
 ## Clone and set up environment
 

--- a/etc/test_make_release.py
+++ b/etc/test_make_release.py
@@ -1,0 +1,65 @@
+import make_release
+import unittest
+import textwrap
+import click
+
+
+class TestMakeRelease(unittest.TestCase):
+    def test_generate_release_notes_v2(self):
+        # Test can generate.
+        changelog = textwrap.dedent("""
+        # Changelog
+
+        All notable changes to this project will be documented in this file.
+
+        The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+        and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+        ## 3.9.0
+
+        ### Added
+
+        - Add CMake option `USE_DEFAULT_INSTALL_PATH`.
+        - Add API to manage Atlas Search Indexes.
+                                    
+        ## 3.8.0
+
+        ### Fixed
+
+        - Fix foo.
+        """).lstrip()
+        expected_release_notes = textwrap.dedent("""
+        ## Added
+
+        - Add CMake option `USE_DEFAULT_INSTALL_PATH`.
+        - Add API to manage Atlas Search Indexes.
+
+        See the [full list of changes in Jira](https://jira.mongodb.org/issues/?jql=project%20%3D%20CXX%20AND%20fixVersion%20%3D%203.9.0).
+
+        ## Feedback
+        To report a bug or request a feature, please open a ticket in the MongoDB issue management tool Jira:
+
+        - [Create an account](https://jira.mongodb.org) and login.
+        - Navigate to the [CXX project](https://jira.mongodb.org/browse/CXX)
+        - Click `Create`.
+        """).lstrip()
+
+        got = make_release.generate_release_notes_v2("3.9.0", changelog)
+        self.assertEqual(got, expected_release_notes)
+
+        # Test exception occurs if CHANGELOG includes extra characters in title.
+        with self.assertRaises(click.ClickException) as ctx:
+            make_release.generate_release_notes_v2(
+                "3.9.0", "## 3.9.0 [Unreleased]")
+        self.assertIn("Unexpected extra characters",
+                      str(ctx.exception.message))
+
+        # Test exception occurs if CHANGELOG does not include matching entry.
+        with self.assertRaises(click.ClickException) as ctx:
+            make_release.generate_release_notes_v2(
+                "3.9.0", "## 3.8.0")
+        self.assertIn("Failed to find", str(ctx.exception.message))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/etc/test_make_release.py
+++ b/etc/test_make_release.py
@@ -5,7 +5,7 @@ import click
 
 
 class TestMakeRelease(unittest.TestCase):
-    def test_generate_release_notes_v2(self):
+    def test_generate_release_notes(self):
         # Test can generate.
         changelog = textwrap.dedent("""
         # Changelog
@@ -44,19 +44,19 @@ class TestMakeRelease(unittest.TestCase):
         - Click `Create`.
         """).lstrip()
 
-        got = make_release.generate_release_notes_v2("3.9.0", changelog)
+        got = make_release.generate_release_notes("3.9.0", changelog)
         self.assertEqual(got, expected_release_notes)
 
         # Test exception occurs if CHANGELOG includes extra characters in title.
         with self.assertRaises(click.ClickException) as ctx:
-            make_release.generate_release_notes_v2(
+            make_release.generate_release_notes(
                 "3.9.0", "## 3.9.0 [Unreleased]")
         self.assertIn("Unexpected extra characters",
                       str(ctx.exception.message))
 
         # Test exception occurs if CHANGELOG does not include matching entry.
         with self.assertRaises(click.ClickException) as ctx:
-            make_release.generate_release_notes_v2(
+            make_release.generate_release_notes(
                 "3.9.0", "## 3.8.0")
         self.assertIn("Failed to find", str(ctx.exception.message))
 


### PR DESCRIPTION
# Summary

This PR proposes adding a changelog to track notable changes in releases.

Changes were tested by locally tagging a commit with `r3.9.0` and temporarily tweaking the script to produce a draft. Here is a sample draft of the produced release notes:
https://github.com/mongodb/mongo-cxx-driver/releases/tag/untagged-fd8ab6ba4086415ac8fa

# Background & Motivation
Having a CHANGELOG may reduce work during releases:
- The [release notes for 3.8.0](https://github.com/mongodb/mongo-cxx-driver/releases/tag/r3.8.0) included written notes not generated by `make_release.py`. Notes can be written incrementally with the changes.
- Tickets requiring release notes can be resolved before a release. Example: CXX-2662.

Listing individual Jira tickets is intentionally removed. IMO a copied list of tickets does not provide much value over linking to Jira. Providing a high level overview of changes may be more helpful. Readers can follow the Jira link or see commits for details.