### PR TITLE
CXX-2749 Fix debian-package-build-mnmlstc

### DIFF
--- a/.evergreen/debian_package_build.sh
+++ b/.evergreen/debian_package_build.sh
@@ -41,6 +41,7 @@ if [ "${IS_PATCH}" = "true" ]; then
 fi
 if [ "${DEB_BUILD_PROFILES#*pkg.mongo-cxx-driver.mnmlstc}" != "${DEB_BUILD_PROFILES}" ]; then
    MNMLSTC_DEPS="git ca-certificates"
+   MNMLSTC_INCLUDE="-I/usr/include/bsoncxx/v_noabi/bsoncxx/third_party/mnmlstc "
 fi
 
 
@@ -66,10 +67,10 @@ sudo DEB_BUILD_PROFILES="${DEB_BUILD_PROFILES}" chroot ./unstable-chroot /bin/ba
   LANG=C /bin/bash -x ./debian/build_snapshot.sh && \
   debc ../*.changes && \
   dpkg -i ../*.deb && \
-  /usr/bin/g++ -I/usr/include/bsoncxx/v_noabi -I/usr/include/mongocxx/v_noabi -o runcommand_examples examples/mongocxx/mongodb.com/runcommand_examples.cpp -lmongocxx -lbsoncxx && \
-  /usr/bin/g++ -I/usr/include/bsoncxx/v_noabi -I/usr/include/mongocxx/v_noabi -o aggregation_examples examples/mongocxx/mongodb.com/aggregation_examples.cpp -lmongocxx -lbsoncxx && \
-  /usr/bin/g++ -I/usr/include/bsoncxx/v_noabi -I/usr/include/mongocxx/v_noabi -o index_examples examples/mongocxx/mongodb.com/index_examples.cpp -lmongocxx -lbsoncxx && \
-  /usr/bin/g++ -I/usr/include/bsoncxx/v_noabi -I/usr/include/mongocxx/v_noabi -o documentation_examples examples/mongocxx/mongodb.com/documentation_examples.cpp -lmongocxx -lbsoncxx )"
+  /usr/bin/g++ ${MNMLSTC_INCLUDE:-}-I/usr/include/bsoncxx/v_noabi -I/usr/include/mongocxx/v_noabi -o runcommand_examples examples/mongocxx/mongodb.com/runcommand_examples.cpp -lmongocxx -lbsoncxx && \
+  /usr/bin/g++ ${MNMLSTC_INCLUDE:-}-I/usr/include/bsoncxx/v_noabi -I/usr/include/mongocxx/v_noabi -o aggregation_examples examples/mongocxx/mongodb.com/aggregation_examples.cpp -lmongocxx -lbsoncxx && \
+  /usr/bin/g++ ${MNMLSTC_INCLUDE:-}-I/usr/include/bsoncxx/v_noabi -I/usr/include/mongocxx/v_noabi -o index_examples examples/mongocxx/mongodb.com/index_examples.cpp -lmongocxx -lbsoncxx && \
+  /usr/bin/g++ ${MNMLSTC_INCLUDE:-}-I/usr/include/bsoncxx/v_noabi -I/usr/include/mongocxx/v_noabi -o documentation_examples examples/mongocxx/mongodb.com/documentation_examples.cpp -lmongocxx -lbsoncxx )"
 
 [ -e ./unstable-chroot/tmp/mongo-cxx-driver/runcommand_examples ] || (echo "Example 'runcommand_examples' was not built!" ; exit 1)
 [ -e ./unstable-chroot/tmp/mongo-cxx-driver/aggregation_examples ] || (echo "Example 'aggregation_examples' was not built!" ; exit 1)

--- a/debian/rules
+++ b/debian/rules
@@ -26,6 +26,7 @@ ifneq (,$(filter pkg.mongo-cxx-driver.mnmlstc,$(DEB_BUILD_PROFILES)))
 	dh_auto_configure -B$(CURDIR)/build -- \
 	-DBUILD_VERSION=$(DEB_VERSION_UPSTREAM) \
 	-DBSONCXX_POLY_USE_MNMLSTC=1 \
+	-DFETCHCONTENT_FULLY_DISCONNECTED=OFF \
 	-DENABLE_UNINSTALL=OFF
 else
 	dh_auto_configure -B$(CURDIR)/build -- \

--- a/debian/rules
+++ b/debian/rules
@@ -46,12 +46,6 @@ override_dh_auto_install:
 	dh_auto_install -B$(CURDIR)/build
 	find $(CURDIR)/debian/tmp -type d -empty -delete
 	rm -f $(CURDIR)/debian/tmp/usr/share/mongo-cxx-driver/LICENSE
-ifneq (,$(filter pkg.mongo-cxx-driver.mnmlstc,$(DEB_BUILD_PROFILES)))
-	# Drop MNMLSTC headers in a location where dh_install will pick them up
-	mv $(CURDIR)/debian/tmp-mnmlstc/usr/include/bsoncxx/v_noabi/bsoncxx/third_party \
-	   $(CURDIR)/debian/tmp/usr/include/bsoncxx/v_noabi/bsoncxx/
-	rm -rf $(CURDIR)/debian/tmp-mnmlstc
-endif
 
 override_dh_auto_test:
 	# do nothing

--- a/debian/rules
+++ b/debian/rules
@@ -36,11 +36,7 @@ else
 endif
 
 override_dh_auto_build:
-ifneq (,$(filter pkg.mongo-cxx-driver.mnmlstc,$(DEB_BUILD_PROFILES)))
-	dh_auto_build -B$(CURDIR)/build -- all doxygen-current DESTDIR=$(CURDIR)/debian/tmp-mnmlstc
-else
 	dh_auto_build -B$(CURDIR)/build -- all doxygen-current
-endif
 
 override_dh_auto_install:
 	dh_auto_install -B$(CURDIR)/build


### PR DESCRIPTION
Related to CXX-2749. Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1019 and https://github.com/mongodb/mongo-cxx-driver/pull/1024. Verified by [this patch](https://spruce.mongodb.com/task/cxx_driver_packaging_debian_package_build_mnmlstc_patch_3d959fb6825f67969cb2e23c8d85a47f03d608fe_652413b39ccd4e8ae4c20411_23_10_09_14_52_36/logs?execution=0).

Applies changes made in prior PRs to install rules and include paths for mnmlstc/core to the Debian packaging rules (removal of custom header file installation/management, addition of mnmlstc directory to include directories). Additionally, default Debian packaging commands disable downloads via `FETCHCONTENT_FULLY_DISCONNECTED=ON`. Disabling this to allow downloads during package build is considered acceptable, as the mnmlstc polyfill package configuration is not the officially supported package configuration that is maintained and distributed on Debian (+ the prior method via ExternalProject was doing it anyways).