### PR TITLE
Defer to C++ standard library specification for make_unique polyfills

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
@@ -83,22 +83,7 @@ struct make_unique_impl<T&&> {};
 
 }  // namespace detail
 
-/**
- * @brief Create a new std::unique_ptr that points-to the given type, direct-initialized based on
- * the given arguments.
- *
- * @tparam T Any non-array object type or any array of unknown bound.
- * @param args If T is a non-array object type, these are the constructor arguments used to
- * direct-initialize the object. If T is an array of unknown bound, then the sole argument must be a
- * single std::size_t that specifies the number of objects to allocate in the array.
- *
- * Requires:
- * - If T is an array of unknown bounds, then args... must be a single size_t and the element type
- * of T must be value-initializable.
- * - Otherwise, if T is a non-array object type, then T must be direct-initializable with arguments
- * `args...`
- * - Otherwise, this function is excluded from overload resolution.
- */
+/// Equivalent to `std::make_unique<T>(args...)` where `T` is a non-array type.
 template <typename T,
           typename... Args,
           typename Impl = detail::make_unique_impl<T>,
@@ -109,9 +94,7 @@ std::unique_ptr<T> make_unique(Args&&... args) {
     return Impl::make(std::true_type{}, std::forward<Args>(args)...);
 }
 
-/**
- * @copydoc bsoncxx::v_noabi::stdx::make_unique
- */
+/// Equivalent to `std::make_unique<T>(count)` where `T` is an array type.
 template <
     typename T,
     typename Impl = detail::make_unique_impl<T>,
@@ -122,21 +105,7 @@ std::unique_ptr<T> make_unique(std::size_t count) {
     return Impl::make(std::true_type{}, count);
 }
 
-/**
- * @brief Create a new std::unique_ptr that points-to a default-initialized instance of the given
- * type.
- *
- * @tparam T A non-array object type or an array of unknown bound
- * @param args If T is an object type, then args... must no arguments are allowed.
- * If T is an array of unknown bound, then args... must be a single size_t specifying
- * the length of the array to allocate.
- *
- * Requires:
- * - T must be default-initializable
- * - If T is an array of unknown bounds, then args... must be a single size_t
- * - Otherwise, if T is a non-array object type, args... must be empty
- * - Otherwise, this function is excluded from overload resolution
- */
+/// Equivalent to `std::make_unique_for_overwrite<T>()` where `T` is a non-array type.
 template <typename T,
           typename... Args,
           typename Impl = detail::make_unique_impl<T>,
@@ -147,9 +116,7 @@ std::unique_ptr<T> make_unique_for_overwrite(Args&&... args) {
     return Impl::make(std::false_type{}, std::forward<Args>(args)...);
 }
 
-/**
- * @copydoc bsoncxx::v_noabi::stdx::make_unique_for_overwrite
- */
+/// Equivalent to `std::make_unique_for_overwrite<T>(count)` where `T` is an array type.
 template <
     typename T,
     typename Impl = detail::make_unique_impl<T>,

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
@@ -107,13 +107,11 @@ std::unique_ptr<T> make_unique(std::size_t count) {
 
 /// Equivalent to `std::make_unique_for_overwrite<T>()` where `T` is a non-array type.
 template <typename T,
-          typename... Args,
           typename Impl = detail::make_unique_impl<T>,
           typename std::enable_if<!std::is_array<T>::value,
-                                  decltype(Impl::make(std::false_type{}, std::declval<Args>()...),
-                                           void())>::type* = nullptr>
-std::unique_ptr<T> make_unique_for_overwrite(Args&&... args) {
-    return Impl::make(std::false_type{}, std::forward<Args>(args)...);
+                                  decltype(Impl::make(std::false_type{}), void())>::type* = nullptr>
+std::unique_ptr<T> make_unique_for_overwrite() {
+    return Impl::make(std::false_type{});
 }
 
 /// Equivalent to `std::make_unique_for_overwrite<T>(count)` where `T` is an array type.


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1044.

Addresses the following Doxygen warnings due to improper use of `@copydoc`:

```
warning: argument 'args' of command @param is not found in the argument list of bsoncxx::v_noabi::stdx::make_unique(std::size_t count)
warning: The following parameter of bsoncxx::v_noabi::stdx::make_unique(std::size_t count) is not documented:
  parameter 'count'
warning: argument 'args' of command @param is not found in the argument list of bsoncxx::v_noabi::stdx::make_unique_for_overwrite(std::size_t count)
warning: The following parameter of bsoncxx::v_noabi::stdx::make_unique_for_overwrite(std::size_t count) is not documented:
  parameter 'count'
```

Given these polyfills are intended to conform to their stdlib counterparts, this PR proposes simplifying the documentation to merely state their intent: equivalence with their stdlib counterparts.

As another drive-by improvement to stdlib equivalence (similar to https://github.com/mongodb/mongo-cxx-driver/pull/1044 concerning the `std::size_t` parameter), the non-array `make_unique_for_overwrite()` is updated to accept no function arguments, rather than a parameter pack that triggers SFINAE for `N > 0` arguments, for better consistency with the stdlib spec.

Technically, the bounded array case should be a separate overload with `= delete` behavior, rather than being SFINAE-friendly, but I think (I hope) this is not a significant compatibility issue (rarity of cases of SFINAE on `make_unique_for_overwrite()` validity).