### PR TITLE
CXX-2740 ensure GCC pragmas are not manipulated when compiling with clang

### DIFF
--- a/src/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/document/value.hpp
@@ -231,7 +231,7 @@ class BSONCXX_API value {
     std::size_t _length{0};
 };
 
-#if defined(__GNUC__) && (__cplusplus >= 201709L)
+#if !defined(__clang__) && defined(__GNUC__) && (__cplusplus >= 201709L)
 // Silence false positive with g++ 10.2.1 on Debian 11.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
@@ -239,7 +239,7 @@ class BSONCXX_API value {
 BSONCXX_INLINE document::view value::view() const noexcept {
     return document::view{static_cast<uint8_t*>(_data.get()), _length};
 }
-#if defined(__GNUC__) && (__cplusplus >= 201709L)
+#if !defined(__clang__) && defined(__GNUC__) && (__cplusplus >= 201709L)
 #pragma GCC diagnostic pop
 #endif
 

--- a/src/mongocxx/options/private/transaction.hh
+++ b/src/mongocxx/options/private/transaction.hh
@@ -104,13 +104,13 @@ class transaction::impl {
     stdx::optional<std::chrono::milliseconds> max_commit_time_ms() const {
         auto ms = libmongoc::transaction_opts_get_max_commit_time_ms(_transaction_opt_t.get());
         if (!ms) {
-#if defined(__GNUC__) && (__cplusplus >= 201709L)
+#if !defined(__clang__) && defined(__GNUC__) && (__cplusplus >= 201709L)
 // Silence false positive with g++ 10.2.1 on Debian 11.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
             return {};
-#if defined(__GNUC__) && (__cplusplus >= 201709L)
+#if !defined(__clang__) && defined(__GNUC__) && (__cplusplus >= 201709L)
 #pragma GCC diagnostic pop
 #endif
         }

--- a/src/third_party/catch/include/catch.hpp
+++ b/src/third_party/catch/include/catch.hpp
@@ -10875,7 +10875,7 @@ namespace Catch {
 // Older GCCs trigger -Wmissing-field-initializers for T foo = {}
 // which is zero initialization, but not explicit. We want to avoid
 // that.
-#if defined(__GNUC__)
+#if !defined(__clang__) && defined(__GNUC__)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif


### PR DESCRIPTION
This PR is an alternate solution to the one proposed in #972 