### PR TITLE
Fix formatting of make_unique.hpp

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
@@ -112,11 +112,12 @@ std::unique_ptr<T> make_unique(Args&&... args) {
 /**
  * @copydoc bsoncxx::v_noabi::stdx::make_unique
  */
-template <typename T,
-          typename Impl = detail::make_unique_impl<T>,
-          typename std::enable_if<std::is_array<T>::value,
-                                  decltype(Impl::make(std::true_type{}, std::declval<std::size_t>()),
-                                           void())>::type* = nullptr>
+template <
+    typename T,
+    typename Impl = detail::make_unique_impl<T>,
+    typename std::enable_if<std::is_array<T>::value,
+                            decltype(Impl::make(std::true_type{}, std::declval<std::size_t>()),
+                                     void())>::type* = nullptr>
 std::unique_ptr<T> make_unique(std::size_t count) {
     return Impl::make(std::true_type{}, count);
 }
@@ -149,11 +150,12 @@ std::unique_ptr<T> make_unique_for_overwrite(Args&&... args) {
 /**
  * @copydoc bsoncxx::v_noabi::stdx::make_unique_for_overwrite
  */
-template <typename T,
-          typename Impl = detail::make_unique_impl<T>,
-          typename std::enable_if<std::is_array<T>::value,
-                                  decltype(Impl::make(std::false_type{}, std::declval<std::size_t>()),
-                                           void())>::type* = nullptr>
+template <
+    typename T,
+    typename Impl = detail::make_unique_impl<T>,
+    typename std::enable_if<std::is_array<T>::value,
+                            decltype(Impl::make(std::false_type{}, std::declval<std::size_t>()),
+                                     void())>::type* = nullptr>
 std::unique_ptr<T> make_unique_for_overwrite(std::size_t count) {
     return Impl::make(std::false_type{}, count);
 }


### PR DESCRIPTION
Minor followup to https://github.com/mongodb/mongo-cxx-driver/pull/1044 that fixes the `lint` task failure on EVG.