### PR TITLE
Fix configuring a second time with USE_DEFAULT_INSTALL_PATH=TRUE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Directories that are generated
 /tags
 cmake-build*
+_build/
 
 # Filetypes
 *~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 3.9.0 [Unreleased]
 
-### Added 
+### Added
 
-- Add CMake option `USE_DEFAULT_INSTALL_PATH`.
+- Add CMake option `MONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX` (default is `TRUE`
+  for backwards-compatibility).
 - Add API to manage Atlas Search Indexes.
 - Automatically download C driver dependency if not provided.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,12 +202,14 @@ To build static libraries only, set both BUILD_SHARED_LIBS and BUILD_SHARED_AND_
 endif()
 
 
-option(USE_DEFAULT_INSTALL_PATH "Override the CMake default installation path" OFF)
-if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND USE_DEFAULT_INSTALL_PATH)
-    message(FATAL_ERROR "You cannot set both CMAKE_INSTALL_PREFIX and USE_DEFAULT_INSTALL_PATH")
-endif()
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND NOT USE_DEFAULT_INSTALL_PATH)
-    message(WARNING "the CMake default install path is being overridden to the build directory. This behavior will not be the default in a future release. Build with -DUSE_DEFAULT_INSTALL_PATH=ON to opt into what will be the default behavior in a future release. Setting install path to: ${CMAKE_BINARY_DIR}/install")
+option(MONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX "If enabled, mongocxx will set a default CMAKE_INSTALL_PREFIX if one is not already defined" TRUE)
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND MONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX)
+    message(WARNING
+        "mongocxx: The default CMAKE_INSTALL_PREFIX is being overridden to the "
+        "build directory. This behavior will not be the default in a future "
+        "release. Build with 'MONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX=ON' to opt "
+        "into what will be the default behavior in a future release. Setting install "
+        "path to: ${CMAKE_BINARY_DIR}/install")
     set (CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "default install path" FORCE)
 endif()
 

--- a/docs/content/mongocxx-v3/installation/linux.md
+++ b/docs/content/mongocxx-v3/installation/linux.md
@@ -71,7 +71,7 @@ from source. To configure `mongocxx` for installation into `/usr/local` as well,
 ```
 cmake ..                                \
     -DCMAKE_BUILD_TYPE=Release          \
-    -DUSE_DEFAULT_INSTALL_PATH=ON
+    -DMONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX=OFF
 ```
 
 These options can be freely mixed with a C++17 polyfill option. For instance, this is how a user
@@ -80,7 +80,7 @@ would run the command above with the Boost polyfill option:
 cmake ..                                            \
     -DCMAKE_BUILD_TYPE=Release                      \
     -DBSONCXX_POLY_USE_BOOST=1                      \
-    -DUSE_DEFAULT_INSTALL_PATH=ON
+    -DMONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX=OFF
 ```
 
 ### Step 4: Build and install the driver

--- a/docs/content/mongocxx-v3/installation/macos.md
+++ b/docs/content/mongocxx-v3/installation/macos.md
@@ -71,7 +71,7 @@ from source. To configure `mongocxx` for installation into `/usr/local` as well,
 ```
 cmake ..                                \
     -DCMAKE_BUILD_TYPE=Release          \
-    -DUSE_DEFAULT_INSTALL_PATH=ON
+    -DMONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX=OFF
 ```
 
 These options can be freely mixed with a C++17 polyfill option. For instance, this is how a user
@@ -80,7 +80,7 @@ would run the command above with the Boost polyfill option:
 cmake ..                                            \
     -DCMAKE_BUILD_TYPE=Release                      \
     -DBSONCXX_POLY_USE_BOOST=1                      \
-    -DUSE_DEFAULT_INSTALL_PATH=ON
+    -DMONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX=OFF
 ```
 
 ### Step 4: Build and install the driver

--- a/etc/test_make_release.py
+++ b/etc/test_make_release.py
@@ -19,7 +19,8 @@ class TestMakeRelease(unittest.TestCase):
 
         ### Added
 
-        - Add CMake option `USE_DEFAULT_INSTALL_PATH`.
+        - Add CMake option `MONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX` (default is `TRUE`
+          for backwards-compatibility).
         - Add API to manage Atlas Search Indexes.
                                     
         ## 3.8.0
@@ -31,7 +32,8 @@ class TestMakeRelease(unittest.TestCase):
         expected_release_notes = textwrap.dedent("""
         ## Added
 
-        - Add CMake option `USE_DEFAULT_INSTALL_PATH`.
+        - Add CMake option `MONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX` (default is `TRUE`
+          for backwards-compatibility).
         - Add API to manage Atlas Search Indexes.
 
         See the [full list of changes in Jira](https://jira.mongodb.org/issues/?jql=project%20%3D%20CXX%20AND%20fixVersion%20%3D%203.9.0).


### PR DESCRIPTION
[Refer to this comment](https://github.com/mongodb/mongo-cxx-driver/pull/994#discussion_r1302269847) for an explainer