### PR TITLE
Temporarily use CMake version 3.25.3 instead of find-cmake-latest

### DIFF
--- a/.evergreen/install_c_driver.sh
+++ b/.evergreen/install_c_driver.sh
@@ -63,10 +63,11 @@ else
   echo "${build_version}" >|"${mongoc_dir}/VERSION_CURRENT"
 fi
 
+# TODO: revert to using find-cmake-latest once `mongoc_version_minimum` contains commit 6a23bd37.
 # shellcheck source=/dev/null
-. "${mongoc_dir}/.evergreen/scripts/find-cmake-latest.sh"
+. "${mongoc_dir}/.evergreen/scripts/find-cmake-version.sh"
 declare cmake_binary
-cmake_binary="$(find_cmake_latest)"
+cmake_binary="$(find_cmake_version 3 25 3)"
 command -v "${cmake_binary:?}"
 
 # Install libmongocrypt.

--- a/.evergreen/install_c_driver.sh
+++ b/.evergreen/install_c_driver.sh
@@ -122,7 +122,7 @@ darwin*)
   ;;
 esac
 
-if [[ "${BSON_EXTRA_ALIGNMENT}" == "1" ]]; then
+if [[ "${BSON_EXTRA_ALIGNMENT:-}" == "1" ]]; then
   echo "Building C Driver with ENABLE_EXTRA_ALIGNMENT=ON"
   configure_flags+=("-DENABLE_EXTRA_ALIGNMENT=ON")
 else

--- a/.mci.yml
+++ b/.mci.yml
@@ -402,9 +402,11 @@ functions:
                   if [[ "$OSTYPE" =~ cygwin ]]; then
                       MONGOC_PREFIX=$(cygpath -m "$MONGOC_PREFIX")
                   fi
-                  . "$MONGOC_PREFIX/.evergreen/scripts/find-cmake-latest.sh"
-                  declare cmake_binary
-                  export cmake_binary="$(find_cmake_latest)"
+
+                  # TODO: revert to using find-cmake-latest once `mongoc_version_minimum` contains commit 6a23bd37.
+                  . "$MONGOC_PREFIX/.evergreen/scripts/find-cmake-version.sh"
+                  export cmake_binary
+                  cmake_binary="$(find_cmake_version 3 25 3)"
                   command -v "$cmake_binary"
 
                   if [ ! -d ../drivers-evergreen-tools ]; then
@@ -714,9 +716,10 @@ functions:
                   # is true.
                   if [[ -z "$MONGODB_API_VERSION" ]]; then
                     echo "Building example projects..."
-                    . "$PREFIX/.evergreen/scripts/find-cmake-latest.sh"
-                    declare cmake_binary
-                    export cmake_binary="$(find_cmake_latest)"
+                    # TODO: revert to using find-cmake-latest once `mongoc_version_minimum` contains commit 6a23bd37.
+                    . "$PREFIX/.evergreen/scripts/find-cmake-version.sh"
+                    export cmake_binary
+                    cmake_binary="$(find_cmake_version 3 25 3)"
                     command -v "$cmake_binary"
                     .evergreen/build_example_projects.sh
                     echo "Building example projects... done."
@@ -1113,8 +1116,10 @@ tasks:
             [ -d mongo-c-driver ] || git clone --depth 1 https://github.com/mongodb/mongo-c-driver
             rsync -aq --exclude='examples/add_subdirectory' $(readlink -f ../..) .
             [ -d build ] || mkdir build
-            . ./mongo-c-driver/.evergreen/scripts/find-cmake-latest.sh
-            export CMAKE="$(find_cmake_latest)"
+            # TODO: revert to using find-cmake-latest once `mongoc_version_minimum` contains commit 6a23bd37.
+            . ./mongo-c-driver/.evergreen/scripts/find-cmake-version.sh
+            export CMAKE
+            CMAKE="$(find_cmake_version 3 25 3)"
             cd build
             $CMAKE ..
             $CMAKE --build . -- -j $(nproc)

--- a/.mci.yml
+++ b/.mci.yml
@@ -420,6 +420,7 @@ functions:
 
                   export GENERATOR="${generator}"
 
+                  ignore_deprecated=""
                   if [ "$(echo ${branch_name} | cut -f2 -d'/')" != "${branch_name}" ]; then
                       # ignore deprecation warnings when building on a release branch
                       ignore_deprecated=-Wno-deprecated-declarations


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1403 and https://github.com/mongodb/mongo-c-driver/pull/1404.

This _might_ address [flaky task failures](https://parsley.mongodb.com/evergreen/cxx_driver_auth__os~windows_2k8_mongodb_version~latest_compile_and_test_auth_with_shared_libs_60a3e7c4bf04079116c37a7eb9de5d30f67c02cb_23_09_13_19_02_31/0/task?bookmarks=0,366&shareLine=289) observed in the CXX Driver EVG waterfall due to the following error (cached CMake binary no longer binary/script-compatible with Git?):

```
      0 [main] sh (1044) C:\Program Files\Git\usr\bin\sh.exe: *** fatal error - cygheap base mismatch detected - 0xFB6410/0xE56410.
This problem is probably due to using incompatible versions of the cygwin DLL.
Search for cygwin1.dll using the Windows Start->Find/Search facility
and delete all but the most recent version.  The most recent version *should*
reside in x:\cygwin\bin, where 'x' is the drive on which you have
installed the cygwin distribution.  Rebooting is also suggested if you
are unable to find another cygwin DLL.
3078162 [main] sh 2884 fork: child -1 - forked process 1044 died unexpectedly, retry 0, exit code 0xC0000142, errno 11
C:\Program Files\Git\mingw32/libexec/git-core\git-submodule: fork: retry: Resource temporarily unavailable
```

Otherwise, this is just a simple patch version bump. Considered bumping to the latest minor version 3.27.4 but decided to postpone it for now.

Sourcing `find-cmake-version.sh` (which sets `nounset`) triggered some nounset failures which are also addressed by this PR.