### PR TITLE
Use consistent pattern for type_traits header include directives

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
@@ -18,12 +18,12 @@
 #include <stdexcept>
 #include <type_traits>
 
-#include "bsoncxx/stdx/type_traits.hpp"
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
+#include <bsoncxx/stdx/type_traits.hpp>
 #include <bsoncxx/types.hpp>
 
 #include <bsoncxx/config/prelude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
@@ -18,9 +18,9 @@
 #include <memory>
 #include <type_traits>
 
-#include "bsoncxx/stdx/type_traits.hpp"
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/document/view.hpp>
+#include <bsoncxx/stdx/type_traits.hpp>
 
 #include <bsoncxx/config/prelude.hpp>
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
@@ -19,7 +19,7 @@
 #include <type_traits>
 #include <utility>
 
-#include "./type_traits.hpp"
+#include <bsoncxx/stdx/type_traits.hpp>
 
 #include <bsoncxx/config/prelude.hpp>
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/test_util/mock.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/test_util/mock.hh
@@ -26,7 +26,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "bsoncxx/stdx/type_traits.hpp"
+#include <bsoncxx/stdx/type_traits.hpp>
 
 #include <mongocxx/config/private/prelude.hh>
 


### PR DESCRIPTION
Overlooked during review of https://github.com/mongodb/mongo-cxx-driver/pull/1042. Applies consistent use of `#include <bsoncxx/stdx/type_traits.hpp>` pattern to directives for consistency with other bsoncxx public header include directives.