### PR TITLE
Update comment to more accurately reflect sharded cluster behavior

### DIFF
--- a/src/mongocxx/test/database.cpp
+++ b/src/mongocxx/test/database.cpp
@@ -344,7 +344,8 @@ TEST_CASE("Database integration tests", "[database]") {
                 return;
             }
 
-            // SERVER-79306: Ensure the database exists for consistent behavior with sharded clusters.
+            // SERVER-79306: Ensure the database exists for consistent behavior with sharded
+            // clusters.
             database.create_collection("dummy");
 
             auto session1 = mongo_client.start_session();

--- a/src/mongocxx/test/database.cpp
+++ b/src/mongocxx/test/database.cpp
@@ -344,8 +344,7 @@ TEST_CASE("Database integration tests", "[database]") {
                 return;
             }
 
-            // SERVER-79306: $listLocalSessions does not behave as expect if the database does not
-            // already exist on sharded clusters.
+            // SERVER-79306: Ensure the database exists for consistent behavior with sharded clusters.
             database.create_collection("dummy");
 
             auto session1 = mongo_client.start_session();


### PR DESCRIPTION
SERVER-79306 clarified this is expected behavior. This PR updates the relevant comment accordingly to avoid misleading implications + to be consistency with the existing comment in [aggregation_examples.cpp](https://github.com/mongodb/mongo-cxx-driver/blob/8c81c21e66b0b52b90bf8bfa43457ecbb3ea903c/examples/mongocxx/mongodb.com/aggregation_examples.cpp#L155).

The equivalent [unified spec test](https://github.com/mongodb/specifications/blob/82da02ba96d5d3ec4f48f6d2d4f2d0ebb1dce241/source/unified-test-format/tests/valid-pass/poc-crud.yml#L174) likely does not encounter this issue due to reuse of the `client0` object used to create collections in `database0` during the `createEntities` stage, which adds entries to the logical session cache that are visible by the time the aggregate command is executed.