### PR TITLE
Bump required C driver to 1.25.0

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -12,7 +12,7 @@ variables:
     # If updating mongoc_version_minimum, also update:
     # - the default value of --c-driver-build-ref in etc/make_release.py
     # - LIBMONGOC_REQUIRED_VERSION in src/mongocxx/CMakeLists.txt
-    mongoc_version_minimum: &mongoc_version_minimum "1.24.0"
+    mongoc_version_minimum: &mongoc_version_minimum "1.25.0"
 
     integration_matrix:
         integration_matrix_tasks_single: &integration_matrix_tasks_single

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,11 +44,11 @@ else()
     message(WARNING "Unknown compiler... recklessly proceeding without a version check")
 endif()
 
-set(LIBBSON_REQUIRED_VERSION 1.24.0)
+set(LIBBSON_REQUIRED_VERSION 1.25.0)
 set(LIBBSON_REQUIRED_ABI_VERSION 1.0)
 
-set(LIBMONGOC_REQUIRED_VERSION 1.24.0)
-set(LIBMONGOC_DOWNLOAD_VERSION ba5ab6de26a874d33b0abc3d2b46961a69380e7a) # TODO: update to 1.25.0 once C driver 1.25.0 is released.
+set(LIBMONGOC_REQUIRED_VERSION 1.25.0)
+set(LIBMONGOC_DOWNLOAD_VERSION 1.25.0)
 set(LIBMONGOC_REQUIRED_ABI_VERSION 1.0)
 
 set(NEED_DOWNLOAD_C_DRIVER false)

--- a/docs/content/mongocxx-v3/installation/advanced.md
+++ b/docs/content/mongocxx-v3/installation/advanced.md
@@ -23,7 +23,7 @@ The above command would produce libraries named `libcustom_bsoncxx.so` and `libc
 
 The mongocxx driver builds on top of the [MongoDB C driver](https://www.mongodb.com/docs/drivers/c/).
 
-The build of mongocxx-3.8.1 automatically downloads and installs the C driver if the C driver is not detected.
+The build of mongocxx-3.9.0 automatically downloads and installs the C driver if the C driver is not detected.
 To use an existing install of the C driver, set `CMAKE_PREFIX_PATH` to the directory containing the C driver install.
 
 * For mongocxx-3.8.x, libmongoc 1.24.0 or later is required.

--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -155,8 +155,6 @@ def release(jira_creds_file,
         click.echo('Nothing to do here...exiting!', err=True)
         sys.exit(1)
 
-    check_docker_file_versions(release_version)
-
     if not working_dir_on_valid_branch(release_version):
         # working_dir_on_valid_branch() has already produced an error message
         sys.exit(1)
@@ -229,56 +227,6 @@ def release(jira_creds_file,
     else:
         create_github_release_draft(gh_repo, release_tag, is_pre_release, dist_file,
                                     release_notes_text, output_file, quiet)
-
-
-def check_docker_file_versions(mongo_cxx_release_ver: str):
-    """
-    Checks that `MONGOC_VERSION` defined in Dockerfiles matches `LIBMONGOC_REQUIRED_VERSION` from CMakeLists.txt.
-    Checks that `MONGOCXX_VERSION` defined in Docker Makefiles matches version to be released: `mongo_cxx_release_ver`.
-    """
-
-    extras_docker = pathlib.Path("./extras/docker")
-    dockerfiles = extras_docker.rglob("Dockerfile")
-    makefiles = extras_docker.rglob("Makefile")
-
-    # Get LIBMONGOC_REQUIRED_VERSION from CMakeLists.txt.
-    got_LIBMONGOC_REQUIRED_VERSION = None
-    contents = pathlib.Path("CMakeLists.txt").read_text()
-    matches = re.findall(
-        r"set\(LIBMONGOC_REQUIRED_VERSION\s+(.*?)\)", contents)
-    if len(matches) != 1:
-        click.echo('Expected to match one LIBMONGOC_REQUIRED_VERSION, got: {}'.format(
-            matches), err=True)
-        sys.exit(1)
-    got_LIBMONGOC_REQUIRED_VERSION = matches[0]
-
-    # Check that `MONGOC_VERSION` defined in Dockerfiles matches `LIBMONGOC_REQUIRED_VERSION` from CMakeLists.txt.
-    for dockerfile in dockerfiles:
-        contents = pathlib.Path(dockerfile).read_text()
-        matches = re.findall(r"MONGOC_VERSION=(.*)", contents)
-        if len(matches) != 1:
-            click.echo('Expected to match one MONGOC_VERSION in {}, got: {}'.format(
-                dockerfile, matches), err=True)
-            sys.exit(1)
-        got_MONGOC_VERSION = matches[0]
-        if got_MONGOC_VERSION != got_LIBMONGOC_REQUIRED_VERSION:
-            click.echo('Expected MONGOC_VERSION({}) in {} to match LIBMONGOC_REQUIRED_VERSION({})'.format(
-                got_MONGOC_VERSION, dockerfile, got_LIBMONGOC_REQUIRED_VERSION), err=True)
-            sys.exit(1)
-
-    # Check that `MONGOCXX_VERSION` defined in Docker Makefiles matches version to be released: `mongo_cxx_release_ver`.
-    for makefile in makefiles:
-        contents = pathlib.Path(makefile).read_text()
-        matches = re.findall(r"MONGOCXX_VERSION=(.*)", contents)
-        if len(matches) != 1:
-            click.echo('Expected to match one MONGOCXX_VERSION in {}, got: {}'.format(
-                makefile, matches), err=True)
-            sys.exit(1)
-        got_MONGOCXX_VERSION = matches[0]
-        if got_MONGOCXX_VERSION != mongo_cxx_release_ver:
-            click.echo('Expected MONGOCXX_VERSION({}) in {} to match release tag({})'.format(
-                got_MONGOCXX_VERSION, makefile, mongo_cxx_release_ver), err=True)
-            sys.exit(1)
 
 
 def check_libmongoc_version():

--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -88,7 +88,7 @@ ISSUE_TYPE_ID = {'Backport': '10300',
               show_default=True,
               help='The remote reference which points to the mongodb/mongo-cxx-driver repo')
 @click.option('--c-driver-build-ref',
-              default='1.24.0',
+              default='1.25.0',
               show_default=True,
               help='When building the C driver, build at this Git reference')
 @click.option('--with-c-driver',

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -19,10 +19,6 @@ releasing 3.7.3, then refer to the the waterfall tracking
 If there are test failures, ensure they are at least expected or not introduced
 by changes in the new release.
 
-In particular, check that the "Ubuntu 18.04 with minimum libmongoc" variant is
-passing to ensure that backports have not introduced a dependency on later
-versions of libmongoc.
-
 ## Check driver versions are correct for the Docker images
 
 In `extras/docker/generate.py` check that the versions are correct and if

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -19,14 +19,6 @@ releasing 3.7.3, then refer to the the waterfall tracking
 If there are test failures, ensure they are at least expected or not introduced
 by changes in the new release.
 
-## Check driver versions are correct for the Docker images
-
-In `extras/docker/generate.py` check that the versions are correct and if
-appropriate, bump the version numbers for:
-- `MONGOCXX_VERSION`
-- `MONGOC_VERSION`
-- `MONGOCRYPT_VERSION`
-
 ## Check fixVersions in Jira
 
 Ensure that all tickets under the

--- a/examples/projects/bsoncxx/pkg-config/static/build.sh
+++ b/examples/projects/bsoncxx/pkg-config/static/build.sh
@@ -13,5 +13,6 @@ CXX_STANDARD=${CXX_STANDARD:-11}
 rm -rf build/*
 cd build
 $CXX $CXXFLAGS -Wall -Wextra -Werror -std="c++${CXX_STANDARD}" -c -o hello_bsoncxx.o ../../../hello_bsoncxx.cpp $(pkg-config --cflags libbsoncxx-static)
-$CXX $LDFLAGS -std="c++${CXX_STANDARD}" -o hello_bsoncxx hello_bsoncxx.o $(pkg-config --libs libbsoncxx-static)
+# TODO: remove `-pthread` once CDRIVER-4776 is resolved.
+$CXX $LDFLAGS -pthread -std="c++${CXX_STANDARD}" -o hello_bsoncxx hello_bsoncxx.o $(pkg-config --libs libbsoncxx-static)
 ./hello_bsoncxx

--- a/examples/projects/mongocxx/pkg-config/static/build.sh
+++ b/examples/projects/mongocxx/pkg-config/static/build.sh
@@ -15,5 +15,6 @@ CXX_STANDARD=${CXX_STANDARD:-11}
 rm -rf build/*
 cd build
 $CXX $CXXFLAGS -Wall -Wextra -Werror -std="c++${CXX_STANDARD}" -c -o hello_mongocxx.o ../../../hello_mongocxx.cpp $(pkg-config --cflags libmongocxx-static) $PKGCONFIG_EXTRA_OPTS
-$CXX $LDFLAGS -std="c++${CXX_STANDARD}" -o hello_mongocxx hello_mongocxx.o $(pkg-config --libs libmongocxx-static) $PKGCONFIG_EXTRA_OPTS
+# TODO: remove `-pthread` once CDRIVER-4776 is resolved.
+$CXX $LDFLAGS -pthread -std="c++${CXX_STANDARD}" -o hello_mongocxx hello_mongocxx.o $(pkg-config --libs libmongocxx-static) $PKGCONFIG_EXTRA_OPTS
 ./hello_mongocxx


### PR DESCRIPTION
# Summary

This PR bumps the required C driver to 1.25.0 and includes additional changes intended before the 3.9.0 release:

- Fix documented version of the auto C driver download introduction (3.9.0, not 3.8.1).
- Remove extra step for updating versions in Dockerfile.
- Remove `check_docker_file_versions`.
- Remove reference to removed Evergreen variant.
- Add `-pthread` to pkg-config example projects to work around CDRIVER-4776

# Background & Motivation

Updating `MONGOCXX_VERSION` in Dockerfile before tagging a release may result in error downloading the not-yet-released tarball. This PR assumes it is preferable to update versions in the Dockerfiles after tagging a release.
