### PR TITLE
CXX-2736 document data compression

### DIFF
--- a/docs/content/mongocxx-v3/configuration.md
+++ b/docs/content/mongocxx-v3/configuration.md
@@ -169,3 +169,11 @@ auto pool = mongocxx::pool{uri{"mongodb://host1/?minPoolSize=3&maxPoolSize=5"}};
 ```
  
 See [connection pool documentation](../connection-pools) for more details.
+
+## Compressing data to and from MongoDB
+
+MongoDB 3.4 added Snappy compression support, while zlib compression was added
+in 3.6, and zstd compression in 4.2.
+
+Data compression can be enabled with the appropriate URI options, as documented
+in [the C driver](https://mongoc.org/libmongoc/current/data-compression.html).


### PR DESCRIPTION
Before this PR is merged, mongodb/mongo-c-driver#1392 should be merged and the location of [the page](https://mongoc.org/libmongoc/current/data-compression.html) linked in this PR should be confirmed.