### PR TITLE
use https://jira.mongodb.org, not https://jira.mongodb.com

### DIFF
--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -131,7 +131,7 @@ def release(jira_creds_file,
 
     # Read Jira credentials and GitHub token first, to check that
     # user has proper credentials before embarking on lengthy builds.
-    jira_options = {'server': 'https://jira.mongodb.com'}
+    jira_options = {'server': 'https://jira.mongodb.org'}
     jira_oauth_dict = read_jira_oauth_creds(jira_creds_file)
     auth_jira = JIRA(jira_options, oauth=jira_oauth_dict)
 


### PR DESCRIPTION
Link was accidentally renamed in the mass replacement of https://github.com/mongodb/mongo-cxx-driver/commit/effc286c962c93b14406ef41d314558e5cad7b5f.

Resolves an observed error when running the release script:

```
% python ./etc/make_release.py \
    --dry-run \
    --jira-creds-file ~/.secrets/jira_creds.txt \
    --github-token-file ~/.secrets/github_token.txt \
    r3.8.1 
```

Results in error:
```
  File "/Users/kevin.albertson/.venv/lib/python3.11/site-packages/jira/resilientsession.py", line 71, in raise_on_error
    raise JIRAError(
jira.exceptions.JIRAError: JiraError HTTP 401 url: https://jira.mongodb.com/rest/api/2/serverInfo
```