### PR TITLE
ensure `LIBMONGOC_DOWNLOAD_VERSION` matches `LIBMONGOC_REQUIRED_VERSION`

### DIFF
--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -315,6 +315,10 @@ def check_libmongoc_version():
         click.echo("Expected LIBMONGOC_REQUIRED_VERSION to match: {}, got: {}".format(
             libmongoc_version_pattern, got_LIBMONGOC_REQUIRED_VERSION))
         sys.exit(1)
+    if got_LIBMONGOC_DOWNLOAD_VERSION != got_LIBMONGOC_REQUIRED_VERSION:
+        click.echo("Expected LIBMONGOC_DOWNLOAD_VERSION({}) to match LIBMONGOC_REQUIRED_VERSION({})".format(
+            got_LIBMONGOC_DOWNLOAD_VERSION, got_LIBMONGOC_REQUIRED_VERSION))
+        sys.exit(1)
 
 
 # pylint: enable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements

--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -316,7 +316,7 @@ def check_libmongoc_version():
             libmongoc_version_pattern, got_LIBMONGOC_REQUIRED_VERSION))
         sys.exit(1)
     if got_LIBMONGOC_DOWNLOAD_VERSION != got_LIBMONGOC_REQUIRED_VERSION:
-        click.echo("Expected LIBMONGOC_DOWNLOAD_VERSION({}) to match LIBMONGOC_REQUIRED_VERSION({})".format(
+        click.echo("Expected LIBMONGOC_DOWNLOAD_VERSION ({}) to match LIBMONGOC_REQUIRED_VERSION ({})".format(
             got_LIBMONGOC_DOWNLOAD_VERSION, got_LIBMONGOC_REQUIRED_VERSION))
         sys.exit(1)
 


### PR DESCRIPTION
# Summary
Check that `LIBMONGOC_DOWNLOAD_VERSION` equals `LIBMONGOC_REQUIRED_VERSION` in `make_release.py`.

# Background & Motivation

Check is intended to ensure `LIBMONGOC_DOWNLOAD_VERSION` matches `LIBMONGOC_REQUIRED_VERSION` before a release.
`LIBMONGOC_DOWNLOAD_VERSION` may differ during development if a non-tagged C driver is needed for testing. `LIBMONGOC_REQUIRED_VERSION` is expected to be a tag intended for `find_package`.

Locally setting `LIBMONGOC_DOWNLOAD_VERSION` to `1.24.1` results in this error:

```bash
% python ./etc/make_release.py HEAD        
Expected LIBMONGOC_DOWNLOAD_VERSION(1.24.1) to match LIBMONGOC_REQUIRED_VERSION(1.24.0)
```