### PR TITLE
CXX-2785 do not apply `readConcern` or `writeConcern` to search index commands

### DIFF
--- a/data/index-management/searchIndexIgnoresReadWriteConcern.json
+++ b/data/index-management/searchIndexIgnoresReadWriteConcern.json
@@ -1,0 +1,252 @@
+{
+  "description": "search index operations ignore read and write concern",
+  "schemaVersion": "1.4",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "uriOptions": {
+          "readConcernLevel": "local",
+          "w": 1
+        },
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "collection0"
+      }
+    }
+  ],
+  "runOnRequirements": [
+    {
+      "minServerVersion": "7.0.0",
+      "topologies": [
+        "replicaset",
+        "load-balanced",
+        "sharded"
+      ],
+      "serverless": "forbid"
+    }
+  ],
+  "tests": [
+    {
+      "description": "createSearchIndex ignores read and write concern",
+      "operations": [
+        {
+          "name": "createSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "model": {
+              "definition": {
+                "mappings": {
+                  "dynamic": true
+                }
+              }
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Search index commands are only supported with Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "mappings": {
+                          "dynamic": true
+                        }
+                      }
+                    }
+                  ],
+                  "$db": "database0",
+                  "writeConcern": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "createSearchIndex ignores read and write concern",
+      "operations": [
+        {
+          "name": "createSearchIndexes",
+          "object": "collection0",
+          "arguments": {
+            "models": []
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Search index commands are only supported with Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [],
+                  "$db": "database0",
+                  "writeConcern": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "dropSearchIndex ignores read and write concern",
+      "operations": [
+        {
+          "name": "dropSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "name": "test index"
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Search index commands are only supported with Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "dropSearchIndex": "collection0",
+                  "name": "test index",
+                  "$db": "database0",
+                  "writeConcern": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "listSearchIndexes ignores read and write concern",
+      "operations": [
+        {
+          "name": "listSearchIndexes",
+          "object": "collection0",
+          "expectError": {
+            "isError": true,
+            "errorContains": "Search index commands are only supported with Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "pipeline": [
+                    {
+                      "$listSearchIndexes": {}
+                    }
+                  ],
+                  "writeConcern": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "updateSearchIndex ignores the read and write concern",
+      "operations": [
+        {
+          "name": "updateSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "name": "test index",
+            "definition": {}
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Search index commands are only supported with Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "updateSearchIndex": "collection0",
+                  "name": "test index",
+                  "definition": {},
+                  "$db": "database0",
+                  "writeConcern": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/index-management/test_files.txt
+++ b/data/index-management/test_files.txt
@@ -3,3 +3,4 @@ createSearchIndexes.json
 dropSearchIndex.json
 listSearchIndexes.json
 updateSearchIndex.json
+searchIndexIgnoresReadWriteConcern.json

--- a/src/mongocxx/test/search_index_view.cpp
+++ b/src/mongocxx/test/search_index_view.cpp
@@ -250,7 +250,9 @@ TEST_CASE("atlas search indexes prose tests", "") {
             return does_search_index_exist_on_cursor(cursor, model, false);
         });
 
-        std::cout << "create one with name and definition SUCCESS" << std::endl;
+        std::cout << "create and list search indexes with non-default readConcern and writeConcern "
+                     "SUCCESS"
+                  << std::endl;
     }
 }
 }  // namespace

--- a/src/mongocxx/test/search_index_view.cpp
+++ b/src/mongocxx/test/search_index_view.cpp
@@ -223,5 +223,34 @@ TEST_CASE("atlas search indexes prose tests", "") {
 
         std::cout << "drop one supress namespace not found SUCCESS" << std::endl;
     }
+
+    SECTION("create and list search indexes with non-default readConcern and writeConcern") {
+        bsoncxx::oid id;
+        auto coll = db.create_collection(id.to_string());
+
+        // Apply non-default write concern.
+        auto nondefault_wc = mongocxx::write_concern();
+        nondefault_wc.nodes(1);
+        coll.write_concern(nondefault_wc);
+
+        // Apply non-default read concern.
+        auto nondefault_rc = mongocxx::read_concern();
+        nondefault_rc.acknowledge_level(mongocxx::read_concern::level::k_local);
+        coll.read_concern(nondefault_rc);
+
+        auto siv = coll.search_indexes();
+        auto name = "test-search-index-case6";
+        auto definition = make_document(kvp("mappings", make_document(kvp("dynamic", false))));
+        auto model = search_index_model(name, definition.view());
+
+        REQUIRE(siv.create_one(name, definition.view()) == "test-search-index-case6");
+
+        assert_soon([&siv, &model](void) -> bool {
+            auto cursor = siv.list();
+            return does_search_index_exist_on_cursor(cursor, model, false);
+        });
+
+        std::cout << "create one with name and definition SUCCESS" << std::endl;
+    }
 }
 }  // namespace


### PR DESCRIPTION
# Summary

Do not apply `readConcern` or `writeConcern` to search index commands

Tests verified with this patch: https://spruce.mongodb.com/version/654b89333e8e86f7a940c6e3

# Background & Motivation
This is a follow-up to https://github.com/mongodb/mongo-cxx-driver/issues/986

Search index commands return an error if `readConcern` or `writeConcern` is included.

Prior to the fix, applying a non-default `readConcern` or `writeConcern` to the `mongocxx::collection`, `mongocxx::database`, or `mongocxx::client` resulted in the `readConcern` or `writeConcern` being included in the search index command.

Prior to the fix, the added test "create and list search indexes with non-default readConcern and writeConcern" fails when run against an Atlas cluster:

```
/Users/kevin.albertson/code/tasks/mongo-cxx-driver-CXX-2697/src/mongocxx/test/search_index_view.cpp:246: FAILED:
  REQUIRE( siv.create_one(name, definition.view()) == "test-search-index-case6" )
due to unexpected exception with message:
  Command does not support writeConcern: generic server error
```

These changes are intended to be included in 3.9.0. The API added in https://github.com/mongodb/mongo-cxx-driver/pull/986 has not yet been released. The error may give a poor user experience.

The new tests are specified in https://github.com/mongodb/specifications/pull/1474.
