### PR TITLE
Arm64 docker build

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -840,6 +840,9 @@ functions:
             set -o errexit
             set -o pipefail
             set -x
+            # TODO: Re-enable Alpine test once MONGOCRYPT-601 is released.
+            # echo "Building Alpine Docker image"
+            # make -C extras/docker/alpine3.18 nocachebuild test
             echo "Building Debian Docker image"
             make -C extras/docker/bookworm nocachebuild test
             echo "Building Red Hat UBI Docker image"
@@ -1235,14 +1238,14 @@ tasks:
         - func: "test"
 
     - name: docker_build_arm
-      run_on: &docker-distros
-        - ubuntu2004-arm64-small
+      run_on:
+        - ubuntu2204-arm64-small
       commands:
          - func: "setup"
          - func: "docker-image-build"
 
     - name: docker_build
-      run_on: &docker-distros
+      run_on:
         - ubuntu2204-small
       commands:
          - func: "setup"
@@ -1412,10 +1415,6 @@ buildvariants:
       display_name: "Docker builder"
       tasks:
           - name: docker_build
-
-    - name: docker-arm-builder
-      display_name: "Docker ARM builder"
-      tasks:
           - name: docker_build_arm
 
     - name: rhel9-release-latest

--- a/.mci.yml
+++ b/.mci.yml
@@ -1234,6 +1234,13 @@ tasks:
         - func: "run_kms_servers"
         - func: "test"
 
+    - name: docker_build_arm
+      run_on: &docker-distros
+        - ubuntu2004-arm64-small
+      commands:
+         - func: "setup"
+         - func: "docker-image-build"
+
     - name: docker_build
       run_on: &docker-distros
         - ubuntu2204-small
@@ -1405,6 +1412,11 @@ buildvariants:
       display_name: "Docker builder"
       tasks:
           - name: docker_build
+
+    - name: docker-arm-builder
+      display_name: "Docker ARM builder"
+      tasks:
+          - name: docker_build_arm
 
     - name: rhel9-release-latest
       display_name: "RHEL 9 Release (MongoDB Latest)"

--- a/.mci.yml
+++ b/.mci.yml
@@ -840,8 +840,6 @@ functions:
             set -o errexit
             set -o pipefail
             set -x
-            echo "Building Alpine Docker image"
-            make -C extras/docker/alpine3.18 nocachebuild test
             echo "Building Debian Docker image"
             make -C extras/docker/bookworm nocachebuild test
             echo "Building Red Hat UBI Docker image"


### PR DESCRIPTION
CXX-2766

In order to better support ARM hosts, such as recent Apple computers that use ARM chips, we will provide both AMD64 and ARM64 images on Docker Hub.

libmongocrypt does not currently build on Alpine on ARM64, so the Alpine build is being temporarily removed. The build is fixed with the following [PR](https://github.com/mongodb/libmongocrypt/pull/706) and the Alpine build should be re-enabled once a new libmongocrypt release is done that has that PR.