### PR TITLE
CXX-2288 Add forward headers for bsoncxx and mongocxx

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,12 +9,14 @@ Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 IncludeBlocks: Regroup
 IncludeCategories:
-  - Regex:    'prelude\.(hpp|hh)' # preludes
-    Priority: 3
-  - Regex:    '<[[:alnum:]_.]+>' # system headers
+  - Regex: 'prelude\.(hpp|hh)' # preludes
+    Priority: 4
+  - Regex: '<[[:alnum:]_.]+>' # system headers
     Priority: 1
-  - Regex:    '.*' # driver headers
+  - Regex: '.*(-|\/)fwd\.(hpp|hh)' # forwarding headers
     Priority: 2
+  - Regex: '.*' # driver headers
+    Priority: 3
 IndentWidth: 4
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None

--- a/src/bsoncxx/include/CMakeLists.txt
+++ b/src/bsoncxx/include/CMakeLists.txt
@@ -35,6 +35,7 @@ set_dist_list(src_bsoncxx_include_DIST
     bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array.hpp
     bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document.hpp
     bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
+    bsoncxx/v_noabi/bsoncxx/builder/core-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/core.hpp
     bsoncxx/v_noabi/bsoncxx/builder/list-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/list.hpp

--- a/src/bsoncxx/include/CMakeLists.txt
+++ b/src/bsoncxx/include/CMakeLists.txt
@@ -47,6 +47,7 @@ set_dist_list(src_bsoncxx_include_DIST
     bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/key_context-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/key_context.hpp
+    bsoncxx/v_noabi/bsoncxx/builder/stream/single_context-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/single_context.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/value_context.hpp
     bsoncxx/v_noabi/bsoncxx/config/compiler.hpp

--- a/src/bsoncxx/include/CMakeLists.txt
+++ b/src/bsoncxx/include/CMakeLists.txt
@@ -62,6 +62,7 @@ set_dist_list(src_bsoncxx_include_DIST
     bsoncxx/v_noabi/bsoncxx/stdx/type_traits.hpp
     bsoncxx/v_noabi/bsoncxx/string/to_string.hpp
     bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
+    bsoncxx/v_noabi/bsoncxx/types-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/types.hpp
     bsoncxx/v_noabi/bsoncxx/types/bson_value/make_value.hpp
     bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp

--- a/src/bsoncxx/include/CMakeLists.txt
+++ b/src/bsoncxx/include/CMakeLists.txt
@@ -41,6 +41,7 @@ set_dist_list(src_bsoncxx_include_DIST
     bsoncxx/v_noabi/bsoncxx/builder/list.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
+    bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp

--- a/src/bsoncxx/include/CMakeLists.txt
+++ b/src/bsoncxx/include/CMakeLists.txt
@@ -76,6 +76,7 @@ set_dist_list(src_bsoncxx_include_DIST
     bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
     bsoncxx/v_noabi/bsoncxx/types/value.hpp
     bsoncxx/v_noabi/bsoncxx/util/functor.hpp
+    bsoncxx/v_noabi/bsoncxx/validate-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/validate.hpp
     bsoncxx/v_noabi/bsoncxx/view_or_value.hpp
 )

--- a/src/bsoncxx/include/CMakeLists.txt
+++ b/src/bsoncxx/include/CMakeLists.txt
@@ -35,6 +35,7 @@ set_dist_list(src_bsoncxx_include_DIST
     bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document.hpp
     bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
     bsoncxx/v_noabi/bsoncxx/builder/core.hpp
+    bsoncxx/v_noabi/bsoncxx/builder/list-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/list.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp

--- a/src/bsoncxx/include/CMakeLists.txt
+++ b/src/bsoncxx/include/CMakeLists.txt
@@ -58,6 +58,7 @@ set_dist_list(src_bsoncxx_include_DIST
     bsoncxx/v_noabi/bsoncxx/document/element.hpp
     bsoncxx/v_noabi/bsoncxx/document/value.hpp
     bsoncxx/v_noabi/bsoncxx/document/view_or_value.hpp
+    bsoncxx/v_noabi/bsoncxx/document/view-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/document/view.hpp
     bsoncxx/v_noabi/bsoncxx/enums/binary_sub_type.hpp
     bsoncxx/v_noabi/bsoncxx/enums/type.hpp

--- a/src/bsoncxx/include/CMakeLists.txt
+++ b/src/bsoncxx/include/CMakeLists.txt
@@ -68,6 +68,7 @@ set_dist_list(src_bsoncxx_include_DIST
     bsoncxx/v_noabi/bsoncxx/types/bson_value/value-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
     bsoncxx/v_noabi/bsoncxx/types/bson_value/view_or_value.hpp
+    bsoncxx/v_noabi/bsoncxx/types/bson_value/view-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
     bsoncxx/v_noabi/bsoncxx/types/value.hpp
     bsoncxx/v_noabi/bsoncxx/util/functor.hpp

--- a/src/bsoncxx/include/CMakeLists.txt
+++ b/src/bsoncxx/include/CMakeLists.txt
@@ -45,6 +45,7 @@ set_dist_list(src_bsoncxx_include_DIST
     bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp
+    bsoncxx/v_noabi/bsoncxx/builder/stream/key_context-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/key_context.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/single_context.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/value_context.hpp

--- a/src/bsoncxx/include/CMakeLists.txt
+++ b/src/bsoncxx/include/CMakeLists.txt
@@ -20,6 +20,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
 
 set_dist_list(src_bsoncxx_include_DIST
     CMakeLists.txt
+    bsoncxx/v_noabi/bsoncxx/array/element-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/array/element.hpp
     bsoncxx/v_noabi/bsoncxx/array/value.hpp
     bsoncxx/v_noabi/bsoncxx/array/view_or_value.hpp

--- a/src/bsoncxx/include/CMakeLists.txt
+++ b/src/bsoncxx/include/CMakeLists.txt
@@ -22,55 +22,72 @@ set_dist_list(src_bsoncxx_include_DIST
     CMakeLists.txt
     bsoncxx/v_noabi/bsoncxx/array/element-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/array/element.hpp
+    bsoncxx/v_noabi/bsoncxx/array/value-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/array/value.hpp
     bsoncxx/v_noabi/bsoncxx/array/view_or_value.hpp
     bsoncxx/v_noabi/bsoncxx/array/view-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/array/view.hpp
     bsoncxx/v_noabi/bsoncxx/builder/basic/array-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
+    bsoncxx/v_noabi/bsoncxx/builder/basic/document-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
     bsoncxx/v_noabi/bsoncxx/builder/basic/helpers.hpp
     bsoncxx/v_noabi/bsoncxx/builder/basic/impl.hpp
     bsoncxx/v_noabi/bsoncxx/builder/basic/kvp.hpp
+    bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array.hpp
+    bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document.hpp
+    bsoncxx/v_noabi/bsoncxx/builder/concatenate-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
     bsoncxx/v_noabi/bsoncxx/builder/core-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/core.hpp
     bsoncxx/v_noabi/bsoncxx/builder/list-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/list.hpp
+    bsoncxx/v_noabi/bsoncxx/builder/stream/array_context-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
+    bsoncxx/v_noabi/bsoncxx/builder/stream/array-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context.hpp
+    bsoncxx/v_noabi/bsoncxx/builder/stream/document-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
+    bsoncxx/v_noabi/bsoncxx/builder/stream/helpers-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/key_context-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/key_context.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/single_context-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/single_context.hpp
+    bsoncxx/v_noabi/bsoncxx/builder/stream/value_context-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/stream/value_context.hpp
     bsoncxx/v_noabi/bsoncxx/config/compiler.hpp
     bsoncxx/v_noabi/bsoncxx/config/postlude.hpp
     bsoncxx/v_noabi/bsoncxx/config/prelude.hpp
+    bsoncxx/v_noabi/bsoncxx/decimal128-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/decimal128.hpp
     bsoncxx/v_noabi/bsoncxx/document/element-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/document/element.hpp
+    bsoncxx/v_noabi/bsoncxx/document/value-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/document/value.hpp
     bsoncxx/v_noabi/bsoncxx/document/view_or_value.hpp
     bsoncxx/v_noabi/bsoncxx/document/view-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/document/view.hpp
     bsoncxx/v_noabi/bsoncxx/enums/binary_sub_type.hpp
     bsoncxx/v_noabi/bsoncxx/enums/type.hpp
+    bsoncxx/v_noabi/bsoncxx/exception/error_code-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/exception/error_code.hpp
+    bsoncxx/v_noabi/bsoncxx/exception/exception-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/exception/exception.hpp
+    bsoncxx/v_noabi/bsoncxx/json-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/json.hpp
+    bsoncxx/v_noabi/bsoncxx/oid-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/oid.hpp
     bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
     bsoncxx/v_noabi/bsoncxx/stdx/optional.hpp
     bsoncxx/v_noabi/bsoncxx/stdx/string_view.hpp
     bsoncxx/v_noabi/bsoncxx/stdx/type_traits.hpp
     bsoncxx/v_noabi/bsoncxx/string/to_string.hpp
+    bsoncxx/v_noabi/bsoncxx/string/view_or_value-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
     bsoncxx/v_noabi/bsoncxx/types-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/types.hpp
@@ -84,5 +101,6 @@ set_dist_list(src_bsoncxx_include_DIST
     bsoncxx/v_noabi/bsoncxx/util/functor.hpp
     bsoncxx/v_noabi/bsoncxx/validate-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/validate.hpp
+    bsoncxx/v_noabi/bsoncxx/view_or_value-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/view_or_value.hpp
 )

--- a/src/bsoncxx/include/CMakeLists.txt
+++ b/src/bsoncxx/include/CMakeLists.txt
@@ -24,6 +24,7 @@ set_dist_list(src_bsoncxx_include_DIST
     bsoncxx/v_noabi/bsoncxx/array/element.hpp
     bsoncxx/v_noabi/bsoncxx/array/value.hpp
     bsoncxx/v_noabi/bsoncxx/array/view_or_value.hpp
+    bsoncxx/v_noabi/bsoncxx/array/view-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/array/view.hpp
     bsoncxx/v_noabi/bsoncxx/builder/basic/array-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp

--- a/src/bsoncxx/include/CMakeLists.txt
+++ b/src/bsoncxx/include/CMakeLists.txt
@@ -65,6 +65,7 @@ set_dist_list(src_bsoncxx_include_DIST
     bsoncxx/v_noabi/bsoncxx/types-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/types.hpp
     bsoncxx/v_noabi/bsoncxx/types/bson_value/make_value.hpp
+    bsoncxx/v_noabi/bsoncxx/types/bson_value/value-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
     bsoncxx/v_noabi/bsoncxx/types/bson_value/view_or_value.hpp
     bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp

--- a/src/bsoncxx/include/CMakeLists.txt
+++ b/src/bsoncxx/include/CMakeLists.txt
@@ -25,6 +25,7 @@ set_dist_list(src_bsoncxx_include_DIST
     bsoncxx/v_noabi/bsoncxx/array/value.hpp
     bsoncxx/v_noabi/bsoncxx/array/view_or_value.hpp
     bsoncxx/v_noabi/bsoncxx/array/view.hpp
+    bsoncxx/v_noabi/bsoncxx/builder/basic/array-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
     bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
     bsoncxx/v_noabi/bsoncxx/builder/basic/helpers.hpp

--- a/src/bsoncxx/include/CMakeLists.txt
+++ b/src/bsoncxx/include/CMakeLists.txt
@@ -47,6 +47,7 @@ set_dist_list(src_bsoncxx_include_DIST
     bsoncxx/v_noabi/bsoncxx/config/postlude.hpp
     bsoncxx/v_noabi/bsoncxx/config/prelude.hpp
     bsoncxx/v_noabi/bsoncxx/decimal128.hpp
+    bsoncxx/v_noabi/bsoncxx/document/element-fwd.hpp
     bsoncxx/v_noabi/bsoncxx/document/element.hpp
     bsoncxx/v_noabi/bsoncxx/document/value.hpp
     bsoncxx/v_noabi/bsoncxx/document/view_or_value.hpp

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/config/prelude.hpp>
+
+namespace bsoncxx {
+inline namespace v_noabi {
+namespace array {
+
+class BSONCXX_API element;
+
+}  // namespace array
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+#include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
@@ -17,6 +17,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include <bsoncxx/array/element-fwd.hpp>
 #include <bsoncxx/types/bson_value/view-fwd.hpp>
 
 #include <bsoncxx/document/element.hpp>
@@ -34,7 +35,7 @@ namespace array {
 /// interrogated by calling type() and a specific value can be extracted through
 /// get_X() accessors.
 ///
-class BSONCXX_API element : private document::element {
+class element : private document::element {
    public:
     element();
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
@@ -17,18 +17,14 @@
 #include <cstddef>
 #include <cstdint>
 
+#include <bsoncxx/types/bson_value/view-fwd.hpp>
+
 #include <bsoncxx/document/element.hpp>
 
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 inline namespace v_noabi {
-namespace types {
-namespace bson_value {
-class view;
-}  // namespace bson_value
-}  // namespace types
-
 namespace array {
 
 ///
@@ -121,7 +117,6 @@ BSONCXX_API bool BSONCXX_CALL operator!=(const types::bson_value::view& v, const
 ///
 
 }  // namespace array
-
 }  // namespace v_noabi
 }  // namespace bsoncxx
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 
 #include <bsoncxx/array/element-fwd.hpp>
+#include <bsoncxx/array/view-fwd.hpp>
 #include <bsoncxx/types/bson_value/view-fwd.hpp>
 
 #include <bsoncxx/document/element.hpp>
@@ -77,7 +78,7 @@ class element : private document::element {
     using document::element::raw;
 
    private:
-    friend class view;
+    friend class ::bsoncxx::v_noabi::array::view;
 
     BSONCXX_PRIVATE explicit element(const std::uint8_t* raw,
                                      std::uint32_t length,

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2023 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,22 +14,15 @@
 
 #pragma once
 
-#include <system_error>
-
-#include <bsoncxx/exception/exception-fwd.hpp>
-
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 inline namespace v_noabi {
-///
-/// Class representing any exceptions emitted from the bsoncxx library or
-/// its underlying implementation.
-///
-class exception : public std::system_error {
-    using std::system_error::system_error;
-};
+namespace array {
 
+class BSONCXX_API value;
+
+}  // namespace array
 }  // namespace v_noabi
 }  // namespace bsoncxx
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value.hpp
@@ -17,6 +17,8 @@
 #include <cstdlib>
 #include <memory>
 
+#include <bsoncxx/array/value-fwd.hpp>
+
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/document/value.hpp>
 
@@ -31,7 +33,7 @@ namespace array {
 /// out of scope, the underlying buffer is freed. Generally this class should be used
 /// sparingly; array::view should be used instead wherever possible.
 ///
-class BSONCXX_API value {
+class value {
    public:
     using deleter_type = void (*)(std::uint8_t*);
     using unique_ptr_type = std::unique_ptr<uint8_t[], deleter_type>;

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/config/prelude.hpp>
+
+namespace bsoncxx {
+inline namespace v_noabi {
+namespace array {
+
+class BSONCXX_API view;
+
+}  // namespace array
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+#include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view.hpp
@@ -151,7 +151,7 @@ class BSONCXX_API view {
 /// This iterator type provides a const forward iterator interface to array
 /// view elements.
 ///
-class BSONCXX_API view::const_iterator {
+class view::const_iterator {
    public:
     ///
     /// std::iterator_traits

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view.hpp
@@ -18,6 +18,8 @@
 #include <cstdint>
 #include <iterator>
 
+#include <bsoncxx/types/bson_value/view-fwd.hpp>
+
 #include <bsoncxx/array/element.hpp>
 #include <bsoncxx/document/view.hpp>
 
@@ -25,12 +27,6 @@
 
 namespace bsoncxx {
 inline namespace v_noabi {
-namespace types {
-namespace bson_value {
-class view;
-}  // namespace bson_value
-}  // namespace types
-
 namespace array {
 
 ///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view.hpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <iterator>
 
+#include <bsoncxx/array/view-fwd.hpp>
 #include <bsoncxx/types/bson_value/view-fwd.hpp>
 
 #include <bsoncxx/array/element.hpp>
@@ -32,7 +33,7 @@ namespace array {
 ///
 /// A read-only, non-owning view of a BSON document.
 ///
-class BSONCXX_API view {
+class view {
    public:
     class BSONCXX_API const_iterator;
     using iterator = const_iterator;

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array-fwd.hpp
@@ -1,0 +1,27 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace bsoncxx {
+inline namespace v_noabi {
+namespace builder {
+namespace basic {
+
+class array;
+
+}  // namespace basic
+}  // namespace builder
+}  // namespace v_noabi
+}  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <bsoncxx/builder/basic/array-fwd.hpp>
+
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/builder/basic/impl.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2023 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,14 @@
 
 #pragma once
 
-#include <system_error>
-
-#include <bsoncxx/exception/exception-fwd.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
-
 namespace bsoncxx {
 inline namespace v_noabi {
-///
-/// Class representing any exceptions emitted from the bsoncxx library or
-/// its underlying implementation.
-///
-class exception : public std::system_error {
-    using std::system_error::system_error;
-};
+namespace builder {
+namespace basic {
 
+class document;
+
+}  // namespace basic
+}  // namespace builder
 }  // namespace v_noabi
 }  // namespace bsoncxx
-
-#include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <bsoncxx/builder/basic/array-fwd.hpp>
+
 #include <bsoncxx/builder/basic/impl.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/builder/basic/sub_document.hpp>
@@ -27,8 +29,6 @@ namespace bsoncxx {
 inline namespace v_noabi {
 namespace builder {
 namespace basic {
-
-class array;
 
 ///
 /// A traditional builder-style interface for constructing

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <bsoncxx/builder/basic/array-fwd.hpp>
+#include <bsoncxx/builder/basic/document-fwd.hpp>
 
 #include <bsoncxx/builder/basic/impl.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2023 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,14 @@
 
 #pragma once
 
-#include <system_error>
-
-#include <bsoncxx/exception/exception-fwd.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
-
 namespace bsoncxx {
 inline namespace v_noabi {
-///
-/// Class representing any exceptions emitted from the bsoncxx library or
-/// its underlying implementation.
-///
-class exception : public std::system_error {
-    using std::system_error::system_error;
-};
+namespace builder {
+namespace basic {
 
+class sub_array;
+
+}  // namespace basic
+}  // namespace builder
 }  // namespace v_noabi
 }  // namespace bsoncxx
-
-#include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <bsoncxx/builder/basic/sub_array-fwd.hpp>
+
 #include <bsoncxx/builder/basic/helpers.hpp>
 #include <bsoncxx/builder/concatenate.hpp>
 #include <bsoncxx/builder/core.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2023 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,14 @@
 
 #pragma once
 
-#include <system_error>
-
-#include <bsoncxx/exception/exception-fwd.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
-
 namespace bsoncxx {
 inline namespace v_noabi {
-///
-/// Class representing any exceptions emitted from the bsoncxx library or
-/// its underlying implementation.
-///
-class exception : public std::system_error {
-    using std::system_error::system_error;
-};
+namespace builder {
+namespace basic {
 
+class sub_document;
+
+}  // namespace basic
+}  // namespace builder
 }  // namespace v_noabi
 }  // namespace bsoncxx
-
-#include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <bsoncxx/builder/basic/sub_document-fwd.hpp>
+
 #include <bsoncxx/builder/basic/helpers.hpp>
 #include <bsoncxx/builder/concatenate.hpp>
 #include <bsoncxx/builder/core.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2023 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,13 @@
 
 #pragma once
 
-#include <system_error>
-
-#include <bsoncxx/exception/exception-fwd.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
-
 namespace bsoncxx {
 inline namespace v_noabi {
-///
-/// Class representing any exceptions emitted from the bsoncxx library or
-/// its underlying implementation.
-///
-class exception : public std::system_error {
-    using std::system_error::system_error;
-};
+namespace builder {
 
+struct concatenate_doc;
+struct concatenate_array;
+
+}  // namespace builder
 }  // namespace v_noabi
 }  // namespace bsoncxx
-
-#include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <bsoncxx/builder/concatenate-fwd.hpp>
+
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2023 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,27 +14,14 @@
 
 #pragma once
 
-#include <bsoncxx/builder/core-fwd.hpp>
-
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 inline namespace v_noabi {
 namespace builder {
-namespace stream {
 
-///
-/// The closed_context, when used as a template parameter for array_context,
-/// value_context or key_context, indicates that the document cannot be closed
-/// further. This could indicate that the document is the root, or that the type
-/// stack has been intentionally erased, as is the case when using callbacks in
-/// the stream api.
-///
-struct closed_context {
-    closed_context(core*) {}
-};
+class BSONCXX_API core;
 
-}  // namespace stream
 }  // namespace builder
 }  // namespace v_noabi
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
@@ -18,6 +18,8 @@
 #include <stdexcept>
 #include <type_traits>
 
+#include <bsoncxx/builder/core-fwd.hpp>
+
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/document/value.hpp>
@@ -40,7 +42,7 @@ namespace builder {
 ///   using this class directly. However, developers who wish to write their own abstractions may
 ///   find this class useful.
 ///
-class BSONCXX_API core {
+class core {
    public:
     class BSONCXX_PRIVATE impl;
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
@@ -159,7 +159,7 @@ class BSONCXX_API core {
     /// @throws
     ///   bsoncxx::exception if one of the keys fails to append.
     ///
-    core& concatenate(const document::view& view);
+    core& concatenate(const bsoncxx::document::view& view);
 
     ///
     /// Appends a BSON double.
@@ -605,7 +605,7 @@ class BSONCXX_API core {
     ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
     ///   appended to start a new key/value pair.
     ///
-    core& append(document::view view);
+    core& append(bsoncxx::document::view view);
 
     ///
     /// Appends the given array view.
@@ -618,7 +618,7 @@ class BSONCXX_API core {
     ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
     ///   appended to start a new key/value pair.
     ///
-    core& append(array::view view);
+    core& append(bsoncxx::array::view view);
 
     ///
     /// Gets a view over the document.
@@ -632,7 +632,7 @@ class BSONCXX_API core {
     ///
     /// @throws bsoncxx::exception if the precondition is violated.
     ///
-    document::view view_document() const;
+    bsoncxx::document::view view_document() const;
 
     ///
     /// Gets a view over the array.
@@ -645,7 +645,7 @@ class BSONCXX_API core {
     ///
     /// @throws bsoncxx::exception if the precondition is violated.
     ///
-    array::view view_array() const;
+    bsoncxx::array::view view_array() const;
 
     ///
     /// Transfers ownership of the underlying document to the caller.
@@ -663,7 +663,7 @@ class BSONCXX_API core {
     ///   After calling extract_document() it is illegal to call any methods on this class, unless
     ///   it is subsequenly moved into.
     ///
-    document::value extract_document();
+    bsoncxx::document::value extract_document();
 
     ///
     /// Transfers ownership of the underlying document to the caller.
@@ -680,7 +680,7 @@ class BSONCXX_API core {
     ///   After calling extract_array() it is illegal to call any methods on this class, unless it
     ///   is subsequenly moved into.
     ///
-    array::value extract_array();
+    bsoncxx::array::value extract_array();
 
     ///
     /// Deletes the contents of the underlying BSON datum. After calling clear(), the state of this

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list-fwd.hpp
@@ -1,0 +1,27 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace bsoncxx {
+inline namespace v_noabi {
+namespace builder {
+
+class list;
+class document;
+class array;
+
+}  // namespace builder
+}  // namespace v_noabi
+}  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
@@ -28,7 +28,16 @@
 namespace bsoncxx {
 inline namespace v_noabi {
 namespace builder {
+
 using namespace bsoncxx::types;
+
+}  // namespace builder
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+inline namespace v_noabi {
+namespace builder {
 
 ///
 /// A JSON-like builder for creating documents and arrays.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
@@ -16,6 +16,8 @@
 
 #include <sstream>
 
+#include <bsoncxx/builder/basic/array-fwd.hpp>
+
 #include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/exception/error_code.hpp>
 #include <bsoncxx/exception/exception.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
@@ -17,6 +17,7 @@
 #include <sstream>
 
 #include <bsoncxx/builder/basic/array-fwd.hpp>
+#include <bsoncxx/builder/list-fwd.hpp>
 
 #include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/exception/error_code.hpp>
@@ -105,8 +106,8 @@ class list {
    private:
     bson_value::value val;
 
-    friend class document;
-    friend class array;
+    friend class ::bsoncxx::v_noabi::builder::document;
+    friend class ::bsoncxx::v_noabi::builder::array;
 
     list(initializer_list_t init, bool type_deduction, bool is_array) : val{nullptr} {
         std::stringstream err_msg{"cannot construct document"};

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2023 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,14 @@
 
 #pragma once
 
-#include <system_error>
-
-#include <bsoncxx/exception/exception-fwd.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
-
 namespace bsoncxx {
 inline namespace v_noabi {
-///
-/// Class representing any exceptions emitted from the bsoncxx library or
-/// its underlying implementation.
-///
-class exception : public std::system_error {
-    using std::system_error::system_error;
-};
+namespace builder {
+namespace stream {
 
+class array;
+
+}  // namespace stream
+}  // namespace builder
 }  // namespace v_noabi
 }  // namespace bsoncxx
-
-#include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <bsoncxx/builder/stream/array-fwd.hpp>
+
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/builder/core.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2023 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,17 @@
 
 #pragma once
 
-#include <system_error>
-
-#include <bsoncxx/exception/exception-fwd.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
+#include <bsoncxx/builder/stream/closed_context-fwd.hpp>
 
 namespace bsoncxx {
 inline namespace v_noabi {
-///
-/// Class representing any exceptions emitted from the bsoncxx library or
-/// its underlying implementation.
-///
-class exception : public std::system_error {
-    using std::system_error::system_error;
-};
+namespace builder {
+namespace stream {
 
+template <class base = closed_context>
+class array_context;
+
+}  // namespace stream
+}  // namespace builder
 }  // namespace v_noabi
 }  // namespace bsoncxx
-
-#include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <bsoncxx/builder/stream/array_context-fwd.hpp>
 #include <bsoncxx/builder/stream/key_context-fwd.hpp>
 #include <bsoncxx/builder/stream/single_context-fwd.hpp>
 
@@ -46,7 +47,7 @@ namespace stream {
 ///
 /// This builds a bson array with successively higher index keys
 ///
-template <class base = closed_context>
+template <class base>
 class array_context {
    public:
     ///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <bsoncxx/builder/stream/key_context-fwd.hpp>
+#include <bsoncxx/builder/stream/single_context-fwd.hpp>
 
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/builder/concatenate.hpp>
@@ -29,8 +30,6 @@ namespace bsoncxx {
 inline namespace v_noabi {
 namespace builder {
 namespace stream {
-
-class single_context;
 
 ///
 /// A stream context which expects any number of values.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <bsoncxx/builder/stream/key_context-fwd.hpp>
+
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/builder/concatenate.hpp>
 #include <bsoncxx/builder/core.hpp>
@@ -27,9 +29,6 @@ namespace bsoncxx {
 inline namespace v_noabi {
 namespace builder {
 namespace stream {
-
-template <class T>
-class key_context;
 
 class single_context;
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2023 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,30 +14,14 @@
 
 #pragma once
 
-#include <bsoncxx/builder/core-fwd.hpp>
-#include <bsoncxx/builder/stream/closed_context-fwd.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
-
 namespace bsoncxx {
 inline namespace v_noabi {
 namespace builder {
 namespace stream {
 
-///
-/// The closed_context, when used as a template parameter for array_context,
-/// value_context or key_context, indicates that the document cannot be closed
-/// further. This could indicate that the document is the root, or that the type
-/// stack has been intentionally erased, as is the case when using callbacks in
-/// the stream api.
-///
-struct closed_context {
-    closed_context(core*) {}
-};
+struct closed_context;
 
 }  // namespace stream
 }  // namespace builder
 }  // namespace v_noabi
 }  // namespace bsoncxx
-
-#include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2023 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,14 @@
 
 #pragma once
 
-#include <system_error>
-
-#include <bsoncxx/exception/exception-fwd.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
-
 namespace bsoncxx {
 inline namespace v_noabi {
-///
-/// Class representing any exceptions emitted from the bsoncxx library or
-/// its underlying implementation.
-///
-class exception : public std::system_error {
-    using std::system_error::system_error;
-};
+namespace builder {
+namespace stream {
 
+class document;
+
+}  // namespace stream
+}  // namespace builder
 }  // namespace v_noabi
 }  // namespace bsoncxx
-
-#include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <bsoncxx/builder/stream/document-fwd.hpp>
+
 #include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/builder/stream/key_context.hpp>
 #include <bsoncxx/builder/stream/single_context.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2023 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,22 +14,21 @@
 
 #pragma once
 
-#include <system_error>
-
-#include <bsoncxx/exception/exception-fwd.hpp>
-
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 inline namespace v_noabi {
-///
-/// Class representing any exceptions emitted from the bsoncxx library or
-/// its underlying implementation.
-///
-class exception : public std::system_error {
-    using std::system_error::system_error;
-};
+namespace builder {
+namespace stream {
 
+struct BSONCXX_API open_document_type;
+struct BSONCXX_API close_document_type;
+struct BSONCXX_API open_array_type;
+struct BSONCXX_API close_array_type;
+struct BSONCXX_API finalize_type;
+
+}  // namespace stream
+}  // namespace builder
 }  // namespace v_noabi
 }  // namespace bsoncxx
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp
@@ -29,7 +29,7 @@ using bsoncxx::builder::concatenate;
 ///
 /// The type of a stream manipulator to open a subdocument.
 ///
-struct BSONCXX_API open_document_type {
+struct open_document_type {
     constexpr open_document_type() {}
 };
 
@@ -41,7 +41,7 @@ constexpr open_document_type open_document;
 ///
 /// The type of a stream manipulator to close a subdocument.
 ///
-struct BSONCXX_API close_document_type {
+struct close_document_type {
     constexpr close_document_type() {}
 };
 
@@ -53,7 +53,7 @@ constexpr close_document_type close_document;
 ///
 /// The type of a stream manipulator to open a subarray.
 ///
-struct BSONCXX_API open_array_type {
+struct open_array_type {
     constexpr open_array_type() {}
 };
 
@@ -68,7 +68,7 @@ constexpr open_array_type open_array;
 ///
 /// The type of a stream manipulator to close a subarray.
 ///
-struct BSONCXX_API close_array_type {
+struct close_array_type {
     constexpr close_array_type() {}
 };
 
@@ -80,7 +80,7 @@ constexpr close_array_type close_array;
 ///
 /// The type of a stream manipulator to finalize a document.
 ///
-struct BSONCXX_API finalize_type {
+struct finalize_type {
     constexpr finalize_type() {}
 };
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context-fwd.hpp
@@ -1,0 +1,30 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/builder/stream/closed_context-fwd.hpp>
+
+namespace bsoncxx {
+inline namespace v_noabi {
+namespace builder {
+namespace stream {
+
+template <class base = closed_context>
+class key_context;
+
+}  // namespace stream
+}  // namespace builder
+}  // namespace v_noabi
+}  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context.hpp
@@ -15,8 +15,10 @@
 
 #pragma once
 
+#include <bsoncxx/builder/stream/closed_context-fwd.hpp>
+#include <bsoncxx/builder/stream/key_context-fwd.hpp>
+
 #include <bsoncxx/builder/core.hpp>
-#include <bsoncxx/builder/stream/closed_context.hpp>
 #include <bsoncxx/builder/stream/value_context.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/stdx/type_traits.hpp>
@@ -45,7 +47,7 @@ namespace stream {
 /// I.e.
 /// builder << key_context << value_context << key_context << ...
 ///
-template <class base = closed_context>
+template <class base>
 class key_context {
    public:
     ///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/builder/stream/closed_context-fwd.hpp>
+
+namespace bsoncxx {
+inline namespace v_noabi {
+namespace builder {
+namespace stream {
+
+class single_context;
+
+}  // namespace stream
+}  // namespace builder
+}  // namespace v_noabi
+}  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <bsoncxx/builder/stream/single_context-fwd.hpp>
+
 #include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/builder/stream/array_context.hpp>
 #include <bsoncxx/builder/stream/key_context.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2023 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,22 +14,18 @@
 
 #pragma once
 
-#include <system_error>
-
-#include <bsoncxx/exception/exception-fwd.hpp>
-
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 inline namespace v_noabi {
-///
-/// Class representing any exceptions emitted from the bsoncxx library or
-/// its underlying implementation.
-///
-class exception : public std::system_error {
-    using std::system_error::system_error;
-};
+namespace builder {
+namespace stream {
 
+template <class base>
+class value_context;
+
+}  // namespace stream
+}  // namespace builder
 }  // namespace v_noabi
 }  // namespace bsoncxx
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <bsoncxx/builder/stream/value_context-fwd.hpp>
+
 #include <bsoncxx/builder/core.hpp>
 #include <bsoncxx/builder/stream/array_context.hpp>
 #include <bsoncxx/builder/stream/closed_context.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2023 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,10 @@
 
 #pragma once
 
-#include <system_error>
-
-#include <bsoncxx/exception/exception-fwd.hpp>
-
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
-///
-/// Class representing any exceptions emitted from the bsoncxx library or
-/// its underlying implementation.
-///
-class exception : public std::system_error {
-    using std::system_error::system_error;
-};
-
-}  // namespace v_noabi
+inline namespace v_noabi { class BSONCXX_API decimal128; }  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
@@ -17,6 +17,8 @@
 #include <cstdint>
 #include <string>
 
+#include <bsoncxx/decimal128-fwd.hpp>
+
 #include <bsoncxx/stdx/string_view.hpp>
 
 #include <bsoncxx/config/prelude.hpp>
@@ -26,7 +28,7 @@ inline namespace v_noabi {
 ///
 /// Represents an IEEE 754-2008 BSON Decimal128 value in a platform-independent way.
 ///
-class BSONCXX_API decimal128 {
+class decimal128 {
    public:
     ///
     /// Constructs a BSON Decimal128 value representing zero.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/config/prelude.hpp>
+
+namespace bsoncxx {
+inline namespace v_noabi {
+namespace document {
+
+class BSONCXX_API element;
+
+}  // namespace document
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+#include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
@@ -19,6 +19,7 @@
 
 #include <bsoncxx/types-fwd.hpp>
 #include <bsoncxx/types/bson_value/value-fwd.hpp>
+#include <bsoncxx/types/bson_value/view-fwd.hpp>
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
@@ -27,14 +28,6 @@
 
 namespace bsoncxx {
 inline namespace v_noabi {
-namespace types {
-
-namespace bson_value {
-class view;
-}  // namespace bson_value
-
-}  // namespace types
-
 namespace array {
 class element;
 }  // namespace array

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
@@ -19,6 +19,7 @@
 
 #include <bsoncxx/array/element-fwd.hpp>
 #include <bsoncxx/document/element-fwd.hpp>
+#include <bsoncxx/document/view-fwd.hpp>
 #include <bsoncxx/types-fwd.hpp>
 #include <bsoncxx/types/bson_value/value-fwd.hpp>
 #include <bsoncxx/types/bson_value/view-fwd.hpp>
@@ -373,7 +374,7 @@ class element {
     BSONCXX_PRIVATE explicit element(const stdx::string_view key);
 
     friend class ::bsoncxx::v_noabi::array::element;
-    friend class view;
+    friend class ::bsoncxx::v_noabi::document::view;
 
     const std::uint8_t* _raw;
     std::uint32_t _length;

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
@@ -17,6 +17,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include <bsoncxx/array/element-fwd.hpp>
 #include <bsoncxx/types-fwd.hpp>
 #include <bsoncxx/types/bson_value/value-fwd.hpp>
 #include <bsoncxx/types/bson_value/view-fwd.hpp>
@@ -28,10 +29,6 @@
 
 namespace bsoncxx {
 inline namespace v_noabi {
-namespace array {
-class element;
-}  // namespace array
-
 namespace document {
 
 ///
@@ -374,8 +371,8 @@ class BSONCXX_API element {
     // Construct an invalid element with a key. Useful for exceptions.
     BSONCXX_PRIVATE explicit element(const stdx::string_view key);
 
+    friend class ::bsoncxx::v_noabi::array::element;
     friend class view;
-    friend class array::element;
 
     const std::uint8_t* _raw;
     std::uint32_t _length;
@@ -418,7 +415,6 @@ BSONCXX_API bool BSONCXX_CALL operator!=(const types::bson_value::view& v, const
 ///
 
 }  // namespace document
-
 }  // namespace v_noabi
 }  // namespace bsoncxx
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
@@ -17,6 +17,8 @@
 #include <cstddef>
 #include <cstdint>
 
+#include <bsoncxx/types-fwd.hpp>
+
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 
@@ -24,32 +26,7 @@
 
 namespace bsoncxx {
 inline namespace v_noabi {
-enum class type : std::uint8_t;
-enum class binary_sub_type : std::uint8_t;
-
 namespace types {
-struct b_eod;
-struct b_double;
-struct b_string;
-struct b_document;
-struct b_array;
-struct b_binary;
-struct b_undefined;
-struct b_oid;
-struct b_bool;
-struct b_date;
-struct b_null;
-struct b_regex;
-struct b_dbpointer;
-struct b_code;
-struct b_symbol;
-struct b_codewscope;
-struct b_int32;
-struct b_timestamp;
-struct b_int64;
-struct b_decimal128;
-struct b_minkey;
-struct b_maxkey;
 
 namespace bson_value {
 class value;

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 
 #include <bsoncxx/array/element-fwd.hpp>
+#include <bsoncxx/document/element-fwd.hpp>
 #include <bsoncxx/types-fwd.hpp>
 #include <bsoncxx/types/bson_value/value-fwd.hpp>
 #include <bsoncxx/types/bson_value/view-fwd.hpp>
@@ -40,7 +41,7 @@ namespace document {
 ///
 /// @relatesalso array::element
 ///
-class BSONCXX_API element {
+class element {
    public:
     ///
     /// Construct an invalid element.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 
 #include <bsoncxx/types-fwd.hpp>
+#include <bsoncxx/types/bson_value/value-fwd.hpp>
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
@@ -29,7 +30,6 @@ inline namespace v_noabi {
 namespace types {
 
 namespace bson_value {
-class value;
 class view;
 }  // namespace bson_value
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2023 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,22 +14,15 @@
 
 #pragma once
 
-#include <system_error>
-
-#include <bsoncxx/exception/exception-fwd.hpp>
-
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 inline namespace v_noabi {
-///
-/// Class representing any exceptions emitted from the bsoncxx library or
-/// its underlying implementation.
-///
-class exception : public std::system_error {
-    using std::system_error::system_error;
-};
+namespace document {
 
+class BSONCXX_API value;
+
+}  // namespace document
 }  // namespace v_noabi
 }  // namespace bsoncxx
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
@@ -18,6 +18,8 @@
 #include <memory>
 #include <type_traits>
 
+#include <bsoncxx/document/value-fwd.hpp>
+
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/type_traits.hpp>
@@ -33,7 +35,7 @@ namespace document {
 /// out of scope, the underlying buffer is freed. Generally this class should be used
 /// sparingly; document::view should be used instead wherever possible.
 ///
-class BSONCXX_API value {
+class value {
    public:
     using deleter_type = void (*)(std::uint8_t*);
     using unique_ptr_type = std::unique_ptr<uint8_t[], deleter_type>;

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/config/prelude.hpp>
+
+namespace bsoncxx {
+inline namespace v_noabi {
+namespace document {
+
+class BSONCXX_API view;
+
+}  // namespace document
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+#include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view.hpp
@@ -18,6 +18,8 @@
 #include <cstdint>
 #include <iterator>
 
+#include <bsoncxx/document/view-fwd.hpp>
+
 #include <bsoncxx/document/element.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 
@@ -30,7 +32,7 @@ namespace document {
 ///
 /// A read-only, non-owning view of a BSON document.
 ///
-class BSONCXX_API view {
+class view {
    public:
     class BSONCXX_API const_iterator;
     using iterator = const_iterator;

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view.hpp
@@ -150,7 +150,7 @@ class BSONCXX_API view {
 /// This iterator type provides a const forward iterator interface to document
 /// view elements.
 ///
-class BSONCXX_API view::const_iterator {
+class view::const_iterator {
    public:
     ///
     /// std::iterator_traits

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2023 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,16 @@
 
 #pragma once
 
+#include <cstdint>
 #include <system_error>
 
-#include <bsoncxx/exception/exception-fwd.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
-
 namespace bsoncxx {
-inline namespace v_noabi {
-///
-/// Class representing any exceptions emitted from the bsoncxx library or
-/// its underlying implementation.
-///
-class exception : public std::system_error {
-    using std::system_error::system_error;
-};
-
-}  // namespace v_noabi
+inline namespace v_noabi { enum class error_code : std::int32_t; }  // namespace v_noabi
 }  // namespace bsoncxx
 
-#include <bsoncxx/config/postlude.hpp>
+namespace std {
+
+template <>
+struct is_error_code_enum<bsoncxx::error_code>;
+
+}  // namespace std

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code.hpp
@@ -17,6 +17,8 @@
 #include <cstdint>
 #include <system_error>
 
+#include <bsoncxx/exception/error_code-fwd.hpp>
+
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
@@ -122,7 +124,9 @@ BSONCXX_INLINE std::error_code make_error_code(error_code error) {
 #include <bsoncxx/config/postlude.hpp>
 
 namespace std {
+
 // Specialize is_error_code_enum so we get simpler std::error_code construction
 template <>
 struct is_error_code_enum<bsoncxx::error_code> : public true_type {};
+
 }  // namespace std

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2023 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,10 @@
 
 #pragma once
 
-#include <system_error>
-
-#include <bsoncxx/exception/exception-fwd.hpp>
-
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
-///
-/// Class representing any exceptions emitted from the bsoncxx library or
-/// its underlying implementation.
-///
-class exception : public std::system_error {
-    using std::system_error::system_error;
-};
-
-}  // namespace v_noabi
+inline namespace v_noabi { class BSONCXX_API exception; }  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/fwd.hpp
@@ -1,0 +1,48 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/array/element-fwd.hpp>
+#include <bsoncxx/array/value-fwd.hpp>
+#include <bsoncxx/array/view-fwd.hpp>
+#include <bsoncxx/builder/basic/array-fwd.hpp>
+#include <bsoncxx/builder/basic/document-fwd.hpp>
+#include <bsoncxx/builder/basic/sub_array-fwd.hpp>
+#include <bsoncxx/builder/basic/sub_document-fwd.hpp>
+#include <bsoncxx/builder/concatenate-fwd.hpp>
+#include <bsoncxx/builder/core-fwd.hpp>
+#include <bsoncxx/builder/list-fwd.hpp>
+#include <bsoncxx/builder/stream/array-fwd.hpp>
+#include <bsoncxx/builder/stream/array_context-fwd.hpp>
+#include <bsoncxx/builder/stream/closed_context-fwd.hpp>
+#include <bsoncxx/builder/stream/document-fwd.hpp>
+#include <bsoncxx/builder/stream/helpers-fwd.hpp>
+#include <bsoncxx/builder/stream/key_context-fwd.hpp>
+#include <bsoncxx/builder/stream/single_context-fwd.hpp>
+#include <bsoncxx/builder/stream/value_context-fwd.hpp>
+#include <bsoncxx/decimal128-fwd.hpp>
+#include <bsoncxx/document/element-fwd.hpp>
+#include <bsoncxx/document/value-fwd.hpp>
+#include <bsoncxx/document/view-fwd.hpp>
+#include <bsoncxx/exception/error_code-fwd.hpp>
+#include <bsoncxx/exception/exception-fwd.hpp>
+#include <bsoncxx/json-fwd.hpp>
+#include <bsoncxx/oid-fwd.hpp>
+#include <bsoncxx/string/view_or_value-fwd.hpp>
+#include <bsoncxx/types-fwd.hpp>
+#include <bsoncxx/types/bson_value/value-fwd.hpp>
+#include <bsoncxx/types/bson_value/view-fwd.hpp>
+#include <bsoncxx/validate-fwd.hpp>
+#include <bsoncxx/view_or_value-fwd.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2023 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,8 @@
 
 #pragma once
 
-#include <system_error>
-
-#include <bsoncxx/exception/exception-fwd.hpp>
-
-#include <bsoncxx/config/prelude.hpp>
+#include <cstdint>
 
 namespace bsoncxx {
-inline namespace v_noabi {
-///
-/// Class representing any exceptions emitted from the bsoncxx library or
-/// its underlying implementation.
-///
-class exception : public std::system_error {
-    using std::system_error::system_error;
-};
-
-}  // namespace v_noabi
+inline namespace v_noabi { enum class ExtendedJsonMode : std::uint8_t; }  // namespace v_noabi
 }  // namespace bsoncxx
-
-#include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
@@ -16,6 +16,8 @@
 
 #include <string>
 
+#include <bsoncxx/json-fwd.hpp>
+
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2023 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,10 @@
 
 #pragma once
 
-#include <system_error>
-
-#include <bsoncxx/exception/exception-fwd.hpp>
-
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
-///
-/// Class representing any exceptions emitted from the bsoncxx library or
-/// its underlying implementation.
-///
-class exception : public std::system_error {
-    using std::system_error::system_error;
-};
-
-}  // namespace v_noabi
+inline namespace v_noabi { class BSONCXX_API oid; }  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
@@ -18,6 +18,8 @@
 #include <ctime>
 #include <string>
 
+#include <bsoncxx/oid-fwd.hpp>
+
 #include <bsoncxx/stdx/string_view.hpp>
 
 #include <bsoncxx/config/prelude.hpp>
@@ -34,7 +36,7 @@ inline namespace v_noabi {
 ///
 /// @see https://www.mongodb.com/docs/manual/reference/object-id/
 ///
-class BSONCXX_API oid {
+class oid {
    public:
     static constexpr std::size_t k_oid_length = 12;
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2023 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,22 +14,15 @@
 
 #pragma once
 
-#include <system_error>
-
-#include <bsoncxx/exception/exception-fwd.hpp>
-
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 inline namespace v_noabi {
-///
-/// Class representing any exceptions emitted from the bsoncxx library or
-/// its underlying implementation.
-///
-class exception : public std::system_error {
-    using std::system_error::system_error;
-};
+namespace string {
 
+class BSONCXX_API view_or_value;
+
+}  // namespace string
 }  // namespace v_noabi
 }  // namespace bsoncxx
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
@@ -16,6 +16,8 @@
 
 #include <string>
 
+#include <bsoncxx/string/view_or_value-fwd.hpp>
+
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/view_or_value.hpp>
 
@@ -33,7 +35,7 @@ namespace string {
 /// - a constructor overload for std::string by l-value reference
 /// - a safe c_str() operation to return null-terminated c-style strings.
 ///
-class BSONCXX_API view_or_value : public bsoncxx::view_or_value<stdx::string_view, std::string> {
+class view_or_value : public bsoncxx::view_or_value<stdx::string_view, std::string> {
    public:
     ///
     /// Forward all bsoncxx::view_or_value constructors.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types-fwd.hpp
@@ -1,0 +1,40 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+#include <bsoncxx/config/prelude.hpp>
+
+namespace bsoncxx {
+inline namespace v_noabi {
+enum class type : std::uint8_t;
+enum class binary_sub_type : std::uint8_t;
+
+namespace types {
+
+#pragma push_macro("BSONCXX_ENUM")
+#undef BSONCXX_ENUM
+#define BSONCXX_ENUM(name, val) struct BSONCXX_API b_##name;
+#include <bsoncxx/enums/type.hpp>
+#undef BSONCXX_ENUM
+#pragma pop_macro("BSONCXX_ENUM")
+
+}  // namespace types
+
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+#include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types.hpp
@@ -17,6 +17,8 @@
 #include <chrono>
 #include <cstring>
 
+#include <bsoncxx/types-fwd.hpp>
+
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/decimal128.hpp>
 #include <bsoncxx/document/view.hpp>
@@ -98,7 +100,7 @@ namespace types {
 ///
 /// A BSON double value.
 ///
-struct BSONCXX_API b_double {
+struct b_double {
     static constexpr auto type_id = type::k_double;
 
     double value;
@@ -123,7 +125,7 @@ BSONCXX_INLINE bool operator==(const b_double& lhs, const b_double& rhs) {
 ///
 /// A BSON UTF-8 encoded string value.
 ///
-struct BSONCXX_API b_string {
+struct b_string {
     static constexpr auto type_id = type::k_string;
 
     ///
@@ -164,7 +166,7 @@ BSONCXX_DEPRECATED typedef b_string b_utf8;
 ///
 /// A BSON document value.
 ///
-struct BSONCXX_API b_document {
+struct b_document {
     static constexpr auto type_id = type::k_document;
 
     document::view value;
@@ -196,7 +198,7 @@ BSONCXX_INLINE bool operator==(const b_document& lhs, const b_document& rhs) {
 ///
 /// A BSON array value.
 ///
-struct BSONCXX_API b_array {
+struct b_array {
     static constexpr auto type_id = type::k_array;
 
     array::view value;
@@ -221,7 +223,7 @@ BSONCXX_INLINE bool operator==(const b_array& lhs, const b_array& rhs) {
 ///
 /// A BSON binary data value.
 ///
-struct BSONCXX_API b_binary {
+struct b_binary {
     static constexpr auto type_id = type::k_binary;
 
     binary_sub_type sub_type;
@@ -245,7 +247,7 @@ BSONCXX_INLINE bool operator==(const b_binary& lhs, const b_binary& rhs) {
 /// @deprecated
 ///   This BSON type is deprecated and use by clients is discouraged.
 ///
-struct BSONCXX_API b_undefined {
+struct b_undefined {
     static constexpr auto type_id = type::k_undefined;
 };
 
@@ -261,7 +263,7 @@ BSONCXX_INLINE bool operator==(const b_undefined&, const b_undefined&) {
 ///
 /// A BSON ObjectId value.
 ///
-struct BSONCXX_API b_oid {
+struct b_oid {
     static constexpr auto type_id = type::k_oid;
 
     oid value;
@@ -279,7 +281,7 @@ BSONCXX_INLINE bool operator==(const b_oid& lhs, const b_oid& rhs) {
 ///
 /// A BSON boolean value.
 ///
-struct BSONCXX_API b_bool {
+struct b_bool {
     static constexpr auto type_id = type::k_bool;
 
     bool value;
@@ -304,7 +306,7 @@ BSONCXX_INLINE bool operator==(const b_bool& lhs, const b_bool& rhs) {
 ///
 /// A BSON date value.
 ///
-struct BSONCXX_API b_date {
+struct b_date {
     static constexpr auto type_id = type::k_date;
 
     ///
@@ -363,7 +365,7 @@ BSONCXX_INLINE bool operator==(const b_date& lhs, const b_date& rhs) {
 ///
 /// A BSON null value.
 ///
-struct BSONCXX_API b_null {
+struct b_null {
     static constexpr auto type_id = type::k_null;
 };
 
@@ -379,7 +381,7 @@ BSONCXX_INLINE bool operator==(const b_null&, const b_null&) {
 ///
 /// A BSON regex value.
 ///
-struct BSONCXX_API b_regex {
+struct b_regex {
     static constexpr auto type_id = type::k_regex;
 
     ///
@@ -416,7 +418,7 @@ BSONCXX_INLINE bool operator==(const b_regex& lhs, const b_regex& rhs) {
 /// @deprecated
 ///   A BSON DBPointer (aka DBRef) is still supported but deprecated.
 ///
-struct BSONCXX_API b_dbpointer {
+struct b_dbpointer {
     static constexpr auto type_id = type::k_dbpointer;
 
     stdx::string_view collection;
@@ -435,7 +437,7 @@ BSONCXX_INLINE bool operator==(const b_dbpointer& lhs, const b_dbpointer& rhs) {
 ///
 /// A BSON JavaScript code value.
 ///
-struct BSONCXX_API b_code {
+struct b_code {
     static constexpr auto type_id = type::k_code;
 
     ///
@@ -472,7 +474,7 @@ BSONCXX_INLINE bool operator==(const b_code& lhs, const b_code& rhs) {
 /// @deprecated
 ///   This BSON type is deprecated and use by clients is discouraged.
 ///
-struct BSONCXX_API b_symbol {
+struct b_symbol {
     static constexpr auto type_id = type::k_symbol;
 
     ///
@@ -506,7 +508,7 @@ BSONCXX_INLINE bool operator==(const b_symbol& lhs, const b_symbol& rhs) {
 ///
 /// A BSON JavaScript code with scope value.
 ///
-struct BSONCXX_API b_codewscope {
+struct b_codewscope {
     static constexpr auto type_id = type::k_codewscope;
 
     ///
@@ -540,7 +542,7 @@ BSONCXX_INLINE bool operator==(const b_codewscope& lhs, const b_codewscope& rhs)
 ///
 /// A BSON signed 32-bit integer value.
 ///
-struct BSONCXX_API b_int32 {
+struct b_int32 {
     static constexpr auto type_id = type::k_int32;
 
     int32_t value;
@@ -565,7 +567,7 @@ BSONCXX_INLINE bool operator==(const b_int32& lhs, const b_int32& rhs) {
 ///
 /// A BSON replication timestamp value.
 ///
-struct BSONCXX_API b_timestamp {
+struct b_timestamp {
     static constexpr auto type_id = type::k_timestamp;
 
     uint32_t increment;
@@ -584,7 +586,7 @@ BSONCXX_INLINE bool operator==(const b_timestamp& lhs, const b_timestamp& rhs) {
 ///
 /// A BSON 64-bit signed integer value.
 ///
-struct BSONCXX_API b_int64 {
+struct b_int64 {
     static constexpr auto type_id = type::k_int64;
 
     int64_t value;
@@ -609,7 +611,7 @@ BSONCXX_INLINE bool operator==(const b_int64& lhs, const b_int64& rhs) {
 ///
 /// A BSON Decimal128 value.
 ///
-struct BSONCXX_API b_decimal128 {
+struct b_decimal128 {
     static constexpr auto type_id = type::k_decimal128;
 
     decimal128 value;
@@ -636,7 +638,7 @@ BSONCXX_INLINE bool operator==(const b_decimal128& lhs, const b_decimal128& rhs)
 ///
 /// A BSON min-key value.
 ///
-struct BSONCXX_API b_minkey {
+struct b_minkey {
     static constexpr auto type_id = type::k_minkey;
 };
 
@@ -652,7 +654,7 @@ BSONCXX_INLINE bool operator==(const b_minkey&, const b_minkey&) {
 ///
 /// A BSON max-key value.
 ///
-struct BSONCXX_API b_maxkey {
+struct b_maxkey {
     static constexpr auto type_id = type::k_maxkey;
 };
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value-fwd.hpp
@@ -1,0 +1,31 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/config/prelude.hpp>
+
+namespace bsoncxx {
+inline namespace v_noabi {
+namespace types {
+namespace bson_value {
+
+class BSONCXX_API value;
+
+}  // namespace bson_value
+}  // namespace types
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+#include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
@@ -18,6 +18,8 @@
 #include <memory>
 #include <vector>
 
+#include <bsoncxx/types/bson_value/value-fwd.hpp>
+
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/make_unique.hpp>
@@ -40,7 +42,7 @@ namespace bson_value {
 ///
 /// @relatesalso bson_value::view
 ///
-class BSONCXX_API value {
+class value {
    public:
 ///
 /// Constructor for each BSON type.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <vector>
 
+#include <bsoncxx/document/element-fwd.hpp>
 #include <bsoncxx/types/bson_value/value-fwd.hpp>
 
 #include <bsoncxx/array/view_or_value.hpp>
@@ -257,7 +258,7 @@ class value {
     operator bson_value::view() const noexcept;
 
    private:
-    friend class bsoncxx::document::element;
+    friend class ::bsoncxx::v_noabi::document::element;
 
     value(const std::uint8_t* raw,
           std::uint32_t length,

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view-fwd.hpp
@@ -1,0 +1,31 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/config/prelude.hpp>
+
+namespace bsoncxx {
+inline namespace v_noabi {
+namespace types {
+namespace bson_value {
+
+class BSONCXX_API view;
+
+}  // namespace bson_value
+}  // namespace types
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+#include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
@@ -19,6 +19,7 @@
 #include <type_traits>
 
 #include <bsoncxx/types/bson_value/value-fwd.hpp>
+#include <bsoncxx/types/bson_value/view-fwd.hpp>
 
 #include <bsoncxx/stdx/type_traits.hpp>
 #include <bsoncxx/types.hpp>
@@ -40,7 +41,7 @@ namespace bson_value {
 ///   Calling the wrong get_<type> method will cause an exception
 ///   to be thrown.
 ///
-class BSONCXX_API view {
+class view {
    public:
 ///
 /// Construct a bson_value::view from any of the various BSON types. Defines

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
@@ -18,6 +18,8 @@
 #include <cstdint>
 #include <type_traits>
 
+#include <bsoncxx/types/bson_value/value-fwd.hpp>
+
 #include <bsoncxx/stdx/type_traits.hpp>
 #include <bsoncxx/types.hpp>
 
@@ -31,9 +33,6 @@ class element;
 
 namespace types {
 namespace bson_value {
-
-class value;
-
 ///
 /// A view-only variant that can contain any BSON type.
 ///
@@ -271,8 +270,8 @@ class BSONCXX_API view {
     const b_maxkey& get_maxkey() const;
 
    private:
+    friend class ::bsoncxx::v_noabi::types::bson_value::value;
     friend class document::element;
-    friend class bson_value::value;
 
     view(const std::uint8_t* raw, std::uint32_t length, std::uint32_t offset, std::uint32_t keylen);
     view(void* internal_value) noexcept;

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <type_traits>
 
+#include <bsoncxx/document/element-fwd.hpp>
 #include <bsoncxx/types/bson_value/value-fwd.hpp>
 #include <bsoncxx/types/bson_value/view-fwd.hpp>
 
@@ -28,10 +29,6 @@
 
 namespace bsoncxx {
 inline namespace v_noabi {
-namespace document {
-class element;
-}  // namespace document
-
 namespace types {
 namespace bson_value {
 ///
@@ -272,7 +269,7 @@ class view {
 
    private:
     friend class ::bsoncxx::v_noabi::types::bson_value::value;
-    friend class document::element;
+    friend class ::bsoncxx::v_noabi::document::element;
 
     view(const std::uint8_t* raw, std::uint32_t length, std::uint32_t offset, std::uint32_t keylen);
     view(void* internal_value) noexcept;
@@ -342,7 +339,6 @@ operator!=(T&& lhs, const bson_value::view& rhs) {
 
 }  // namespace bson_value
 }  // namespace types
-
 }  // namespace v_noabi
 }  // namespace bsoncxx
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/config/prelude.hpp>
+
+namespace bsoncxx {
+inline namespace v_noabi { class BSONCXX_API validator; }  // namespace v_noabi
+}  // namespace bsoncxx
+
+#include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate.hpp
@@ -17,6 +17,8 @@
 #include <cstdint>
 #include <memory>
 
+#include <bsoncxx/validate-fwd.hpp>
+
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 
@@ -24,8 +26,6 @@
 
 namespace bsoncxx {
 inline namespace v_noabi {
-class validator;
-
 ///
 /// Validates a BSON document. This is a simplified overload that will
 /// only do the bare minimum validation of document structure, and does
@@ -72,7 +72,7 @@ validate(const std::uint8_t* data,
 /// A validator is used to enable or disable specific checks that can be
 /// performed during BSON validation.
 ///
-class BSONCXX_API validator {
+class validator {
    public:
     ///
     /// Constructs a validator.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2023 MongoDB Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,21 +14,12 @@
 
 #pragma once
 
-#include <system_error>
-
-#include <bsoncxx/exception/exception-fwd.hpp>
-
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
 inline namespace v_noabi {
-///
-/// Class representing any exceptions emitted from the bsoncxx library or
-/// its underlying implementation.
-///
-class exception : public std::system_error {
-    using std::system_error::system_error;
-};
+template <typename View, typename Value>
+class view_or_value;
 
 }  // namespace v_noabi
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value.hpp
@@ -16,6 +16,8 @@
 
 #include <type_traits>
 
+#include <bsoncxx/view_or_value-fwd.hpp>
+
 #include <bsoncxx/stdx/optional.hpp>
 
 #include <bsoncxx/config/prelude.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.cpp
@@ -219,7 +219,7 @@ value::value(void* internal_value)
 
 value::value(const value& rhs) : value(&rhs._impl->_value) {}
 
-value::value(const class view& bson_view) {
+value::value(const bson_value::view& bson_view) {
     _impl = stdx::make_unique<impl>();
     convert_to_libbson(&_impl->_value, bson_view);
 }

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -62,6 +62,7 @@ set_dist_list(src_mongocxx_include_DIST
     mongocxx/v_noabi/mongocxx/exception/query_exception.hpp
     mongocxx/v_noabi/mongocxx/exception/server_error_code.hpp
     mongocxx/v_noabi/mongocxx/exception/write_exception.hpp
+    mongocxx/v_noabi/mongocxx/gridfs/bucket-fwd.hpp
     mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
     mongocxx/v_noabi/mongocxx/gridfs/downloader.hpp
     mongocxx/v_noabi/mongocxx/gridfs/uploader.hpp

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -68,6 +68,7 @@ set_dist_list(src_mongocxx_include_DIST
     mongocxx/v_noabi/mongocxx/index_model.hpp
     mongocxx/v_noabi/mongocxx/index_view.hpp
     mongocxx/v_noabi/mongocxx/instance.hpp
+    mongocxx/v_noabi/mongocxx/logger-fwd.hpp
     mongocxx/v_noabi/mongocxx/logger.hpp
     mongocxx/v_noabi/mongocxx/model/delete_many.hpp
     mongocxx/v_noabi/mongocxx/model/delete_one.hpp

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -123,6 +123,7 @@ set_dist_list(src_mongocxx_include_DIST
     mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey.hpp
     mongocxx/v_noabi/mongocxx/result/update.hpp
     mongocxx/v_noabi/mongocxx/search_index_model.hpp
+    mongocxx/v_noabi/mongocxx/search_index_view-fwd.hpp
     mongocxx/v_noabi/mongocxx/search_index_view.hpp
     mongocxx/v_noabi/mongocxx/stdx.hpp
     mongocxx/v_noabi/mongocxx/uri-fwd.hpp

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -116,6 +116,7 @@ set_dist_list(src_mongocxx_include_DIST
     mongocxx/v_noabi/mongocxx/pool.hpp
     mongocxx/v_noabi/mongocxx/read_concern-fwd.hpp
     mongocxx/v_noabi/mongocxx/read_concern.hpp
+    mongocxx/v_noabi/mongocxx/read_preference-fwd.hpp
     mongocxx/v_noabi/mongocxx/read_preference.hpp
     mongocxx/v_noabi/mongocxx/result/bulk_write.hpp
     mongocxx/v_noabi/mongocxx/result/delete.hpp

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -123,6 +123,7 @@ set_dist_list(src_mongocxx_include_DIST
     mongocxx/v_noabi/mongocxx/search_index_model.hpp
     mongocxx/v_noabi/mongocxx/search_index_view.hpp
     mongocxx/v_noabi/mongocxx/stdx.hpp
+    mongocxx/v_noabi/mongocxx/uri-fwd.hpp
     mongocxx/v_noabi/mongocxx/uri.hpp
     mongocxx/v_noabi/mongocxx/validation_criteria.hpp
     mongocxx/v_noabi/mongocxx/write_concern.hpp

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -24,6 +24,7 @@ set_dist_list(src_mongocxx_include_DIST
     mongocxx/v_noabi/mongocxx/change_stream.hpp
     mongocxx/v_noabi/mongocxx/client_encryption.hpp
     mongocxx/v_noabi/mongocxx/client_session.hpp
+    mongocxx/v_noabi/mongocxx/client-fwd.hpp
     mongocxx/v_noabi/mongocxx/client.hpp
     mongocxx/v_noabi/mongocxx/collection.hpp
     mongocxx/v_noabi/mongocxx/config/compiler.hpp

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -110,6 +110,7 @@ set_dist_list(src_mongocxx_include_DIST
     mongocxx/v_noabi/mongocxx/options/server_api.hpp
     mongocxx/v_noabi/mongocxx/options/ssl.hpp
     mongocxx/v_noabi/mongocxx/options/tls.hpp
+    mongocxx/v_noabi/mongocxx/options/transaction-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/transaction.hpp
     mongocxx/v_noabi/mongocxx/options/update.hpp
     mongocxx/v_noabi/mongocxx/pipeline.hpp

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -22,6 +22,7 @@ set_dist_list(src_mongocxx_include_DIST
     CMakeLists.txt
     mongocxx/v_noabi/mongocxx/bulk_write.hpp
     mongocxx/v_noabi/mongocxx/change_stream.hpp
+    mongocxx/v_noabi/mongocxx/client_encryption-fwd.hpp
     mongocxx/v_noabi/mongocxx/client_encryption.hpp
     mongocxx/v_noabi/mongocxx/client_session-fwd.hpp
     mongocxx/v_noabi/mongocxx/client_session.hpp

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -112,6 +112,7 @@ set_dist_list(src_mongocxx_include_DIST
     mongocxx/v_noabi/mongocxx/options/transaction.hpp
     mongocxx/v_noabi/mongocxx/options/update.hpp
     mongocxx/v_noabi/mongocxx/pipeline.hpp
+    mongocxx/v_noabi/mongocxx/pool-fwd.hpp
     mongocxx/v_noabi/mongocxx/pool.hpp
     mongocxx/v_noabi/mongocxx/read_concern.hpp
     mongocxx/v_noabi/mongocxx/read_preference.hpp

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -49,6 +49,7 @@ set_dist_list(src_mongocxx_include_DIST
     mongocxx/v_noabi/mongocxx/events/server_opening_event.hpp
     mongocxx/v_noabi/mongocxx/events/topology_changed_event.hpp
     mongocxx/v_noabi/mongocxx/events/topology_closed_event.hpp
+    mongocxx/v_noabi/mongocxx/events/topology_description-fwd.hpp
     mongocxx/v_noabi/mongocxx/events/topology_description.hpp
     mongocxx/v_noabi/mongocxx/events/topology_opening_event.hpp
     mongocxx/v_noabi/mongocxx/exception/authentication_exception.hpp

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -32,6 +32,7 @@ set_dist_list(src_mongocxx_include_DIST
     mongocxx/v_noabi/mongocxx/config/postlude.hpp
     mongocxx/v_noabi/mongocxx/config/prelude.hpp
     mongocxx/v_noabi/mongocxx/cursor.hpp
+    mongocxx/v_noabi/mongocxx/database-fwd.hpp
     mongocxx/v_noabi/mongocxx/database.hpp
     mongocxx/v_noabi/mongocxx/events/command_failed_event.hpp
     mongocxx/v_noabi/mongocxx/events/command_started_event.hpp

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -20,6 +20,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
 
 set_dist_list(src_mongocxx_include_DIST
     CMakeLists.txt
+    mongocxx/v_noabi/mongocxx/bulk_write-fwd.hpp
     mongocxx/v_noabi/mongocxx/bulk_write.hpp
     mongocxx/v_noabi/mongocxx/change_stream.hpp
     mongocxx/v_noabi/mongocxx/client_encryption-fwd.hpp

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -67,6 +67,7 @@ set_dist_list(src_mongocxx_include_DIST
     mongocxx/v_noabi/mongocxx/gridfs/uploader.hpp
     mongocxx/v_noabi/mongocxx/hint.hpp
     mongocxx/v_noabi/mongocxx/index_model.hpp
+    mongocxx/v_noabi/mongocxx/index_view-fwd.hpp
     mongocxx/v_noabi/mongocxx/index_view.hpp
     mongocxx/v_noabi/mongocxx/instance.hpp
     mongocxx/v_noabi/mongocxx/logger-fwd.hpp

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -23,6 +23,7 @@ set_dist_list(src_mongocxx_include_DIST
     mongocxx/v_noabi/mongocxx/bulk_write.hpp
     mongocxx/v_noabi/mongocxx/change_stream.hpp
     mongocxx/v_noabi/mongocxx/client_encryption.hpp
+    mongocxx/v_noabi/mongocxx/client_session-fwd.hpp
     mongocxx/v_noabi/mongocxx/client_session.hpp
     mongocxx/v_noabi/mongocxx/client-fwd.hpp
     mongocxx/v_noabi/mongocxx/client.hpp

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -22,6 +22,7 @@ set_dist_list(src_mongocxx_include_DIST
     CMakeLists.txt
     mongocxx/v_noabi/mongocxx/bulk_write-fwd.hpp
     mongocxx/v_noabi/mongocxx/bulk_write.hpp
+    mongocxx/v_noabi/mongocxx/change_stream-fwd.hpp
     mongocxx/v_noabi/mongocxx/change_stream.hpp
     mongocxx/v_noabi/mongocxx/client_encryption-fwd.hpp
     mongocxx/v_noabi/mongocxx/client_encryption.hpp
@@ -34,89 +35,155 @@ set_dist_list(src_mongocxx_include_DIST
     mongocxx/v_noabi/mongocxx/config/compiler.hpp
     mongocxx/v_noabi/mongocxx/config/postlude.hpp
     mongocxx/v_noabi/mongocxx/config/prelude.hpp
+    mongocxx/v_noabi/mongocxx/cursor-fwd.hpp
     mongocxx/v_noabi/mongocxx/cursor.hpp
     mongocxx/v_noabi/mongocxx/database-fwd.hpp
     mongocxx/v_noabi/mongocxx/database.hpp
+    mongocxx/v_noabi/mongocxx/events/command_failed_event-fwd.hpp
     mongocxx/v_noabi/mongocxx/events/command_failed_event.hpp
+    mongocxx/v_noabi/mongocxx/events/command_started_event-fwd.hpp
     mongocxx/v_noabi/mongocxx/events/command_started_event.hpp
+    mongocxx/v_noabi/mongocxx/events/command_succeeded_event-fwd.hpp
     mongocxx/v_noabi/mongocxx/events/command_succeeded_event.hpp
+    mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event-fwd.hpp
     mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event.hpp
+    mongocxx/v_noabi/mongocxx/events/heartbeat_started_event-fwd.hpp
     mongocxx/v_noabi/mongocxx/events/heartbeat_started_event.hpp
+    mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event-fwd.hpp
     mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event.hpp
+    mongocxx/v_noabi/mongocxx/events/server_changed_event-fwd.hpp
     mongocxx/v_noabi/mongocxx/events/server_changed_event.hpp
+    mongocxx/v_noabi/mongocxx/events/server_closed_event-fwd.hpp
     mongocxx/v_noabi/mongocxx/events/server_closed_event.hpp
+    mongocxx/v_noabi/mongocxx/events/server_description-fwd.hpp
     mongocxx/v_noabi/mongocxx/events/server_description.hpp
+    mongocxx/v_noabi/mongocxx/events/server_opening_event-fwd.hpp
     mongocxx/v_noabi/mongocxx/events/server_opening_event.hpp
+    mongocxx/v_noabi/mongocxx/events/topology_changed_event-fwd.hpp
     mongocxx/v_noabi/mongocxx/events/topology_changed_event.hpp
+    mongocxx/v_noabi/mongocxx/events/topology_closed_event-fwd.hpp
     mongocxx/v_noabi/mongocxx/events/topology_closed_event.hpp
     mongocxx/v_noabi/mongocxx/events/topology_description-fwd.hpp
     mongocxx/v_noabi/mongocxx/events/topology_description.hpp
+    mongocxx/v_noabi/mongocxx/events/topology_opening_event-fwd.hpp
     mongocxx/v_noabi/mongocxx/events/topology_opening_event.hpp
+    mongocxx/v_noabi/mongocxx/exception/authentication_exception-fwd.hpp
     mongocxx/v_noabi/mongocxx/exception/authentication_exception.hpp
+    mongocxx/v_noabi/mongocxx/exception/bulk_write_exception-fwd.hpp
     mongocxx/v_noabi/mongocxx/exception/bulk_write_exception.hpp
+    mongocxx/v_noabi/mongocxx/exception/error_code-fwd.hpp
     mongocxx/v_noabi/mongocxx/exception/error_code.hpp
+    mongocxx/v_noabi/mongocxx/exception/exception-fwd.hpp
     mongocxx/v_noabi/mongocxx/exception/exception.hpp
+    mongocxx/v_noabi/mongocxx/exception/gridfs_exception-fwd.hpp
     mongocxx/v_noabi/mongocxx/exception/gridfs_exception.hpp
+    mongocxx/v_noabi/mongocxx/exception/logic_error-fwd.hpp
     mongocxx/v_noabi/mongocxx/exception/logic_error.hpp
+    mongocxx/v_noabi/mongocxx/exception/operation_exception-fwd.hpp
     mongocxx/v_noabi/mongocxx/exception/operation_exception.hpp
+    mongocxx/v_noabi/mongocxx/exception/query_exception-fwd.hpp
     mongocxx/v_noabi/mongocxx/exception/query_exception.hpp
+    mongocxx/v_noabi/mongocxx/exception/server_error_code-fwd.hpp
     mongocxx/v_noabi/mongocxx/exception/server_error_code.hpp
+    mongocxx/v_noabi/mongocxx/exception/write_exception-fwd.hpp
     mongocxx/v_noabi/mongocxx/exception/write_exception.hpp
     mongocxx/v_noabi/mongocxx/gridfs/bucket-fwd.hpp
     mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
+    mongocxx/v_noabi/mongocxx/gridfs/downloader-fwd.hpp
     mongocxx/v_noabi/mongocxx/gridfs/downloader.hpp
+    mongocxx/v_noabi/mongocxx/gridfs/uploader-fwd.hpp
     mongocxx/v_noabi/mongocxx/gridfs/uploader.hpp
+    mongocxx/v_noabi/mongocxx/hint-fwd.hpp
     mongocxx/v_noabi/mongocxx/hint.hpp
+    mongocxx/v_noabi/mongocxx/index_model-fwd.hpp
     mongocxx/v_noabi/mongocxx/index_model.hpp
     mongocxx/v_noabi/mongocxx/index_view-fwd.hpp
     mongocxx/v_noabi/mongocxx/index_view.hpp
+    mongocxx/v_noabi/mongocxx/instance-fwd.hpp
     mongocxx/v_noabi/mongocxx/instance.hpp
     mongocxx/v_noabi/mongocxx/logger-fwd.hpp
     mongocxx/v_noabi/mongocxx/logger.hpp
+    mongocxx/v_noabi/mongocxx/model/delete_many-fwd.hpp
     mongocxx/v_noabi/mongocxx/model/delete_many.hpp
+    mongocxx/v_noabi/mongocxx/model/delete_one-fwd.hpp
     mongocxx/v_noabi/mongocxx/model/delete_one.hpp
+    mongocxx/v_noabi/mongocxx/model/insert_one-fwd.hpp
     mongocxx/v_noabi/mongocxx/model/insert_one.hpp
+    mongocxx/v_noabi/mongocxx/model/replace_one-fwd.hpp
     mongocxx/v_noabi/mongocxx/model/replace_one.hpp
+    mongocxx/v_noabi/mongocxx/model/update_many-fwd.hpp
     mongocxx/v_noabi/mongocxx/model/update_many.hpp
+    mongocxx/v_noabi/mongocxx/model/update_one-fwd.hpp
     mongocxx/v_noabi/mongocxx/model/update_one.hpp
+    mongocxx/v_noabi/mongocxx/model/write-fwd.hpp
     mongocxx/v_noabi/mongocxx/model/write.hpp
+    mongocxx/v_noabi/mongocxx/options/aggregate-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/aggregate.hpp
+    mongocxx/v_noabi/mongocxx/options/apm-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/apm.hpp
     mongocxx/v_noabi/mongocxx/options/auto_encryption-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
+    mongocxx/v_noabi/mongocxx/options/bulk_write-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/bulk_write.hpp
+    mongocxx/v_noabi/mongocxx/options/change_stream-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/change_stream.hpp
     mongocxx/v_noabi/mongocxx/options/client_encryption-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/client_encryption.hpp
+    mongocxx/v_noabi/mongocxx/options/client_session-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/client_session.hpp
+    mongocxx/v_noabi/mongocxx/options/client-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/client.hpp
+    mongocxx/v_noabi/mongocxx/options/count-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/count.hpp
     mongocxx/v_noabi/mongocxx/options/create_collection.hpp
+    mongocxx/v_noabi/mongocxx/options/data_key-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/data_key.hpp
+    mongocxx/v_noabi/mongocxx/options/delete-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/delete.hpp
+    mongocxx/v_noabi/mongocxx/options/distinct-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/distinct.hpp
+    mongocxx/v_noabi/mongocxx/options/encrypt-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/encrypt.hpp
+    mongocxx/v_noabi/mongocxx/options/estimated_document_count-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/estimated_document_count.hpp
+    mongocxx/v_noabi/mongocxx/options/find_one_and_delete-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/find_one_and_delete.hpp
+    mongocxx/v_noabi/mongocxx/options/find_one_and_replace-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/find_one_and_replace.hpp
+    mongocxx/v_noabi/mongocxx/options/find_one_and_update-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/find_one_and_update.hpp
+    mongocxx/v_noabi/mongocxx/options/find_one_common_options-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/find_one_common_options.hpp
+    mongocxx/v_noabi/mongocxx/options/find-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/find.hpp
+    mongocxx/v_noabi/mongocxx/options/gridfs/bucket-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/gridfs/bucket.hpp
+    mongocxx/v_noabi/mongocxx/options/gridfs/upload-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/gridfs/upload.hpp
+    mongocxx/v_noabi/mongocxx/options/index_view-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/index_view.hpp
+    mongocxx/v_noabi/mongocxx/options/index-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/index.hpp
+    mongocxx/v_noabi/mongocxx/options/insert-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/insert.hpp
+    mongocxx/v_noabi/mongocxx/options/pool-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/pool.hpp
+    mongocxx/v_noabi/mongocxx/options/range-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/range.hpp
+    mongocxx/v_noabi/mongocxx/options/replace-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/replace.hpp
+    mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey.hpp
+    mongocxx/v_noabi/mongocxx/options/server_api-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/server_api.hpp
     mongocxx/v_noabi/mongocxx/options/ssl.hpp
+    mongocxx/v_noabi/mongocxx/options/tls-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/tls.hpp
     mongocxx/v_noabi/mongocxx/options/transaction-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/transaction.hpp
+    mongocxx/v_noabi/mongocxx/options/update-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/update.hpp
+    mongocxx/v_noabi/mongocxx/pipeline-fwd.hpp
     mongocxx/v_noabi/mongocxx/pipeline.hpp
     mongocxx/v_noabi/mongocxx/pool-fwd.hpp
     mongocxx/v_noabi/mongocxx/pool.hpp
@@ -124,22 +191,33 @@ set_dist_list(src_mongocxx_include_DIST
     mongocxx/v_noabi/mongocxx/read_concern.hpp
     mongocxx/v_noabi/mongocxx/read_preference-fwd.hpp
     mongocxx/v_noabi/mongocxx/read_preference.hpp
+    mongocxx/v_noabi/mongocxx/result/bulk_write-fwd.hpp
     mongocxx/v_noabi/mongocxx/result/bulk_write.hpp
+    mongocxx/v_noabi/mongocxx/result/delete-fwd.hpp
     mongocxx/v_noabi/mongocxx/result/delete.hpp
+    mongocxx/v_noabi/mongocxx/result/gridfs/upload-fwd.hpp
     mongocxx/v_noabi/mongocxx/result/gridfs/upload.hpp
+    mongocxx/v_noabi/mongocxx/result/insert_many-fwd.hpp
     mongocxx/v_noabi/mongocxx/result/insert_many.hpp
+    mongocxx/v_noabi/mongocxx/result/insert_one-fwd.hpp
     mongocxx/v_noabi/mongocxx/result/insert_one.hpp
+    mongocxx/v_noabi/mongocxx/result/replace_one-fwd.hpp
     mongocxx/v_noabi/mongocxx/result/replace_one.hpp
+    mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey-fwd.hpp
     mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey.hpp
+    mongocxx/v_noabi/mongocxx/result/update-fwd.hpp
     mongocxx/v_noabi/mongocxx/result/update.hpp
+    mongocxx/v_noabi/mongocxx/search_index_model-fwd.hpp
     mongocxx/v_noabi/mongocxx/search_index_model.hpp
     mongocxx/v_noabi/mongocxx/search_index_view-fwd.hpp
     mongocxx/v_noabi/mongocxx/search_index_view.hpp
     mongocxx/v_noabi/mongocxx/stdx.hpp
     mongocxx/v_noabi/mongocxx/uri-fwd.hpp
     mongocxx/v_noabi/mongocxx/uri.hpp
+    mongocxx/v_noabi/mongocxx/validation_criteria-fwd.hpp
     mongocxx/v_noabi/mongocxx/validation_criteria.hpp
     mongocxx/v_noabi/mongocxx/write_concern-fwd.hpp
     mongocxx/v_noabi/mongocxx/write_concern.hpp
+    mongocxx/v_noabi/mongocxx/write_type-fwd.hpp
     mongocxx/v_noabi/mongocxx/write_type.hpp
 )

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -87,6 +87,7 @@ set_dist_list(src_mongocxx_include_DIST
     mongocxx/v_noabi/mongocxx/exception/server_error_code.hpp
     mongocxx/v_noabi/mongocxx/exception/write_exception-fwd.hpp
     mongocxx/v_noabi/mongocxx/exception/write_exception.hpp
+    mongocxx/v_noabi/mongocxx/fwd.hpp
     mongocxx/v_noabi/mongocxx/gridfs/bucket-fwd.hpp
     mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
     mongocxx/v_noabi/mongocxx/gridfs/downloader-fwd.hpp

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -26,6 +26,7 @@ set_dist_list(src_mongocxx_include_DIST
     mongocxx/v_noabi/mongocxx/client_session.hpp
     mongocxx/v_noabi/mongocxx/client-fwd.hpp
     mongocxx/v_noabi/mongocxx/client.hpp
+    mongocxx/v_noabi/mongocxx/collection-fwd.hpp
     mongocxx/v_noabi/mongocxx/collection.hpp
     mongocxx/v_noabi/mongocxx/config/compiler.hpp
     mongocxx/v_noabi/mongocxx/config/postlude.hpp

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -86,6 +86,7 @@ set_dist_list(src_mongocxx_include_DIST
     mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
     mongocxx/v_noabi/mongocxx/options/bulk_write.hpp
     mongocxx/v_noabi/mongocxx/options/change_stream.hpp
+    mongocxx/v_noabi/mongocxx/options/client_encryption-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/client_encryption.hpp
     mongocxx/v_noabi/mongocxx/options/client_session.hpp
     mongocxx/v_noabi/mongocxx/options/client.hpp

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -114,6 +114,7 @@ set_dist_list(src_mongocxx_include_DIST
     mongocxx/v_noabi/mongocxx/pipeline.hpp
     mongocxx/v_noabi/mongocxx/pool-fwd.hpp
     mongocxx/v_noabi/mongocxx/pool.hpp
+    mongocxx/v_noabi/mongocxx/read_concern-fwd.hpp
     mongocxx/v_noabi/mongocxx/read_concern.hpp
     mongocxx/v_noabi/mongocxx/read_preference.hpp
     mongocxx/v_noabi/mongocxx/result/bulk_write.hpp

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -132,6 +132,7 @@ set_dist_list(src_mongocxx_include_DIST
     mongocxx/v_noabi/mongocxx/uri-fwd.hpp
     mongocxx/v_noabi/mongocxx/uri.hpp
     mongocxx/v_noabi/mongocxx/validation_criteria.hpp
+    mongocxx/v_noabi/mongocxx/write_concern-fwd.hpp
     mongocxx/v_noabi/mongocxx/write_concern.hpp
     mongocxx/v_noabi/mongocxx/write_type.hpp
 )

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -82,6 +82,7 @@ set_dist_list(src_mongocxx_include_DIST
     mongocxx/v_noabi/mongocxx/model/write.hpp
     mongocxx/v_noabi/mongocxx/options/aggregate.hpp
     mongocxx/v_noabi/mongocxx/options/apm.hpp
+    mongocxx/v_noabi/mongocxx/options/auto_encryption-fwd.hpp
     mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
     mongocxx/v_noabi/mongocxx/options/bulk_write.hpp
     mongocxx/v_noabi/mongocxx/options/change_stream.hpp

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API bulk_write; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <mongocxx/bulk_write-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 
 #include <mongocxx/client_session.hpp>
@@ -39,7 +40,7 @@ inline namespace v_noabi {
 /// @see https://www.mongodb.com/docs/manual/core/crud/
 /// @see https://www.mongodb.com/docs/manual/core/bulk-write-operations/
 ///
-class MONGOCXX_API bulk_write {
+class bulk_write {
    public:
     ///
     /// Move constructs a bulk write operation.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/collection-fwd.hpp>
+
 #include <mongocxx/client_session.hpp>
 #include <mongocxx/model/write.hpp>
 #include <mongocxx/options/bulk_write.hpp>
@@ -23,8 +25,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class collection;
-
 ///
 /// Class representing a batch of write operations that can be sent to the server as a group.
 ///
@@ -92,7 +92,7 @@ class MONGOCXX_API bulk_write {
     stdx::optional<result::bulk_write> execute() const;
 
    private:
-    friend class collection;
+    friend class ::mongocxx::v_noabi::collection;
 
     class MONGOCXX_PRIVATE impl;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API change_stream; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream.hpp
@@ -18,6 +18,7 @@
 
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
+#include <mongocxx/database-fwd.hpp>
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -26,8 +27,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class database;
-
 ///
 /// Class representing a MongoDB change stream.
 ///
@@ -110,7 +109,7 @@ class MONGOCXX_API change_stream {
    private:
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
-    friend class database;
+    friend class ::mongocxx::v_noabi::database;
     friend class change_stream::iterator;
 
     MONGOCXX_PRIVATE change_stream(void* change_stream_ptr);

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream.hpp
@@ -121,7 +121,7 @@ class MONGOCXX_API change_stream {
 ///
 /// Class representing a MongoDB change stream iterator.
 ///
-class MONGOCXX_API change_stream::iterator {
+class change_stream::iterator {
    public:
     // Support input-iterator (caveat of post-increment returning void)
     using difference_type = std::int64_t;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream.hpp
@@ -16,6 +16,8 @@
 
 #include <memory>
 
+#include <mongocxx/client-fwd.hpp>
+
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 
@@ -23,7 +25,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class client;
 class collection;
 class database;
 
@@ -107,7 +108,7 @@ class MONGOCXX_API change_stream {
     bsoncxx::stdx::optional<bsoncxx::document::view> get_resume_token() const;
 
    private:
-    friend class client;
+    friend class ::mongocxx::v_noabi::client;
     friend class collection;
     friend class database;
     friend class change_stream::iterator;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream.hpp
@@ -16,6 +16,7 @@
 
 #include <memory>
 
+#include <mongocxx/change_stream-fwd.hpp>
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
@@ -30,7 +31,7 @@ inline namespace v_noabi {
 ///
 /// Class representing a MongoDB change stream.
 ///
-class MONGOCXX_API change_stream {
+class change_stream {
    public:
     /// A change stream iterator.
     class MONGOCXX_API iterator;
@@ -110,7 +111,8 @@ class MONGOCXX_API change_stream {
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::v_noabi::database;
-    friend class change_stream::iterator;
+
+    friend class ::mongocxx::v_noabi::change_stream::iterator;
 
     MONGOCXX_PRIVATE change_stream(void* change_stream_ptr);
 
@@ -184,7 +186,8 @@ class change_stream::iterator {
     void operator++(int);
 
    private:
-    friend class change_stream;
+    friend class ::mongocxx::v_noabi::change_stream;
+
     enum class iter_type { k_tracking, k_default_constructed, k_end };
 
     MONGOCXX_PRIVATE explicit iterator(iter_type type, const change_stream* change_stream);

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream.hpp
@@ -17,6 +17,7 @@
 #include <memory>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/collection-fwd.hpp>
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -25,7 +26,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class collection;
 class database;
 
 ///
@@ -109,7 +109,7 @@ class MONGOCXX_API change_stream {
 
    private:
     friend class ::mongocxx::v_noabi::client;
-    friend class collection;
+    friend class ::mongocxx::v_noabi::collection;
     friend class database;
     friend class change_stream::iterator;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API client; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
@@ -20,6 +20,7 @@
 #include <mongocxx/client_session-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
+#include <mongocxx/options/auto_encryption-fwd.hpp>
 #include <mongocxx/pool-fwd.hpp>
 
 #include <mongocxx/client_session.hpp>
@@ -425,8 +426,8 @@ class client {
     friend class ::mongocxx::v_noabi::client_session;
     friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::v_noabi::database;
+    friend class ::mongocxx::v_noabi::options::auto_encryption;
     friend class ::mongocxx::v_noabi::pool;
-    friend class options::auto_encryption;
     friend class options::client_encryption;
 
     MONGOCXX_PRIVATE explicit client(void* implementation);

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
@@ -17,6 +17,7 @@
 #include <memory>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/collection-fwd.hpp>
 
 #include <mongocxx/client_session.hpp>
 #include <mongocxx/database.hpp>
@@ -420,7 +421,7 @@ class client {
     void reset();
 
    private:
-    friend class collection;
+    friend class ::mongocxx::v_noabi::collection;
     friend class database;
     friend class pool;
     friend class client_session;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
@@ -17,6 +17,7 @@
 #include <memory>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/client_session-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
 
@@ -35,8 +36,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class client_session;
-
 ///
 /// Class representing a client connection to MongoDB.
 ///
@@ -422,10 +421,10 @@ class client {
     void reset();
 
    private:
+    friend class ::mongocxx::v_noabi::client_session;
     friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::v_noabi::database;
     friend class pool;
-    friend class client_session;
     friend class options::auto_encryption;
     friend class options::client_encryption;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
@@ -16,6 +16,8 @@
 
 #include <memory>
 
+#include <mongocxx/client-fwd.hpp>
+
 #include <mongocxx/client_session.hpp>
 #include <mongocxx/database.hpp>
 #include <mongocxx/options/client.hpp>
@@ -51,7 +53,7 @@ class client_session;
 ///
 /// Note that client is not thread-safe. See
 /// https://mongodb.github.io/mongo-cxx-driver/mongocxx-v3/thread-safety/ for more details.
-class MONGOCXX_API client {
+class client {
    public:
     ///
     /// Default constructs a new client. The client is not connected and is equivalent to the

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
@@ -18,6 +18,7 @@
 
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
+#include <mongocxx/database-fwd.hpp>
 
 #include <mongocxx/client_session.hpp>
 #include <mongocxx/database.hpp>
@@ -422,7 +423,7 @@ class client {
 
    private:
     friend class ::mongocxx::v_noabi::collection;
-    friend class database;
+    friend class ::mongocxx::v_noabi::database;
     friend class pool;
     friend class client_session;
     friend class options::auto_encryption;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
@@ -20,6 +20,7 @@
 #include <mongocxx/client_session-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
+#include <mongocxx/pool-fwd.hpp>
 
 #include <mongocxx/client_session.hpp>
 #include <mongocxx/database.hpp>
@@ -424,7 +425,7 @@ class client {
     friend class ::mongocxx::v_noabi::client_session;
     friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::v_noabi::database;
-    friend class pool;
+    friend class ::mongocxx::v_noabi::pool;
     friend class options::auto_encryption;
     friend class options::client_encryption;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
@@ -21,6 +21,7 @@
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
 #include <mongocxx/options/auto_encryption-fwd.hpp>
+#include <mongocxx/options/client_encryption-fwd.hpp>
 #include <mongocxx/pool-fwd.hpp>
 
 #include <mongocxx/client_session.hpp>
@@ -427,8 +428,8 @@ class client {
     friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::v_noabi::database;
     friend class ::mongocxx::v_noabi::options::auto_encryption;
+    friend class ::mongocxx::v_noabi::options::client_encryption;
     friend class ::mongocxx::v_noabi::pool;
-    friend class options::client_encryption;
 
     MONGOCXX_PRIVATE explicit client(void* implementation);
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API client_encryption; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <mongocxx/collection-fwd.hpp>
+#include <mongocxx/database-fwd.hpp>
 
 #include <bsoncxx/types/bson_value/value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
@@ -31,8 +32,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class database;
-
 ///
 /// Class supporting operations for MongoDB Client-Side Field Level Encryption.
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <mongocxx/client_encryption-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
 
@@ -35,7 +36,7 @@ inline namespace v_noabi {
 ///
 /// Class supporting operations for MongoDB Client-Side Field Level Encryption.
 ///
-class MONGOCXX_API client_encryption {
+class client_encryption {
    public:
     ///
     /// Creates a client_encryption object.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/collection-fwd.hpp>
+
 #include <bsoncxx/types/bson_value/value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
 #include <mongocxx/cursor.hpp>
@@ -30,7 +32,6 @@
 namespace mongocxx {
 inline namespace v_noabi {
 class database;
-class collection;
 
 ///
 /// Class supporting operations for MongoDB Client-Side Field Level Encryption.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API client_session; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
@@ -17,6 +17,8 @@
 #include <functional>
 #include <memory>
 
+#include <mongocxx/client-fwd.hpp>
+
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/options/client_session.hpp>
@@ -25,8 +27,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class client;
-
 ///
 /// Use a session for a sequence of operations, optionally with either causal consistency
 /// or snapshots.
@@ -186,8 +186,8 @@ class MONGOCXX_API client_session {
     void with_transaction(with_transaction_cb cb, options::transaction opts = {});
 
    private:
+    friend class ::mongocxx::v_noabi::client;
     friend class bulk_write;
-    friend class client;
     friend class collection;
     friend class database;
     friend class index_view;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
@@ -17,6 +17,7 @@
 #include <functional>
 #include <memory>
 
+#include <mongocxx/bulk_write-fwd.hpp>
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/client_session-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
@@ -189,10 +190,10 @@ class client_session {
     void with_transaction(with_transaction_cb cb, options::transaction opts = {});
 
    private:
+    friend class ::mongocxx::v_noabi::bulk_write;
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::v_noabi::database;
-    friend class bulk_write;
     friend class index_view;
     friend class search_index_view;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
@@ -22,6 +22,7 @@
 #include <mongocxx/client_session-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
+#include <mongocxx/index_view-fwd.hpp>
 #include <mongocxx/search_index_view-fwd.hpp>
 
 #include <bsoncxx/document/view.hpp>
@@ -195,8 +196,8 @@ class client_session {
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::v_noabi::database;
+    friend class ::mongocxx::v_noabi::index_view;
     friend class ::mongocxx::v_noabi::search_index_view;
-    friend class index_view;
 
     class MONGOCXX_PRIVATE impl;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
@@ -22,6 +22,7 @@
 #include <mongocxx/client_session-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
+#include <mongocxx/search_index_view-fwd.hpp>
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -194,8 +195,8 @@ class client_session {
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::v_noabi::database;
+    friend class ::mongocxx::v_noabi::search_index_view;
     friend class index_view;
-    friend class search_index_view;
 
     class MONGOCXX_PRIVATE impl;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/client_session-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
 
@@ -39,7 +40,7 @@ inline namespace v_noabi {
 /// @see
 /// https://www.mongodb.com/docs/manual/core/read-isolation-consistency-recency/#causal-consistency
 ///
-class MONGOCXX_API client_session {
+class client_session {
    public:
     enum class transaction_state {
         k_transaction_none,

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/collection-fwd.hpp>
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -187,8 +188,8 @@ class MONGOCXX_API client_session {
 
    private:
     friend class ::mongocxx::v_noabi::client;
+    friend class ::mongocxx::v_noabi::collection;
     friend class bulk_write;
-    friend class collection;
     friend class database;
     friend class index_view;
     friend class search_index_view;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
@@ -19,6 +19,7 @@
 
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
+#include <mongocxx/database-fwd.hpp>
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -189,8 +190,8 @@ class MONGOCXX_API client_session {
    private:
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
+    friend class ::mongocxx::v_noabi::database;
     friend class bulk_write;
-    friend class database;
     friend class index_view;
     friend class search_index_view;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API collection; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <string>
 
+#include <mongocxx/bulk_write-fwd.hpp>
 #include <mongocxx/client_encryption-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
@@ -67,8 +68,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class bulk_write;
-
 ///
 /// Class representing server side document groupings within a MongoDB database.
 ///
@@ -1860,9 +1859,9 @@ class collection {
     search_index_view search_indexes();
 
    private:
+    friend class ::mongocxx::v_noabi::bulk_write;
     friend class ::mongocxx::v_noabi::client_encryption;
     friend class ::mongocxx::v_noabi::database;
-    friend class bulk_write;
 
     MONGOCXX_PRIVATE collection(const database& database,
                                 bsoncxx::string::view_or_value collection_name);

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
@@ -17,6 +17,8 @@
 #include <algorithm>
 #include <string>
 
+#include <mongocxx/collection-fwd.hpp>
+
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
@@ -81,7 +83,7 @@ class database;
 ///   auto coll = mongo_client["database"]["collection"];
 /// @endcode
 ///
-class MONGOCXX_API collection {
+class collection {
     //
     // Utility class supporting the convenience of {} meaning an empty bsoncxx::document.
     //

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
@@ -65,7 +65,6 @@ namespace mongocxx {
 inline namespace v_noabi {
 class bulk_write;
 class client_encryption;
-class client;
 class database;
 
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <string>
 
+#include <mongocxx/client_encryption-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
 
@@ -67,7 +68,6 @@
 namespace mongocxx {
 inline namespace v_noabi {
 class bulk_write;
-class client_encryption;
 
 ///
 /// Class representing server side document groupings within a MongoDB database.
@@ -1860,9 +1860,9 @@ class collection {
     search_index_view search_indexes();
 
    private:
+    friend class ::mongocxx::v_noabi::client_encryption;
     friend class ::mongocxx::v_noabi::database;
     friend class bulk_write;
-    friend class client_encryption;
 
     MONGOCXX_PRIVATE collection(const database& database,
                                 bsoncxx::string::view_or_value collection_name);

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include <mongocxx/collection-fwd.hpp>
+#include <mongocxx/database-fwd.hpp>
 
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
@@ -67,7 +68,6 @@ namespace mongocxx {
 inline namespace v_noabi {
 class bulk_write;
 class client_encryption;
-class database;
 
 ///
 /// Class representing server side document groupings within a MongoDB database.
@@ -1860,9 +1860,9 @@ class collection {
     search_index_view search_indexes();
 
    private:
+    friend class ::mongocxx::v_noabi::database;
     friend class bulk_write;
     friend class client_encryption;
-    friend class database;
 
     MONGOCXX_PRIVATE collection(const database& database,
                                 bsoncxx::string::view_or_value collection_name);

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API cursor; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
@@ -20,6 +20,7 @@
 #include <mongocxx/client_encryption-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
+#include <mongocxx/search_index_view-fwd.hpp>
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -28,8 +29,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class search_index_view;
-
 ///
 /// Class representing a pointer to the result set of a query on a MongoDB server.
 ///
@@ -87,8 +86,8 @@ class MONGOCXX_API cursor {
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::v_noabi::database;
+    friend class ::mongocxx::v_noabi::search_index_view;
     friend class index_view;
-    friend class search_index_view;
     friend class cursor::iterator;
 
     MONGOCXX_PRIVATE cursor(void* cursor_ptr,

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
@@ -112,7 +112,7 @@ class MONGOCXX_API cursor {
 /// exhausted iterator so that it no longer compares equal to the
 /// end-iterator.
 ///
-class MONGOCXX_API cursor::iterator {
+class cursor::iterator {
    public:
     ///
     /// std::iterator_traits

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
@@ -19,6 +19,7 @@
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/client_encryption-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
+#include <mongocxx/cursor-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
 #include <mongocxx/index_view-fwd.hpp>
 #include <mongocxx/search_index_view-fwd.hpp>
@@ -37,7 +38,7 @@ inline namespace v_noabi {
 ///
 /// @note By default, cursors timeout after 10 minutes of inactivity.
 ///
-class MONGOCXX_API cursor {
+class cursor {
    public:
     enum class type { k_non_tailable, k_tailable, k_tailable_await };
 
@@ -89,7 +90,8 @@ class MONGOCXX_API cursor {
     friend class ::mongocxx::v_noabi::database;
     friend class ::mongocxx::v_noabi::index_view;
     friend class ::mongocxx::v_noabi::search_index_view;
-    friend class cursor::iterator;
+
+    friend class ::mongocxx::v_noabi::cursor::iterator;
 
     MONGOCXX_PRIVATE cursor(void* cursor_ptr,
                             bsoncxx::stdx::optional<type> cursor_type = bsoncxx::stdx::nullopt);
@@ -152,7 +154,7 @@ class cursor::iterator {
     void operator++(int);
 
    private:
-    friend class cursor;
+    friend class ::mongocxx::v_noabi::cursor;
 
     ///
     /// @{

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
@@ -16,6 +16,8 @@
 
 #include <memory>
 
+#include <mongocxx/client-fwd.hpp>
+
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 
@@ -79,8 +81,8 @@ class MONGOCXX_API cursor {
     iterator end();
 
    private:
+    friend class ::mongocxx::v_noabi::client;
     friend class collection;
-    friend class client;
     friend class client_encryption;
     friend class database;
     friend class index_view;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
@@ -18,6 +18,7 @@
 
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
+#include <mongocxx/database-fwd.hpp>
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -83,8 +84,8 @@ class MONGOCXX_API cursor {
    private:
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
+    friend class ::mongocxx::v_noabi::database;
     friend class client_encryption;
-    friend class database;
     friend class index_view;
     friend class search_index_view;
     friend class cursor::iterator;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
@@ -20,6 +20,7 @@
 #include <mongocxx/client_encryption-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
+#include <mongocxx/index_view-fwd.hpp>
 #include <mongocxx/search_index_view-fwd.hpp>
 
 #include <bsoncxx/document/view.hpp>
@@ -86,8 +87,8 @@ class MONGOCXX_API cursor {
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::v_noabi::database;
+    friend class ::mongocxx::v_noabi::index_view;
     friend class ::mongocxx::v_noabi::search_index_view;
-    friend class index_view;
     friend class cursor::iterator;
 
     MONGOCXX_PRIVATE cursor(void* cursor_ptr,

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
@@ -17,6 +17,7 @@
 #include <memory>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/client_encryption-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
 
@@ -82,10 +83,10 @@ class MONGOCXX_API cursor {
     iterator end();
 
    private:
+    friend class ::mongocxx::v_noabi::client_encryption;
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::v_noabi::database;
-    friend class client_encryption;
     friend class index_view;
     friend class search_index_view;
     friend class cursor::iterator;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
@@ -17,6 +17,7 @@
 #include <memory>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/collection-fwd.hpp>
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -25,7 +26,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class collection;
 class search_index_view;
 
 ///
@@ -82,7 +82,7 @@ class MONGOCXX_API cursor {
 
    private:
     friend class ::mongocxx::v_noabi::client;
-    friend class collection;
+    friend class ::mongocxx::v_noabi::collection;
     friend class client_encryption;
     friend class database;
     friend class index_view;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API database; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/client_encryption-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
 
@@ -35,8 +36,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class client_encryption;
-
 ///
 /// Class representing a MongoDB database.
 ///
@@ -626,9 +625,9 @@ class database {
     ///
 
    private:
+    friend class ::mongocxx::v_noabi::client_encryption;
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
-    friend class client_encryption;
 
     MONGOCXX_PRIVATE database(const class client& client, bsoncxx::string::view_or_value name);
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/collection-fwd.hpp>
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
@@ -34,7 +35,6 @@
 namespace mongocxx {
 inline namespace v_noabi {
 class client_encryption;
-class collection;
 
 ///
 /// Class representing a MongoDB database.
@@ -626,8 +626,8 @@ class MONGOCXX_API database {
 
    private:
     friend class ::mongocxx::v_noabi::client;
+    friend class ::mongocxx::v_noabi::collection;
     friend class client_encryption;
-    friend class collection;
 
     MONGOCXX_PRIVATE database(const class client& client, bsoncxx::string::view_or_value name);
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
@@ -19,6 +19,7 @@
 
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
+#include <mongocxx/database-fwd.hpp>
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
@@ -42,7 +43,7 @@ class client_encryption;
 /// Acts as a gateway for accessing collections that are contained within a database. It inherits
 /// all of its default settings from the client that creates it.
 ///
-class MONGOCXX_API database {
+class database {
    public:
     ///
     /// Default constructs a new database. The database is not valid for use and is equivalent

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
@@ -550,7 +550,7 @@ class MONGOCXX_API database {
     ///
     /// @throws mongocxx::logic_error if `options` are invalid.
     ///
-    class gridfs::bucket gridfs_bucket(
+    class mongocxx::gridfs::bucket gridfs_bucket(
         const options::gridfs::bucket& options = options::gridfs::bucket()) const;
 
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
@@ -17,6 +17,8 @@
 #include <memory>
 #include <string>
 
+#include <mongocxx/client-fwd.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
 #include <mongocxx/client_session.hpp>
@@ -32,7 +34,6 @@
 namespace mongocxx {
 inline namespace v_noabi {
 class client_encryption;
-class client;
 class collection;
 
 ///
@@ -624,8 +625,8 @@ class MONGOCXX_API database {
     ///
 
    private:
+    friend class ::mongocxx::v_noabi::client;
     friend class client_encryption;
-    friend class client;
     friend class collection;
 
     MONGOCXX_PRIVATE database(const class client& client, bsoncxx::string::view_or_value name);

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_failed_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_failed_event-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace events {
+
+class MONGOCXX_API command_failed_event;
+
+}  // namespace events
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_failed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_failed_event.hpp
@@ -16,6 +16,8 @@
 
 #include <memory>
 
+#include <mongocxx/events/command_failed_event-fwd.hpp>
+
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/oid.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -32,7 +34,7 @@ namespace events {
 /// @see "CommandFailedEvent" in
 /// https://github.com/mongodb/specifications/blob/master/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
 ///
-class MONGOCXX_API command_failed_event {
+class command_failed_event {
    public:
     MONGOCXX_PRIVATE explicit command_failed_event(const void* event);
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_started_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_started_event-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace events {
+
+class MONGOCXX_API command_started_event;
+
+}  // namespace events
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_started_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_started_event.hpp
@@ -16,6 +16,8 @@
 
 #include <memory>
 
+#include <mongocxx/events/command_started_event-fwd.hpp>
+
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/oid.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -32,7 +34,7 @@ namespace events {
 /// @see "CommandStartedEvent" in
 /// https://github.com/mongodb/specifications/blob/master/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
 ///
-class MONGOCXX_API command_started_event {
+class command_started_event {
    public:
     MONGOCXX_PRIVATE explicit command_started_event(const void* event);
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_succeeded_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_succeeded_event-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace events {
+
+class MONGOCXX_API command_succeeded_event;
+
+}  // namespace events
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_succeeded_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_succeeded_event.hpp
@@ -16,6 +16,8 @@
 
 #include <memory>
 
+#include <mongocxx/events/command_succeeded_event-fwd.hpp>
+
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/oid.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -32,7 +34,7 @@ namespace events {
 /// @see "CommandSucceededEvent" in
 /// https://github.com/mongodb/specifications/blob/master/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
 ///
-class MONGOCXX_API command_succeeded_event {
+class command_succeeded_event {
    public:
     MONGOCXX_PRIVATE explicit command_succeeded_event(const void* event);
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace events {
+
+class MONGOCXX_API heartbeat_failed_event;
+
+}  // namespace events
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event.hpp
@@ -16,6 +16,8 @@
 
 #include <cstdint>
 
+#include <mongocxx/events/heartbeat_failed_event-fwd.hpp>
+
 #include <bsoncxx/stdx/string_view.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -31,7 +33,7 @@ namespace events {
 /// @see "ServerHeartbeatFailedEvent" in
 /// https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
 ///
-class MONGOCXX_API heartbeat_failed_event {
+class heartbeat_failed_event {
    public:
     MONGOCXX_PRIVATE explicit heartbeat_failed_event(const void* event);
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace events {
+
+class MONGOCXX_API heartbeat_started_event;
+
+}  // namespace events
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event.hpp
@@ -16,6 +16,8 @@
 
 #include <cstdint>
 
+#include <mongocxx/events/heartbeat_started_event-fwd.hpp>
+
 #include <bsoncxx/stdx/string_view.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -31,7 +33,7 @@ namespace events {
 /// @see "ServerHeartbeatStartedEvent" in
 /// https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
 ///
-class MONGOCXX_API heartbeat_started_event {
+class heartbeat_started_event {
    public:
     MONGOCXX_PRIVATE explicit heartbeat_started_event(const void* event);
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace events {
+
+class MONGOCXX_API heartbeat_succeeded_event;
+
+}  // namespace events
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/events/heartbeat_succeeded_event-fwd.hpp>
+
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 
@@ -30,7 +32,7 @@ namespace events {
 /// @see "ServerHeartbeatSucceededEvent" in
 /// https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
 ///
-class MONGOCXX_API heartbeat_succeeded_event {
+class heartbeat_succeeded_event {
    public:
     MONGOCXX_PRIVATE explicit heartbeat_succeeded_event(const void* event);
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_changed_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_changed_event-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace events {
+
+class MONGOCXX_API server_changed_event;
+
+}  // namespace events
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_changed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_changed_event.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/events/server_changed_event-fwd.hpp>
+
 #include <bsoncxx/oid.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 #include <mongocxx/events/server_description.hpp>
@@ -31,7 +33,7 @@ namespace events {
 /// @see "ServerDescriptionChangedEvent" in
 /// https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
 ///
-class MONGOCXX_API server_changed_event {
+class server_changed_event {
    public:
     MONGOCXX_PRIVATE explicit server_changed_event(const void* event);
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_closed_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_closed_event-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace events {
+
+class MONGOCXX_API server_closed_event;
+
+}  // namespace events
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_closed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_closed_event.hpp
@@ -16,6 +16,8 @@
 
 #include <cstdint>
 
+#include <mongocxx/events/server_closed_event-fwd.hpp>
+
 #include <bsoncxx/oid.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 
@@ -32,7 +34,7 @@ namespace events {
 /// @see "ServerClosedEvent" in
 /// https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
 ///
-class MONGOCXX_API server_closed_event {
+class server_closed_event {
    public:
     MONGOCXX_PRIVATE explicit server_closed_event(const void* event);
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_description-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_description-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace events {
+
+class MONGOCXX_API server_description;
+
+}  // namespace events
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_description.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_description.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/events/server_description-fwd.hpp>
+
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 
@@ -26,7 +28,7 @@ namespace events {
 ///
 /// Class representing what the driver knows about a MongoDB server.
 ///
-class MONGOCXX_API server_description {
+class server_description {
    public:
     MONGOCXX_PRIVATE explicit server_description(const void* event);
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_opening_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_opening_event-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace events {
+
+class MONGOCXX_API server_opening_event;
+
+}  // namespace events
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_opening_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_opening_event.hpp
@@ -16,6 +16,8 @@
 
 #include <cstdint>
 
+#include <mongocxx/events/server_opening_event-fwd.hpp>
+
 #include <bsoncxx/oid.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -31,7 +33,7 @@ namespace events {
 /// @see "ServerOpeningEvent" in
 /// https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
 ///
-class MONGOCXX_API server_opening_event {
+class server_opening_event {
    public:
     MONGOCXX_PRIVATE explicit server_opening_event(const void* event);
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_changed_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_changed_event-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace events {
+
+class MONGOCXX_API topology_changed_event;
+
+}  // namespace events
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_changed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_changed_event.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/events/topology_changed_event-fwd.hpp>
+
 #include <bsoncxx/oid.hpp>
 #include <mongocxx/events/topology_description.hpp>
 
@@ -30,7 +32,7 @@ namespace events {
 /// @see "TopologyDescriptionChangedEvent" in
 /// https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
 ///
-class MONGOCXX_API topology_changed_event {
+class topology_changed_event {
    public:
     MONGOCXX_PRIVATE explicit topology_changed_event(const void* event);
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_closed_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_closed_event-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace events {
+
+class MONGOCXX_API topology_closed_event;
+
+}  // namespace events
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_closed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_closed_event.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/events/topology_closed_event-fwd.hpp>
+
 #include <bsoncxx/oid.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -29,7 +31,7 @@ namespace events {
 /// @see "TopologyClosedEvent" in
 /// https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
 ///
-class MONGOCXX_API topology_closed_event {
+class topology_closed_event {
    public:
     MONGOCXX_PRIVATE explicit topology_closed_event(const void* event);
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace events {
+
+class MONGOCXX_API topology_description;
+
+}  // namespace events
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description.hpp
@@ -16,6 +16,8 @@
 
 #include <vector>
 
+#include <mongocxx/events/topology_description-fwd.hpp>
+
 #include <bsoncxx/stdx/string_view.hpp>
 #include <mongocxx/events/server_description.hpp>
 #include <mongocxx/read_preference.hpp>
@@ -32,7 +34,7 @@ using mongocxx::read_preference;
 /// Class representing what the driver knows about a topology of MongoDB servers: either a
 /// standalone, a replica set, or a sharded cluster.
 ///
-class MONGOCXX_API topology_description {
+class topology_description {
    public:
     ///
     /// An array of server_description instances.
@@ -100,9 +102,11 @@ class MONGOCXX_API topology_description {
         std::size_t size() const noexcept;
 
        private:
-        friend topology_description;
+        friend class ::mongocxx::v_noabi::events::topology_description;
+
         MONGOCXX_PRIVATE explicit server_descriptions(void* sds, std::size_t size);
         MONGOCXX_PRIVATE void swap(server_descriptions& other) noexcept;
+
         container _container;
         void* _sds;
         std::size_t _size;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_opening_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_opening_event-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace events {
+
+class MONGOCXX_API topology_opening_event;
+
+}  // namespace events
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_opening_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_opening_event.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/events/topology_opening_event-fwd.hpp>
+
 #include <bsoncxx/oid.hpp>
 #include <mongocxx/events/topology_description.hpp>
 
@@ -29,7 +31,7 @@ namespace events {
 /// @see "TopologyOpeningEvent" in
 /// https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
 ///
-class MONGOCXX_API topology_opening_event {
+class topology_opening_event {
    public:
     MONGOCXX_PRIVATE explicit topology_opening_event(const void* event);
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/authentication_exception-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/authentication_exception-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API authentication_exception; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/authentication_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/authentication_exception.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/exception/authentication_exception-fwd.hpp>
+
 #include <bsoncxx/document/value.hpp>
 #include <mongocxx/exception/operation_exception.hpp>
 
@@ -26,7 +28,7 @@ inline namespace v_noabi {
 ///
 /// @see mongocxx::operation_exception
 ///
-class MONGOCXX_API authentication_exception : public operation_exception {
+class authentication_exception : public operation_exception {
    public:
     using operation_exception::operation_exception;
 };

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/bulk_write_exception-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/bulk_write_exception-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API bulk_write_exception; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/bulk_write_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/bulk_write_exception.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/exception/bulk_write_exception-fwd.hpp>
+
 #include <bsoncxx/document/value.hpp>
 #include <mongocxx/exception/operation_exception.hpp>
 
@@ -26,7 +28,7 @@ inline namespace v_noabi {
 ///
 /// @see mongocxx::operation_exception
 ///
-class MONGOCXX_API bulk_write_exception : public operation_exception {
+class bulk_write_exception : public operation_exception {
    public:
     using operation_exception::operation_exception;
 };

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/error_code-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/error_code-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <system_error>
+
+namespace mongocxx {
+inline namespace v_noabi { enum class error_code : std::int32_t; }  // namespace v_noabi
+}  // namespace mongocxx
+
+namespace std {
+
+template <>
+struct is_error_code_enum<mongocxx::error_code>;
+
+}  // namespace std

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/error_code.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/error_code.hpp
@@ -17,6 +17,8 @@
 #include <cstdint>
 #include <system_error>
 
+#include <mongocxx/exception/error_code-fwd.hpp>
+
 #include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/exception-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/exception-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API exception; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/exception.hpp
@@ -17,6 +17,8 @@
 #include <string>
 #include <system_error>
 
+#include <mongocxx/exception/exception-fwd.hpp>
+
 #include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
@@ -24,7 +26,7 @@ inline namespace v_noabi {
 ///
 /// A class to be used as the base class for all mongocxx exceptions.
 ///
-class MONGOCXX_API exception : public std::system_error {
+class exception : public std::system_error {
     using system_error::system_error;
 };
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/gridfs_exception-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/gridfs_exception-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API gridfs_exception; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/gridfs_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/gridfs_exception.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/exception/gridfs_exception-fwd.hpp>
+
 #include <mongocxx/exception/exception.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -26,7 +28,7 @@ inline namespace v_noabi {
 ///
 /// @see mongocxx::exception
 ///
-class MONGOCXX_API gridfs_exception : public exception {
+class gridfs_exception : public exception {
    public:
     using exception::exception;
 };

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/logic_error-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/logic_error-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API logic_error; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/logic_error.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/logic_error.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/exception/logic_error-fwd.hpp>
+
 #include <mongocxx/exception/exception.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -25,7 +27,7 @@ inline namespace v_noabi {
 ///
 /// @see mongocxx::exception
 ///
-class MONGOCXX_API logic_error : public exception {
+class logic_error : public exception {
    public:
     using exception::exception;
 };

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API operation_exception; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/exception/operation_exception-fwd.hpp>
+
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/exception/exception.hpp>
@@ -29,7 +31,7 @@ inline namespace v_noabi {
 ///
 /// @see mongocxx::exception
 ///
-class MONGOCXX_API operation_exception : public exception {
+class operation_exception : public exception {
    public:
     using exception::exception;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/query_exception-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/query_exception-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API query_exception; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/query_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/query_exception.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/exception/query_exception-fwd.hpp>
+
 #include <mongocxx/exception/operation_exception.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -25,7 +27,7 @@ inline namespace v_noabi {
 ///
 /// @see mongocxx::operation_exception
 ///
-class MONGOCXX_API query_exception : public operation_exception {
+class query_exception : public operation_exception {
    public:
     using operation_exception::operation_exception;
 };

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/server_error_code-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/server_error_code-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <system_error>
+
+namespace mongocxx {
+inline namespace v_noabi { enum class server_error_code : std::int32_t; }  // namespace v_noabi
+}  // namespace mongocxx
+
+namespace std {
+
+template <>
+struct is_error_code_enum<mongocxx::server_error_code>;
+
+}  // namespace std

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/server_error_code.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/server_error_code.hpp
@@ -17,6 +17,8 @@
 #include <cstdint>
 #include <system_error>
 
+#include <mongocxx/exception/server_error_code-fwd.hpp>
+
 #include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/write_exception-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/write_exception-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API write_exception; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/write_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/write_exception.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/exception/write_exception-fwd.hpp>
+
 #include <mongocxx/exception/operation_exception.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -25,7 +27,7 @@ inline namespace v_noabi {
 ///
 /// @see mongocxx::operation_exception
 ///
-class MONGOCXX_API write_exception : public operation_exception {
+class write_exception : public operation_exception {
    public:
     using operation_exception::operation_exception;
 };

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/fwd.hpp
@@ -1,0 +1,113 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/bulk_write-fwd.hpp>
+#include <mongocxx/change_stream-fwd.hpp>
+#include <mongocxx/client-fwd.hpp>
+#include <mongocxx/client_encryption-fwd.hpp>
+#include <mongocxx/client_session-fwd.hpp>
+#include <mongocxx/collection-fwd.hpp>
+#include <mongocxx/cursor-fwd.hpp>
+#include <mongocxx/database-fwd.hpp>
+#include <mongocxx/events/command_failed_event-fwd.hpp>
+#include <mongocxx/events/command_started_event-fwd.hpp>
+#include <mongocxx/events/command_succeeded_event-fwd.hpp>
+#include <mongocxx/events/heartbeat_failed_event-fwd.hpp>
+#include <mongocxx/events/heartbeat_started_event-fwd.hpp>
+#include <mongocxx/events/heartbeat_succeeded_event-fwd.hpp>
+#include <mongocxx/events/server_changed_event-fwd.hpp>
+#include <mongocxx/events/server_closed_event-fwd.hpp>
+#include <mongocxx/events/server_description-fwd.hpp>
+#include <mongocxx/events/server_opening_event-fwd.hpp>
+#include <mongocxx/events/topology_changed_event-fwd.hpp>
+#include <mongocxx/events/topology_closed_event-fwd.hpp>
+#include <mongocxx/events/topology_description-fwd.hpp>
+#include <mongocxx/events/topology_opening_event-fwd.hpp>
+#include <mongocxx/exception/authentication_exception-fwd.hpp>
+#include <mongocxx/exception/bulk_write_exception-fwd.hpp>
+#include <mongocxx/exception/error_code-fwd.hpp>
+#include <mongocxx/exception/exception-fwd.hpp>
+#include <mongocxx/exception/gridfs_exception-fwd.hpp>
+#include <mongocxx/exception/logic_error-fwd.hpp>
+#include <mongocxx/exception/operation_exception-fwd.hpp>
+#include <mongocxx/exception/query_exception-fwd.hpp>
+#include <mongocxx/exception/server_error_code-fwd.hpp>
+#include <mongocxx/exception/write_exception-fwd.hpp>
+#include <mongocxx/gridfs/bucket-fwd.hpp>
+#include <mongocxx/gridfs/downloader-fwd.hpp>
+#include <mongocxx/gridfs/uploader-fwd.hpp>
+#include <mongocxx/hint-fwd.hpp>
+#include <mongocxx/index_model-fwd.hpp>
+#include <mongocxx/index_view-fwd.hpp>
+#include <mongocxx/instance-fwd.hpp>
+#include <mongocxx/logger-fwd.hpp>
+#include <mongocxx/model/delete_many-fwd.hpp>
+#include <mongocxx/model/delete_one-fwd.hpp>
+#include <mongocxx/model/insert_one-fwd.hpp>
+#include <mongocxx/model/replace_one-fwd.hpp>
+#include <mongocxx/model/update_many-fwd.hpp>
+#include <mongocxx/model/update_one-fwd.hpp>
+#include <mongocxx/model/write-fwd.hpp>
+#include <mongocxx/options/aggregate-fwd.hpp>
+#include <mongocxx/options/apm-fwd.hpp>
+#include <mongocxx/options/auto_encryption-fwd.hpp>
+#include <mongocxx/options/bulk_write-fwd.hpp>
+#include <mongocxx/options/change_stream-fwd.hpp>
+#include <mongocxx/options/client-fwd.hpp>
+#include <mongocxx/options/client_encryption-fwd.hpp>
+#include <mongocxx/options/client_session-fwd.hpp>
+#include <mongocxx/options/count-fwd.hpp>
+#include <mongocxx/options/data_key-fwd.hpp>
+#include <mongocxx/options/delete-fwd.hpp>
+#include <mongocxx/options/distinct-fwd.hpp>
+#include <mongocxx/options/encrypt-fwd.hpp>
+#include <mongocxx/options/estimated_document_count-fwd.hpp>
+#include <mongocxx/options/find-fwd.hpp>
+#include <mongocxx/options/find_one_and_delete-fwd.hpp>
+#include <mongocxx/options/find_one_and_replace-fwd.hpp>
+#include <mongocxx/options/find_one_and_update-fwd.hpp>
+#include <mongocxx/options/find_one_common_options-fwd.hpp>
+#include <mongocxx/options/gridfs/bucket-fwd.hpp>
+#include <mongocxx/options/gridfs/upload-fwd.hpp>
+#include <mongocxx/options/index-fwd.hpp>
+#include <mongocxx/options/index_view-fwd.hpp>
+#include <mongocxx/options/insert-fwd.hpp>
+#include <mongocxx/options/pool-fwd.hpp>
+#include <mongocxx/options/range-fwd.hpp>
+#include <mongocxx/options/replace-fwd.hpp>
+#include <mongocxx/options/rewrap_many_datakey-fwd.hpp>
+#include <mongocxx/options/server_api-fwd.hpp>
+#include <mongocxx/options/tls-fwd.hpp>
+#include <mongocxx/options/transaction-fwd.hpp>
+#include <mongocxx/options/update-fwd.hpp>
+#include <mongocxx/pipeline-fwd.hpp>
+#include <mongocxx/pool-fwd.hpp>
+#include <mongocxx/read_concern-fwd.hpp>
+#include <mongocxx/read_preference-fwd.hpp>
+#include <mongocxx/result/bulk_write-fwd.hpp>
+#include <mongocxx/result/delete-fwd.hpp>
+#include <mongocxx/result/gridfs/upload-fwd.hpp>
+#include <mongocxx/result/insert_many-fwd.hpp>
+#include <mongocxx/result/insert_one-fwd.hpp>
+#include <mongocxx/result/replace_one-fwd.hpp>
+#include <mongocxx/result/rewrap_many_datakey-fwd.hpp>
+#include <mongocxx/result/update-fwd.hpp>
+#include <mongocxx/search_index_model-fwd.hpp>
+#include <mongocxx/search_index_view-fwd.hpp>
+#include <mongocxx/uri-fwd.hpp>
+#include <mongocxx/validation_criteria-fwd.hpp>
+#include <mongocxx/write_concern-fwd.hpp>
+#include <mongocxx/write_type-fwd.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace gridfs {
+
+class MONGOCXX_API bucket;
+
+}  // namespace gridfs
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
@@ -18,6 +18,8 @@
 #include <memory>
 #include <ostream>
 
+#include <mongocxx/database-fwd.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
@@ -35,8 +37,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class database;
-
 namespace gridfs {
 
 ///
@@ -649,7 +649,7 @@ class MONGOCXX_API bucket {
     stdx::string_view bucket_name() const;
 
    private:
-    friend class mongocxx::database;
+    friend class ::mongocxx::v_noabi::database;
 
     // Constructs a new GridFS bucket.  Throws if options are invalid.
     MONGOCXX_PRIVATE bucket(const database& db, const options::gridfs::bucket& options);

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
@@ -19,6 +19,7 @@
 #include <ostream>
 
 #include <mongocxx/database-fwd.hpp>
+#include <mongocxx/gridfs/bucket-fwd.hpp>
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -59,7 +60,7 @@ namespace gridfs {
 ///
 /// @see https://www.mongodb.com/display/DOCS/GridFS
 ///
-class MONGOCXX_API bucket {
+class bucket {
    public:
     ///
     /// Default constructs a bucket object. The bucket is equivalent to the state of a moved from

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/downloader-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/downloader-fwd.hpp
@@ -1,0 +1,31 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace gridfs {
+
+struct chunks_and_bytes_offset;
+
+class MONGOCXX_API downloader;
+
+}  // namespace gridfs
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/downloader.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/downloader.hpp
@@ -18,6 +18,8 @@
 #include <cstdint>
 #include <memory>
 
+#include <mongocxx/gridfs/bucket-fwd.hpp>
+
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -130,7 +132,7 @@ class MONGOCXX_API downloader {
     bsoncxx::document::view files_document() const;
 
    private:
-    friend class bucket;
+    friend class ::mongocxx::v_noabi::gridfs::bucket;
 
     //
     // Constructs a new downloader stream.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/downloader.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/downloader.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 
 #include <mongocxx/gridfs/bucket-fwd.hpp>
+#include <mongocxx/gridfs/downloader-fwd.hpp>
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
@@ -44,7 +45,7 @@ struct chunks_and_bytes_offset {
 ///
 /// Class used to download a GridFS file.
 ///
-class MONGOCXX_API downloader {
+class downloader {
    public:
     ///
     /// Default constructs a downloader object. The downloader is equivalent to the state of a moved

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/uploader-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/uploader-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace gridfs {
+
+class MONGOCXX_API uploader;
+
+}  // namespace gridfs
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/uploader.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/uploader.hpp
@@ -18,6 +18,8 @@
 #include <cstdint>
 #include <memory>
 
+#include <mongocxx/gridfs/bucket-fwd.hpp>
+
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
@@ -123,7 +125,7 @@ class MONGOCXX_API uploader {
     std::int32_t chunk_size() const;
 
    private:
-    friend class bucket;
+    friend class ::mongocxx::v_noabi::gridfs::bucket;
 
     //
     // Constructs a new uploader stream.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/uploader.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/uploader.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 
 #include <mongocxx/gridfs/bucket-fwd.hpp>
+#include <mongocxx/gridfs/uploader-fwd.hpp>
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -39,7 +40,7 @@ namespace gridfs {
 ///
 /// Class used to upload a GridFS file.
 ///
-class MONGOCXX_API uploader {
+class uploader {
    public:
     ///
     /// Default constructs an uploader object. The uploader is equivalent to the state of a moved

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/hint-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/hint-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API hint; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/hint.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/hint.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/hint-fwd.hpp>
+
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -28,7 +30,7 @@ inline namespace v_noabi {
 ///
 /// Class representing a hint to be passed to a database operation.
 ///
-class MONGOCXX_API hint {
+class hint {
    public:
     ///
     /// Constructs a new hint.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_model-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_model-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API index_model; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_model.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_model.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/index_model-fwd.hpp>
+
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <mongocxx/options/index.hpp>
@@ -25,7 +27,7 @@ inline namespace v_noabi {
 ///
 /// Class representing an index on a MongoDB server.
 ///
-class MONGOCXX_API index_model {
+class index_model {
    public:
     ///
     /// Initializes a new index_model over a mongocxx::collection.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API index_view; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view.hpp
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include <mongocxx/collection-fwd.hpp>
+#include <mongocxx/index_view-fwd.hpp>
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -33,7 +34,7 @@ inline namespace v_noabi {
 ///
 /// Class representing a MongoDB index view.
 ///
-class MONGOCXX_API index_view {
+class index_view {
    public:
     index_view(index_view&&) noexcept;
     index_view& operator=(index_view&&) noexcept;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view.hpp
@@ -17,6 +17,8 @@
 #include <string>
 #include <vector>
 
+#include <mongocxx/collection-fwd.hpp>
+
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/client_session.hpp>
@@ -420,7 +422,7 @@ class MONGOCXX_API index_view {
     ///
 
    private:
-    friend class collection;
+    friend class ::mongocxx::v_noabi::collection;
     class MONGOCXX_PRIVATE impl;
 
     MONGOCXX_PRIVATE index_view(void* coll, void* client);

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/instance-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/instance-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API instance; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/instance.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/instance.hpp
@@ -16,12 +16,12 @@
 
 #include <memory>
 
+#include <mongocxx/logger-fwd.hpp>
+
 #include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 inline namespace v_noabi {
-class logger;
-
 ///
 /// Class representing an instance of the MongoDB driver.
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/instance.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/instance.hpp
@@ -16,6 +16,7 @@
 
 #include <memory>
 
+#include <mongocxx/instance-fwd.hpp>
 #include <mongocxx/logger-fwd.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -75,7 +76,7 @@ inline namespace v_noabi {
 /// For examples of more advanced usage of instance, see
 /// `examples/mongocxx/instance_management.cpp`.
 ///
-class MONGOCXX_API instance {
+class instance {
    public:
     ///
     /// Creates an instance of the driver.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger-fwd.hpp
@@ -1,0 +1,28 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+enum class log_level;
+
+class MONGOCXX_API logger;
+
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger.hpp
@@ -16,6 +16,8 @@
 
 #include <memory>
 
+#include <mongocxx/logger-fwd.hpp>
+
 #include <bsoncxx/stdx/string_view.hpp>
 #include <mongocxx/stdx.hpp>
 
@@ -49,7 +51,7 @@ MONGOCXX_API stdx::string_view MONGOCXX_CALL to_string(log_level level);
 ///
 /// The interface that all user-defined loggers must implement.
 ///
-class MONGOCXX_API logger {
+class logger {
    public:
     virtual ~logger();
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_many-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_many-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace model {
+
+class MONGOCXX_API delete_many;
+
+}  // namespace model
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_many.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_many.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/model/delete_many-fwd.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/hint.hpp>
@@ -28,7 +30,7 @@ namespace model {
 ///
 /// Class representing a MongoDB delete operation that removes multiple documents.
 ///
-class MONGOCXX_API delete_many {
+class delete_many {
    public:
     ///
     /// Constructs a delete operation that will delete all documents matching the filter.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_one-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_one-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace model {
+
+class MONGOCXX_API delete_one;
+
+}  // namespace model
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_one.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/model/delete_one-fwd.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/hint.hpp>
@@ -28,7 +30,7 @@ namespace model {
 ///
 /// Class representing a MongoDB delete operation that removes a single document.
 ///
-class MONGOCXX_API delete_one {
+class delete_one {
    public:
     ///
     /// Constructs a delete operation that will delete the first document matching the filter.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/insert_one-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/insert_one-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace model {
+
+class MONGOCXX_API insert_one;
+
+}  // namespace model
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/insert_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/insert_one.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/model/insert_one-fwd.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -25,7 +27,7 @@ namespace model {
 ///
 /// Class representing a MongoDB insert operation that creates a single document.
 ///
-class MONGOCXX_API insert_one {
+class insert_one {
    public:
     ///
     /// Constructs an insert operation that will create a single document.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/replace_one-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/replace_one-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace model {
+
+class MONGOCXX_API replace_one;
+
+}  // namespace model
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/replace_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/replace_one.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/model/replace_one-fwd.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/hint.hpp>
@@ -28,7 +30,7 @@ namespace model {
 ///
 /// Class representing a MongoDB update operation that replaces a single document.
 ///
-class MONGOCXX_API replace_one {
+class replace_one {
    public:
     ///
     /// Constructs an update operation that will replace a single document matching the filter.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_many-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_many-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace model {
+
+class MONGOCXX_API update_many;
+
+}  // namespace model
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_many.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_many.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/model/update_many-fwd.hpp>
+
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -30,7 +32,7 @@ namespace model {
 ///
 /// Class representing a MongoDB update operation that modifies multiple documents.
 ///
-class MONGOCXX_API update_many {
+class update_many {
     //
     // Utility class supporting the convenience of {} meaning an empty bsoncxx::document.
     //

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_one-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_one-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace model {
+
+class MONGOCXX_API update_one;
+
+}  // namespace model
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_one.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/model/update_one-fwd.hpp>
+
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -30,7 +32,7 @@ namespace model {
 ///
 /// Class representing a MongoDB update operation that modifies a single document.
 ///
-class MONGOCXX_API update_one {
+class update_one {
     //
     // Utility class supporting the convenience of {} meaning an empty bsoncxx::document.
     //

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/write-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/write-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace model {
+
+class MONGOCXX_API write;
+
+}  // namespace model
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/write.hpp
@@ -16,6 +16,8 @@
 
 #include <cstdint>
 
+#include <mongocxx/model/write-fwd.hpp>
+
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/model/delete_many.hpp>
 #include <mongocxx/model/delete_one.hpp>
@@ -34,7 +36,7 @@ namespace model {
 ///
 /// Models a single write operation within a mongocxx::bulk_write.
 ///
-class MONGOCXX_API write {
+class write {
    public:
     ///
     /// Constructs a write from a model::insert_one.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API aggregate;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate.hpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 
 #include <mongocxx/collection-fwd.hpp>
+#include <mongocxx/database-fwd.hpp>
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
@@ -306,7 +307,7 @@ class MONGOCXX_API aggregate {
 
    private:
     friend class ::mongocxx::v_noabi::collection;
-    friend class ::mongocxx::database;
+    friend class ::mongocxx::v_noabi::database;
 
     void append(bsoncxx::builder::basic::document& builder) const;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate.hpp
@@ -17,6 +17,8 @@
 #include <chrono>
 #include <cstdint>
 
+#include <mongocxx/collection-fwd.hpp>
+
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -303,8 +305,8 @@ class MONGOCXX_API aggregate {
     const stdx::optional<bsoncxx::types::bson_value::view_or_value>& comment() const;
 
    private:
+    friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::database;
-    friend class ::mongocxx::collection;
 
     void append(bsoncxx::builder::basic::document& builder) const;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate.hpp
@@ -19,6 +19,7 @@
 
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
+#include <mongocxx/options/aggregate-fwd.hpp>
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
@@ -39,7 +40,7 @@ namespace options {
 ///
 /// Class representing the optional arguments to a MongoDB aggregation operation.
 ///
-class MONGOCXX_API aggregate {
+class aggregate {
    public:
     ///
     /// Enables writing to temporary files. When set to @c true, aggregation stages can write data

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/apm-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/apm-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API apm;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/apm.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/apm.hpp
@@ -16,6 +16,8 @@
 
 #include <functional>
 
+#include <mongocxx/options/apm-fwd.hpp>
+
 #include <mongocxx/events/command_failed_event.hpp>
 #include <mongocxx/events/command_started_event.hpp>
 #include <mongocxx/events/command_succeeded_event.hpp>
@@ -38,7 +40,7 @@ namespace options {
 ///
 /// Class representing MongoDB application performance monitoring.
 ///
-class MONGOCXX_API apm {
+class apm {
    public:
     ///
     /// Set the command started monitoring callback. The callback takes a reference to a

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API auto_encryption;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
@@ -17,6 +17,7 @@
 #include <string>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/options/auto_encryption-fwd.hpp>
 #include <mongocxx/pool-fwd.hpp>
 
 #include <bsoncxx/document/view_or_value.hpp>
@@ -32,7 +33,7 @@ namespace options {
 ///
 /// Class representing options for automatic client-side encryption.
 ///
-class MONGOCXX_API auto_encryption {
+class auto_encryption {
    public:
     ///
     /// Default constructs a new auto_encryption object.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
@@ -55,7 +55,7 @@ class MONGOCXX_API auto_encryption {
     ///
     /// @see https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
     ///
-    auto_encryption& key_vault_client(client* client);
+    auto_encryption& key_vault_client(mongocxx::client* client);
 
     ///
     /// Gets the key vault client.
@@ -63,7 +63,7 @@ class MONGOCXX_API auto_encryption {
     /// @return
     ///   An optional pointer to the key vault client.
     ///
-    const stdx::optional<client*>& key_vault_client() const;
+    const stdx::optional<mongocxx::client*>& key_vault_client() const;
 
     ///
     /// When the key vault collection is on a separate MongoDB cluster,

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
@@ -85,7 +85,7 @@ class MONGOCXX_API auto_encryption {
     ///
     /// @see https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
     ///
-    auto_encryption& key_vault_pool(pool* pool);
+    auto_encryption& key_vault_pool(mongocxx::pool* pool);
 
     ///
     /// Gets the key vault pool.
@@ -93,7 +93,7 @@ class MONGOCXX_API auto_encryption {
     /// @return
     ///   An optional pointer to the key vault pool.
     ///
-    const stdx::optional<pool*>& key_vault_pool() const;
+    const stdx::optional<mongocxx::pool*>& key_vault_pool() const;
 
     ///
     /// Sets the namespace to use to access the key vault collection, which

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
@@ -17,6 +17,7 @@
 #include <string>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/pool-fwd.hpp>
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -26,8 +27,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class pool;
-
 namespace options {
 
 ///
@@ -373,7 +372,7 @@ class MONGOCXX_API auto_encryption {
 
    private:
     friend class ::mongocxx::v_noabi::client;
-    friend class mongocxx::pool;
+    friend class ::mongocxx::v_noabi::pool;
 
     MONGOCXX_PRIVATE void* convert() const;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
@@ -16,6 +16,8 @@
 
 #include <string>
 
+#include <mongocxx/client-fwd.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
@@ -24,7 +26,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class client;
 class pool;
 
 namespace options {
@@ -371,7 +372,7 @@ class MONGOCXX_API auto_encryption {
     const stdx::optional<bsoncxx::document::view_or_value>& extra_options() const;
 
    private:
-    friend class mongocxx::client;
+    friend class ::mongocxx::v_noabi::client;
     friend class mongocxx::pool;
 
     MONGOCXX_PRIVATE void* convert() const;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/bulk_write-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/bulk_write-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API bulk_write;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/bulk_write.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/options/bulk_write-fwd.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
@@ -28,7 +30,7 @@ namespace options {
 ///
 /// Class representing the optional arguments to a MongoDB bulk write
 ///
-class MONGOCXX_API bulk_write {
+class bulk_write {
    public:
     ///
     /// Constructs a new bulk_write object. By default, bulk writes are considered ordered

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API change_stream;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream.hpp
@@ -16,6 +16,8 @@
 
 #include <chrono>
 
+#include <mongocxx/client-fwd.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
 #include <bsoncxx/types.hpp>
@@ -26,7 +28,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class client;
 class collection;
 class database;
 
@@ -257,7 +258,7 @@ class MONGOCXX_API change_stream {
     change_stream& start_at_operation_time(bsoncxx::types::b_timestamp timestamp);
 
    private:
-    friend class ::mongocxx::client;
+    friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::collection;
     friend class ::mongocxx::database;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream.hpp
@@ -18,6 +18,7 @@
 
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
+#include <mongocxx/database-fwd.hpp>
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
@@ -29,8 +30,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class database;
-
 namespace options {
 
 ///
@@ -260,7 +259,7 @@ class MONGOCXX_API change_stream {
    private:
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
-    friend class ::mongocxx::database;
+    friend class ::mongocxx::v_noabi::database;
 
     bsoncxx::document::value as_bson() const;
     stdx::optional<bsoncxx::string::view_or_value> _full_document;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream.hpp
@@ -19,6 +19,7 @@
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
+#include <mongocxx/options/change_stream-fwd.hpp>
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
@@ -35,7 +36,7 @@ namespace options {
 ///
 /// Class representing MongoDB change stream options.
 ///
-class MONGOCXX_API change_stream {
+class change_stream {
    public:
     change_stream();
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream.hpp
@@ -17,6 +17,7 @@
 #include <chrono>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/collection-fwd.hpp>
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
@@ -28,7 +29,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class collection;
 class database;
 
 namespace options {
@@ -259,7 +259,7 @@ class MONGOCXX_API change_stream {
 
    private:
     friend class ::mongocxx::v_noabi::client;
-    friend class ::mongocxx::collection;
+    friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::database;
 
     bsoncxx::document::value as_bson() const;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API client;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client.hpp
@@ -16,6 +16,8 @@
 
 #include <string>
 
+#include <mongocxx/options/client-fwd.hpp>
+
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/options/apm.hpp>
 #include <mongocxx/options/auto_encryption.hpp>
@@ -33,7 +35,7 @@ namespace options {
 ///
 /// Class representing the optional arguments to a MongoDB driver client object.
 ///
-class MONGOCXX_API client {
+class client {
    public:
     ///
     /// Sets the SSL-related options.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API client_encryption;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption.hpp
@@ -17,6 +17,7 @@
 #include <string>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/client_encryption-fwd.hpp>
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -26,8 +27,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class client_encryption;
-
 namespace options {
 
 ///
@@ -172,7 +171,7 @@ class MONGOCXX_API client_encryption {
     const stdx::optional<bsoncxx::document::view_or_value>& tls_opts() const;
 
    private:
-    friend class mongocxx::client_encryption;
+    friend class ::mongocxx::v_noabi::client_encryption;
 
     MONGOCXX_PRIVATE void* convert() const;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption.hpp
@@ -16,6 +16,8 @@
 
 #include <string>
 
+#include <mongocxx/client-fwd.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
@@ -24,7 +26,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class client;
 class client_encryption;
 
 namespace options {

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption.hpp
@@ -18,6 +18,7 @@
 
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/client_encryption-fwd.hpp>
+#include <mongocxx/options/client_encryption-fwd.hpp>
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -32,7 +33,7 @@ namespace options {
 ///
 /// Class representing options for the object managing explicit client-side encryption.
 ///
-class MONGOCXX_API client_encryption {
+class client_encryption {
    public:
     ///
     /// When the key vault collection is on a separate MongoDB cluster,

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_session-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_session-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API client_session;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_session.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/client_session-fwd.hpp>
+
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/options/transaction.hpp>
 #include <mongocxx/stdx.hpp>
@@ -22,8 +24,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class client_session;
-
 namespace options {
 
 ///
@@ -98,8 +98,7 @@ class MONGOCXX_API client_session {
     const stdx::optional<transaction>& default_transaction_opts() const;
 
    private:
-    // Allow the implementation of client_session to see these:
-    friend class mongocxx::client_session;
+    friend class ::mongocxx::v_noabi::client_session;
 
     stdx::optional<bool> _causal_consistency;
     stdx::optional<bool> _enable_snapshot_reads;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_session.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <mongocxx/client_session-fwd.hpp>
+#include <mongocxx/options/client_session-fwd.hpp>
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/options/transaction.hpp>
@@ -29,7 +30,7 @@ namespace options {
 ///
 /// Class representing the optional arguments to mongocxx::client::start_session.
 ///
-class MONGOCXX_API client_session {
+class client_session {
    public:
     ///
     /// Sets the causal_consistency option.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API count;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count.hpp
@@ -18,6 +18,8 @@
 #include <cstdint>
 #include <string>
 
+#include <mongocxx/options/count-fwd.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
@@ -33,7 +35,7 @@ namespace options {
 ///
 /// Class representing the optional arguments to mongocxx::collection::count_documents
 ///
-class MONGOCXX_API count {
+class count {
    public:
     ///
     /// Sets the collation for this operation.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API data_key;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
@@ -17,6 +17,8 @@
 #include <string>
 #include <vector>
 
+#include <mongocxx/client_encryption-fwd.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
@@ -25,8 +27,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class client_encryption;
-
 namespace options {
 
 ///
@@ -153,7 +153,8 @@ class MONGOCXX_API data_key {
     const stdx::optional<key_material_type>& key_material();
 
    private:
-    friend class mongocxx::client_encryption;
+    friend class ::mongocxx::v_noabi::client_encryption;
+
     MONGOCXX_PRIVATE void* convert() const;
 
     stdx::optional<bsoncxx::document::view_or_value> _master_key;
@@ -162,7 +163,6 @@ class MONGOCXX_API data_key {
 };
 
 }  // namespace options
-
 }  // namespace v_noabi
 }  // namespace mongocxx
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include <mongocxx/client_encryption-fwd.hpp>
+#include <mongocxx/options/data_key-fwd.hpp>
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -32,7 +33,7 @@ namespace options {
 ///
 /// Class representing options for data key generation for encryption.
 ///
-class MONGOCXX_API data_key {
+class data_key {
    public:
     ///
     /// Sets a KMS-specific key used to encrypt the new data key.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/delete-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/delete-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API delete_options;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/delete.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/delete.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/options/delete-fwd.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
@@ -29,7 +31,7 @@ namespace options {
 ///
 /// Class representing the optional arguments to a MongoDB delete operation
 ///
-class MONGOCXX_API delete_options {
+class delete_options {
    public:
     ///
     /// Sets the collation for this operation.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API distinct;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct.hpp
@@ -18,6 +18,8 @@
 #include <cstdint>
 #include <string>
 
+#include <mongocxx/options/distinct-fwd.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
@@ -32,7 +34,7 @@ namespace options {
 ///
 /// Class representing the optional arguments to a MongoDB distinct command.
 ///
-class MONGOCXX_API distinct {
+class distinct {
    public:
     ///
     /// Sets the collation for this operation.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API encrypt;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <mongocxx/client_encryption-fwd.hpp>
+#include <mongocxx/options/encrypt-fwd.hpp>
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types.hpp>
@@ -31,7 +32,7 @@ namespace options {
 ///
 /// Class representing options for explicit client-side encryption.
 ///
-class MONGOCXX_API encrypt {
+class encrypt {
    public:
     ///
     /// Sets the key to use for this encryption operation. A key id can be used instead

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/client_encryption-fwd.hpp>
+
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
@@ -24,8 +26,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class client_encryption;
-
 namespace options {
 
 ///
@@ -217,7 +217,8 @@ class MONGOCXX_API encrypt {
     const stdx::optional<options::range>& range_opts() const;
 
    private:
-    friend class mongocxx::client_encryption;
+    friend class ::mongocxx::v_noabi::client_encryption;
+
     MONGOCXX_PRIVATE void* convert() const;
 
     stdx::optional<bsoncxx::types::bson_value::view_or_value> _key_id;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/estimated_document_count-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/estimated_document_count-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API estimated_document_count;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/estimated_document_count.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/estimated_document_count.hpp
@@ -16,6 +16,8 @@
 
 #include <chrono>
 
+#include <mongocxx/options/estimated_document_count-fwd.hpp>
+
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
 #include <mongocxx/read_preference.hpp>
@@ -29,7 +31,7 @@ namespace options {
 ///
 /// Class representing the optional arguments to mongocxx::collection::estimated_document_count
 ///
-class MONGOCXX_API estimated_document_count {
+class estimated_document_count {
    public:
     ///
     /// Sets the maximum amount of time for this operation to run (server-side) in milliseconds.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API find;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find.hpp
@@ -17,6 +17,8 @@
 #include <chrono>
 #include <cstdint>
 
+#include <mongocxx/options/find-fwd.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
@@ -34,7 +36,7 @@ namespace options {
 ///
 /// Class representing the optional arguments to a MongoDB query.
 ///
-class MONGOCXX_API find {
+class find {
    public:
     ///
     /// Enables writing to temporary files on the server. When set to true, the server

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API find_one_and_delete;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.hpp
@@ -17,6 +17,8 @@
 #include <chrono>
 #include <cstdint>
 
+#include <mongocxx/options/find_one_and_delete-fwd.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
@@ -32,7 +34,7 @@ namespace options {
 ///
 /// Class representing the optional arguments to a MongoDB find_and_modify delete operation
 ///
-class MONGOCXX_API find_one_and_delete {
+class find_one_and_delete {
    public:
     /// Sets the collation for this operation.
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API find_one_and_replace;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.hpp
@@ -17,6 +17,8 @@
 #include <chrono>
 #include <cstdint>
 
+#include <mongocxx/options/find_one_and_replace-fwd.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
@@ -34,7 +36,7 @@ namespace options {
 ///
 /// Class representing the optional arguments to a MongoDB find_and_modify replace operation
 ///
-class MONGOCXX_API find_one_and_replace {
+class find_one_and_replace {
    public:
     /// Sets the collation for this operation.
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API find_one_and_update;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update.hpp
@@ -17,6 +17,8 @@
 #include <chrono>
 #include <cstdint>
 
+#include <mongocxx/options/find_one_and_update-fwd.hpp>
+
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -35,7 +37,7 @@ namespace options {
 ///
 /// Class representing the optional arguments to a MongoDB find_and_modify update operation.
 ///
-class MONGOCXX_API find_one_and_update {
+class find_one_and_update {
    public:
     /// Sets the collation for this operation.
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_common_options-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_common_options-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+enum class return_document;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_common_options.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_common_options.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/options/find_one_common_options-fwd.hpp>
+
 #include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/bucket-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/bucket-fwd.hpp
@@ -1,0 +1,31 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+namespace gridfs {
+
+class MONGOCXX_API bucket;
+
+}  // namespace gridfs
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/bucket.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/bucket.hpp
@@ -16,6 +16,8 @@
 
 #include <string>
 
+#include <mongocxx/options/gridfs/bucket-fwd.hpp>
+
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/read_concern.hpp>
 #include <mongocxx/read_preference.hpp>
@@ -32,7 +34,7 @@ namespace gridfs {
 ///
 /// Class representing the optional arguments to a MongoDB GridFS bucket creation operation.
 ///
-class MONGOCXX_API bucket {
+class bucket {
    public:
     ///
     /// Sets the name of the bucket. Defaults to 'fs'.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/upload-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/upload-fwd.hpp
@@ -1,0 +1,31 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+namespace gridfs {
+
+class MONGOCXX_API upload;
+
+}  // namespace gridfs
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/upload.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/upload.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/options/gridfs/upload-fwd.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
@@ -28,7 +30,7 @@ namespace gridfs {
 ///
 /// Class representing the optional arguments to a MongoDB GridFS upload operation.
 ///
-class MONGOCXX_API upload {
+class upload {
    public:
     ///
     /// Sets the chunk size of the GridFS file being uploaded. Defaults to the chunk size specified

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API index;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index.hpp
@@ -17,6 +17,8 @@
 #include <chrono>
 #include <memory>
 
+#include <mongocxx/collection-fwd.hpp>
+
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
@@ -28,8 +30,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class collection;
-
 namespace options {
 
 ///
@@ -74,8 +74,10 @@ class MONGOCXX_API index {
         const stdx::optional<bsoncxx::string::view_or_value>& config_string() const;
 
        private:
-        friend collection;
+        friend class ::mongocxx::v_noabi::collection;
+
         MONGOCXX_PRIVATE int type() const override;
+
         stdx::optional<bsoncxx::string::view_or_value> _config_string;
     };
 
@@ -473,7 +475,7 @@ class MONGOCXX_API index {
     operator bsoncxx::document::view_or_value();
 
    private:
-    friend collection;
+    friend class ::mongocxx::v_noabi::collection;
 
     stdx::optional<bool> _background;
     stdx::optional<bool> _unique;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 
 #include <mongocxx/collection-fwd.hpp>
+#include <mongocxx/options/index-fwd.hpp>
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
@@ -37,7 +38,7 @@ namespace options {
 ///
 /// @see https://www.mongodb.com/docs/manual/reference/command/createIndexes
 ///
-class MONGOCXX_API index {
+class index {
    public:
     ///
     /// Base class representing the optional storage engine options for indexes.
@@ -47,7 +48,8 @@ class MONGOCXX_API index {
         virtual ~base_storage_options();
 
        private:
-        friend class options::index;
+        friend class ::mongocxx::v_noabi::options::index;
+
         MONGOCXX_PRIVATE virtual int type() const = 0;
     };
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API index_view;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view.hpp
@@ -16,6 +16,8 @@
 
 #include <chrono>
 
+#include <mongocxx/options/index_view-fwd.hpp>
+
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/write_concern.hpp>
 
@@ -28,7 +30,7 @@ namespace options {
 ///
 /// Class representing optional arguments to IndexView operations
 ///
-class MONGOCXX_API index_view {
+class index_view {
    public:
     index_view();
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API insert;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/options/insert-fwd.hpp>
+
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
@@ -29,7 +31,7 @@ namespace options {
 ///
 /// Class representing the optional arguments to a MongoDB insert operation
 ///
-class MONGOCXX_API insert {
+class insert {
    public:
     ///
     /// Sets the bypass_document_validation option.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/pool-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/pool-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API pool;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/pool.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/pool.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/options/pool-fwd.hpp>
+
 #include <mongocxx/options/client.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -26,7 +28,7 @@ namespace options {
 /// Class representing the optional arguments to a MongoDB driver pool object. Pool options
 /// logically extend client options.
 ///
-class MONGOCXX_API pool {
+class pool {
    public:
     ///
     /// Constructs a new pool options object. Note that options::pool is implictly convertible from

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/range-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/range-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API range;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/range.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/range.hpp
@@ -16,6 +16,8 @@
 
 #include <cstdint>
 
+#include <mongocxx/options/range-fwd.hpp>
+
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
 #include <mongocxx/stdx.hpp>
@@ -38,7 +40,7 @@ namespace options {
 ///
 /// @warning The Range algorithm is experimental only. It is not intended for public use. It is
 /// subject to breaking changes.
-class MONGOCXX_API range {
+class range {
    public:
     /// @brief Sets `RangeOpts.min`.
     /// @note Required if @ref precision is set.
@@ -78,7 +80,6 @@ class MONGOCXX_API range {
 };
 
 }  // namespace options
-
 }  // namespace v_noabi
 }  // namespace mongocxx
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API replace;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/options/replace-fwd.hpp>
+
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -31,7 +33,7 @@ namespace options {
 ///
 /// Class representing the optional arguments to a MongoDB replace operation.
 ///
-class MONGOCXX_API replace {
+class replace {
    public:
     ///
     /// Sets the bypass_document_validation option.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API rewrap_many_datakey;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <mongocxx/client_encryption-fwd.hpp>
+#include <mongocxx/options/rewrap_many_datakey-fwd.hpp>
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
@@ -31,7 +32,7 @@ namespace options {
 ///
 /// Class representing options for a rewrap many datakey operation.
 ///
-class MONGOCXX_API rewrap_many_datakey {
+class rewrap_many_datakey {
    public:
     ///
     /// Set the optional KMS provider use to encrypt the data keys. Do not set to use the current

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/client_encryption-fwd.hpp>
+
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
 #include <bsoncxx/types.hpp>
@@ -24,8 +26,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class client_encryption;
-
 namespace options {
 
 ///
@@ -99,7 +99,8 @@ class MONGOCXX_API rewrap_many_datakey {
     const stdx::optional<bsoncxx::document::view_or_value>& master_key() const;
 
    private:
-    friend class mongocxx::client_encryption;
+    friend class ::mongocxx::v_noabi::client_encryption;
+
     bsoncxx::string::view_or_value _provider;
     stdx::optional<bsoncxx::document::view_or_value> _master_key;
 };

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/server_api-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/server_api-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API server_api;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/server_api.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/server_api.hpp
@@ -17,6 +17,7 @@
 #include <string>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/options/server_api-fwd.hpp>
 #include <mongocxx/pool-fwd.hpp>
 
 #include <bsoncxx/stdx/optional.hpp>
@@ -32,7 +33,7 @@ namespace options {
 ///
 /// Class representing options for server API.
 ///
-class MONGOCXX_API server_api {
+class server_api {
    public:
     ///
     /// Enum representing the possible values for server API version.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/server_api.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/server_api.hpp
@@ -17,6 +17,7 @@
 #include <string>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/pool-fwd.hpp>
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
@@ -26,8 +27,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class pool;
-
 namespace options {
 
 ///
@@ -129,7 +128,7 @@ class MONGOCXX_API server_api {
 
    private:
     friend class ::mongocxx::v_noabi::client;
-    friend class mongocxx::pool;
+    friend class ::mongocxx::v_noabi::pool;
 
     version _version;
     stdx::optional<bool> _strict;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/server_api.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/server_api.hpp
@@ -16,6 +16,8 @@
 
 #include <string>
 
+#include <mongocxx/client-fwd.hpp>
+
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 #include <mongocxx/stdx.hpp>
@@ -24,7 +26,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class client;
 class pool;
 
 namespace options {
@@ -127,7 +128,7 @@ class MONGOCXX_API server_api {
     version get_version() const;
 
    private:
-    friend class mongocxx::client;
+    friend class ::mongocxx::v_noabi::client;
     friend class mongocxx::pool;
 
     version _version;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/tls-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/tls-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API tls;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/tls.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/tls.hpp
@@ -16,6 +16,8 @@
 
 #include <string>
 
+#include <mongocxx/options/tls-fwd.hpp>
+
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
 #include <mongocxx/stdx.hpp>
@@ -29,7 +31,7 @@ namespace options {
 ///
 /// Class representing the optional arguments to a MongoDB driver client (TLS)
 ///
-class MONGOCXX_API tls {
+class tls {
    public:
     ///
     /// The path to the .pem file containing a public key certificate and its associated private

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API transaction;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 
 #include <mongocxx/client_session-fwd.hpp>
+#include <mongocxx/read_concern-fwd.hpp>
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
@@ -26,7 +27,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class read_concern;
 class write_concern;
 class read_preference;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction.hpp
@@ -19,6 +19,7 @@
 
 #include <mongocxx/client_session-fwd.hpp>
 #include <mongocxx/read_concern-fwd.hpp>
+#include <mongocxx/write_concern-fwd.hpp>
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
@@ -27,7 +28,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class write_concern;
 class read_preference;
 
 namespace options {

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 
 #include <mongocxx/client_session-fwd.hpp>
+#include <mongocxx/options/transaction-fwd.hpp>
 #include <mongocxx/read_concern-fwd.hpp>
 #include <mongocxx/read_preference-fwd.hpp>
 #include <mongocxx/write_concern-fwd.hpp>
@@ -34,7 +35,7 @@ namespace options {
 ///
 /// Class representing the optional arguments for a transaction.
 ///
-class MONGOCXX_API transaction {
+class transaction {
    public:
     transaction();
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction.hpp
@@ -19,6 +19,7 @@
 
 #include <mongocxx/client_session-fwd.hpp>
 #include <mongocxx/read_concern-fwd.hpp>
+#include <mongocxx/read_preference-fwd.hpp>
 #include <mongocxx/write_concern-fwd.hpp>
 
 #include <bsoncxx/stdx/optional.hpp>
@@ -28,8 +29,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class read_preference;
-
 namespace options {
 
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction.hpp
@@ -17,6 +17,8 @@
 #include <chrono>
 #include <memory>
 
+#include <mongocxx/client_session-fwd.hpp>
+
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
 
@@ -24,7 +26,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class client_session;
 class read_concern;
 class write_concern;
 class read_preference;
@@ -146,7 +147,7 @@ class MONGOCXX_API transaction {
     stdx::optional<std::chrono::milliseconds> max_commit_time_ms() const;
 
    private:
-    friend class ::mongocxx::client_session;
+    friend class ::mongocxx::v_noabi::client_session;
 
     class MONGOCXX_PRIVATE impl;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/update-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/update-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace options {
+
+class MONGOCXX_API update;
+
+}  // namespace options
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/update.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/update.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/options/update-fwd.hpp>
+
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -31,7 +33,7 @@ namespace options {
 ///
 /// Class representing the optional arguments to a MongoDB update operation.
 ///
-class MONGOCXX_API update {
+class update {
    public:
     ///
     /// Sets the bypass_document_validation option.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API pipeline; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline.hpp
@@ -21,6 +21,7 @@
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
+#include <mongocxx/pipeline-fwd.hpp>
 
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/array/view_or_value.hpp>
@@ -34,7 +35,7 @@ inline namespace v_noabi {
 ///
 /// Class representing a MongoDB aggregation pipeline.
 ///
-class MONGOCXX_API pipeline {
+class pipeline {
    public:
     ///
     /// Creates a new aggregation pipeline.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline.hpp
@@ -19,6 +19,7 @@
 #include <string>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/collection-fwd.hpp>
 
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/array/view_or_value.hpp>
@@ -29,7 +30,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class collection;
 class database;
 
 ///
@@ -545,7 +545,7 @@ class MONGOCXX_API pipeline {
 
    private:
     friend class ::mongocxx::v_noabi::client;
-    friend class collection;
+    friend class ::mongocxx::v_noabi::collection;
     friend class database;
 
     class MONGOCXX_PRIVATE impl;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline.hpp
@@ -18,6 +18,8 @@
 #include <memory>
 #include <string>
 
+#include <mongocxx/client-fwd.hpp>
+
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view.hpp>
@@ -27,7 +29,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class client;
 class collection;
 class database;
 
@@ -543,7 +544,7 @@ class MONGOCXX_API pipeline {
     bsoncxx::array::view view_array() const;
 
    private:
-    friend class client;
+    friend class ::mongocxx::v_noabi::client;
     friend class collection;
     friend class database;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline.hpp
@@ -20,6 +20,7 @@
 
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
+#include <mongocxx/database-fwd.hpp>
 
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/array/view_or_value.hpp>
@@ -30,8 +31,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class database;
-
 ///
 /// Class representing a MongoDB aggregation pipeline.
 ///
@@ -546,7 +545,7 @@ class MONGOCXX_API pipeline {
    private:
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
-    friend class database;
+    friend class ::mongocxx::v_noabi::database;
 
     class MONGOCXX_PRIVATE impl;
     std::unique_ptr<impl> _impl;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API pool; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
@@ -17,6 +17,8 @@
 #include <functional>
 #include <memory>
 
+#include <mongocxx/client-fwd.hpp>
+
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/options/pool.hpp>
 #include <mongocxx/stdx.hpp>
@@ -26,8 +28,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class client;
-
 ///
 /// A pool of @c client objects associated with a MongoDB deployment.
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/pool-fwd.hpp>
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/options/pool.hpp>
@@ -43,7 +44,7 @@ inline namespace v_noabi {
 /// to check the status of the cluster. Because of this, if multiple threads are available, a
 /// connection pool should be used even if the application itself is single-threaded.
 ///
-class MONGOCXX_API pool {
+class pool {
    public:
     ///
     /// Creates a pool associated with a connection string.
@@ -87,7 +88,7 @@ class MONGOCXX_API pool {
         explicit operator bool() const noexcept;
 
        private:
-        friend class pool;
+        friend class ::mongocxx::v_noabi::pool;
 
         using unique_client = std::unique_ptr<client, std::function<void MONGOCXX_CALL(client*)>>;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/options/auto_encryption-fwd.hpp>
 #include <mongocxx/pool-fwd.hpp>
 
 #include <bsoncxx/stdx/optional.hpp>
@@ -110,7 +111,7 @@ class pool {
     stdx::optional<entry> try_acquire();
 
    private:
-    friend class options::auto_encryption;
+    friend class ::mongocxx::v_noabi::options::auto_encryption;
 
     MONGOCXX_PRIVATE void _release(client* client);
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API read_concern; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
@@ -19,6 +19,7 @@
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
+#include <mongocxx/read_concern-fwd.hpp>
 #include <mongocxx/uri-fwd.hpp>
 
 #include <bsoncxx/document/value.hpp>
@@ -54,7 +55,7 @@ class transaction;
 ///
 /// @see https://www.mongodb.com/docs/manual/reference/read-concern/
 ///
-class MONGOCXX_API read_concern {
+class read_concern {
    public:
     ///
     /// A class to represent the read concern level.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
@@ -19,6 +19,7 @@
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
+#include <mongocxx/uri-fwd.hpp>
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -30,8 +31,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class uri;
-
 namespace options {
 class transaction;
 }
@@ -161,7 +160,7 @@ class MONGOCXX_API read_concern {
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::v_noabi::database;
-    friend class uri;
+    friend class ::mongocxx::v_noabi::uri;
 
     friend class options::transaction;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
@@ -18,6 +18,7 @@
 
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
+#include <mongocxx/database-fwd.hpp>
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -29,7 +30,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class database;
 class uri;
 
 namespace options {
@@ -160,7 +160,7 @@ class MONGOCXX_API read_concern {
    private:
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
-    friend class database;
+    friend class ::mongocxx::v_noabi::database;
     friend class uri;
 
     friend class options::transaction;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
@@ -16,6 +16,8 @@
 
 #include <memory>
 
+#include <mongocxx/client-fwd.hpp>
+
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
@@ -26,7 +28,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class client;
 class collection;
 class database;
 class uri;
@@ -157,7 +158,7 @@ class MONGOCXX_API read_concern {
     bsoncxx::document::value to_document() const;
 
    private:
-    friend class client;
+    friend class ::mongocxx::v_noabi::client;
     friend class collection;
     friend class database;
     friend class uri;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
@@ -19,6 +19,7 @@
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
+#include <mongocxx/options/transaction-fwd.hpp>
 #include <mongocxx/read_concern-fwd.hpp>
 #include <mongocxx/uri-fwd.hpp>
 
@@ -32,10 +33,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-namespace options {
-class transaction;
-}
-
 ///
 /// A class to represent the read concern. Read concern can be set at the client, database, or
 /// collection level. The read concern can also be provided via connection string, and will be
@@ -161,9 +158,8 @@ class read_concern {
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::v_noabi::database;
+    friend class ::mongocxx::v_noabi::options::transaction;
     friend class ::mongocxx::v_noabi::uri;
-
-    friend class options::transaction;
 
     ///
     /// @{

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
@@ -17,6 +17,7 @@
 #include <memory>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/collection-fwd.hpp>
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -28,7 +29,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class collection;
 class database;
 class uri;
 
@@ -159,7 +159,7 @@ class MONGOCXX_API read_concern {
 
    private:
     friend class ::mongocxx::v_noabi::client;
-    friend class collection;
+    friend class ::mongocxx::v_noabi::collection;
     friend class database;
     friend class uri;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API read_preference; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
@@ -22,6 +22,7 @@
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
+#include <mongocxx/uri-fwd.hpp>
 
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
@@ -34,7 +35,6 @@
 namespace mongocxx {
 inline namespace v_noabi {
 class search_index_view;
-class uri;
 
 namespace events {
 class topology_description;
@@ -289,8 +289,8 @@ class MONGOCXX_API read_preference {
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::v_noabi::database;
+    friend class ::mongocxx::v_noabi::uri;
     friend class search_index_view;
-    friend class uri;
 
     friend class events::topology_description;
     friend class options::transaction;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
@@ -20,6 +20,7 @@
 #include <string>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/collection-fwd.hpp>
 
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
@@ -31,7 +32,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class collection;
 class database;
 class search_index_view;
 class uri;
@@ -287,7 +287,7 @@ class MONGOCXX_API read_preference {
 
    private:
     friend class ::mongocxx::v_noabi::client;
-    friend class collection;
+    friend class ::mongocxx::v_noabi::collection;
     friend class database;
     friend class search_index_view;
     friend class uri;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
@@ -23,6 +23,7 @@
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
 #include <mongocxx/events/topology_description-fwd.hpp>
+#include <mongocxx/options/transaction-fwd.hpp>
 #include <mongocxx/read_preference-fwd.hpp>
 #include <mongocxx/search_index_view-fwd.hpp>
 #include <mongocxx/uri-fwd.hpp>
@@ -37,10 +38,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-namespace options {
-class transaction;
-}
-
 ///
 /// Class representing a preference for how the driver routes read operations to members of a
 /// replica set or to a sharded cluster.
@@ -287,10 +284,9 @@ class read_preference {
     friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::v_noabi::database;
     friend class ::mongocxx::v_noabi::events::topology_description;
+    friend class ::mongocxx::v_noabi::options::transaction;
     friend class ::mongocxx::v_noabi::search_index_view;
     friend class ::mongocxx::v_noabi::uri;
-
-    friend class options::transaction;
 
     ///
     /// @{

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
@@ -22,6 +22,7 @@
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
+#include <mongocxx/read_preference-fwd.hpp>
 #include <mongocxx/search_index_view-fwd.hpp>
 #include <mongocxx/uri-fwd.hpp>
 
@@ -64,7 +65,7 @@ class transaction;
 ///
 /// @see https://www.mongodb.com/docs/manual/core/read-preference/
 ///
-class MONGOCXX_API read_preference {
+class read_preference {
    public:
     ///
     /// Determines which members in a replica set are acceptable to read from.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
@@ -21,6 +21,7 @@
 
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
+#include <mongocxx/database-fwd.hpp>
 
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
@@ -32,7 +33,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class database;
 class search_index_view;
 class uri;
 
@@ -288,7 +288,7 @@ class MONGOCXX_API read_preference {
    private:
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
-    friend class database;
+    friend class ::mongocxx::v_noabi::database;
     friend class search_index_view;
     friend class uri;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
@@ -22,6 +22,7 @@
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
+#include <mongocxx/search_index_view-fwd.hpp>
 #include <mongocxx/uri-fwd.hpp>
 
 #include <bsoncxx/array/view_or_value.hpp>
@@ -34,8 +35,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class search_index_view;
-
 namespace events {
 class topology_description;
 }
@@ -289,8 +288,8 @@ class MONGOCXX_API read_preference {
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::v_noabi::database;
+    friend class ::mongocxx::v_noabi::search_index_view;
     friend class ::mongocxx::v_noabi::uri;
-    friend class search_index_view;
 
     friend class events::topology_description;
     friend class options::transaction;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
@@ -22,6 +22,7 @@
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
+#include <mongocxx/events/topology_description-fwd.hpp>
 #include <mongocxx/read_preference-fwd.hpp>
 #include <mongocxx/search_index_view-fwd.hpp>
 #include <mongocxx/uri-fwd.hpp>
@@ -36,10 +37,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-namespace events {
-class topology_description;
-}
-
 namespace options {
 class transaction;
 }
@@ -289,10 +286,10 @@ class read_preference {
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::v_noabi::database;
+    friend class ::mongocxx::v_noabi::events::topology_description;
     friend class ::mongocxx::v_noabi::search_index_view;
     friend class ::mongocxx::v_noabi::uri;
 
-    friend class events::topology_description;
     friend class options::transaction;
 
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
@@ -19,6 +19,8 @@
 #include <memory>
 #include <string>
 
+#include <mongocxx/client-fwd.hpp>
+
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -29,7 +31,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class client;
 class collection;
 class database;
 class search_index_view;
@@ -285,7 +286,7 @@ class MONGOCXX_API read_preference {
     const stdx::optional<bsoncxx::document::view> hedge() const;
 
    private:
-    friend class client;
+    friend class ::mongocxx::v_noabi::client;
     friend class collection;
     friend class database;
     friend class search_index_view;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/bulk_write-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/bulk_write-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace result {
+
+class MONGOCXX_API bulk_write;
+
+}  // namespace result
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/bulk_write.hpp
@@ -18,6 +18,8 @@
 #include <map>
 #include <vector>
 
+#include <mongocxx/result/bulk_write-fwd.hpp>
+
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/types.hpp>
@@ -31,7 +33,7 @@ namespace result {
 ///
 /// Class representing the result of a MongoDB bulk write operation.
 ///
-class MONGOCXX_API bulk_write {
+class bulk_write {
    public:
     using id_map = std::map<std::size_t, bsoncxx::document::element>;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/delete-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/delete-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace result {
+
+class MONGOCXX_API delete_result;
+
+}  // namespace result
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/delete.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/delete.hpp
@@ -16,6 +16,8 @@
 
 #include <cstdint>
 
+#include <mongocxx/result/delete-fwd.hpp>
+
 #include <mongocxx/result/bulk_write.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -27,7 +29,7 @@ namespace result {
 ///
 /// Class representing the result of a MongoDB delete operation.
 ///
-class MONGOCXX_API delete_result {
+class delete_result {
    public:
     // This constructor is public for testing purposes only
     explicit delete_result(result::bulk_write result);

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/gridfs/upload-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/gridfs/upload-fwd.hpp
@@ -1,0 +1,31 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace result {
+namespace gridfs {
+
+class MONGOCXX_API upload;
+
+}  // namespace gridfs
+}  // namespace result
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/gridfs/upload.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/gridfs/upload.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/result/gridfs/upload-fwd.hpp>
+
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
 
@@ -25,7 +27,7 @@ namespace result {
 namespace gridfs {
 
 /// Class representing the result of a GridFS upload operation.
-class MONGOCXX_API upload {
+class upload {
    public:
     upload(bsoncxx::types::bson_value::view id);
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_many-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_many-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace result {
+
+class MONGOCXX_API insert_many;
+
+}  // namespace result
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_many.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_many.hpp
@@ -18,6 +18,7 @@
 #include <map>
 
 #include <mongocxx/collection-fwd.hpp>
+#include <mongocxx/result/insert_many-fwd.hpp>
 
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/types.hpp>
@@ -33,7 +34,7 @@ namespace result {
 /// Class representing the result of a MongoDB insert many operation
 /// (executed as a bulk write).
 ///
-class MONGOCXX_API insert_many {
+class insert_many {
    public:
     using id_map = std::map<std::size_t, bsoncxx::document::element>;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_many.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_many.hpp
@@ -17,6 +17,8 @@
 #include <cstdint>
 #include <map>
 
+#include <mongocxx/collection-fwd.hpp>
+
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/types.hpp>
 #include <mongocxx/result/bulk_write.hpp>
@@ -25,8 +27,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class collection;
-
 namespace result {
 
 ///
@@ -69,7 +69,7 @@ class MONGOCXX_API insert_many {
     id_map inserted_ids() const;
 
    private:
-    friend collection;
+    friend class ::mongocxx::v_noabi::collection;
 
     // Construct _inserted_ids from _inserted_ids_owned
     MONGOCXX_PRIVATE void _buildInsertedIds();

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_one-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_one-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace result {
+
+class MONGOCXX_API insert_one;
+
+}  // namespace result
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_one.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/result/insert_one-fwd.hpp>
+
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
@@ -26,7 +28,7 @@ inline namespace v_noabi {
 namespace result {
 
 /// Class representing the result of a MongoDB insert operation.
-class MONGOCXX_API insert_one {
+class insert_one {
    public:
     // This constructor is public for testing purposes only
     insert_one(result::bulk_write result, bsoncxx::types::bson_value::view inserted_id);

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/replace_one-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/replace_one-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace result {
+
+class MONGOCXX_API replace_one;
+
+}  // namespace result
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/replace_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/replace_one.hpp
@@ -16,6 +16,8 @@
 
 #include <cstdint>
 
+#include <mongocxx/result/replace_one-fwd.hpp>
+
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types.hpp>
 #include <mongocxx/result/bulk_write.hpp>
@@ -28,7 +30,7 @@ inline namespace v_noabi {
 namespace result {
 
 /// Class representing the result of a MongoDB replace_one operation.
-class MONGOCXX_API replace_one {
+class replace_one {
    public:
     // This constructor is public for testing purposes only
     explicit replace_one(result::bulk_write result);

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace result {
+
+class MONGOCXX_API rewrap_many_datakey;
+
+}  // namespace result
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/result/rewrap_many_datakey-fwd.hpp>
+
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/bulk_write.hpp>
@@ -25,7 +27,7 @@ inline namespace v_noabi {
 namespace result {
 
 /// Class representing the result of a MongoDB rewrap_many_datakey operation.
-class MONGOCXX_API rewrap_many_datakey {
+class rewrap_many_datakey {
    public:
     rewrap_many_datakey() = default;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/update-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/update-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi {
+namespace result {
+
+class MONGOCXX_API update;
+
+}  // namespace result
+}  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/update.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/update.hpp
@@ -16,6 +16,8 @@
 
 #include <cstdint>
 
+#include <mongocxx/result/update-fwd.hpp>
+
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types.hpp>
 #include <mongocxx/result/bulk_write.hpp>
@@ -28,7 +30,7 @@ inline namespace v_noabi {
 namespace result {
 
 /// Class representing the result of a MongoDB update operation.
-class MONGOCXX_API update {
+class update {
    public:
     // This constructor is public for testing purposes only
     explicit update(result::bulk_write result);

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_model-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_model-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API search_index_model; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_model.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_model.hpp
@@ -2,6 +2,8 @@
 
 #include <string>
 
+#include <mongocxx/search_index_model-fwd.hpp>
+
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -14,7 +16,7 @@ inline namespace v_noabi {
 ///
 /// Class representing a search index on a MongoDB server.
 ///
-class MONGOCXX_API search_index_model {
+class search_index_model {
    public:
     ///
     /// Initializes a new search_index_model over a mongocxx::collection.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_view-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_view-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API search_index_view; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_view.hpp
@@ -3,6 +3,8 @@
 #include <string>
 #include <vector>
 
+#include <mongocxx/collection-fwd.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/cursor.hpp>
@@ -249,7 +251,8 @@ class MONGOCXX_API search_index_view {
     ///
 
    private:
-    friend class collection;
+    friend class ::mongocxx::v_noabi::collection;
+
     class MONGOCXX_PRIVATE impl;
 
     MONGOCXX_PRIVATE search_index_view(void* coll, void* client);

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_view.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include <mongocxx/collection-fwd.hpp>
+#include <mongocxx/search_index_view-fwd.hpp>
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -18,7 +19,7 @@ inline namespace v_noabi {
 ///
 /// Class representing a MongoDB search index view.
 ///
-class MONGOCXX_API search_index_view {
+class search_index_view {
    public:
     search_index_view(search_index_view&&) noexcept;
     search_index_view& operator=(search_index_view&&) noexcept;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API uri; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
@@ -18,6 +18,8 @@
 #include <string>
 #include <vector>
 
+#include <mongocxx/client-fwd.hpp>
+
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
 #include <mongocxx/read_concern.hpp>
@@ -360,7 +362,7 @@ class MONGOCXX_API uri {
     stdx::optional<std::int32_t> zlib_compression_level() const;
 
    private:
-    friend class client;
+    friend class ::mongocxx::v_noabi::client;
     friend class pool;
 
     class MONGOCXX_PRIVATE impl;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/pool-fwd.hpp>
 #include <mongocxx/uri-fwd.hpp>
 
 #include <bsoncxx/document/view.hpp>
@@ -364,7 +365,7 @@ class uri {
 
    private:
     friend class ::mongocxx::v_noabi::client;
-    friend class pool;
+    friend class ::mongocxx::v_noabi::pool;
 
     class MONGOCXX_PRIVATE impl;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/uri-fwd.hpp>
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
@@ -41,7 +42,7 @@ inline namespace v_noabi {
 /// @see https://mongoc.org/libmongoc/current/mongoc_uri_t.html for more information on supported
 /// URI options.
 ///
-class MONGOCXX_API uri {
+class uri {
    public:
     /// A host.
     struct host {

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/validation_criteria-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/validation_criteria-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API validation_criteria; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/validation_criteria.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/validation_criteria.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/validation_criteria-fwd.hpp>
+
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <mongocxx/stdx.hpp>
@@ -27,7 +29,7 @@ inline namespace v_noabi {
 ///
 /// @see https://www.mongodb.com/docs/manual/core/document-validation/
 ///
-class MONGOCXX_API validation_criteria {
+class validation_criteria {
    public:
     ///
     /// Sets a validation rule for this validation object.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { class MONGOCXX_API write_concern; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
@@ -19,6 +19,8 @@
 #include <memory>
 #include <stdexcept>
 
+#include <mongocxx/client-fwd.hpp>
+
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
@@ -30,7 +32,6 @@
 namespace mongocxx {
 inline namespace v_noabi {
 class bulk_write;
-class client;
 class collection;
 class database;
 class uri;
@@ -245,8 +246,8 @@ class MONGOCXX_API write_concern {
     bsoncxx::document::value to_document() const;
 
    private:
+    friend class ::mongocxx::v_noabi::client;
     friend class bulk_write;
-    friend class client;
     friend class collection;
     friend class database;
     friend class uri;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
@@ -22,6 +22,7 @@
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
+#include <mongocxx/uri-fwd.hpp>
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -34,7 +35,6 @@
 namespace mongocxx {
 inline namespace v_noabi {
 class bulk_write;
-class uri;
 
 namespace options {
 class transaction;
@@ -249,8 +249,8 @@ class MONGOCXX_API write_concern {
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::v_noabi::database;
+    friend class ::mongocxx::v_noabi::uri;
     friend class bulk_write;
-    friend class uri;
 
     friend class options::transaction;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
@@ -23,6 +23,7 @@
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
+#include <mongocxx/options/transaction-fwd.hpp>
 #include <mongocxx/uri-fwd.hpp>
 #include <mongocxx/write_concern-fwd.hpp>
 
@@ -36,10 +37,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-namespace options {
-class transaction;
-}
-
 ///
 /// Class representing the server-side requirement for reporting the success of a write
 /// operation. The strength of the write concern setting determines the level of guarantees
@@ -250,9 +247,8 @@ class write_concern {
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::v_noabi::database;
+    friend class ::mongocxx::v_noabi::options::transaction;
     friend class ::mongocxx::v_noabi::uri;
-
-    friend class options::transaction;
 
     ///
     /// @{

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
@@ -24,6 +24,7 @@
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
 #include <mongocxx/uri-fwd.hpp>
+#include <mongocxx/write_concern-fwd.hpp>
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -56,7 +57,7 @@ class transaction;
 ///
 /// @see https://www.mongodb.com/docs/manual/core/write-concern/
 ///
-class MONGOCXX_API write_concern {
+class write_concern {
    public:
     ///
     /// A class to represent the special case values for write_concern::nodes.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
@@ -20,6 +20,7 @@
 #include <stdexcept>
 
 #include <mongocxx/client-fwd.hpp>
+#include <mongocxx/collection-fwd.hpp>
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -32,7 +33,6 @@
 namespace mongocxx {
 inline namespace v_noabi {
 class bulk_write;
-class collection;
 class database;
 class uri;
 
@@ -247,8 +247,8 @@ class MONGOCXX_API write_concern {
 
    private:
     friend class ::mongocxx::v_noabi::client;
+    friend class ::mongocxx::v_noabi::collection;
     friend class bulk_write;
-    friend class collection;
     friend class database;
     friend class uri;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <stdexcept>
 
+#include <mongocxx/bulk_write-fwd.hpp>
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>
@@ -34,8 +35,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class bulk_write;
-
 namespace options {
 class transaction;
 }
@@ -246,11 +245,11 @@ class MONGOCXX_API write_concern {
     bsoncxx::document::value to_document() const;
 
    private:
+    friend class ::mongocxx::v_noabi::bulk_write;
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
     friend class ::mongocxx::v_noabi::database;
     friend class ::mongocxx::v_noabi::uri;
-    friend class bulk_write;
 
     friend class options::transaction;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
@@ -21,6 +21,7 @@
 
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
+#include <mongocxx/database-fwd.hpp>
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
@@ -33,7 +34,6 @@
 namespace mongocxx {
 inline namespace v_noabi {
 class bulk_write;
-class database;
 class uri;
 
 namespace options {
@@ -248,8 +248,8 @@ class MONGOCXX_API write_concern {
    private:
     friend class ::mongocxx::v_noabi::client;
     friend class ::mongocxx::v_noabi::collection;
+    friend class ::mongocxx::v_noabi::database;
     friend class bulk_write;
-    friend class database;
     friend class uri;
 
     friend class options::transaction;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_type-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_type-fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 MongoDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+inline namespace v_noabi { enum class write_type; }  // namespace v_noabi
+}  // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_type.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_type.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mongocxx/write_type-fwd.hpp>
+
 #include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/test_util/mock.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/test_util/mock.hh
@@ -45,7 +45,7 @@ class mock<R (*)(Args...)> {
     using conditional = std::function<bool(Args...)>;
 
     class rule {
-        friend class mock;
+        friend class ::mongocxx::v_noabi::test_util::mock<R (*)(Args...)>;
 
        public:
         rule(callback callback) : _callback(std::move(callback)) {
@@ -70,7 +70,7 @@ class mock<R (*)(Args...)> {
     };
 
     class instance {
-        friend class mock;
+        friend class ::mongocxx::v_noabi::test_util::mock<R (*)(Args...)>;
 
        public:
         instance(const instance&) = delete;
@@ -130,7 +130,7 @@ class mock<R (*)(Args...)> {
         std::stack<rule> _callbacks;
     };
 
-    friend class instance;
+    friend class ::mongocxx::v_noabi::test_util::mock<R (*)(Args...)>::instance;
 
     mock(underlying_ptr func) : _func(std::move(func)) {}
     mock(mock&&) = delete;

--- a/src/mongocxx/test/client_helpers.hh
+++ b/src/mongocxx/test/client_helpers.hh
@@ -37,7 +37,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-class client;
 
 namespace test_util {
 //

--- a/src/mongocxx/test/client_helpers.hh
+++ b/src/mongocxx/test/client_helpers.hh
@@ -37,7 +37,6 @@
 
 namespace mongocxx {
 inline namespace v_noabi {
-
 namespace test_util {
 //
 // Compares to version number strings (i.e. positive integers separated by periods). Comparisons are


### PR DESCRIPTION
## Description

Resolves CXX-2288. Verified by [this patch](https://spruce.mongodb.com/version/654e4c92e3c33169458a6be7).

This PR initially proposes maximizing modularity by providing a forward header per-component_. If this is considered excessive, forward headers can be merged as requested, i.e. merging `mongocxx/events/(.*)-fwd.hpp` into `mongocxx/events/fwd.hpp`.

Requesting reviews keep a close eye on whether `BSONCXX_API` and `MONGOCXX_API` are correctly preserved when moved into forward headers, and that they are not accidentally added to classes that did not have them prior.

## Principles

There are several principles/rules that motivated/directed how changes in this PR were made. These are:

- Any public header `a.hpp` that contains a declaration of a scoped enumeration or class type _in namespace scope_ is given a forward header `a-fwd.hpp` containing a forward declaration of that enumeration or class type.
  - Public headers containing only declarations of deprecated entities are excluded. This only applies to `mongocxx/options/create_collection.hpp`.
- A forward header `a-fwd.hpp` is always included its corresponding `a.hpp`. This is both to physically encode the header dependency and to ensure the definition for class types in `a.hpp` is always consistent with its forward declaration in `a-fwd.hpp`.
- Symbol visibility for class types using `(BSONCXX|MONGOCXX)_API` is always declared in the forward 
header (when applicable). This guarantees consistent symbol visibility regardless whether the class declaration is imported via the forward or normal header. (A followup PR may relocate Doxygen documentation comments for enumeration/class types into the forward header.) The only instances of `(BSONCXX|MONGOCXX)_API` for class declarations in normal headers is now limited to member classes and deprecated classes.
- All friend declarations are fully qualified relative to the global scope to minimize any potential for confusion about what class is being declared as a friend. The addition of forward headers that include these changes are made in separate commits in this PR to make it easier to track the related changes. (Unfortunately, C++ does not provide a mechanism that enforces a friend declaration always refers to an existing declaration, rather than introducing a new declaration.)
- Although using-declarations (`using foo::bar;`), using-directives (`using namespace foo;`), type aliases (`using foo = bar;`), and typedefs in namespace scope could be moved into forward headers, this was avoided to keep the forward headers as simple as possible. Therefore, the forward headers contain no `using` or `typedef` declarations. Headers that _only_ declare a type alias or typedef are not given a forward header due to redundancy, e.g. `bsoncxx/document/view_or_value.hpp`.

Additionally:

- For convenience (and as requested by CXX-2288), a forward header for _all_ bsoncxx/mongocxx entities is provided as `bsoncxx/fwd.hpp` and `mongocxx/fwd.hpp`. These headers simply include all the `(.*)-fwd.hpp` headers.
- Ensured all class declarations have only a _single_ definitive declaration that specifies symbol visibility. This only applied to member classes such as `bsoncxx::document::view::iterator`.
- Reduced potential confusion (both for C++ name lookup and simple readability) when referring to (un/under)qualified names, e.g. `bsoncxx::document` vs. `bsoncxx::builder::document`.

## ClangFormat

The forward headers, identified as either `.../fwd.hpp` or `.../<name>-fwd.hpp`, are prioritized before normal headers. Ideally, system headers should be deprioritized to come after all normal headers (including the macro guard headers), but that change is deferred to avoid increasing the already large PR diff. The header sort is thus the following:

```
#include <system> // System

#include <bsoncxx/document/value-fwd.hpp> // Forward (new!)

#include <bsoncxx/document/view.hpp> // Driver

#include <bsoncxx/config/prelude.hpp> // Macro Guard

// ... (normal header contents)

#include <bsoncxx/config/postlude.hpp> // Macro Guard
```