### PR TITLE
CXX-2790 Redeclare bsoncxx::v_noabi as a non-inline namespace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,50 @@ inline namespace v_noabi {
 #include <driver/config/postlude.hpp>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+### Library Root Namespace
+
+The library root namespace declares ABI namespaces (e.g. `mongocxx::v_noabi`, `mongocxx::v1`, etc.), within which symbols are declared according to their compatibility with an ABI version.
+
+The library root namespace also redeclares ABI-specific entities without an ABI namespace qualifier (e.g. `mongocxx::v_noabi::document::view` as `mongocxx::document::view`) to allow users to automatically opt-into the latest supported ABI version of a given entity without requiring changes to source code. The root namespace redeclarations are intended to be the default method for using library entities. A user should only include the ABI namespace in a qualifier if they require compatibility with that specific ABI version.
+
+To avoid being affected by changes to root namespace redeclarations, interfaces declared within an ABI namespace must not be written in terms of a root namespace redeclaration:
+
+```cpp
+namespace mongocxx {
+namespace v_noabi {
+namespace example {
+
+struct type {}; // The type intended to be referenced below.
+
+// Problem: when `mongocxx::example::type` is changed from `v_noabi` to `v1`,
+// this parameter type will also (incorrectly) change from `v_noabi` to `v1`.
+void fn(mongocxx::example::type param);
+
+}  // namespace example
+}  // namespace v_noabi
+}  // namespace mongocxx
+```
+
+References to ABI-specific entities in ABI namespaces must always be (un)qualified such that it is not affected by changes to root namespace redeclarations:
+
+```cpp
+namespace mongocxx {
+namespace v_noabi {
+namespace example {
+
+struct type {}; // The type intended to be referenced below.
+
+// OK: always resolves to `mongocxx::v_noabi::example::type`.
+void fn(type param);
+
+// Also OK: unambiguously refers to the ABI-specific type.
+void fn(mongocxx::v_noabi::example::type param);
+
+}  // namespace example
+}  // namespace v_noabi
+}  // namespace mongocxx
+```
+
 ### Class Declarations
 
 Guidelines:

--- a/examples/mongocxx/mongodb.com/documentation_examples.cpp
+++ b/examples/mongocxx/mongodb.com/documentation_examples.cpp
@@ -1467,7 +1467,7 @@ static void snapshot_example2(mongocxx::client& client) {
     }
 }
 
-static bool version_at_least(mongocxx::v_noabi::database& db, int minimum_major) {
+static bool version_at_least(mongocxx::database& db, int minimum_major) {
     using bsoncxx::builder::basic::kvp;
     using bsoncxx::builder::basic::make_document;
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element-fwd.hpp
@@ -17,13 +17,21 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace array {
 
 class BSONCXX_API element;
 
 }  // namespace array
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace array {
+
+using ::bsoncxx::v_noabi::array::element;
+
+}  // namespace array
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element-fwd.hpp
@@ -17,13 +17,13 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace array {
 
 class BSONCXX_API element;
 
 }  // namespace array
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
@@ -26,7 +26,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace array {
 
 ///
@@ -78,7 +78,7 @@ class element : private document::element {
     using document::element::raw;
 
    private:
-    friend ::bsoncxx::v_noabi::array::view;
+    friend ::bsoncxx::wip::array::view;
 
     BSONCXX_PRIVATE explicit element(const std::uint8_t* raw,
                                      std::uint32_t length,
@@ -119,7 +119,7 @@ BSONCXX_API bool BSONCXX_CALL operator!=(const types::bson_value::view& v, const
 ///
 
 }  // namespace array
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
@@ -26,7 +26,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace array {
 
 ///
@@ -119,7 +119,16 @@ BSONCXX_API bool BSONCXX_CALL operator!=(const types::bson_value::view& v, const
 ///
 
 }  // namespace array
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace array {
+
+using ::bsoncxx::v_noabi::array::operator==;
+using ::bsoncxx::v_noabi::array::operator!=;
+
+}  // namespace array
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
@@ -78,7 +78,7 @@ class element : private document::element {
     using document::element::raw;
 
    private:
-    friend ::bsoncxx::wip::array::view;
+    friend ::bsoncxx::v_noabi::array::view;
 
     BSONCXX_PRIVATE explicit element(const std::uint8_t* raw,
                                      std::uint32_t length,

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value-fwd.hpp
@@ -17,13 +17,13 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace array {
 
 class BSONCXX_API value;
 
 }  // namespace array
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value-fwd.hpp
@@ -17,13 +17,21 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace array {
 
 class BSONCXX_API value;
 
 }  // namespace array
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace array {
+
+using ::bsoncxx::v_noabi::array::value;
+
+}  // namespace array
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value.hpp
@@ -25,7 +25,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace array {
 
 ///
@@ -116,7 +116,7 @@ BSONCXX_INLINE value::operator array::view() const noexcept {
 }
 
 }  // namespace array
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value.hpp
@@ -25,7 +25,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace array {
 
 ///
@@ -116,7 +116,7 @@ BSONCXX_INLINE value::operator array::view() const noexcept {
 }
 
 }  // namespace array
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view-fwd.hpp
@@ -17,13 +17,21 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace array {
 
 class BSONCXX_API view;
 
 }  // namespace array
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace array {
+
+using ::bsoncxx::v_noabi::array::view;
+
+}  // namespace array
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view-fwd.hpp
@@ -17,13 +17,13 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace array {
 
 class BSONCXX_API view;
 
 }  // namespace array
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view.hpp
@@ -27,7 +27,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace array {
 
 ///
@@ -190,7 +190,7 @@ class view::const_iterator {
 };
 
 }  // namespace array
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view.hpp
@@ -27,7 +27,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace array {
 
 ///
@@ -190,7 +190,7 @@ class view::const_iterator {
 };
 
 }  // namespace array
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view_or_value.hpp
@@ -22,13 +22,21 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace array {
 
-using view_or_value = bsoncxx::view_or_value<array::view, array::value>;
+using view_or_value = ::bsoncxx::v_noabi::view_or_value<view, value>;
 
 }  // namespace array
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace array {
+
+using ::bsoncxx::v_noabi::array::view_or_value;
+
+}  // namespace array
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view_or_value.hpp
@@ -22,13 +22,13 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace array {
 
 using view_or_value = bsoncxx::view_or_value<array::view, array::value>;
 
 }  // namespace array
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array-fwd.hpp
@@ -15,7 +15,7 @@
 #pragma once
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace basic {
 
@@ -23,5 +23,15 @@ class array;
 
 }  // namespace basic
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace builder {
+namespace basic {
+
+using ::bsoncxx::v_noabi::builder::basic::array;
+
+}  // namespace basic
+}  // namespace builder
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array-fwd.hpp
@@ -15,7 +15,7 @@
 #pragma once
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace basic {
 
@@ -23,5 +23,5 @@ class array;
 
 }  // namespace basic
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
@@ -57,7 +57,7 @@ class array : public sub_array {
     ///
     /// @return A view of the BSON array.
     ///
-    BSONCXX_INLINE bsoncxx::array::view view() const {
+    BSONCXX_INLINE bsoncxx::v_noabi::array::view view() const {
         return _core.view_array();
     }
 
@@ -67,7 +67,7 @@ class array : public sub_array {
     ///
     /// @return A view of the current builder contents.
     ///
-    BSONCXX_INLINE operator bsoncxx::array::view() const {
+    BSONCXX_INLINE operator bsoncxx::v_noabi::array::view() const {
         return view();
     }
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
@@ -26,7 +26,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace basic {
 
@@ -114,7 +114,17 @@ bsoncxx::v_noabi::array::value BSONCXX_CALL make_array(Args&&... args) {
 
 }  // namespace basic
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace builder {
+namespace basic {
+
+using ::bsoncxx::v_noabi::builder::basic::make_array;
+
+}  // namespace basic
+}  // namespace builder
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
@@ -26,7 +26,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace basic {
 
@@ -115,7 +115,7 @@ bsoncxx::array::value BSONCXX_CALL make_array(Args&&... args) {
 
 }  // namespace basic
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
@@ -80,7 +80,7 @@ class array : public sub_array {
     ///  After calling extract() it is illegal to call any methods
     ///  on this class, unless it is subsequenly moved into.
     ///
-    BSONCXX_INLINE bsoncxx::array::value extract() {
+    BSONCXX_INLINE bsoncxx::v_noabi::array::value extract() {
         return _core.extract_array();
     }
 
@@ -103,13 +103,12 @@ class array : public sub_array {
 ///   builder::basic::sub_array::append accepts.
 ///
 /// @return
-///   A bsoncxx::array::value containing the elements.
+///   A bsoncxx::v_noabi::array::value containing the elements.
 ///
 template <typename... Args>
-bsoncxx::array::value BSONCXX_CALL make_array(Args&&... args) {
-    basic::array array;
+bsoncxx::v_noabi::array::value BSONCXX_CALL make_array(Args&&... args) {
+    array array;
     array.append(std::forward<Args>(args)...);
-
     return array.extract();
 }
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document-fwd.hpp
@@ -15,7 +15,7 @@
 #pragma once
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace basic {
 
@@ -23,5 +23,15 @@ class document;
 
 }  // namespace basic
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace builder {
+namespace basic {
+
+using ::bsoncxx::v_noabi::builder::basic::document;
+
+}  // namespace basic
+}  // namespace builder
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document-fwd.hpp
@@ -15,7 +15,7 @@
 #pragma once
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace basic {
 
@@ -23,5 +23,5 @@ class document;
 
 }  // namespace basic
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
@@ -82,7 +82,7 @@ class document : public sub_document {
     ///  After calling extract() it is illegal to call any methods
     ///  on this class, unless it is subsequently moved into.
     ///
-    BSONCXX_INLINE bsoncxx::document::value extract() {
+    BSONCXX_INLINE bsoncxx::v_noabi::document::value extract() {
         return _core.extract_document();
     }
 
@@ -105,13 +105,12 @@ class document : public sub_document {
 ///   builder::basic::sub_document::append accepts.
 ///
 /// @return
-///   A bsoncxx::document::value containing the elements.
+///   A bsoncxx::v_noabi::document::value containing the elements.
 ///
 template <typename... Args>
-bsoncxx::document::value BSONCXX_CALL make_document(Args&&... args) {
-    basic::document document;
+bsoncxx::v_noabi::document::value BSONCXX_CALL make_document(Args&&... args) {
+    document document;
     document.append(std::forward<Args>(args)...);
-
     return document.extract();
 }
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
@@ -27,7 +27,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace basic {
 
@@ -117,7 +117,7 @@ bsoncxx::document::value BSONCXX_CALL make_document(Args&&... args) {
 
 }  // namespace basic
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
@@ -59,7 +59,7 @@ class document : public sub_document {
     ///
     /// @return A view of the BSON document.
     ///
-    BSONCXX_INLINE bsoncxx::document::view view() const {
+    BSONCXX_INLINE bsoncxx::v_noabi::document::view view() const {
         return _core.view_document();
     }
 
@@ -69,7 +69,7 @@ class document : public sub_document {
     ///
     /// @return A view of the current builder contents.
     ///
-    BSONCXX_INLINE operator bsoncxx::document::view() const {
+    BSONCXX_INLINE operator bsoncxx::v_noabi::document::view() const {
         return view();
     }
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
@@ -27,7 +27,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace basic {
 
@@ -116,7 +116,17 @@ bsoncxx::v_noabi::document::value BSONCXX_CALL make_document(Args&&... args) {
 
 }  // namespace basic
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace builder {
+namespace basic {
+
+using ::bsoncxx::v_noabi::builder::basic::make_document;
+
+}  // namespace basic
+}  // namespace builder
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/helpers.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/helpers.hpp
@@ -19,15 +19,25 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace basic {
 
-using bsoncxx::builder::concatenate;
+using ::bsoncxx::v_noabi::builder::concatenate;
 
 }  // namespace basic
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace builder {
+namespace basic {
+
+using ::bsoncxx::v_noabi::builder::basic::concatenate;
+
+}  // namespace basic
+}  // namespace builder
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/helpers.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/helpers.hpp
@@ -19,7 +19,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace basic {
 
@@ -27,7 +27,7 @@ using bsoncxx::builder::concatenate;
 
 }  // namespace basic
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/impl.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/impl.hpp
@@ -21,7 +21,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace basic {
 namespace impl {
@@ -58,7 +58,7 @@ BSONCXX_INLINE void value_append(core* core, T&& t) {
 }  // namespace impl
 }  // namespace basic
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/impl.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/impl.hpp
@@ -21,7 +21,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace basic {
 namespace impl {
@@ -58,7 +58,7 @@ BSONCXX_INLINE void value_append(core* core, T&& t) {
 }  // namespace impl
 }  // namespace basic
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/kvp.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/kvp.hpp
@@ -19,7 +19,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace basic {
 
@@ -34,7 +34,7 @@ BSONCXX_INLINE std::tuple<T&&, U&&> kvp(T&& t, U&& u) {
 
 }  // namespace basic
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/kvp.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/kvp.hpp
@@ -19,7 +19,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace basic {
 
@@ -34,7 +34,17 @@ BSONCXX_INLINE std::tuple<T&&, U&&> kvp(T&& t, U&& u) {
 
 }  // namespace basic
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace builder {
+namespace basic {
+
+using ::bsoncxx::v_noabi::builder::basic::kvp;
+
+}  // namespace basic
+}  // namespace builder
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array-fwd.hpp
@@ -15,7 +15,7 @@
 #pragma once
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace basic {
 
@@ -23,5 +23,15 @@ class sub_array;
 
 }  // namespace basic
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace builder {
+namespace basic {
+
+using ::bsoncxx::v_noabi::builder::basic::sub_array;
+
+}  // namespace basic
+}  // namespace builder
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array-fwd.hpp
@@ -15,7 +15,7 @@
 #pragma once
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace basic {
 
@@ -23,5 +23,5 @@ class sub_array;
 
 }  // namespace basic
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array.hpp
@@ -23,7 +23,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace basic {
 
@@ -82,7 +82,7 @@ class sub_array {
 
 }  // namespace basic
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array.hpp
@@ -23,7 +23,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace basic {
 
@@ -82,7 +82,7 @@ class sub_array {
 
 }  // namespace basic
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document-fwd.hpp
@@ -15,7 +15,7 @@
 #pragma once
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace basic {
 
@@ -23,5 +23,15 @@ class sub_document;
 
 }  // namespace basic
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace builder {
+namespace basic {
+
+using ::bsoncxx::v_noabi::builder::basic::sub_document;
+
+}  // namespace basic
+}  // namespace builder
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document-fwd.hpp
@@ -15,7 +15,7 @@
 #pragma once
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace basic {
 
@@ -23,5 +23,5 @@ class sub_document;
 
 }  // namespace basic
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document.hpp
@@ -25,13 +25,15 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace basic {
 
 namespace impl {
+
 template <typename T>
 void value_append(core* core, T&& t);
+
 }  // namespace impl
 
 ///
@@ -100,7 +102,7 @@ class sub_document {
 
 }  // namespace basic
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document.hpp
@@ -25,7 +25,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace basic {
 
@@ -100,7 +100,7 @@ class sub_document {
 
 }  // namespace basic
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate-fwd.hpp
@@ -15,12 +15,12 @@
 #pragma once
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 
 struct concatenate_doc;
 struct concatenate_array;
 
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate-fwd.hpp
@@ -15,12 +15,21 @@
 #pragma once
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 
 struct concatenate_doc;
 struct concatenate_array;
 
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace builder {
+
+using ::bsoncxx::v_noabi::builder::concatenate_array;
+using ::bsoncxx::v_noabi::builder::concatenate_doc;
+
+}  // namespace builder
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
@@ -22,7 +22,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 
 ///
@@ -118,7 +118,7 @@ BSONCXX_INLINE concatenate_array concatenate(array::view_or_value array) {
 }
 
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
@@ -22,7 +22,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 
 ///
@@ -118,7 +118,15 @@ BSONCXX_INLINE concatenate_array concatenate(array::view_or_value array) {
 }
 
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace builder {
+
+using ::bsoncxx::v_noabi::builder::concatenate;
+
+}  // namespace builder
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core-fwd.hpp
@@ -17,13 +17,21 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 
 class BSONCXX_API core;
 
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace builder {
+
+using ::bsoncxx::v_noabi::builder::core;
+
+}  // namespace builder
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core-fwd.hpp
@@ -17,13 +17,13 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 
 class BSONCXX_API core;
 
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
@@ -31,7 +31,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 
 ///
@@ -695,7 +695,7 @@ class core {
 };
 
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
@@ -76,8 +76,8 @@ class core {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @throws bsoncxx::exception if the current BSON datum is an array or if the previous value
-    /// appended to the builder was also a key.
+    /// @throws bsoncxx::v_noabi::exception if the current BSON datum is an array or if the previous
+    /// value appended to the builder was also a key.
     ///
     core& key_view(stdx::string_view key);
 
@@ -91,8 +91,8 @@ class core {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @throws bsoncxx::exception if the current BSON datum is an array or if the previous value
-    /// appended to the builder was a key.
+    /// @throws bsoncxx::v_noabi::exception if the current BSON datum is an array or if the previous
+    /// value appended to the builder was a key.
     ///
     core& key_owned(std::string key);
 
@@ -104,8 +104,8 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
     ///
     core& open_document();
 
@@ -117,8 +117,8 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
     ///
     core& open_array();
 
@@ -129,7 +129,7 @@ class core {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @throws bsoncxx::exception if the current BSON datum is not an open sub-document.
+    /// @throws bsoncxx::v_noabi::exception if the current BSON datum is not an open sub-document.
     ///
     core& close_document();
 
@@ -140,7 +140,7 @@ class core {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @throws bsoncxx::exception if the current BSON datum is not an open sub-array.
+    /// @throws bsoncxx::v_noabi::exception if the current BSON datum is not an open sub-array.
     ///
     core& close_array();
 
@@ -159,7 +159,7 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if one of the keys fails to append.
+    ///   bsoncxx::v_noabi::exception if one of the keys fails to append.
     ///
     core& concatenate(const bsoncxx::v_noabi::document::view& view);
 
@@ -171,9 +171,9 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
-    ///   bsoncxx::exception if the double fails to append.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the double fails to append.
     ///
     core& append(const types::b_double& value);
 
@@ -185,9 +185,9 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
-    ///   bsoncxx::exception if the string fails to append.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the string fails to append.
     ///
     core& append(const types::b_string& value);
 
@@ -199,9 +199,9 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
-    ///   bsoncxx::exception if the document fails to append.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the document fails to append.
     ///
     core& append(const types::b_document& value);
 
@@ -213,9 +213,9 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
-    ///   bsoncxx::exception if the array fails to append.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the array fails to append.
     ///
     core& append(const types::b_array& value);
 
@@ -227,9 +227,9 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
-    ///   bsoncxx::exception if the binary fails to append.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the binary fails to append.
     ///
     core& append(const types::b_binary& value);
 
@@ -241,9 +241,9 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
-    ///   bsoncxx::exception if undefined fails to append.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if undefined fails to append.
     ///
     core& append(const types::b_undefined& value);
 
@@ -255,9 +255,9 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
-    ///   bsoncxx::exception if the ObjectId fails to append.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the ObjectId fails to append.
     ///
     core& append(const types::b_oid& value);
 
@@ -269,9 +269,9 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
-    ///   bsoncxx::exception if the boolean fails to append.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the boolean fails to append.
     ///
     core& append(const types::b_bool& value);
 
@@ -283,9 +283,9 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
-    ///   bsoncxx::exception if the date fails to append.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the date fails to append.
     ///
     core& append(const types::b_date& value);
 
@@ -297,9 +297,9 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
-    ///   bsoncxx::exception if null fails to append.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if null fails to append.
     ///
     core& append(const types::b_null& value);
 
@@ -311,9 +311,9 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
-    ///   bsoncxx::exception if the regex fails to append.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the regex fails to append.
     ///
     core& append(const types::b_regex& value);
 
@@ -325,9 +325,9 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
-    ///   bsoncxx::exception if the DBPointer fails to append.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the DBPointer fails to append.
     ///
     core& append(const types::b_dbpointer& value);
 
@@ -339,9 +339,9 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
-    ///   bsoncxx::exception if the JavaScript code fails to append.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the JavaScript code fails to append.
     ///
     core& append(const types::b_code& value);
 
@@ -353,9 +353,9 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
-    ///   bsoncxx::exception if the symbol fails to append.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the symbol fails to append.
     ///
     core& append(const types::b_symbol& value);
 
@@ -367,9 +367,9 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
-    ///   bsoncxx::exception if the JavaScript code with scope fails to append.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the JavaScript code with scope fails to append.
     ///
     core& append(const types::b_codewscope& value);
 
@@ -381,9 +381,9 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
-    ///   bsoncxx::exception if the 32-bit signed integer fails to append.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the 32-bit signed integer fails to append.
     ///
     core& append(const types::b_int32& value);
 
@@ -395,9 +395,9 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
-    ///   bsoncxx::exception if the timestamp fails to append.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the timestamp fails to append.
     ///
     core& append(const types::b_timestamp& value);
 
@@ -409,9 +409,9 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
-    ///   bsoncxx::exception if the 64-bit signed integer fails to append.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the 64-bit signed integer fails to append.
     ///
     core& append(const types::b_int64& value);
 
@@ -423,9 +423,9 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
-    ///   bsoncxx::exception if the Decimal128 fails to append.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the Decimal128 fails to append.
     ///
     core& append(const types::b_decimal128& value);
 
@@ -437,9 +437,9 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
-    ///   bsoncxx::exception if the min-key fails to append.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the min-key fails to append.
     ///
     core& append(const types::b_minkey& value);
 
@@ -451,9 +451,9 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
-    ///   bsoncxx::exception if the max-key fails to append.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the max-key fails to append.
     ///
     core& append(const types::b_maxkey& value);
 
@@ -465,8 +465,8 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
     ///
     core& append(const types::bson_value::view& value);
 
@@ -478,8 +478,8 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
     ///
     core& append(std::string str);
 
@@ -491,8 +491,8 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
     ///
     core& append(stdx::string_view str);
 
@@ -506,8 +506,8 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
     ///
     template <typename T>
     BSONCXX_INLINE core& append(T* v) {
@@ -526,8 +526,8 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
     ///
     core& append(bool value);
 
@@ -539,8 +539,8 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
     ///
     core& append(double value);
 
@@ -552,8 +552,8 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
     ///
     core& append(std::int32_t value);
 
@@ -565,8 +565,8 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
     ///
     core& append(std::int64_t value);
 
@@ -578,8 +578,8 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
     ///
     core& append(const oid& value);
 
@@ -591,8 +591,8 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
     ///
     core& append(decimal128 value);
 
@@ -604,8 +604,8 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
     ///
     core& append(bsoncxx::v_noabi::document::view view);
 
@@ -617,8 +617,8 @@ class core {
     ///   method chaining.
     ///
     /// @throws
-    ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
-    ///   appended to start a new key/value pair.
+    ///   bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting for a
+    ///   key to be appended to start a new key/value pair.
     ///
     core& append(bsoncxx::v_noabi::array::view view);
 
@@ -632,7 +632,7 @@ class core {
     ///    appended to start a new key/value pair, and does contain any open sub-documents or open
     ///    sub-arrays.
     ///
-    /// @throws bsoncxx::exception if the precondition is violated.
+    /// @throws bsoncxx::v_noabi::exception if the precondition is violated.
     ///
     bsoncxx::v_noabi::document::view view_document() const;
 
@@ -645,7 +645,7 @@ class core {
     ///    The top-level BSON datum should be an array that does not contain any open sub-documents
     ///    or open sub-arrays.
     ///
-    /// @throws bsoncxx::exception if the precondition is violated.
+    /// @throws bsoncxx::v_noabi::exception if the precondition is violated.
     ///
     bsoncxx::v_noabi::array::view view_array() const;
 
@@ -659,7 +659,7 @@ class core {
     ///    appended to start a new key/value pair, and does not contain any open sub-documents or
     ///    open sub-arrays.
     ///
-    /// @throws bsoncxx::exception if the precondition is violated.
+    /// @throws bsoncxx::v_noabi::exception if the precondition is violated.
     ///
     /// @warning
     ///   After calling extract_document() it is illegal to call any methods on this class, unless
@@ -676,7 +676,7 @@ class core {
     ///    The top-level BSON datum should be an array that does not contain any open sub-documents
     ///    or open sub-arrays.
     ///
-    /// @throws bsoncxx::exception if the precondition is violated.
+    /// @throws bsoncxx::v_noabi::exception if the precondition is violated.
     ///
     /// @warning
     ///   After calling extract_array() it is illegal to call any methods on this class, unless it

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
@@ -682,7 +682,7 @@ class core {
     ///   After calling extract_array() it is illegal to call any methods on this class, unless it
     ///   is subsequenly moved into.
     ///
-    bsoncxx::array::value extract_array();
+    bsoncxx::v_noabi::array::value extract_array();
 
     ///
     /// Deletes the contents of the underlying BSON datum. After calling clear(), the state of this

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
@@ -31,7 +31,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 
 ///
@@ -695,7 +695,7 @@ class core {
 };
 
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
@@ -620,7 +620,7 @@ class core {
     ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
     ///   appended to start a new key/value pair.
     ///
-    core& append(bsoncxx::array::view view);
+    core& append(bsoncxx::v_noabi::array::view view);
 
     ///
     /// Gets a view over the document.
@@ -647,7 +647,7 @@ class core {
     ///
     /// @throws bsoncxx::exception if the precondition is violated.
     ///
-    bsoncxx::array::view view_array() const;
+    bsoncxx::v_noabi::array::view view_array() const;
 
     ///
     /// Transfers ownership of the underlying document to the caller.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
@@ -665,7 +665,7 @@ class core {
     ///   After calling extract_document() it is illegal to call any methods on this class, unless
     ///   it is subsequenly moved into.
     ///
-    bsoncxx::document::value extract_document();
+    bsoncxx::v_noabi::document::value extract_document();
 
     ///
     /// Transfers ownership of the underlying document to the caller.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
@@ -161,7 +161,7 @@ class core {
     /// @throws
     ///   bsoncxx::exception if one of the keys fails to append.
     ///
-    core& concatenate(const bsoncxx::document::view& view);
+    core& concatenate(const bsoncxx::v_noabi::document::view& view);
 
     ///
     /// Appends a BSON double.
@@ -607,7 +607,7 @@ class core {
     ///   bsoncxx::exception if the current BSON datum is a document that is waiting for a key to be
     ///   appended to start a new key/value pair.
     ///
-    core& append(bsoncxx::document::view view);
+    core& append(bsoncxx::v_noabi::document::view view);
 
     ///
     /// Appends the given array view.
@@ -634,7 +634,7 @@ class core {
     ///
     /// @throws bsoncxx::exception if the precondition is violated.
     ///
-    bsoncxx::document::view view_document() const;
+    bsoncxx::v_noabi::document::view view_document() const;
 
     ///
     /// Gets a view over the array.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list-fwd.hpp
@@ -15,7 +15,7 @@
 #pragma once
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 
 class list;
@@ -23,5 +23,15 @@ class document;
 class array;
 
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace builder {
+
+using ::bsoncxx::v_noabi::builder::array;
+using ::bsoncxx::v_noabi::builder::document;
+using ::bsoncxx::v_noabi::builder::list;
+
+}  // namespace builder
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list-fwd.hpp
@@ -15,7 +15,7 @@
 #pragma once
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 
 class list;
@@ -23,5 +23,5 @@ class document;
 class array;
 
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
@@ -88,7 +88,7 @@ class list {
     ///
     /// Provides a view of the underlying BSON value.
     ///
-    /// @see bsoncxx::types::bson_value::view.
+    /// @see bsoncxx::v_noabi::types::bson_value::view.
     ///
     operator bson_value::view() {
         return view();
@@ -97,7 +97,7 @@ class list {
     ///
     /// Provides a view of the underlying BSON value.
     ///
-    /// @see bsoncxx::types::bson_value::view.
+    /// @see bsoncxx::v_noabi::types::bson_value::view.
     ///
     bson_value::view view() {
         return val.view();

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
@@ -54,13 +54,13 @@ class list {
 
     ///
     /// Creates a bsoncxx::builder::list from a value of type T. T must be a
-    /// bsoncxx::types::bson_value::value or implicitly convertible to a
-    /// bsoncxx::types::bson_value::value.
+    /// bsoncxx::v_noabi::types::bson_value::value or implicitly convertible to a
+    /// bsoncxx::v_noabi::types::bson_value::value.
     ///
     /// @param value
     ///     the BSON value
     ///
-    /// @see bsoncxx::types::bson_value::value.
+    /// @see bsoncxx::v_noabi::types::bson_value::value.
     ///
     template <typename T>
     list(T value) : val{value} {}

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
@@ -27,17 +27,17 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 
 using namespace bsoncxx::types;
 
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 
 ///
@@ -106,8 +106,8 @@ class list {
    private:
     bson_value::value val;
 
-    friend ::bsoncxx::v_noabi::builder::document;
-    friend ::bsoncxx::v_noabi::builder::array;
+    friend ::bsoncxx::wip::builder::document;
+    friend ::bsoncxx::wip::builder::array;
 
     list(initializer_list_t init, bool type_deduction, bool is_array) : val{nullptr} {
         std::stringstream err_msg{"cannot construct document"};
@@ -196,7 +196,7 @@ class array : public list {
     array(initializer_list_t init) : list(init, false, true) {}
 };
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 // CXX-2770: missing include of postlude header.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
@@ -27,17 +27,17 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 
-using namespace bsoncxx::types;
+using namespace ::bsoncxx::v_noabi::types;  // Deprecated.
 
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 
 ///
@@ -53,7 +53,7 @@ class list {
     list() : list({}) {}
 
     ///
-    /// Creates a bsoncxx::builder::list from a value of type T. T must be a
+    /// Creates a bsoncxx::v_noabi::builder::list from a value of type T. T must be a
     /// bsoncxx::v_noabi::types::bson_value::value or implicitly convertible to a
     /// bsoncxx::v_noabi::types::bson_value::value.
     ///
@@ -77,11 +77,12 @@ class list {
     ///     the initializer list used to construct the BSON document or array
     ///
     /// @note
-    ///     to enforce the creation of a BSON document or array use the bsoncxx::builder::document
-    ///     or bsoncxx::builder::array constructor, respectively.
+    ///     to enforce the creation of a BSON document or array use the
+    ///     bsoncxx::v_noabi::builder::document or bsoncxx::v_noabi::builder::array constructor,
+    ///     respectively.
     ///
-    /// @see bsoncxx::builder::document
-    /// @see bsoncxx::builder::array
+    /// @see bsoncxx::v_noabi::builder::document
+    /// @see bsoncxx::v_noabi::builder::array
     ///
     list(initializer_list_t init) : list(init, true, true) {}
 
@@ -106,8 +107,8 @@ class list {
    private:
     bson_value::value val;
 
-    friend ::bsoncxx::wip::builder::document;
-    friend ::bsoncxx::wip::builder::array;
+    friend ::bsoncxx::v_noabi::builder::document;
+    friend ::bsoncxx::v_noabi::builder::array;
 
     list(initializer_list_t init, bool type_deduction, bool is_array) : val{nullptr} {
         std::stringstream err_msg{"cannot construct document"};
@@ -166,8 +167,8 @@ class document : public list {
     /// @param init
     ///     the initializer list used to construct the BSON document
     ///
-    /// @see bsoncxx::builder::list
-    /// @see bsoncxx::builder::array
+    /// @see bsoncxx::v_noabi::builder::list
+    /// @see bsoncxx::v_noabi::builder::array
     ///
     document(initializer_list_t init) : list(init, false, false) {}
 };
@@ -190,13 +191,21 @@ class array : public list {
     /// @param init
     ///     the initializer list used to construct the BSON array
     ///
-    /// @see bsoncxx::builder::list
-    /// @see bsoncxx::builder::document
+    /// @see bsoncxx::v_noabi::builder::list
+    /// @see bsoncxx::v_noabi::builder::document
     ///
     array(initializer_list_t init) : list(init, false, true) {}
 };
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace builder {
+
+using namespace ::bsoncxx::v_noabi::types;  // Deprecated.
+
+}  // namespace builder
 }  // namespace bsoncxx
 
 // CXX-2770: missing include of postlude header.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
@@ -144,7 +144,8 @@ class list {
                 _core.append(ele.val);
             val = bson_value::value(_core.extract_array());
         } else {
-            throw bsoncxx::exception{error_code::k_unmatched_key_in_builder, err_msg.str()};
+            throw bsoncxx::v_noabi::exception{error_code::k_unmatched_key_in_builder,
+                                              err_msg.str()};
         }
     }
 };

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array-fwd.hpp
@@ -15,7 +15,7 @@
 #pragma once
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace stream {
 
@@ -23,5 +23,15 @@ class array;
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace builder {
+namespace stream {
+
+using ::bsoncxx::v_noabi::builder::stream::array;
+
+}  // namespace stream
+}  // namespace builder
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array-fwd.hpp
@@ -15,7 +15,7 @@
 #pragma once
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace stream {
 
@@ -23,5 +23,5 @@ class array;
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
@@ -69,7 +69,7 @@ class array : public array_context<> {
     ///  After calling extract() it is illegal to call any methods
     ///  on this class, unless it is subsequenly moved into.
     ///
-    BSONCXX_INLINE bsoncxx::array::value extract() {
+    BSONCXX_INLINE bsoncxx::v_noabi::array::value extract() {
         return _core.extract_array();
     }
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
@@ -27,7 +27,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace stream {
 
@@ -86,7 +86,7 @@ class array : public array_context<> {
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
@@ -49,14 +49,14 @@ class array : public array_context<> {
     ///
     /// @return A view of the BSON array.
     ///
-    BSONCXX_INLINE bsoncxx::array::view view() const {
+    BSONCXX_INLINE bsoncxx::v_noabi::array::view view() const {
         return _core.view_array();
     }
 
     ///
     /// @return A view of the BSON array.
     ///
-    BSONCXX_INLINE operator bsoncxx::array::view() const {
+    BSONCXX_INLINE operator bsoncxx::v_noabi::array::view() const {
         return view();
     }
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
@@ -27,7 +27,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace stream {
 
@@ -86,7 +86,7 @@ class array : public array_context<> {
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context-fwd.hpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/builder/stream/closed_context-fwd.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace stream {
 
@@ -26,5 +26,5 @@ class array_context;
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context-fwd.hpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/builder/stream/closed_context-fwd.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace stream {
 
@@ -26,5 +26,15 @@ class array_context;
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace builder {
+namespace stream {
+
+using ::bsoncxx::v_noabi::builder::stream::array_context;
+
+}  // namespace stream
+}  // namespace builder
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
@@ -28,7 +28,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace stream {
 
@@ -189,7 +189,7 @@ class array_context {
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
@@ -28,7 +28,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace stream {
 
@@ -189,7 +189,7 @@ class array_context {
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
@@ -104,7 +104,7 @@ class array_context {
     /// @return A value type which holds the complete bson document.
     ///
     template <typename T>
-    BSONCXX_INLINE detail::requires_t<bsoncxx::array::value,
+    BSONCXX_INLINE detail::requires_t<bsoncxx::v_noabi::array::value,
                                       std::is_same<base, closed_context>,
                                       detail::is_alike<T, finalize_type>>
     // VS2015U1 can't resolve the name.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context-fwd.hpp
@@ -15,7 +15,7 @@
 #pragma once
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace stream {
 
@@ -23,5 +23,5 @@ struct closed_context;
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context-fwd.hpp
@@ -15,7 +15,7 @@
 #pragma once
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace stream {
 
@@ -23,5 +23,15 @@ struct closed_context;
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace builder {
+namespace stream {
+
+using ::bsoncxx::v_noabi::builder::stream::closed_context;
+
+}  // namespace stream
+}  // namespace builder
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context.hpp
@@ -20,7 +20,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace stream {
 
@@ -37,7 +37,7 @@ struct closed_context {
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context.hpp
@@ -20,7 +20,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace stream {
 
@@ -37,7 +37,7 @@ struct closed_context {
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document-fwd.hpp
@@ -15,7 +15,7 @@
 #pragma once
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace stream {
 
@@ -23,5 +23,5 @@ class document;
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document-fwd.hpp
@@ -15,7 +15,7 @@
 #pragma once
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace stream {
 
@@ -23,5 +23,15 @@ class document;
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace builder {
+namespace stream {
+
+using ::bsoncxx::v_noabi::builder::stream::document;
+
+}  // namespace stream
+}  // namespace builder
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
@@ -47,14 +47,14 @@ class document : public key_context<> {
     ///
     /// @return A view of the BSON document.
     ///
-    BSONCXX_INLINE bsoncxx::document::view view() const {
+    BSONCXX_INLINE bsoncxx::v_noabi::document::view view() const {
         return _core.view_document();
     }
 
     ///
     /// @return A view of the BSON document.
     ///
-    BSONCXX_INLINE operator bsoncxx::document::view() const {
+    BSONCXX_INLINE operator bsoncxx::v_noabi::document::view() const {
         return view();
     }
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
@@ -25,7 +25,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace stream {
 
@@ -84,7 +84,7 @@ class document : public key_context<> {
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
@@ -25,7 +25,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace stream {
 
@@ -84,7 +84,7 @@ class document : public key_context<> {
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
@@ -67,7 +67,7 @@ class document : public key_context<> {
     ///  After calling extract() it is illegal to call any methods
     ///  on this class, unless it is subsequenly moved into.
     ///
-    BSONCXX_INLINE bsoncxx::document::value extract() {
+    BSONCXX_INLINE bsoncxx::v_noabi::document::value extract() {
         return _core.extract_document();
     }
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers-fwd.hpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace stream {
 
@@ -29,7 +29,7 @@ struct BSONCXX_API finalize_type;
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers-fwd.hpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace stream {
 
@@ -29,7 +29,7 @@ struct BSONCXX_API finalize_type;
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp
@@ -20,11 +20,11 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace stream {
 
-using bsoncxx::builder::concatenate;
+using ::bsoncxx::v_noabi::builder::concatenate;  // Deprecated.
 
 ///
 /// The type of a stream manipulator to open a subdocument.
@@ -92,7 +92,23 @@ constexpr finalize_type finalize;
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace builder {
+namespace stream {
+
+using ::bsoncxx::v_noabi::builder::stream::concatenate;  // Deprecated.
+
+using ::bsoncxx::v_noabi::builder::stream::close_array;
+using ::bsoncxx::v_noabi::builder::stream::close_document;
+using ::bsoncxx::v_noabi::builder::stream::finalize;
+using ::bsoncxx::v_noabi::builder::stream::open_array;
+using ::bsoncxx::v_noabi::builder::stream::open_document;
+
+}  // namespace stream
+}  // namespace builder
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp
@@ -20,7 +20,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace stream {
 
@@ -92,7 +92,7 @@ constexpr finalize_type finalize;
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context-fwd.hpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/builder/stream/closed_context-fwd.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace stream {
 
@@ -26,5 +26,15 @@ class key_context;
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace builder {
+namespace stream {
+
+using ::bsoncxx::v_noabi::builder::stream::key_context;
+
+}  // namespace stream
+}  // namespace builder
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context-fwd.hpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/builder/stream/closed_context-fwd.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace stream {
 
@@ -26,5 +26,5 @@ class key_context;
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context.hpp
@@ -26,7 +26,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace stream {
 
@@ -176,7 +176,7 @@ class key_context {
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context.hpp
@@ -26,7 +26,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace stream {
 
@@ -176,7 +176,7 @@ class key_context {
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context.hpp
@@ -127,7 +127,7 @@ class key_context {
     /// @return A value type which holds the complete bson document.
     ///
     template <typename T>
-    BSONCXX_INLINE detail::requires_t<bsoncxx::document::value,
+    BSONCXX_INLINE detail::requires_t<bsoncxx::v_noabi::document::value,
                                       std::is_same<base, closed_context>,
                                       detail::is_alike<T, finalize_type>>
     operator<<(T&&) {

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context.hpp
@@ -65,7 +65,8 @@ class key_context {
     /// @param v
     ///   The key to append
     ///
-    /// @throws bsoncxx::exception if the previous value appended to the builder was also a key.
+    /// @throws bsoncxx::v_noabi::exception if the previous value appended to the builder was also a
+    /// key.
     ///
     template <std::size_t n>
     BSONCXX_INLINE value_context<key_context> operator<<(const char (&v)[n]) {
@@ -80,7 +81,8 @@ class key_context {
     /// @param str
     ///   The key to append
     ///
-    /// @throws bsoncxx::exception if the previous value appended to the builder was also a key.
+    /// @throws bsoncxx::v_noabi::exception if the previous value appended to the builder was also a
+    /// key.
     ///
     BSONCXX_INLINE value_context<key_context> operator<<(std::string str) {
         _core->key_owned(std::move(str));
@@ -94,7 +96,8 @@ class key_context {
     /// @param str
     ///   The key to append
     ///
-    /// @throws bsoncxx::exception if the previous value appended to the builder was also a key.
+    /// @throws bsoncxx::v_noabi::exception if the previous value appended to the builder was also a
+    /// key.
     ///
     BSONCXX_INLINE value_context<key_context> operator<<(stdx::string_view str) {
         _core->key_view(std::move(str));

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context-fwd.hpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/builder/stream/closed_context-fwd.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace stream {
 
@@ -25,5 +25,5 @@ class single_context;
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context-fwd.hpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/builder/stream/closed_context-fwd.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace stream {
 
@@ -25,5 +25,15 @@ class single_context;
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace builder {
+namespace stream {
+
+using ::bsoncxx::v_noabi::builder::stream::single_context;
+
+}  // namespace stream
+}  // namespace builder
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context.hpp
@@ -24,7 +24,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace stream {
 
@@ -109,7 +109,7 @@ BSONCXX_INLINE value_context<T>::operator single_context() {
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context.hpp
@@ -24,7 +24,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace stream {
 
@@ -109,7 +109,7 @@ BSONCXX_INLINE value_context<T>::operator single_context() {
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context-fwd.hpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace stream {
 
@@ -26,7 +26,17 @@ class value_context;
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace builder {
+namespace stream {
+
+using ::bsoncxx::v_noabi::builder::stream::value_context;
+
+}  // namespace stream
+}  // namespace builder
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context-fwd.hpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace stream {
 
@@ -26,7 +26,7 @@ class value_context;
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context.hpp
@@ -25,7 +25,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 namespace stream {
 
@@ -137,7 +137,7 @@ class value_context {
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context.hpp
@@ -25,7 +25,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 namespace stream {
 
@@ -137,7 +137,7 @@ class value_context {
 
 }  // namespace stream
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128-fwd.hpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi { class BSONCXX_API decimal128; }  // namespace v_noabi
+inline namespace wip { class BSONCXX_API decimal128; }  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128-fwd.hpp
@@ -17,7 +17,17 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip { class BSONCXX_API decimal128; }  // namespace wip
+namespace v_noabi {
+
+class BSONCXX_API decimal128;
+
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+
+using ::bsoncxx::v_noabi::decimal128;
+
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
@@ -52,7 +52,7 @@ class decimal128 {
     /// @param str
     ///     A string representation of a decimal number.
     ///
-    /// @throws bsoncxx::exception if the string isn't a valid BSON Decimal128
+    /// @throws bsoncxx::v_noabi::exception if the string isn't a valid BSON Decimal128
     /// representation.
     ///
     explicit decimal128(stdx::string_view str);

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
@@ -24,7 +24,8 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
+
 ///
 /// Represents an IEEE 754-2008 BSON Decimal128 value in a platform-independent way.
 ///
@@ -95,7 +96,7 @@ class decimal128 {
     uint64_t _low = 0;
 };
 
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
@@ -24,7 +24,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 ///
 /// Represents an IEEE 754-2008 BSON Decimal128 value in a platform-independent way.
 ///
@@ -95,7 +95,7 @@ class decimal128 {
     uint64_t _low = 0;
 };
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element-fwd.hpp
@@ -17,13 +17,21 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace document {
 
 class BSONCXX_API element;
 
 }  // namespace document
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace document {
+
+using ::bsoncxx::v_noabi::document::element;
+
+}  // namespace document
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element-fwd.hpp
@@ -17,13 +17,13 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace document {
 
 class BSONCXX_API element;
 
 }  // namespace document
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
@@ -84,7 +84,7 @@ class element {
     ///
     /// @return the element's type.
     ///
-    /// @throws bsoncxx::exception if this element is invalid.
+    /// @throws bsoncxx::v_noabi::exception if this element is invalid.
     ///
     bsoncxx::v_noabi::type type() const;
 
@@ -93,7 +93,7 @@ class element {
     ///
     /// @return the element's key.
     ///
-    /// @throws bsoncxx::exception if this element is invalid.
+    /// @throws bsoncxx::v_noabi::exception if this element is invalid.
     ///
     stdx::string_view key() const;
 
@@ -107,7 +107,7 @@ class element {
     ///
     /// Getter for elements of the b_double type.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_double.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_double.
     ///
     /// @return the element's value.
     ///
@@ -118,7 +118,7 @@ class element {
     ///
     /// @deprecated use document::element::get_string() instead.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_string.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_string.
     ///
     /// @return the element's value.
     ///
@@ -127,7 +127,7 @@ class element {
     ///
     /// Getter for elements of the b_string type.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_string.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_string.
     ///
     /// @return the element's value.
     ///
@@ -136,7 +136,7 @@ class element {
     ///
     /// Getter for elements of the b_document type.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_document.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_document.
     ///
     /// @return the element's value.
     ///
@@ -145,7 +145,7 @@ class element {
     ///
     /// Getter for elements of the b_array type.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_array.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_array.
     ///
     /// @return the element's value.
     ///
@@ -154,7 +154,7 @@ class element {
     ///
     /// Getter for elements of the b_binary type.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_binary.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_binary.
     ///
     /// @return the element's value.
     ///
@@ -163,7 +163,7 @@ class element {
     ///
     /// Getter for elements of the b_undefined type.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_undefined.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_undefined.
     ///
     /// @return the element's value.
     ///
@@ -172,7 +172,7 @@ class element {
     ///
     /// Getter for elements of the b_oid type.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_oid.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_oid.
     ///
     /// @return the element's value.
     ///
@@ -181,7 +181,7 @@ class element {
     ///
     /// Getter for elements of the b_bool type.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_bool.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_bool.
     ///
     /// @return the element's value.
     ///
@@ -190,7 +190,7 @@ class element {
     ///
     /// Getter for elements of the b_date type.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_date.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_date.
     ///
     /// @return the element's value.
     ///
@@ -199,7 +199,7 @@ class element {
     ///
     /// Getter for elements of the b_null type.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_null.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_null.
     ///
     /// @return the element's value.
     ///
@@ -208,7 +208,7 @@ class element {
     ///
     /// Getter for elements of the b_regex type.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_regex.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_regex.
     ///
     /// @return the element's value.
     ///
@@ -217,7 +217,7 @@ class element {
     ///
     /// Getter for elements of the b_dbpointer type.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_dbpointer.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_dbpointer.
     ///
     /// @return the element's value.
     ///
@@ -226,7 +226,7 @@ class element {
     ///
     /// Getter for elements of the b_code type.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_code.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_code.
     ///
     /// @return the element's value.
     ///
@@ -235,7 +235,7 @@ class element {
     ///
     /// Getter for elements of the b_symbol type.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_symbol.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_symbol.
     ///
     /// @return the element's value.
     ///
@@ -244,7 +244,7 @@ class element {
     ///
     /// Getter for elements of the b_codewscope type.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_codewscope.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_codewscope.
     ///
     /// @return the element's value.
     ///
@@ -253,7 +253,7 @@ class element {
     ///
     /// Getter for elements of the b_int32 type.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_int32.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_int32.
     ///
     /// @return the element's value.
     ///
@@ -262,7 +262,7 @@ class element {
     ///
     /// Getter for elements of the b_timestamp type.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_timestamp.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_timestamp.
     ///
     /// @return the element's value.
     ///
@@ -271,7 +271,7 @@ class element {
     ///
     /// Getter for elements of the b_int64 type.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_int64.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_int64.
     ///
     /// @return the element's value.
     ///
@@ -280,7 +280,7 @@ class element {
     ///
     /// Getter for elements of the b_decimal128 type.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_decimal128.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_decimal128.
     ///
     /// @return the element's value.
     ///
@@ -289,7 +289,7 @@ class element {
     ///
     /// Getter for elements of the b_minkey type.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_minkey.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_minkey.
     ///
     /// @return the element's value.
     ///
@@ -298,7 +298,7 @@ class element {
     ///
     /// Getter for elements of the b_maxkey type.
     ///
-    /// @throws bsoncxx::exception if this element is not a b_maxkey.
+    /// @throws bsoncxx::v_noabi::exception if this element is not a b_maxkey.
     ///
     /// @return the element's value.
     ///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
@@ -86,7 +86,7 @@ class element {
     ///
     /// @throws bsoncxx::exception if this element is invalid.
     ///
-    bsoncxx::type type() const;
+    bsoncxx::v_noabi::type type() const;
 
     ///
     /// Getter for the element's key.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
@@ -373,7 +373,7 @@ class element {
     // Construct an invalid element with a key. Useful for exceptions.
     BSONCXX_PRIVATE explicit element(const stdx::string_view key);
 
-    friend ::bsoncxx::wip::array::element;
+    friend ::bsoncxx::v_noabi::array::element;
     friend ::bsoncxx::wip::document::view;
 
     const std::uint8_t* _raw;

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
@@ -30,7 +30,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace document {
 
 ///
@@ -417,7 +417,16 @@ BSONCXX_API bool BSONCXX_CALL operator!=(const types::bson_value::view& v, const
 ///
 
 }  // namespace document
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace document {
+
+using ::bsoncxx::v_noabi::document::operator==;
+using ::bsoncxx::v_noabi::document::operator!=;
+
+}  // namespace document
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
@@ -30,7 +30,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace document {
 
 ///
@@ -373,8 +373,8 @@ class element {
     // Construct an invalid element with a key. Useful for exceptions.
     BSONCXX_PRIVATE explicit element(const stdx::string_view key);
 
-    friend ::bsoncxx::v_noabi::array::element;
-    friend ::bsoncxx::v_noabi::document::view;
+    friend ::bsoncxx::wip::array::element;
+    friend ::bsoncxx::wip::document::view;
 
     const std::uint8_t* _raw;
     std::uint32_t _length;
@@ -417,7 +417,7 @@ BSONCXX_API bool BSONCXX_CALL operator!=(const types::bson_value::view& v, const
 ///
 
 }  // namespace document
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
@@ -374,7 +374,7 @@ class element {
     BSONCXX_PRIVATE explicit element(const stdx::string_view key);
 
     friend ::bsoncxx::v_noabi::array::element;
-    friend ::bsoncxx::wip::document::view;
+    friend ::bsoncxx::v_noabi::document::view;
 
     const std::uint8_t* _raw;
     std::uint32_t _length;

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value-fwd.hpp
@@ -17,13 +17,21 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace document {
 
 class BSONCXX_API value;
 
 }  // namespace document
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace document {
+
+using ::bsoncxx::v_noabi::document::value;
+
+}  // namespace document
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value-fwd.hpp
@@ -17,13 +17,13 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace document {
 
 class BSONCXX_API value;
 
 }  // namespace document
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
@@ -27,7 +27,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace document {
 
 ///
@@ -83,7 +83,8 @@ class value {
 
     ///
     /// Constructor used for serialization of user objects. This uses argument-dependent lookup
-    /// to find the function declaration `void to_bson(T& t, bsoncxx::document::value doc)`.
+    /// to find the function declaration
+    /// `void to_bson(T& t, bsoncxx::v_noabi::document::value doc)`.
     ///
     /// @param t
     ///   A user-defined object to serialize into a BSON object.
@@ -270,7 +271,16 @@ BSONCXX_INLINE bool operator!=(const value& lhs, const value& rhs) {
 ///
 
 }  // namespace document
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace document {
+
+using ::bsoncxx::v_noabi::document::operator==;
+using ::bsoncxx::v_noabi::document::operator!=;
+
+}  // namespace document
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
@@ -188,7 +188,7 @@ class value {
     ///
     /// Constructs an object of type T from this document object. This method uses
     /// argument-dependent lookup to find the function declaration
-    /// `void from_bson(T& t, const bsoncxx::document::view& doc)`.
+    /// `void from_bson(T& t, const bsoncxx::v_noabi::document::view& doc)`.
     ///
     /// @note Type T must be default-constructible. Otherwise, use `void get(T& t)`.
     ///
@@ -202,7 +202,7 @@ class value {
     ///
     /// Constructs an object of type T from this document object. This method uses
     /// argument-dependent lookup to find the function declaration
-    /// `void from_bson(T& t, const bsoncxx::document::view& doc)`.
+    /// `void from_bson(T& t, const bsoncxx::v_noabi::document::view& doc)`.
     ///
     /// @param t
     ///   The object to construct. The contents of the document object will be deserialized

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
@@ -27,7 +27,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace document {
 
 ///
@@ -270,7 +270,7 @@ BSONCXX_INLINE bool operator!=(const value& lhs, const value& rhs) {
 ///
 
 }  // namespace document
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view-fwd.hpp
@@ -17,13 +17,13 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace document {
 
 class BSONCXX_API view;
 
 }  // namespace document
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view-fwd.hpp
@@ -17,13 +17,21 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace document {
 
 class BSONCXX_API view;
 
 }  // namespace document
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace document {
+
+using ::bsoncxx::v_noabi::document::view;
+
+}  // namespace document
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view.hpp
@@ -26,7 +26,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace document {
 
 ///
@@ -190,7 +190,7 @@ class view::const_iterator {
 };
 
 }  // namespace document
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view.hpp
@@ -26,7 +26,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace document {
 
 ///
@@ -190,7 +190,7 @@ class view::const_iterator {
 };
 
 }  // namespace document
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view_or_value.hpp
@@ -21,13 +21,13 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace document {
 
 using view_or_value = bsoncxx::view_or_value<document::view, document::value>;
 
 }  // namespace document
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view_or_value.hpp
@@ -21,13 +21,21 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace document {
 
-using view_or_value = bsoncxx::view_or_value<document::view, document::value>;
+using view_or_value = bsoncxx::v_noabi::view_or_value<view, value>;
 
 }  // namespace document
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace document {
+
+using ::bsoncxx::v_noabi::document::view_or_value;
+
+}  // namespace document
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code-fwd.hpp
@@ -18,7 +18,7 @@
 #include <system_error>
 
 namespace bsoncxx {
-inline namespace v_noabi { enum class error_code : std::int32_t; }  // namespace v_noabi
+inline namespace wip { enum class error_code : std::int32_t; }  // namespace wip
 }  // namespace bsoncxx
 
 namespace std {

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code-fwd.hpp
@@ -18,12 +18,22 @@
 #include <system_error>
 
 namespace bsoncxx {
-inline namespace wip { enum class error_code : std::int32_t; }  // namespace wip
+namespace v_noabi {
+
+enum class error_code : std::int32_t;
+
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+
+using ::bsoncxx::v_noabi::error_code;
+
 }  // namespace bsoncxx
 
 namespace std {
 
 template <>
-struct is_error_code_enum<bsoncxx::error_code>;
+struct is_error_code_enum<bsoncxx::v_noabi::error_code>;
 
 }  // namespace std

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code.hpp
@@ -22,7 +22,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 ///
 /// Enum representing the various error types that can occur while operating on BSON values.
 ///
@@ -118,7 +118,7 @@ BSONCXX_INLINE std::error_code make_error_code(error_code error) {
     return {static_cast<int>(error), error_category()};
 }
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code.hpp
@@ -22,7 +22,8 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
+
 ///
 /// Enum representing the various error types that can occur while operating on BSON values.
 ///
@@ -109,7 +110,7 @@ enum class error_code : std::int32_t {
 BSONCXX_API const std::error_category& BSONCXX_CALL error_category();
 
 ///
-/// Translate a bsoncxx::error_code into a std::error_code.
+/// Translate a bsoncxx::v_noabi::error_code into a std::error_code.
 ///
 /// @param error An error from bsoncxx
 /// @return An error_code
@@ -118,7 +119,14 @@ BSONCXX_INLINE std::error_code make_error_code(error_code error) {
     return {static_cast<int>(error), error_category()};
 }
 
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+
+using ::bsoncxx::v_noabi::error_category;
+using ::bsoncxx::v_noabi::make_error_code;
+
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
@@ -127,6 +135,6 @@ namespace std {
 
 // Specialize is_error_code_enum so we get simpler std::error_code construction
 template <>
-struct is_error_code_enum<bsoncxx::error_code> : public true_type {};
+struct is_error_code_enum<bsoncxx::v_noabi::error_code> : public true_type {};
 
 }  // namespace std

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception-fwd.hpp
@@ -17,7 +17,17 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip { class BSONCXX_API exception; }  // namespace wip
+namespace v_noabi {
+
+class BSONCXX_API exception;
+
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+
+using ::bsoncxx::v_noabi::exception;
+
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception-fwd.hpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi { class BSONCXX_API exception; }  // namespace v_noabi
+inline namespace wip { class BSONCXX_API exception; }  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception.hpp
@@ -21,7 +21,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 ///
 /// Class representing any exceptions emitted from the bsoncxx library or
 /// its underlying implementation.
@@ -30,7 +30,7 @@ class exception : public std::system_error {
     using std::system_error::system_error;
 };
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception.hpp
@@ -21,7 +21,8 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
+
 ///
 /// Class representing any exceptions emitted from the bsoncxx library or
 /// its underlying implementation.
@@ -30,7 +31,7 @@ class exception : public std::system_error {
     using std::system_error::system_error;
 };
 
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json-fwd.hpp
@@ -17,5 +17,5 @@
 #include <cstdint>
 
 namespace bsoncxx {
-inline namespace v_noabi { enum class ExtendedJsonMode : std::uint8_t; }  // namespace v_noabi
+inline namespace wip { enum class ExtendedJsonMode : std::uint8_t; }  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json-fwd.hpp
@@ -17,5 +17,15 @@
 #include <cstdint>
 
 namespace bsoncxx {
-inline namespace wip { enum class ExtendedJsonMode : std::uint8_t; }  // namespace wip
+namespace v_noabi {
+
+enum class ExtendedJsonMode : std::uint8_t;
+
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+
+using ::bsoncxx::v_noabi::ExtendedJsonMode;
+
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
@@ -26,7 +26,8 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
+
 ///
 /// An enumeration of the types of Extended JSON that the to_json function accepts
 enum class ExtendedJsonMode : std::uint8_t {
@@ -79,9 +80,18 @@ BSONCXX_API document::value BSONCXX_CALL from_json(stdx::string_view json);
 ///
 /// @throws bsoncxx::v_noabi::exception with error details if the conversion failed.
 ///
-BSONCXX_API document::value BSONCXX_CALL operator"" _bson(const char* json, size_t len);
+BSONCXX_API document::value BSONCXX_CALL operator""_bson(const char* json, size_t len);
 
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+
+using ::bsoncxx::v_noabi::from_json;
+using ::bsoncxx::v_noabi::to_json;
+
+using ::bsoncxx::v_noabi::operator""_bson;
+
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
@@ -26,7 +26,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 ///
 /// An enumeration of the types of Extended JSON that the to_json function accepts
 enum class ExtendedJsonMode : std::uint8_t {
@@ -81,7 +81,7 @@ BSONCXX_API document::value BSONCXX_CALL from_json(stdx::string_view json);
 ///
 BSONCXX_API document::value BSONCXX_CALL operator"" _bson(const char* json, size_t len);
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
@@ -43,7 +43,7 @@ enum class ExtendedJsonMode : std::uint8_t {
 /// @param mode
 ///   An optional JSON representation mode.
 ///
-/// @throws bsoncxx::exception with error details if the conversion failed.
+/// @throws bsoncxx::v_noabi::exception with error details if the conversion failed.
 ///
 /// @returns An extended JSON string.
 ///
@@ -61,7 +61,7 @@ BSONCXX_API std::string BSONCXX_CALL to_json(array::view view,
 ///
 /// @returns A document::value if conversion worked.
 ///
-/// @throws bsoncxx::exception with error details if the conversion failed.
+/// @throws bsoncxx::v_noabi::exception with error details if the conversion failed.
 ///
 BSONCXX_API document::value BSONCXX_CALL from_json(stdx::string_view json);
 
@@ -77,7 +77,7 @@ BSONCXX_API document::value BSONCXX_CALL from_json(stdx::string_view json);
 ///
 /// @returns A document::value if conversion worked.
 ///
-/// @throws bsoncxx::exception with error details if the conversion failed.
+/// @throws bsoncxx::v_noabi::exception with error details if the conversion failed.
 ///
 BSONCXX_API document::value BSONCXX_CALL operator"" _bson(const char* json, size_t len);
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid-fwd.hpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi { class BSONCXX_API oid; }  // namespace v_noabi
+inline namespace wip { class BSONCXX_API oid; }  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid-fwd.hpp
@@ -17,7 +17,17 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip { class BSONCXX_API oid; }  // namespace wip
+namespace v_noabi {
+
+class BSONCXX_API oid;
+
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+
+using ::bsoncxx::v_noabi::oid;
+
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
@@ -54,7 +54,7 @@ class oid {
     /// @param len
     ///   The length of the buffer. Should be equal to oid::size().
     ///
-    /// @throws bsoncxx::exception if the length is not equal to oid::size().
+    /// @throws bsoncxx::v_noabi::exception if the length is not equal to oid::size().
     ///
     explicit oid(const char* bytes, std::size_t len);
 
@@ -64,7 +64,7 @@ class oid {
     /// @param str
     ///   A string of a hexadecimal representation of a valid ObjectId.
     ///
-    /// @throws bsoncxx::exception if the string isn't an OID-sized hex
+    /// @throws bsoncxx::v_noabi::exception if the string isn't an OID-sized hex
     /// string.
     ///
     explicit oid(const bsoncxx::v_noabi::stdx::string_view& str);

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
@@ -66,7 +66,7 @@ class oid {
     /// @throws bsoncxx::exception if the string isn't an OID-sized hex
     /// string.
     ///
-    explicit oid(const bsoncxx::stdx::string_view& str);
+    explicit oid(const bsoncxx::v_noabi::stdx::string_view& str);
 
     ///
     /// Converts this oid to a hexadecimal string.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
@@ -25,7 +25,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 ///
 /// Represents a MongoDB ObjectId. As this BSON type is used within the MongoDB server
 /// as a primary key for each document, it is useful for representing a 'pointer'
@@ -121,7 +121,7 @@ class oid {
     std::array<char, k_oid_length> _bytes;
 };
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
@@ -25,7 +25,8 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
+
 ///
 /// Represents a MongoDB ObjectId. As this BSON type is used within the MongoDB server
 /// as a primary key for each document, it is useful for representing a 'pointer'
@@ -121,7 +122,7 @@ class oid {
     std::array<char, k_oid_length> _bytes;
 };
 
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
@@ -67,7 +67,7 @@ class oid {
     /// @throws bsoncxx::v_noabi::exception if the string isn't an OID-sized hex
     /// string.
     ///
-    explicit oid(const bsoncxx::v_noabi::stdx::string_view& str);
+    explicit oid(const stdx::string_view& str);
 
     ///
     /// Converts this oid to a hexadecimal string.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
@@ -24,7 +24,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace stdx {
 
 namespace detail {
@@ -128,7 +128,7 @@ std::unique_ptr<T> make_unique_for_overwrite(std::size_t count) {
 }
 
 }  // namespace stdx
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
@@ -24,7 +24,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace stdx {
 
 namespace detail {
@@ -128,7 +128,16 @@ std::unique_ptr<T> make_unique_for_overwrite(std::size_t count) {
 }
 
 }  // namespace stdx
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+namespace bsoncxx {
+namespace stdx {
+
+using ::bsoncxx::v_noabi::stdx::make_unique;
+using ::bsoncxx::v_noabi::stdx::make_unique_for_overwrite;
+
+}  // namespace stdx
+}  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/optional.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/optional.hpp
@@ -21,7 +21,7 @@
 #include <core/optional.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace stdx {
 
 using ::core::make_optional;
@@ -30,7 +30,7 @@ using ::core::nullopt_t;
 using ::core::optional;
 
 }  // namespace stdx
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #elif defined(BSONCXX_POLY_USE_BOOST)
@@ -40,7 +40,7 @@ using ::core::optional;
 #include <boost/optional/optional_io.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace stdx {
 
 using ::boost::optional;
@@ -51,7 +51,7 @@ const nullopt_t nullopt{::boost::none};
 using ::boost::make_optional;
 
 }  // namespace stdx
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #elif defined(BSONCXX_POLY_USE_STD_EXPERIMENTAL)
@@ -59,7 +59,7 @@ using ::boost::make_optional;
 #include <experimental/optional>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace stdx {
 
 using ::std::experimental::make_optional;
@@ -68,7 +68,7 @@ using ::std::experimental::nullopt_t;
 using ::std::experimental::optional;
 
 }  // namespace stdx
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #elif defined(BSONCXX_POLY_USE_STD)
@@ -76,7 +76,7 @@ using ::std::experimental::optional;
 #include <optional>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace stdx {
 
 using ::std::make_optional;
@@ -85,7 +85,7 @@ using ::std::nullopt_t;
 using ::std::optional;
 
 }  // namespace stdx
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #else
@@ -93,3 +93,14 @@ using ::std::optional;
 #endif
 
 #include <bsoncxx/config/postlude.hpp>
+
+namespace bsoncxx {
+namespace stdx {
+
+using ::bsoncxx::v_noabi::stdx::make_optional;
+using ::bsoncxx::v_noabi::stdx::nullopt;
+using ::bsoncxx::v_noabi::stdx::nullopt_t;
+using ::bsoncxx::v_noabi::stdx::optional;
+
+}  // namespace stdx
+}  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/optional.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/optional.hpp
@@ -21,7 +21,7 @@
 #include <core/optional.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace stdx {
 
 using ::core::make_optional;
@@ -30,7 +30,7 @@ using ::core::nullopt_t;
 using ::core::optional;
 
 }  // namespace stdx
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #elif defined(BSONCXX_POLY_USE_BOOST)
@@ -40,7 +40,7 @@ using ::core::optional;
 #include <boost/optional/optional_io.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace stdx {
 
 using ::boost::optional;
@@ -51,7 +51,7 @@ const nullopt_t nullopt{::boost::none};
 using ::boost::make_optional;
 
 }  // namespace stdx
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #elif defined(BSONCXX_POLY_USE_STD_EXPERIMENTAL)
@@ -59,7 +59,7 @@ using ::boost::make_optional;
 #include <experimental/optional>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace stdx {
 
 using ::std::experimental::make_optional;
@@ -68,7 +68,7 @@ using ::std::experimental::nullopt_t;
 using ::std::experimental::optional;
 
 }  // namespace stdx
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #elif defined(BSONCXX_POLY_USE_STD)
@@ -76,7 +76,7 @@ using ::std::experimental::optional;
 #include <optional>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace stdx {
 
 using ::std::make_optional;
@@ -85,7 +85,7 @@ using ::std::nullopt_t;
 using ::std::optional;
 
 }  // namespace stdx
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #else

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/string_view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/string_view.hpp
@@ -21,14 +21,14 @@
 #include <core/string.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace stdx {
 
 using ::core::basic_string_view;
 using ::core::string_view;
 
 }  // namespace stdx
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #elif defined(BSONCXX_POLY_USE_BOOST)
@@ -40,14 +40,14 @@ using ::core::string_view;
 #include <boost/utility/string_view.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace stdx {
 
 using ::boost::basic_string_view;
 using ::boost::string_view;
 
 }  // namespace stdx
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #else
@@ -55,7 +55,7 @@ using ::boost::string_view;
 #include <boost/utility/string_ref.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace stdx {
 
 template <typename charT, typename traits = std::char_traits<charT>>
@@ -63,7 +63,7 @@ using basic_string_view = ::boost::basic_string_ref<charT, traits>;
 using string_view = ::boost::string_ref;
 
 }  // namespace stdx
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #endif
@@ -73,14 +73,14 @@ using string_view = ::boost::string_ref;
 #include <experimental/string_view>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace stdx {
 
 using ::std::experimental::basic_string_view;
 using ::std::experimental::string_view;
 
 }  // namespace stdx
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #elif defined(BSONCXX_POLY_USE_STD)
@@ -88,14 +88,14 @@ using ::std::experimental::string_view;
 #include <string_view>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace stdx {
 
 using ::std::basic_string_view;
 using ::std::string_view;
 
 }  // namespace stdx
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #else
@@ -103,3 +103,12 @@ using ::std::string_view;
 #endif
 
 #include <bsoncxx/config/postlude.hpp>
+
+namespace bsoncxx {
+namespace stdx {
+
+using ::bsoncxx::v_noabi::stdx::basic_string_view;
+using ::bsoncxx::v_noabi::stdx::string_view;
+
+}  // namespace stdx
+}  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/string_view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/string_view.hpp
@@ -21,14 +21,14 @@
 #include <core/string.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace stdx {
 
 using ::core::basic_string_view;
 using ::core::string_view;
 
 }  // namespace stdx
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #elif defined(BSONCXX_POLY_USE_BOOST)
@@ -40,14 +40,14 @@ using ::core::string_view;
 #include <boost/utility/string_view.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace stdx {
 
 using ::boost::basic_string_view;
 using ::boost::string_view;
 
 }  // namespace stdx
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #else
@@ -55,7 +55,7 @@ using ::boost::string_view;
 #include <boost/utility/string_ref.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace stdx {
 
 template <typename charT, typename traits = std::char_traits<charT>>
@@ -63,7 +63,7 @@ using basic_string_view = ::boost::basic_string_ref<charT, traits>;
 using string_view = ::boost::string_ref;
 
 }  // namespace stdx
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #endif
@@ -73,14 +73,14 @@ using string_view = ::boost::string_ref;
 #include <experimental/string_view>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace stdx {
 
 using ::std::experimental::basic_string_view;
 using ::std::experimental::string_view;
 
 }  // namespace stdx
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #elif defined(BSONCXX_POLY_USE_STD)
@@ -88,14 +88,14 @@ using ::std::experimental::string_view;
 #include <string_view>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace stdx {
 
 using ::std::basic_string_view;
 using ::std::string_view;
 
 }  // namespace stdx
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #else

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/type_traits.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/type_traits.hpp
@@ -5,7 +5,6 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
 namespace detail {
 
 #define bsoncxx_ttparam \
@@ -421,9 +420,6 @@ template <typename T, typename U>
 struct is_alike : std::is_same<remove_cvref_t<T>, remove_cvref_t<U>> {};
 
 }  // namespace detail
-
-}  // namespace wip
-
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/type_traits.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/type_traits.hpp
@@ -5,7 +5,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace detail {
 
 #define bsoncxx_ttparam \
@@ -422,7 +422,7 @@ struct is_alike : std::is_same<remove_cvref_t<T>, remove_cvref_t<U>> {};
 
 }  // namespace detail
 
-}  // namespace v_noabi
+}  // namespace wip
 
 }  // namespace bsoncxx
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/to_string.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/to_string.hpp
@@ -22,7 +22,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace string {
 
 template <class CharT,
@@ -34,7 +34,15 @@ BSONCXX_INLINE std::basic_string<CharT, Traits, Allocator> to_string(
 }
 
 }  // namespace string
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace string {
+
+using ::bsoncxx::v_noabi::string::to_string;
+
+}  // namespace string
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/to_string.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/to_string.hpp
@@ -22,7 +22,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace string {
 
 template <class CharT,
@@ -34,7 +34,7 @@ BSONCXX_INLINE std::basic_string<CharT, Traits, Allocator> to_string(
 }
 
 }  // namespace string
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value-fwd.hpp
@@ -17,13 +17,21 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace string {
 
 class BSONCXX_API view_or_value;
 
 }  // namespace string
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace string {
+
+using ::bsoncxx::v_noabi::string::view_or_value;
+
+}  // namespace string
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value-fwd.hpp
@@ -17,13 +17,13 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace string {
 
 class BSONCXX_API view_or_value;
 
 }  // namespace string
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
@@ -30,17 +30,17 @@ namespace string {
 ///
 /// Class representing a view-or-value variant type for strings.
 ///
-/// This class adds several string-specific methods to the bsoncxx::view_or_value template:
+/// This class adds several string-specific methods to the bsoncxx::v_noabi::view_or_value template:
 /// - a constructor overload for const char*
 /// - a constructor overload for std::string by l-value reference
 /// - a safe c_str() operation to return null-terminated c-style strings.
 ///
-class view_or_value : public bsoncxx::view_or_value<stdx::string_view, std::string> {
+class view_or_value : public bsoncxx::v_noabi::view_or_value<stdx::string_view, std::string> {
    public:
     ///
-    /// Forward all bsoncxx::view_or_value constructors.
+    /// Forward all bsoncxx::v_noabi::view_or_value constructors.
     ///
-    using bsoncxx::view_or_value<stdx::string_view, std::string>::view_or_value;
+    using bsoncxx::v_noabi::view_or_value<stdx::string_view, std::string>::view_or_value;
 
     ///
     /// Default constructor, equivalent to using an empty string.
@@ -55,7 +55,7 @@ class view_or_value : public bsoncxx::view_or_value<stdx::string_view, std::stri
     /// @param str A null-terminated string
     ///
     BSONCXX_INLINE view_or_value(const char* str)
-        : bsoncxx::view_or_value<stdx::string_view, std::string>(stdx::string_view(str)) {}
+        : bsoncxx::v_noabi::view_or_value<stdx::string_view, std::string>(stdx::string_view(str)) {}
 
     ///
     /// Allow construction with an l-value reference to a std::string. The resulting
@@ -68,7 +68,7 @@ class view_or_value : public bsoncxx::view_or_value<stdx::string_view, std::stri
     /// @param str A std::string l-value reference.
     ///
     BSONCXX_INLINE view_or_value(const std::string& str)
-        : bsoncxx::view_or_value<stdx::string_view, std::string>(stdx::string_view(str)) {}
+        : bsoncxx::v_noabi::view_or_value<stdx::string_view, std::string>(stdx::string_view(str)) {}
 
     ///
     /// Return a string_view_or_value that is guaranteed to hold a null-terminated

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
@@ -24,7 +24,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace string {
 
 ///
@@ -119,7 +119,16 @@ BSONCXX_INLINE bool operator!=(const char* lhs, const view_or_value& rhs) {
 ///
 
 }  // namespace string
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace string {
+
+using ::bsoncxx::v_noabi::string::operator==;
+using ::bsoncxx::v_noabi::string::operator!=;
+
+}  // namespace string
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
@@ -24,7 +24,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace string {
 
 ///
@@ -119,7 +119,7 @@ BSONCXX_INLINE bool operator!=(const char* lhs, const view_or_value& rhs) {
 ///
 
 }  // namespace string
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types-fwd.hpp
@@ -19,10 +19,16 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
+
 enum class type : std::uint8_t;
 enum class binary_sub_type : std::uint8_t;
 
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace v_noabi {
 namespace types {
 
 #pragma push_macro("BSONCXX_ENUM")
@@ -33,8 +39,27 @@ namespace types {
 #pragma pop_macro("BSONCXX_ENUM")
 
 }  // namespace types
+}  // namespace v_noabi
+}  // namespace bsoncxx
 
-}  // namespace wip
+namespace bsoncxx {
+
+using ::bsoncxx::v_noabi::binary_sub_type;
+using ::bsoncxx::v_noabi::type;
+
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace types {
+
+#pragma push_macro("BSONCXX_ENUM")
+#undef BSONCXX_ENUM
+#define BSONCXX_ENUM(name, val) using ::bsoncxx::v_noabi::types::b_##name;
+#include <bsoncxx/enums/type.hpp>
+#undef BSONCXX_ENUM
+#pragma pop_macro("BSONCXX_ENUM")
+
+}  // namespace types
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types-fwd.hpp
@@ -19,7 +19,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 enum class type : std::uint8_t;
 enum class binary_sub_type : std::uint8_t;
 
@@ -34,7 +34,7 @@ namespace types {
 
 }  // namespace types
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types.hpp
@@ -40,7 +40,8 @@
 #endif
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
+
 ///
 /// An enumeration of each BSON type.
 /// These x-macros will expand to be of the form:
@@ -675,7 +676,24 @@ BSONCXX_INLINE bool operator==(const b_maxkey&, const b_maxkey&) {
 #undef BSONCXX_ENUM
 
 }  // namespace types
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+
+using ::bsoncxx::v_noabi::to_string;
+
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace types {
+
+using ::bsoncxx::v_noabi::types::b_utf8;  // Deprecated.
+
+using ::bsoncxx::v_noabi::types::operator==;
+using ::bsoncxx::v_noabi::types::operator!=;
+
+}  // namespace types
 }  // namespace bsoncxx
 
 #if defined(__clang__)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types.hpp
@@ -40,7 +40,7 @@
 #endif
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 ///
 /// An enumeration of each BSON type.
 /// These x-macros will expand to be of the form:
@@ -675,7 +675,7 @@ BSONCXX_INLINE bool operator==(const b_maxkey&, const b_maxkey&) {
 #undef BSONCXX_ENUM
 
 }  // namespace types
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #if defined(__clang__)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/make_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/make_value.hpp
@@ -21,7 +21,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace types {
 namespace bson_value {
 
@@ -37,7 +37,7 @@ BSONCXX_INLINE bson_value::value make_value(T&& t) {
 
 }  // namespace bson_value
 }  // namespace types
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/make_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/make_value.hpp
@@ -21,7 +21,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace types {
 namespace bson_value {
 
@@ -37,7 +37,17 @@ BSONCXX_INLINE bson_value::value make_value(T&& t) {
 
 }  // namespace bson_value
 }  // namespace types
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace types {
+namespace bson_value {
+
+using ::bsoncxx::v_noabi::types::bson_value::make_value;
+
+}  // namespace bson_value
+}  // namespace types
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value-fwd.hpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace types {
 namespace bson_value {
 
@@ -25,7 +25,17 @@ class BSONCXX_API value;
 
 }  // namespace bson_value
 }  // namespace types
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace types {
+namespace bson_value {
+
+using ::bsoncxx::v_noabi::types::bson_value::value;
+
+}  // namespace bson_value
+}  // namespace types
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value-fwd.hpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace types {
 namespace bson_value {
 
@@ -25,7 +25,7 @@ class BSONCXX_API value;
 
 }  // namespace bson_value
 }  // namespace types
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
@@ -29,7 +29,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace types {
 namespace bson_value {
 
@@ -322,8 +322,18 @@ BSONCXX_INLINE bool operator!=(const view& lhs, const value& rhs) {
 
 }  // namespace bson_value
 }  // namespace types
+}  // namespace v_noabi
+}  // namespace bsoncxx
 
-}  // namespace wip
+namespace bsoncxx {
+namespace types {
+namespace bson_value {
+
+using ::bsoncxx::v_noabi::types::bson_value::operator==;
+using ::bsoncxx::v_noabi::types::bson_value::operator!=;
+
+}  // namespace bson_value
+}  // namespace types
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
@@ -29,7 +29,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace types {
 namespace bson_value {
 
@@ -258,7 +258,7 @@ class value {
     operator bson_value::view() const noexcept;
 
    private:
-    friend ::bsoncxx::v_noabi::document::element;
+    friend ::bsoncxx::wip::document::element;
 
     value(const std::uint8_t* raw,
           std::uint32_t length,
@@ -323,7 +323,7 @@ BSONCXX_INLINE bool operator!=(const view& lhs, const value& rhs) {
 }  // namespace bson_value
 }  // namespace types
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
@@ -190,7 +190,7 @@ class value {
     ///     the symbol, JavaScript code, or regex pattern for the BSON symbol, code, or regex value
     ///     respectively.
     ///
-    /// @throws bsoncxx::exception if the type's value is not k_code, k_regex, or k_symbol.
+    /// @throws bsoncxx::v_noabi::exception if the type's value is not k_code, k_regex, or k_symbol.
     ///
     /// @deprecated
     ///   The BSON symbol type is deprecated and use by clients is discouraged.
@@ -208,7 +208,8 @@ class value {
     /// @param id
     ///     the type of BSON value to construct.
     ///
-    /// @throws bsoncxx::exception if the type's value is not k_maxkey, k_minkey, or k_undefined.
+    /// @throws bsoncxx::v_noabi::exception if the type's value is not k_maxkey, k_minkey, or
+    /// k_undefined.
     ///
     value(const type id);
 
@@ -226,7 +227,7 @@ class value {
     ///     If a BSON decimal128 value is to be constructed, this is the low value.
     ///     If a BSON timestamp value is to be constructed, this is the timestamp.
     ///
-    /// @throws bsoncxx::exception if the specified type is missing its required arguments.
+    /// @throws bsoncxx::v_noabi::exception if the specified type is missing its required arguments.
     ///
     /// @warning
     ///   The BSON timestamp type is used internally by the MongoDB server - use by clients

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
@@ -116,7 +116,7 @@ class value {
     ///
     /// Constructs a BSON document value.
     ///
-    value(bsoncxx::document::view v);
+    value(bsoncxx::v_noabi::document::view v);
 
     ///
     /// Constructs a BSON array value.
@@ -166,7 +166,7 @@ class value {
     /// @param scope
     ///     a bson document view holding the scope environment
     ///
-    value(stdx::string_view code, bsoncxx::document::view_or_value scope);
+    value(stdx::string_view code, bsoncxx::v_noabi::document::view_or_value scope);
 
     ///
     /// Constructs a BSON regex value with options.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
@@ -258,7 +258,7 @@ class value {
     operator bson_value::view() const noexcept;
 
    private:
-    friend ::bsoncxx::wip::document::element;
+    friend ::bsoncxx::v_noabi::document::element;
 
     value(const std::uint8_t* raw,
           std::uint32_t length,

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
@@ -121,7 +121,7 @@ class value {
     ///
     /// Constructs a BSON array value.
     ///
-    value(bsoncxx::array::view v);
+    value(bsoncxx::v_noabi::array::view v);
 
     ///
     /// Constructs a BSON binary data value.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view-fwd.hpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace types {
 namespace bson_value {
 
@@ -25,7 +25,7 @@ class BSONCXX_API view;
 
 }  // namespace bson_value
 }  // namespace types
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view-fwd.hpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace types {
 namespace bson_value {
 
@@ -25,7 +25,17 @@ class BSONCXX_API view;
 
 }  // namespace bson_value
 }  // namespace types
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace types {
+namespace bson_value {
+
+using ::bsoncxx::v_noabi::types::bson_value::view;
+
+}  // namespace bson_value
+}  // namespace types
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
@@ -269,7 +269,7 @@ class view {
 
    private:
     friend ::bsoncxx::v_noabi::types::bson_value::value;
-    friend ::bsoncxx::wip::document::element;
+    friend ::bsoncxx::v_noabi::document::element;
 
     view(const std::uint8_t* raw, std::uint32_t length, std::uint32_t offset, std::uint32_t keylen);
     view(void* internal_value) noexcept;

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
@@ -268,7 +268,7 @@ class view {
     const b_maxkey& get_maxkey() const;
 
    private:
-    friend ::bsoncxx::wip::types::bson_value::value;
+    friend ::bsoncxx::v_noabi::types::bson_value::value;
     friend ::bsoncxx::wip::document::element;
 
     view(const std::uint8_t* raw, std::uint32_t length, std::uint32_t offset, std::uint32_t keylen);

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
@@ -87,7 +87,7 @@ class view {
     ///
     /// @return The type of the underlying BSON value stored in this object.
     ///
-    bsoncxx::type type() const;
+    bsoncxx::v_noabi::type type() const;
 
     ///
     /// @return The underlying BSON double value.
@@ -278,7 +278,8 @@ class view {
 
     void BSONCXX_PRIVATE destroy() noexcept;
 
-    bsoncxx::type _type;
+    bsoncxx::v_noabi::type _type;
+
     union {
         struct b_double _b_double;
         struct b_string _b_string;

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
@@ -28,7 +28,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace types {
 namespace bson_value {
 ///
@@ -268,8 +268,8 @@ class view {
     const b_maxkey& get_maxkey() const;
 
    private:
-    friend ::bsoncxx::v_noabi::types::bson_value::value;
-    friend ::bsoncxx::v_noabi::document::element;
+    friend ::bsoncxx::wip::types::bson_value::value;
+    friend ::bsoncxx::wip::document::element;
 
     view(const std::uint8_t* raw, std::uint32_t length, std::uint32_t offset, std::uint32_t keylen);
     view(void* internal_value) noexcept;
@@ -339,7 +339,7 @@ operator!=(T&& lhs, const bson_value::view& rhs) {
 
 }  // namespace bson_value
 }  // namespace types
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
@@ -28,7 +28,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace types {
 namespace bson_value {
 ///
@@ -340,7 +340,18 @@ operator!=(T&& lhs, const bson_value::view& rhs) {
 
 }  // namespace bson_value
 }  // namespace types
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace types {
+namespace bson_value {
+
+using ::bsoncxx::v_noabi::types::bson_value::operator==;
+using ::bsoncxx::v_noabi::types::bson_value::operator!=;
+
+}  // namespace bson_value
+}  // namespace types
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view_or_value.hpp
@@ -21,7 +21,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace types {
 namespace bson_value {
 
@@ -29,7 +29,7 @@ using view_or_value = bsoncxx::view_or_value<bson_value::view, bson_value::value
 
 }  // namespace bson_value
 }  // namespace types
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view_or_value.hpp
@@ -21,15 +21,25 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace types {
 namespace bson_value {
 
-using view_or_value = bsoncxx::view_or_value<bson_value::view, bson_value::value>;
+using view_or_value = bsoncxx::v_noabi::view_or_value<view, value>;
 
 }  // namespace bson_value
 }  // namespace types
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+namespace types {
+namespace bson_value {
+
+using ::bsoncxx::v_noabi::types::bson_value::view_or_value;
+
+}  // namespace bson_value
+}  // namespace types
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/value.hpp
@@ -19,7 +19,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace types {
 
 ///
@@ -32,7 +32,7 @@ BSONCXX_DEPRECATED typedef types::bson_value::view value;
 
 }  // namespace types
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/value.hpp
@@ -23,10 +23,10 @@ inline namespace wip {
 namespace types {
 
 ///
-/// The bsoncxx::types::bson_value::view class has been renamed to
-/// bsoncxx::types::bson_value::view.
+/// The bsoncxx::v_noabi::types::bson_value::view class has been renamed to
+/// bsoncxx::v_noabi::types::bson_value::view.
 ///
-/// @deprecated use bsoncxx::types::bson_value::view instead.
+/// @deprecated use bsoncxx::v_noabi::types::bson_value::view instead.
 ///
 BSONCXX_DEPRECATED typedef types::bson_value::view value;
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/value.hpp
@@ -19,7 +19,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace types {
 
 ///
@@ -31,8 +31,15 @@ namespace types {
 BSONCXX_DEPRECATED typedef types::bson_value::view value;
 
 }  // namespace types
+}  // namespace v_noabi
+}  // namespace bsoncxx
 
-}  // namespace wip
+namespace bsoncxx {
+namespace types {
+
+using ::bsoncxx::v_noabi::types::value;  // Deprecated
+
+}  // namespace types
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/util/functor.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/util/functor.hpp
@@ -20,7 +20,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace util {
 
 // TODO(MSVC): VS2015U1 Completely falls apart trying to honor the
@@ -108,7 +108,7 @@ struct is_functor : functor::is_functor_impl<C, S, std::is_class<C>::value> {};
 #endif
 
 }  // namespace util
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/util/functor.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/util/functor.hpp
@@ -20,7 +20,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace util {
 
 // TODO(MSVC): VS2015U1 Completely falls apart trying to honor the
@@ -108,7 +108,7 @@ struct is_functor : functor::is_functor_impl<C, S, std::is_class<C>::value> {};
 #endif
 
 }  // namespace util
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate-fwd.hpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi { class BSONCXX_API validator; }  // namespace v_noabi
+inline namespace wip { class BSONCXX_API validator; }  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate-fwd.hpp
@@ -17,7 +17,17 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip { class BSONCXX_API validator; }  // namespace wip
+namespace v_noabi {
+
+class BSONCXX_API validator;
+
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+
+using ::bsoncxx::v_noabi::validator;
+
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate.hpp
@@ -25,7 +25,8 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
+
 ///
 /// Validates a BSON document. This is a simplified overload that will
 /// only do the bare minimum validation of document structure, and does
@@ -68,6 +69,7 @@ validate(const std::uint8_t* data,
          std::size_t length,
          const validator& validator,
          std::size_t* invalid_offset = nullptr);
+
 ///
 /// A validator is used to enable or disable specific checks that can be
 /// performed during BSON validation.
@@ -155,7 +157,13 @@ class validator {
     std::unique_ptr<impl> _impl;
 };
 
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+
+using ::bsoncxx::v_noabi::validate;
+
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate.hpp
@@ -25,7 +25,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 ///
 /// Validates a BSON document. This is a simplified overload that will
 /// only do the bare minimum validation of document structure, and does
@@ -155,7 +155,7 @@ class validator {
     std::unique_ptr<impl> _impl;
 };
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value-fwd.hpp
@@ -17,11 +17,18 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
+
 template <typename View, typename Value>
 class view_or_value;
 
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+
+using ::bsoncxx::v_noabi::view_or_value;
+
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value-fwd.hpp
@@ -17,11 +17,11 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 template <typename View, typename Value>
 class view_or_value;
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value.hpp
@@ -23,7 +23,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 ///
 /// Class representing a view-or-value variant type.
 ///
@@ -210,7 +210,7 @@ BSONCXX_INLINE bool operator!=(const Value& lhs, const view_or_value<View, Value
 /// @}
 ///
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value.hpp
@@ -23,7 +23,8 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
+
 ///
 /// Class representing a view-or-value variant type.
 ///
@@ -210,7 +211,14 @@ BSONCXX_INLINE bool operator!=(const Value& lhs, const view_or_value<View, Value
 /// @}
 ///
 
-}  // namespace wip
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+namespace bsoncxx {
+
+using ::bsoncxx::v_noabi::operator==;
+using ::bsoncxx::v_noabi::operator!=;
+
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/element.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/element.cpp
@@ -20,7 +20,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace array {
 
 element::element() : document::element() {}
@@ -50,5 +50,5 @@ bool BSONCXX_CALL operator!=(const types::bson_value::view& v, const element& el
 }
 
 }  // namespace array
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/element.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/element.cpp
@@ -20,7 +20,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace array {
 
 element::element() : document::element() {}
@@ -50,5 +50,5 @@ bool BSONCXX_CALL operator!=(const types::bson_value::view& v, const element& el
 }
 
 }  // namespace array
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/value.cpp
@@ -19,7 +19,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace array {
 
 value::value(std::uint8_t* data, std::size_t length, deleter_type dtor)
@@ -54,5 +54,5 @@ value::unique_ptr_type value::release() {
 }
 
 }  // namespace array
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/value.cpp
@@ -19,7 +19,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace array {
 
 value::value(std::uint8_t* data, std::size_t length, deleter_type dtor)
@@ -54,5 +54,5 @@ value::unique_ptr_type value::release() {
 }
 
 }  // namespace array
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/view.cpp
@@ -24,7 +24,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace array {
 
 namespace {
@@ -168,5 +168,5 @@ bool BSONCXX_CALL operator!=(view lhs, view rhs) {
 }
 
 }  // namespace array
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/view.cpp
@@ -24,7 +24,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace array {
 
 namespace {
@@ -168,5 +168,5 @@ bool BSONCXX_CALL operator!=(view lhs, view rhs) {
 }
 
 }  // namespace array
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/builder/core.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/builder/core.cpp
@@ -644,7 +644,7 @@ core& core::concatenate(const bsoncxx::document::view& view) {
     return *this;
 }
 
-core& core::append(const bsoncxx::types::bson_value::view& value) {
+core& core::append(const types::bson_value::view& value) {
     switch (static_cast<int>(value.type())) {
 #define BSONCXX_ENUM(type, val)     \
     case val:                       \

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/builder/core.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/builder/core.cpp
@@ -87,7 +87,7 @@ class core::impl {
     }
 
     // Throws bsoncxx::exception if the top-level BSON datum is an array.
-    bsoncxx::document::value steal_document() {
+    bsoncxx::v_noabi::document::value steal_document() {
         if (_root_is_array) {
             throw bsoncxx::exception{error_code::k_cannot_perform_document_operation_on_array};
         }
@@ -96,7 +96,7 @@ class core::impl {
         uint8_t* buf_ptr = bson_destroy_with_steal(_root.get(), true, &buf_len);
         bson_init(_root.get());
 
-        return bsoncxx::document::value{buf_ptr, buf_len, bson_free_deleter};
+        return bsoncxx::v_noabi::document::value{buf_ptr, buf_len, bson_free_deleter};
     }
 
     // Throws bsoncxx::exception if the top-level BSON datum is a document.
@@ -694,7 +694,7 @@ bsoncxx::document::view core::view_document() const {
                                    _impl->root_document()->len);
 }
 
-bsoncxx::document::value core::extract_document() {
+bsoncxx::v_noabi::document::value core::extract_document() {
     if (!_impl->is_viewable()) {
         throw bsoncxx::exception{error_code::k_unmatched_key_in_builder};
     }

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/builder/core.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/builder/core.cpp
@@ -86,10 +86,11 @@ class core::impl {
         _has_user_key = false;
     }
 
-    // Throws bsoncxx::exception if the top-level BSON datum is an array.
+    // Throws bsoncxx::v_noabi::exception if the top-level BSON datum is an array.
     bsoncxx::v_noabi::document::value steal_document() {
         if (_root_is_array) {
-            throw bsoncxx::exception{error_code::k_cannot_perform_document_operation_on_array};
+            throw bsoncxx::v_noabi::exception{
+                error_code::k_cannot_perform_document_operation_on_array};
         }
 
         uint32_t buf_len;
@@ -99,10 +100,11 @@ class core::impl {
         return bsoncxx::v_noabi::document::value{buf_ptr, buf_len, bson_free_deleter};
     }
 
-    // Throws bsoncxx::exception if the top-level BSON datum is a document.
+    // Throws bsoncxx::v_noabi::exception if the top-level BSON datum is a document.
     bsoncxx::v_noabi::array::value steal_array() {
         if (!_root_is_array) {
-            throw bsoncxx::exception{error_code::k_cannot_perform_array_operation_on_document};
+            throw bsoncxx::v_noabi::exception{
+                error_code::k_cannot_perform_array_operation_on_document};
         }
 
         uint32_t buf_len;
@@ -135,15 +137,15 @@ class core::impl {
         _stack.pop_back();
     }
 
-    // Throws bsoncxx::exception if the current BSON datum is a document that is waiting for a key
-    // to be appended to start a new key/value pair.
+    // Throws bsoncxx::v_noabi::exception if the current BSON datum is a document that is waiting
+    // for a key to be appended to start a new key/value pair.
     stdx::string_view next_key() {
         if (is_array()) {
             _itoa_key = _stack.empty() ? static_cast<std::uint32_t>(_n++)
                                        : static_cast<std::uint32_t>(_stack.back().n++);
             _user_key_view = stdx::string_view{_itoa_key.c_str(), _itoa_key.length()};
         } else if (!_has_user_key) {
-            throw bsoncxx::exception{error_code::k_need_key};
+            throw bsoncxx::v_noabi::exception{error_code::k_need_key};
         }
 
         _has_user_key = false;
@@ -153,7 +155,7 @@ class core::impl {
 
     void push_key(stdx::string_view str) {
         if (_has_user_key) {
-            throw bsoncxx::exception{error_code::k_unmatched_key_in_builder};
+            throw bsoncxx::v_noabi::exception{error_code::k_unmatched_key_in_builder};
         }
 
         _user_key_view = std::move(str);
@@ -162,7 +164,7 @@ class core::impl {
 
     void push_key(std::string str) {
         if (_has_user_key) {
-            throw bsoncxx::exception{error_code::k_unmatched_key_in_builder};
+            throw bsoncxx::v_noabi::exception{error_code::k_unmatched_key_in_builder};
         }
 
         _user_key_owned = std::move(str);
@@ -170,19 +172,21 @@ class core::impl {
         _has_user_key = true;
     }
 
-    // Throws bsoncxx::exception if the top-level BSON datum is an array.
+    // Throws bsoncxx::v_noabi::exception if the top-level BSON datum is an array.
     bson_t* root_document() {
         if (_root_is_array) {
-            throw bsoncxx::exception{error_code::k_cannot_perform_document_operation_on_array};
+            throw bsoncxx::v_noabi::exception{
+                error_code::k_cannot_perform_document_operation_on_array};
         }
 
         return _root.get();
     }
 
-    // Throws bsoncxx::exception if the top-level BSON datum is a document.
+    // Throws bsoncxx::v_noabi::exception if the top-level BSON datum is a document.
     bson_t* root_array() {
         if (!_root_is_array) {
-            throw bsoncxx::exception{error_code::k_cannot_perform_array_operation_on_document};
+            throw bsoncxx::v_noabi::exception{
+                error_code::k_cannot_perform_array_operation_on_document};
         }
 
         return _root.get();
@@ -206,11 +210,12 @@ class core::impl {
             : n(0), is_array(is_array), parent(parent) {
             if (is_array) {
                 if (!bson_append_array_begin(parent, key, len, &bson)) {
-                    throw bsoncxx::exception{error_code::k_cannot_begin_appending_array};
+                    throw bsoncxx::v_noabi::exception{error_code::k_cannot_begin_appending_array};
                 }
             } else {
                 if (!bson_append_document_begin(parent, key, len, &bson)) {
-                    throw bsoncxx::exception{error_code::k_cannot_begin_appending_document};
+                    throw bsoncxx::v_noabi::exception{
+                        error_code::k_cannot_begin_appending_document};
                 }
             }
         }
@@ -218,11 +223,11 @@ class core::impl {
         void close() {
             if (is_array) {
                 if (!bson_append_array_end(parent, &bson)) {
-                    throw bsoncxx::exception{error_code::k_cannot_end_appending_array};
+                    throw bsoncxx::v_noabi::exception{error_code::k_cannot_end_appending_array};
                 }
             } else {
                 if (!bson_append_document_end(parent, &bson)) {
-                    throw bsoncxx::exception{error_code::k_cannot_end_appending_document};
+                    throw bsoncxx::v_noabi::exception{error_code::k_cannot_end_appending_document};
                 }
             }
         }
@@ -260,7 +265,7 @@ core::~core() = default;
 
 core& core::key_view(stdx::string_view key) {
     if (_impl->is_array()) {
-        throw bsoncxx::exception{error_code::k_cannot_append_key_in_sub_array};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_key_in_sub_array};
     }
     _impl->push_key(std::move(key));
 
@@ -269,7 +274,7 @@ core& core::key_view(stdx::string_view key) {
 
 core& core::key_owned(std::string key) {
     if (_impl->is_array()) {
-        throw bsoncxx::exception{error_code::k_cannot_append_key_in_sub_array};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_key_in_sub_array};
     }
     _impl->push_key(std::move(key));
 
@@ -281,7 +286,7 @@ core& core::append(const types::b_double& value) {
 
     if (!bson_append_double(
             _impl->back(), key.data(), static_cast<std::int32_t>(key.length()), value.value)) {
-        throw bsoncxx::exception{error_code::k_cannot_append_double};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_double};
     }
 
     return *this;
@@ -295,7 +300,7 @@ core& core::append(const types::b_string& value) {
                           static_cast<std::int32_t>(key.length()),
                           value.value.data(),
                           static_cast<std::int32_t>(value.value.length()))) {
-        throw bsoncxx::exception{error_code::k_cannot_append_string};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_string};
     }
 
     return *this;
@@ -308,7 +313,7 @@ core& core::append(const types::b_document& value) {
 
     if (!bson_append_document(
             _impl->back(), key.data(), static_cast<std::int32_t>(key.length()), &bson)) {
-        throw bsoncxx::exception{error_code::k_cannot_append_document};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_document};
     }
 
     return *this;
@@ -321,7 +326,7 @@ core& core::append(const types::b_array& value) {
 
     if (!bson_append_array(
             _impl->back(), key.data(), static_cast<std::int32_t>(key.length()), &bson)) {
-        throw bsoncxx::exception{error_code::k_cannot_append_array};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_array};
     }
 
     return *this;
@@ -336,7 +341,7 @@ core& core::append(const types::b_binary& value) {
                             static_cast<bson_subtype_t>(value.sub_type),
                             value.bytes,
                             value.size)) {
-        throw bsoncxx::exception{error_code::k_cannot_append_binary};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_binary};
     }
 
     return *this;
@@ -347,7 +352,7 @@ core& core::append(const types::b_undefined&) {
 
     if (!bson_append_undefined(
             _impl->back(), key.data(), static_cast<std::int32_t>(key.length()))) {
-        throw bsoncxx::exception{error_code::k_cannot_append_undefined};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_undefined};
     }
 
     return *this;
@@ -360,7 +365,7 @@ core& core::append(const types::b_oid& value) {
 
     if (!bson_append_oid(
             _impl->back(), key.data(), static_cast<std::int32_t>(key.length()), &oid)) {
-        throw bsoncxx::exception{error_code::k_cannot_append_oid};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_oid};
     }
 
     return *this;
@@ -371,7 +376,7 @@ core& core::append(const types::b_bool& value) {
 
     if (!bson_append_bool(
             _impl->back(), key.data(), static_cast<std::int32_t>(key.length()), value.value)) {
-        throw bsoncxx::exception{error_code::k_cannot_append_bool};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_bool};
     }
 
     return *this;
@@ -382,7 +387,7 @@ core& core::append(const types::b_date& value) {
 
     if (!bson_append_date_time(
             _impl->back(), key.data(), static_cast<std::int32_t>(key.length()), value.to_int64())) {
-        throw bsoncxx::exception{error_code::k_cannot_append_date};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_date};
     }
 
     return *this;
@@ -392,7 +397,7 @@ core& core::append(const types::b_null&) {
     stdx::string_view key = _impl->next_key();
 
     if (!bson_append_null(_impl->back(), key.data(), static_cast<std::int32_t>(key.length()))) {
-        throw bsoncxx::exception{error_code::k_cannot_append_null};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_null};
     }
 
     return *this;
@@ -406,7 +411,7 @@ core& core::append(const types::b_regex& value) {
                            static_cast<std::int32_t>(key.length()),
                            string::to_string(value.regex).data(),
                            string::to_string(value.options).data())) {
-        throw bsoncxx::exception{error_code::k_cannot_append_regex};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_regex};
     }
 
     return *this;
@@ -423,7 +428,7 @@ core& core::append(const types::b_dbpointer& value) {
                                static_cast<std::int32_t>(key.length()),
                                string::to_string(value.collection).data(),
                                &oid)) {
-        throw bsoncxx::exception{error_code::k_cannot_append_dbpointer};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_dbpointer};
     }
 
     return *this;
@@ -436,7 +441,7 @@ core& core::append(const types::b_code& value) {
                           key.data(),
                           static_cast<std::int32_t>(key.length()),
                           string::to_string(value.code).data())) {
-        throw bsoncxx::exception{error_code::k_cannot_append_code};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_code};
     }
 
     return *this;
@@ -450,7 +455,7 @@ core& core::append(const types::b_symbol& value) {
                             static_cast<std::int32_t>(key.length()),
                             value.symbol.data(),
                             static_cast<std::int32_t>(value.symbol.length()))) {
-        throw bsoncxx::exception{error_code::k_cannot_append_symbol};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_symbol};
     }
 
     return *this;
@@ -467,7 +472,7 @@ core& core::append(const types::b_codewscope& value) {
                                      static_cast<std::int32_t>(key.length()),
                                      string::to_string(value.code).data(),
                                      &bson)) {
-        throw bsoncxx::exception{error_code::k_cannot_append_codewscope};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_codewscope};
     }
 
     return *this;
@@ -478,7 +483,7 @@ core& core::append(const types::b_int32& value) {
 
     if (!bson_append_int32(
             _impl->back(), key.data(), static_cast<std::int32_t>(key.length()), value.value)) {
-        throw bsoncxx::exception{error_code::k_cannot_append_int32};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_int32};
     }
 
     return *this;
@@ -492,7 +497,7 @@ core& core::append(const types::b_timestamp& value) {
                                static_cast<std::int32_t>(key.length()),
                                value.timestamp,
                                value.increment)) {
-        throw bsoncxx::exception{error_code::k_cannot_append_timestamp};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_timestamp};
     }
 
     return *this;
@@ -503,7 +508,7 @@ core& core::append(const types::b_int64& value) {
 
     if (!bson_append_int64(
             _impl->back(), key.data(), static_cast<std::int32_t>(key.length()), value.value)) {
-        throw bsoncxx::exception{error_code::k_cannot_append_int64};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_int64};
     }
 
     return *this;
@@ -517,7 +522,7 @@ core& core::append(const types::b_decimal128& value) {
 
     if (!bson_append_decimal128(
             _impl->back(), key.data(), static_cast<std::int32_t>(key.length()), &d128)) {
-        throw bsoncxx::exception{error_code::k_cannot_append_decimal128};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_decimal128};
     }
 
     return *this;
@@ -527,7 +532,7 @@ core& core::append(const types::b_minkey&) {
     stdx::string_view key = _impl->next_key();
 
     if (!bson_append_minkey(_impl->back(), key.data(), static_cast<std::int32_t>(key.length()))) {
-        throw bsoncxx::exception{error_code::k_cannot_append_minkey};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_minkey};
     }
 
     return *this;
@@ -537,7 +542,7 @@ core& core::append(const types::b_maxkey&) {
     stdx::string_view key = _impl->next_key();
 
     if (!bson_append_maxkey(_impl->back(), key.data(), static_cast<std::int32_t>(key.length()))) {
-        throw bsoncxx::exception{error_code::k_cannot_append_maxkey};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_maxkey};
     }
 
     return *this;
@@ -623,7 +628,7 @@ core& core::concatenate(const bsoncxx::v_noabi::document::view& view) {
     if (_impl->is_array()) {
         bson_iter_t iter;
         if (!bson_iter_init_from_data(&iter, view.data(), view.length())) {
-            throw bsoncxx::exception{error_code::k_cannot_append_document};
+            throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_document};
         }
 
         while (bson_iter_next(&iter)) {
@@ -631,7 +636,7 @@ core& core::concatenate(const bsoncxx::v_noabi::document::view& view) {
 
             if (!bson_append_iter(
                     _impl->back(), key.data(), static_cast<std::int32_t>(key.length()), &iter)) {
-                throw bsoncxx::exception{error_code::k_cannot_append_document};
+                throw bsoncxx::v_noabi::exception{error_code::k_cannot_append_document};
             }
         }
 
@@ -659,11 +664,11 @@ core& core::append(const types::bson_value::view& value) {
 
 core& core::close_document() {
     if (_impl->is_array()) {
-        throw bsoncxx::exception{error_code::k_cannot_close_document_in_sub_array};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_close_document_in_sub_array};
     }
 
     if (_impl->depth() == 0) {
-        throw bsoncxx::exception{error_code::k_no_document_to_close};
+        throw bsoncxx::v_noabi::exception{error_code::k_no_document_to_close};
     }
 
     _impl->pop_back();
@@ -673,11 +678,11 @@ core& core::close_document() {
 
 core& core::close_array() {
     if (!_impl->is_array()) {
-        throw bsoncxx::exception{error_code::k_cannot_close_array_in_sub_document};
+        throw bsoncxx::v_noabi::exception{error_code::k_cannot_close_array_in_sub_document};
     }
 
     if (_impl->depth() == 0) {
-        throw bsoncxx::exception{error_code::k_no_array_to_close};
+        throw bsoncxx::v_noabi::exception{error_code::k_no_array_to_close};
     }
 
     _impl->pop_back();
@@ -687,7 +692,7 @@ core& core::close_array() {
 
 bsoncxx::v_noabi::document::view core::view_document() const {
     if (!_impl->is_viewable()) {
-        throw bsoncxx::exception{error_code::k_unmatched_key_in_builder};
+        throw bsoncxx::v_noabi::exception{error_code::k_unmatched_key_in_builder};
     }
 
     return bsoncxx::v_noabi::document::view(bson_get_data(_impl->root_document()),
@@ -696,7 +701,7 @@ bsoncxx::v_noabi::document::view core::view_document() const {
 
 bsoncxx::v_noabi::document::value core::extract_document() {
     if (!_impl->is_viewable()) {
-        throw bsoncxx::exception{error_code::k_unmatched_key_in_builder};
+        throw bsoncxx::v_noabi::exception{error_code::k_unmatched_key_in_builder};
     }
 
     return _impl->steal_document();
@@ -704,7 +709,7 @@ bsoncxx::v_noabi::document::value core::extract_document() {
 
 bsoncxx::v_noabi::array::view core::view_array() const {
     if (!_impl->is_viewable()) {
-        throw bsoncxx::exception{error_code::k_unmatched_key_in_builder};
+        throw bsoncxx::v_noabi::exception{error_code::k_unmatched_key_in_builder};
     }
 
     return bsoncxx::v_noabi::array::view(bson_get_data(_impl->root_array()),
@@ -713,7 +718,7 @@ bsoncxx::v_noabi::array::view core::view_array() const {
 
 bsoncxx::v_noabi::array::value core::extract_array() {
     if (!_impl->is_viewable()) {
-        throw bsoncxx::exception{error_code::k_unmatched_key_in_builder};
+        throw bsoncxx::v_noabi::exception{error_code::k_unmatched_key_in_builder};
     }
 
     return _impl->steal_array();

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/builder/core.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/builder/core.cpp
@@ -100,7 +100,7 @@ class core::impl {
     }
 
     // Throws bsoncxx::exception if the top-level BSON datum is a document.
-    bsoncxx::array::value steal_array() {
+    bsoncxx::v_noabi::array::value steal_array() {
         if (!_root_is_array) {
             throw bsoncxx::exception{error_code::k_cannot_perform_array_operation_on_document};
         }
@@ -109,7 +109,7 @@ class core::impl {
         uint8_t* buf_ptr = bson_destroy_with_steal(_root.get(), true, &buf_len);
         bson_init(_root.get());
 
-        return bsoncxx::array::value{buf_ptr, buf_len, bson_free_deleter};
+        return bsoncxx::v_noabi::array::value{buf_ptr, buf_len, bson_free_deleter};
     }
 
     bson_t* back() {
@@ -702,15 +702,16 @@ bsoncxx::document::value core::extract_document() {
     return _impl->steal_document();
 }
 
-bsoncxx::array::view core::view_array() const {
+bsoncxx::v_noabi::array::view core::view_array() const {
     if (!_impl->is_viewable()) {
         throw bsoncxx::exception{error_code::k_unmatched_key_in_builder};
     }
 
-    return bsoncxx::array::view(bson_get_data(_impl->root_array()), _impl->root_array()->len);
+    return bsoncxx::v_noabi::array::view(bson_get_data(_impl->root_array()),
+                                         _impl->root_array()->len);
 }
 
-bsoncxx::array::value core::extract_array() {
+bsoncxx::v_noabi::array::value core::extract_array() {
     if (!_impl->is_viewable()) {
         throw bsoncxx::exception{error_code::k_unmatched_key_in_builder};
     }

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/builder/core.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/builder/core.cpp
@@ -30,7 +30,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace builder {
 
 namespace {
@@ -724,5 +724,5 @@ void core::clear() {
 }
 
 }  // namespace builder
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/builder/core.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/builder/core.cpp
@@ -30,7 +30,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace builder {
 
 namespace {
@@ -723,5 +723,5 @@ void core::clear() {
 }
 
 }  // namespace builder
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/builder/core.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/builder/core.cpp
@@ -619,7 +619,7 @@ core& core::open_array() {
     return *this;
 }
 
-core& core::concatenate(const bsoncxx::document::view& view) {
+core& core::concatenate(const bsoncxx::v_noabi::document::view& view) {
     if (_impl->is_array()) {
         bson_iter_t iter;
         if (!bson_iter_init_from_data(&iter, view.data(), view.length())) {
@@ -685,13 +685,13 @@ core& core::close_array() {
     return *this;
 }
 
-bsoncxx::document::view core::view_document() const {
+bsoncxx::v_noabi::document::view core::view_document() const {
     if (!_impl->is_viewable()) {
         throw bsoncxx::exception{error_code::k_unmatched_key_in_builder};
     }
 
-    return bsoncxx::document::view(bson_get_data(_impl->root_document()),
-                                   _impl->root_document()->len);
+    return bsoncxx::v_noabi::document::view(bson_get_data(_impl->root_document()),
+                                            _impl->root_document()->len);
 }
 
 bsoncxx::v_noabi::document::value core::extract_document() {

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/decimal128.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/decimal128.cpp
@@ -22,7 +22,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 decimal128::decimal128(stdx::string_view str) {
     bson_decimal128_t d128;
     if (!bson_decimal128_from_string(string::to_string(str).c_str(), &d128)) {
@@ -49,5 +49,5 @@ bool BSONCXX_CALL operator!=(const decimal128& lhs, const decimal128& rhs) {
     return !(lhs == rhs);
 }
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/decimal128.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/decimal128.cpp
@@ -22,7 +22,8 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
+
 decimal128::decimal128(stdx::string_view str) {
     bson_decimal128_t d128;
     if (!bson_decimal128_from_string(string::to_string(str).c_str(), &d128)) {
@@ -49,5 +50,5 @@ bool BSONCXX_CALL operator!=(const decimal128& lhs, const decimal128& rhs) {
     return !(lhs == rhs);
 }
 
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/decimal128.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/decimal128.cpp
@@ -27,7 +27,7 @@ namespace v_noabi {
 decimal128::decimal128(stdx::string_view str) {
     bson_decimal128_t d128;
     if (!bson_decimal128_from_string(string::to_string(str).c_str(), &d128)) {
-        throw bsoncxx::exception{error_code::k_invalid_decimal128};
+        throw bsoncxx::v_noabi::exception{error_code::k_invalid_decimal128};
     }
     _high = d128.high;
     _low = d128.low;

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/element.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/element.cpp
@@ -61,7 +61,7 @@ std::uint32_t element::keylen() const {
 
 bsoncxx::v_noabi::type element::type() const {
     if (_raw == nullptr) {
-        throw bsoncxx::exception{
+        throw bsoncxx::v_noabi::exception{
             error_code::k_unset_element,
             "cannot return the type of uninitialized element" +
                 std::string(_key ? " with key \"" + std::string(_key.value().data()) + "\"" : "")};
@@ -73,7 +73,7 @@ bsoncxx::v_noabi::type element::type() const {
 
 stdx::string_view element::key() const {
     if (_raw == nullptr) {
-        throw bsoncxx::exception{
+        throw bsoncxx::v_noabi::exception{
             error_code::k_unset_element,
             "cannot return the key from an uninitialized element" +
                 std::string(_key ? " with key \"" + std::string(_key.value().data()) + "\"" : "")};
@@ -89,7 +89,7 @@ stdx::string_view element::key() const {
 #define BSONCXX_ENUM(name, val)                                                                 \
     types::b_##name element::get_##name() const {                                               \
         if (_raw == nullptr) {                                                                  \
-            throw bsoncxx::exception{                                                           \
+            throw bsoncxx::v_noabi::exception{                                                  \
                 error_code::k_unset_element,                                                    \
                 "cannot get " #name " from an uninitialized element" +                          \
                     std::string(_key ? " with key \"" + std::string(_key.value().data()) + "\"" \
@@ -103,7 +103,7 @@ stdx::string_view element::key() const {
 
 types::b_string element::get_utf8() const {
     if (_raw == nullptr) {
-        throw bsoncxx::exception{
+        throw bsoncxx::v_noabi::exception{
             error_code::k_unset_element,
             "cannot get string from an uninitialized element" +
                 std::string(_key ? " with key \"" + std::string(_key.value().data()) + "\"" : "")};

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/element.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/element.cpp
@@ -30,7 +30,7 @@
     bson_iter_init_from_data_at_offset(&iter, _raw, _length, _offset, _keylen);
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace document {
 
 element::element() : element(nullptr, 0, 0, 0) {}
@@ -164,5 +164,5 @@ bool BSONCXX_CALL operator!=(const types::bson_value::view& v, const element& el
 }
 
 }  // namespace document
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/element.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/element.cpp
@@ -59,7 +59,7 @@ std::uint32_t element::keylen() const {
     return _keylen;
 }
 
-bsoncxx::type element::type() const {
+bsoncxx::v_noabi::type element::type() const {
     if (_raw == nullptr) {
         throw bsoncxx::exception{
             error_code::k_unset_element,
@@ -68,7 +68,7 @@ bsoncxx::type element::type() const {
     }
 
     BSONCXX_CITER;
-    return static_cast<bsoncxx::type>(bson_iter_type(&iter));
+    return static_cast<bsoncxx::v_noabi::type>(bson_iter_type(&iter));
 }
 
 stdx::string_view element::key() const {
@@ -130,14 +130,14 @@ types::bson_value::value element::get_owning_value() const {
 }
 
 element element::operator[](stdx::string_view key) const {
-    if (_raw == nullptr || type() != bsoncxx::type::k_document)
+    if (_raw == nullptr || type() != bsoncxx::v_noabi::type::k_document)
         return element();
     document::view doc = get_document();
     return doc[key];
 }
 
 array::element element::operator[](std::uint32_t i) const {
-    if (_raw == nullptr || type() != bsoncxx::type::k_array)
+    if (_raw == nullptr || type() != bsoncxx::v_noabi::type::k_array)
         return array::element();
     array::view arr = get_array();
     return arr[i];

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/element.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/element.cpp
@@ -30,7 +30,7 @@
     bson_iter_init_from_data_at_offset(&iter, _raw, _length, _offset, _keylen);
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace document {
 
 element::element() : element(nullptr, 0, 0, 0) {}
@@ -164,5 +164,5 @@ bool BSONCXX_CALL operator!=(const types::bson_value::view& v, const element& el
 }
 
 }  // namespace document
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/value.cpp
@@ -19,7 +19,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace document {
 
 value::value(std::uint8_t* data, std::size_t length, deleter_type dtor)
@@ -97,5 +97,5 @@ void value::reset(document::view view) {
 }
 
 }  // namespace document
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/value.cpp
@@ -19,7 +19,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace document {
 
 value::value(std::uint8_t* data, std::size_t length, deleter_type dtor)
@@ -97,5 +97,5 @@ void value::reset(document::view view) {
 }
 
 }  // namespace document
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/view.cpp
@@ -22,15 +22,17 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace document {
 
 namespace {
+
 bson_iter_t to_bson_iter_t(element e) {
     bson_iter_t iter{};
     bson_iter_init_from_data_at_offset(&iter, e.raw(), e.length(), e.offset(), e.keylen());
     return iter;
 }
+
 }  // namespace
 
 view::const_iterator::const_iterator() {}
@@ -174,5 +176,5 @@ bool BSONCXX_CALL operator!=(view lhs, view rhs) {
 }
 
 }  // namespace document
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/view.cpp
@@ -22,7 +22,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace document {
 
 namespace {
@@ -174,5 +174,5 @@ bool BSONCXX_CALL operator!=(view lhs, view rhs) {
 }
 
 }  // namespace document
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/exception/error_code.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/exception/error_code.cpp
@@ -19,7 +19,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace {
 
 class error_category_impl final : public std::error_category {
@@ -91,5 +91,5 @@ const std::error_category& BSONCXX_CALL error_category() {
     return instance;
 }
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/exception/error_code.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/exception/error_code.cpp
@@ -19,7 +19,8 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
+
 namespace {
 
 class error_category_impl final : public std::error_category {
@@ -91,5 +92,5 @@ const std::error_category& BSONCXX_CALL error_category() {
     return instance;
 }
 
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/json.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/json.cpp
@@ -28,7 +28,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace {
 
 void bson_free_deleter(std::uint8_t* ptr) {
@@ -102,5 +102,5 @@ document::value BSONCXX_CALL operator"" _bson(const char* str, size_t len) {
     return from_json(stdx::string_view{str, len});
 }
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/json.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/json.cpp
@@ -28,7 +28,8 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
+
 namespace {
 
 void bson_free_deleter(std::uint8_t* ptr) {
@@ -102,5 +103,5 @@ document::value BSONCXX_CALL operator"" _bson(const char* str, size_t len) {
     return from_json(stdx::string_view{str, len});
 }
 
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/oid.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/oid.cpp
@@ -31,7 +31,7 @@ oid::oid() {
     std::memcpy(_bytes.data(), oid.bytes, sizeof(oid.bytes));
 }
 
-oid::oid(const bsoncxx::v_noabi::stdx::string_view& str) {
+oid::oid(const stdx::string_view& str) {
     if (!bson_oid_is_valid(str.data(), str.size())) {
         throw bsoncxx::v_noabi::exception{error_code::k_invalid_oid};
     }

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/oid.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/oid.cpp
@@ -30,7 +30,7 @@ oid::oid() {
     std::memcpy(_bytes.data(), oid.bytes, sizeof(oid.bytes));
 }
 
-oid::oid(const bsoncxx::stdx::string_view& str) {
+oid::oid(const bsoncxx::v_noabi::stdx::string_view& str) {
     if (!bson_oid_is_valid(str.data(), str.size())) {
         throw bsoncxx::exception{error_code::k_invalid_oid};
     }

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/oid.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/oid.cpp
@@ -33,7 +33,7 @@ oid::oid() {
 
 oid::oid(const bsoncxx::v_noabi::stdx::string_view& str) {
     if (!bson_oid_is_valid(str.data(), str.size())) {
-        throw bsoncxx::exception{error_code::k_invalid_oid};
+        throw bsoncxx::v_noabi::exception{error_code::k_invalid_oid};
     }
     bson_oid_t oid;
     bson_oid_init_from_string(&oid, str.data());
@@ -42,7 +42,7 @@ oid::oid(const bsoncxx::v_noabi::stdx::string_view& str) {
 
 oid::oid(const char* bytes, std::size_t len) {
     if (len != this->size()) {
-        throw bsoncxx::exception{error_code::k_invalid_oid};
+        throw bsoncxx::v_noabi::exception{error_code::k_invalid_oid};
     }
     std::memcpy(_bytes.data(), bytes, _bytes.size());
 }

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/oid.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/oid.cpp
@@ -22,7 +22,8 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
+
 oid::oid() {
     bson_oid_t oid;
     bson_oid_init(&oid, nullptr);
@@ -101,5 +102,5 @@ bool BSONCXX_CALL operator!=(const oid& lhs, const oid& rhs) {
     return oid_compare(lhs, rhs) != 0;
 }
 
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/oid.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/oid.cpp
@@ -22,7 +22,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 oid::oid() {
     bson_oid_t oid;
     bson_oid_init(&oid, nullptr);
@@ -101,5 +101,5 @@ bool BSONCXX_CALL operator!=(const oid& lhs, const oid& rhs) {
     return oid_compare(lhs, rhs) != 0;
 }
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/b64_ntop.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/b64_ntop.hh
@@ -48,7 +48,6 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace wip {
 namespace b64 {
 
 #define BSONCXX_B64_ASSERT(Cond) \
@@ -120,10 +119,10 @@ const char Pad64 = '=';
  *    characters followed by one "=" padding character.
  */
 
-BSONCXX_INLINE int ntop(std::uint8_t const* src,
-                        std::size_t srclength,
-                        char* target,
-                        std::size_t targsize) {
+inline int ntop(std::uint8_t const* src,
+                std::size_t srclength,
+                char* target,
+                std::size_t targsize) {
     std::size_t datalength = 0;
     std::uint8_t input[3];
     std::uint8_t output[4];
@@ -190,7 +189,6 @@ BSONCXX_INLINE int ntop(std::uint8_t const* src,
 }
 
 }  // namespace b64
-}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/b64_ntop.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/b64_ntop.hh
@@ -48,7 +48,7 @@
 #include <bsoncxx/config/prelude.hpp>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace b64 {
 
 #define BSONCXX_B64_ASSERT(Cond) \
@@ -190,7 +190,7 @@ BSONCXX_INLINE int ntop(std::uint8_t const* src,
 }
 
 }  // namespace b64
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/helpers.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/helpers.hh
@@ -42,8 +42,9 @@ Note: Deduction guides aren't yet available to us, so a factory it is! This is
 something that can be improved as part of CXX-2350 (migration to more recent C++
 standards).
 */
-inline bsoncxx::oid make_oid(const bson_oid_t* bson_oid) {
-    return bsoncxx::oid(reinterpret_cast<const char*>(bson_oid), bsoncxx::oid::size());
+inline bsoncxx::v_noabi::oid make_oid(const bson_oid_t* bson_oid) {
+    return bsoncxx::v_noabi::oid(reinterpret_cast<const char*>(bson_oid),
+                                 bsoncxx::v_noabi::oid::size());
 }
 
 }  // namespace helpers

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/helpers.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/helpers.hh
@@ -22,7 +22,6 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace wip {
 namespace helpers {
 
 inline bsoncxx::v_noabi::document::view view_from_bson_t(const bson_t* bson) {
@@ -48,7 +47,6 @@ inline bsoncxx::v_noabi::oid make_oid(const bson_oid_t* bson_oid) {
 }
 
 }  // namespace helpers
-}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/private/postlude.hh>

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/helpers.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/helpers.hh
@@ -22,7 +22,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace helpers {
 
 inline document::view view_from_bson_t(const bson_t* bson) {
@@ -47,7 +47,7 @@ inline bsoncxx::oid make_oid(const bson_oid_t* bson_oid) {
 }
 
 }  // namespace helpers
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/private/postlude.hh>

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/helpers.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/helpers.hh
@@ -29,8 +29,8 @@ inline document::view view_from_bson_t(const bson_t* bson) {
     return {::bson_get_data(bson), bson->len};
 }
 
-inline document::value value_from_bson_t(const bson_t* bson) {
-    return document::value{view_from_bson_t(bson)};
+inline bsoncxx::v_noabi::document::value value_from_bson_t(const bson_t* bson) {
+    return bsoncxx::v_noabi::document::value{view_from_bson_t(bson)};
 }
 
 /*

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/helpers.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/helpers.hh
@@ -25,7 +25,7 @@ namespace bsoncxx {
 inline namespace wip {
 namespace helpers {
 
-inline document::view view_from_bson_t(const bson_t* bson) {
+inline bsoncxx::v_noabi::document::view view_from_bson_t(const bson_t* bson) {
     return {::bson_get_data(bson), bson->len};
 }
 

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/itoa.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/itoa.cpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace {
 
 constexpr char kIndexTable[] =
@@ -1060,5 +1060,5 @@ void itoa::_init() {
     }
 }
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/itoa.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/itoa.cpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace wip {
+
 namespace {
 
 constexpr char kIndexTable[] =
@@ -1060,5 +1060,4 @@ void itoa::_init() {
     }
 }
 
-}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/itoa.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/itoa.hh
@@ -22,7 +22,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 class BSONCXX_TEST_API itoa {
    public:
     explicit itoa(uint32_t i = 0);
@@ -57,7 +57,7 @@ inline std::size_t itoa::length() const {
     return _len;
 }
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/private/postlude.hh>

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/itoa.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/itoa.hh
@@ -22,7 +22,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace wip {
+
 class BSONCXX_TEST_API itoa {
    public:
     explicit itoa(uint32_t i = 0);
@@ -57,7 +57,6 @@ inline std::size_t itoa::length() const {
     return _len;
 }
 
-}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/private/postlude.hh>

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/stack.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/stack.hh
@@ -21,7 +21,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 // Note: This stack is only intended for use with the 'frame' type in
 // builder core.cpp.
 template <typename T, std::size_t size>
@@ -154,7 +154,7 @@ class stack {
     }
 };
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/private/postlude.hh>

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/stack.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/stack.hh
@@ -21,7 +21,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace wip {
+
 // Note: This stack is only intended for use with the 'frame' type in
 // builder core.cpp.
 template <typename T, std::size_t size>
@@ -154,7 +154,6 @@ class stack {
     }
 };
 
-}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/private/postlude.hh>

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/string/view_or_value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/string/view_or_value.cpp
@@ -18,7 +18,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace string {
 
 view_or_value view_or_value::terminated() const {
@@ -37,5 +37,5 @@ const char* view_or_value::data() const {
 }
 
 }  // namespace string
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/string/view_or_value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/string/view_or_value.cpp
@@ -18,7 +18,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace string {
 
 view_or_value view_or_value::terminated() const {
@@ -37,5 +37,5 @@ const char* view_or_value::data() const {
 }
 
 }  // namespace string
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types.cpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 #define BSONCXX_ENUM(name, val) constexpr type types::b_##name::type_id;
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
@@ -49,5 +49,5 @@ std::string BSONCXX_CALL to_string(binary_sub_type rhs) {
 }
 
 namespace types {}  // namespace types
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types.cpp
@@ -17,7 +17,8 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
+
 #define BSONCXX_ENUM(name, val) constexpr type types::b_##name::type_id;
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
@@ -48,6 +49,5 @@ std::string BSONCXX_CALL to_string(binary_sub_type rhs) {
     }
 }
 
-namespace types {}  // namespace types
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/private/value.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/private/value.hh
@@ -55,7 +55,7 @@ class value::impl {
 
 // Helper to create a value from an existing bson_value_t
 // (for mongocxx callers who cannot be added as friends)
-BSONCXX_INLINE bson_value::value make_owning_bson(void* internal_value) {
+inline bson_value::value make_owning_bson(void* internal_value) {
     return bson_value::value{internal_value};
 }
 

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/private/value.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/private/value.hh
@@ -21,7 +21,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace types {
 namespace bson_value {
 
@@ -62,7 +62,7 @@ BSONCXX_INLINE bson_value::value make_owning_bson(void* internal_value) {
 }  // namespace bson_value
 }  // namespace types
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/private/postlude.hh>

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/private/value.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/private/value.hh
@@ -21,7 +21,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace types {
 namespace bson_value {
 
@@ -61,8 +61,7 @@ BSONCXX_INLINE bson_value::value make_owning_bson(void* internal_value) {
 
 }  // namespace bson_value
 }  // namespace types
-
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/private/postlude.hh>

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.cpp
@@ -49,7 +49,7 @@ value::value(std::string v) : value(stdx::string_view{v}) {}
 value::value(b_string v) : value(v.value) {}
 value::value(stdx::string_view v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_UTF8;
-    _impl->_value.value.v_utf8.str = make_copy_for_libbson(v);
+    _impl->_value.value.v_utf8.str = ::bsoncxx::types::make_copy_for_libbson(v);
     _impl->_value.value.v_utf8.len = (uint32_t)v.size();
 }
 
@@ -99,8 +99,9 @@ value::value(b_regex v) : value(v.regex, v.options) {}
 value::value(stdx::string_view regex, stdx::string_view options)
     : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_REGEX;
-    _impl->_value.value.v_regex.regex = make_copy_for_libbson(regex);
-    _impl->_value.value.v_regex.options = options.empty() ? NULL : make_copy_for_libbson(options);
+    _impl->_value.value.v_regex.regex = ::bsoncxx::types::make_copy_for_libbson(regex);
+    _impl->_value.value.v_regex.options =
+        options.empty() ? NULL : ::bsoncxx::types::make_copy_for_libbson(options);
 }
 
 value::value(b_code v) : value(v.type_id, v) {}
@@ -109,17 +110,17 @@ value::value(const type id, stdx::string_view v) : _impl{stdx::make_unique<impl>
     switch (id) {
         case type::k_regex:
             _impl->_value.value_type = BSON_TYPE_REGEX;
-            _impl->_value.value.v_regex.regex = make_copy_for_libbson(v);
+            _impl->_value.value.v_regex.regex = ::bsoncxx::types::make_copy_for_libbson(v);
             _impl->_value.value.v_regex.options = NULL;
             break;
         case type::k_code:
             _impl->_value.value_type = BSON_TYPE_CODE;
-            _impl->_value.value.v_code.code = make_copy_for_libbson(v);
+            _impl->_value.value.v_code.code = ::bsoncxx::types::make_copy_for_libbson(v);
             _impl->_value.value.v_code.code_len = (uint32_t)v.length();
             break;
         case type::k_symbol:
             _impl->_value.value_type = BSON_TYPE_SYMBOL;
-            _impl->_value.value.v_symbol.symbol = make_copy_for_libbson(v);
+            _impl->_value.value.v_symbol.symbol = ::bsoncxx::types::make_copy_for_libbson(v);
             _impl->_value.value.v_symbol.len = (uint32_t)v.length();
             break;
         default:
@@ -150,7 +151,8 @@ value::value(type id, uint64_t a, uint64_t b) : _impl{stdx::make_unique<impl>()}
 value::value(b_dbpointer v) : value(v.collection, v.value) {}
 value::value(stdx::string_view collection, oid value) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_DBPOINTER;
-    _impl->_value.value.v_dbpointer.collection = make_copy_for_libbson(collection);
+    _impl->_value.value.v_dbpointer.collection =
+        ::bsoncxx::types::make_copy_for_libbson(collection);
     _impl->_value.value.v_dbpointer.collection_len = (uint32_t)collection.length();
     std::memcpy(_impl->_value.value.v_dbpointer.oid.bytes, value.bytes(), value.k_oid_length);
 }
@@ -159,7 +161,7 @@ value::value(b_codewscope v) : value(v.code, v.scope) {}
 value::value(stdx::string_view code, bsoncxx::document::view_or_value scope)
     : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_CODEWSCOPE;
-    _impl->_value.value.v_codewscope.code = make_copy_for_libbson(code);
+    _impl->_value.value.v_codewscope.code = ::bsoncxx::types::make_copy_for_libbson(code);
     _impl->_value.value.v_codewscope.code_len = (uint32_t)code.length();
     _impl->_value.value.v_codewscope.scope_len = (uint32_t)scope.view().length();
     _impl->_value.value.v_codewscope.scope_data = (uint8_t*)bson_malloc(scope.view().length());
@@ -221,7 +223,7 @@ value::value(const value& rhs) : value(&rhs._impl->_value) {}
 
 value::value(const bson_value::view& bson_view) {
     _impl = stdx::make_unique<impl>();
-    convert_to_libbson(&_impl->_value, bson_view);
+    ::bsoncxx::types::convert_to_libbson(&_impl->_value, bson_view);
 }
 
 value& value::operator=(const value& rhs) {

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.cpp
@@ -91,7 +91,7 @@ value::value(const type id) : _impl{stdx::make_unique<impl>()} {
             _impl->_value.value_type = BSON_TYPE_UNDEFINED;
             break;
         default:
-            throw bsoncxx::exception(error_code::k_invalid_bson_type_id);
+            throw bsoncxx::v_noabi::exception(error_code::k_invalid_bson_type_id);
     }
 }
 
@@ -124,7 +124,7 @@ value::value(const type id, stdx::string_view v) : _impl{stdx::make_unique<impl>
             _impl->_value.value.v_symbol.len = (uint32_t)v.length();
             break;
         default:
-            throw bsoncxx::exception(error_code::k_invalid_bson_type_id);
+            throw bsoncxx::v_noabi::exception(error_code::k_invalid_bson_type_id);
     }
 }
 
@@ -144,7 +144,7 @@ value::value(type id, uint64_t a, uint64_t b) : _impl{stdx::make_unique<impl>()}
             _impl->_value.value.v_timestamp.timestamp = (uint32_t)b;
             break;
         default:
-            throw bsoncxx::exception(error_code::k_invalid_bson_type_id);
+            throw bsoncxx::v_noabi::exception(error_code::k_invalid_bson_type_id);
     }
 }
 

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.cpp
@@ -158,7 +158,7 @@ value::value(stdx::string_view collection, oid value) : _impl{stdx::make_unique<
 }
 
 value::value(b_codewscope v) : value(v.code, v.scope) {}
-value::value(stdx::string_view code, bsoncxx::document::view_or_value scope)
+value::value(stdx::string_view code, bsoncxx::v_noabi::document::view_or_value scope)
     : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_CODEWSCOPE;
     _impl->_value.value.v_codewscope.code = ::bsoncxx::types::make_copy_for_libbson(code);
@@ -183,7 +183,7 @@ value::value(const uint8_t* data, size_t size, const binary_sub_type sub_type)
 }
 
 value::value(b_document v) : value(v.view()) {}
-value::value(bsoncxx::document::view v) : _impl{stdx::make_unique<impl>()} {
+value::value(bsoncxx::v_noabi::document::view v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_DOCUMENT;
     _impl->_value.value.v_doc.data_len = (uint32_t)v.length();
     _impl->_value.value.v_doc.data = (uint8_t*)bson_malloc(v.length());

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.cpp
@@ -22,7 +22,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace types {
 namespace bson_value {
 
@@ -241,6 +241,5 @@ value::operator bson_value::view() const noexcept {
 
 }  // namespace bson_value
 }  // namespace types
-
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.cpp
@@ -191,7 +191,7 @@ value::value(bsoncxx::document::view v) : _impl{stdx::make_unique<impl>()} {
 }
 
 value::value(b_array v) : value(v.value) {}
-value::value(bsoncxx::array::view v) : _impl{stdx::make_unique<impl>()} {
+value::value(bsoncxx::v_noabi::array::view v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_ARRAY;
     _impl->_value.value.v_doc.data_len = (uint32_t)v.length();
     _impl->_value.value.v_doc.data = (uint8_t*)bson_malloc(v.length());

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.cpp
@@ -22,7 +22,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace types {
 namespace bson_value {
 
@@ -240,5 +240,5 @@ value::operator bson_value::view() const noexcept {
 }  // namespace bson_value
 }  // namespace types
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.cpp
@@ -49,7 +49,7 @@ value::value(std::string v) : value(stdx::string_view{v}) {}
 value::value(b_string v) : value(v.value) {}
 value::value(stdx::string_view v) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_UTF8;
-    _impl->_value.value.v_utf8.str = ::bsoncxx::types::make_copy_for_libbson(v);
+    _impl->_value.value.v_utf8.str = make_copy_for_libbson(v);
     _impl->_value.value.v_utf8.len = (uint32_t)v.size();
 }
 
@@ -99,9 +99,8 @@ value::value(b_regex v) : value(v.regex, v.options) {}
 value::value(stdx::string_view regex, stdx::string_view options)
     : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_REGEX;
-    _impl->_value.value.v_regex.regex = ::bsoncxx::types::make_copy_for_libbson(regex);
-    _impl->_value.value.v_regex.options =
-        options.empty() ? NULL : ::bsoncxx::types::make_copy_for_libbson(options);
+    _impl->_value.value.v_regex.regex = make_copy_for_libbson(regex);
+    _impl->_value.value.v_regex.options = options.empty() ? NULL : make_copy_for_libbson(options);
 }
 
 value::value(b_code v) : value(v.type_id, v) {}
@@ -110,17 +109,17 @@ value::value(const type id, stdx::string_view v) : _impl{stdx::make_unique<impl>
     switch (id) {
         case type::k_regex:
             _impl->_value.value_type = BSON_TYPE_REGEX;
-            _impl->_value.value.v_regex.regex = ::bsoncxx::types::make_copy_for_libbson(v);
+            _impl->_value.value.v_regex.regex = make_copy_for_libbson(v);
             _impl->_value.value.v_regex.options = NULL;
             break;
         case type::k_code:
             _impl->_value.value_type = BSON_TYPE_CODE;
-            _impl->_value.value.v_code.code = ::bsoncxx::types::make_copy_for_libbson(v);
+            _impl->_value.value.v_code.code = make_copy_for_libbson(v);
             _impl->_value.value.v_code.code_len = (uint32_t)v.length();
             break;
         case type::k_symbol:
             _impl->_value.value_type = BSON_TYPE_SYMBOL;
-            _impl->_value.value.v_symbol.symbol = ::bsoncxx::types::make_copy_for_libbson(v);
+            _impl->_value.value.v_symbol.symbol = make_copy_for_libbson(v);
             _impl->_value.value.v_symbol.len = (uint32_t)v.length();
             break;
         default:
@@ -151,8 +150,7 @@ value::value(type id, uint64_t a, uint64_t b) : _impl{stdx::make_unique<impl>()}
 value::value(b_dbpointer v) : value(v.collection, v.value) {}
 value::value(stdx::string_view collection, oid value) : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_DBPOINTER;
-    _impl->_value.value.v_dbpointer.collection =
-        ::bsoncxx::types::make_copy_for_libbson(collection);
+    _impl->_value.value.v_dbpointer.collection = make_copy_for_libbson(collection);
     _impl->_value.value.v_dbpointer.collection_len = (uint32_t)collection.length();
     std::memcpy(_impl->_value.value.v_dbpointer.oid.bytes, value.bytes(), value.k_oid_length);
 }
@@ -161,7 +159,7 @@ value::value(b_codewscope v) : value(v.code, v.scope) {}
 value::value(stdx::string_view code, bsoncxx::v_noabi::document::view_or_value scope)
     : _impl{stdx::make_unique<impl>()} {
     _impl->_value.value_type = BSON_TYPE_CODEWSCOPE;
-    _impl->_value.value.v_codewscope.code = ::bsoncxx::types::make_copy_for_libbson(code);
+    _impl->_value.value.v_codewscope.code = make_copy_for_libbson(code);
     _impl->_value.value.v_codewscope.code_len = (uint32_t)code.length();
     _impl->_value.value.v_codewscope.scope_len = (uint32_t)scope.view().length();
     _impl->_value.value.v_codewscope.scope_data = (uint8_t*)bson_malloc(scope.view().length());
@@ -223,7 +221,7 @@ value::value(const value& rhs) : value(&rhs._impl->_value) {}
 
 value::value(const bson_value::view& bson_view) {
     _impl = stdx::make_unique<impl>();
-    ::bsoncxx::types::convert_to_libbson(&_impl->_value, bson_view);
+    convert_to_libbson(&_impl->_value, bson_view);
 }
 
 value& value::operator=(const value& rhs) {

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.cpp
@@ -35,7 +35,7 @@
     } while (0)
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
 namespace types {
 namespace bson_value {
 
@@ -190,5 +190,5 @@ void view::destroy() noexcept {
 
 }  // namespace bson_value
 }  // namespace types
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.cpp
@@ -35,7 +35,7 @@
     } while (0)
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace types {
 namespace bson_value {
 
@@ -190,5 +190,5 @@ void view::destroy() noexcept {
 
 }  // namespace bson_value
 }  // namespace types
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.cpp
@@ -144,10 +144,10 @@ void view::_init(void* internal_value) noexcept {
     _type = static_cast<bsoncxx::v_noabi::type>(v->value_type);
 
     switch (_type) {
-#define BSONCXX_ENUM(name, val)                                \
-    case bsoncxx::v_noabi::type::k_##name: {                   \
-        ::bsoncxx::types::convert_from_libbson(v, &_b_##name); \
-        break;                                                 \
+#define BSONCXX_ENUM(name, val)                                         \
+    case bsoncxx::v_noabi::type::k_##name: {                            \
+        ::bsoncxx::v_noabi::types::convert_from_libbson(v, &_b_##name); \
+        break;                                                          \
     }
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.cpp
@@ -29,7 +29,7 @@
 
 #define BSONCXX_TYPE_CHECK(name)                                                \
     do {                                                                        \
-        if (type() != bsoncxx::type::k_##name) {                                \
+        if (type() != bsoncxx::v_noabi::type::k_##name) {                       \
             throw bsoncxx::exception{error_code::k_need_element_type_k_##name}; \
         }                                                                       \
     } while (0)
@@ -46,7 +46,7 @@ view::view() noexcept : view(nullptr) {}
 #if !defined(BSONCXX_POLY_USE_BOOST)
 #define BSONCXX_ENUM(name, val)                                                                \
     view::view(b_##name value) noexcept                                                        \
-        : _type(static_cast<bsoncxx::type>(val)), _b_##name(std::move(value)) {                \
+        : _type(static_cast<bsoncxx::v_noabi::type>(val)), _b_##name(std::move(value)) {       \
         static_assert(std::is_nothrow_copy_constructible<b_##name>::value, "Copy may throw");  \
         static_assert(std::is_nothrow_copy_assignable<b_##name>::value, "Copy may throw");     \
         static_assert(std::is_nothrow_destructible<b_##name>::value, "Destruction may throw"); \
@@ -54,7 +54,7 @@ view::view() noexcept : view(nullptr) {}
 #else
 #define BSONCXX_ENUM(name, val)                                                                \
     view::view(b_##name value) noexcept                                                        \
-        : _type(static_cast<bsoncxx::type>(val)), _b_##name(std::move(value)) {                \
+        : _type(static_cast<bsoncxx::v_noabi::type>(val)), _b_##name(std::move(value)) {       \
         static_assert(std::is_nothrow_destructible<b_##name>::value, "Destruction may throw"); \
     }
 #endif
@@ -101,7 +101,7 @@ view::~view() {
     destroy();
 }
 
-bsoncxx::type view::type() const {
+bsoncxx::v_noabi::type view::type() const {
     return _type;
 }
 
@@ -135,19 +135,19 @@ view::view(void* internal_value) noexcept {
 
 void view::_init(void* internal_value) noexcept {
     if (!internal_value) {
-        _type = bsoncxx::type::k_null;
-        _b_null = bsoncxx::types::b_null{};
+        _type = bsoncxx::v_noabi::type::k_null;
+        _b_null = bsoncxx::v_noabi::types::b_null{};
         return;
     }
 
     bson_value_t* v = (bson_value_t*)(internal_value);
-    _type = static_cast<bsoncxx::type>(v->value_type);
+    _type = static_cast<bsoncxx::v_noabi::type>(v->value_type);
 
     switch (_type) {
-#define BSONCXX_ENUM(name, val)              \
-    case bsoncxx::type::k_##name: {          \
-        convert_from_libbson(v, &_b_##name); \
-        break;                               \
+#define BSONCXX_ENUM(name, val)                                \
+    case bsoncxx::v_noabi::type::k_##name: {                   \
+        ::bsoncxx::types::convert_from_libbson(v, &_b_##name); \
+        break;                                                 \
     }
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.cpp
@@ -27,11 +27,11 @@
     bson_iter_t iter; \
     bson_iter_init_from_data_at_offset(&iter, raw, length, offset, keylen);
 
-#define BSONCXX_TYPE_CHECK(name)                                                \
-    do {                                                                        \
-        if (type() != bsoncxx::v_noabi::type::k_##name) {                       \
-            throw bsoncxx::exception{error_code::k_need_element_type_k_##name}; \
-        }                                                                       \
+#define BSONCXX_TYPE_CHECK(name)                                                         \
+    do {                                                                                 \
+        if (type() != bsoncxx::v_noabi::type::k_##name) {                                \
+            throw bsoncxx::v_noabi::exception{error_code::k_need_element_type_k_##name}; \
+        }                                                                                \
     } while (0)
 
 namespace bsoncxx {

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/private/convert.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/private/convert.hh
@@ -24,7 +24,6 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace wip {
 namespace types {
 
 BSONCXX_INLINE char* make_copy_for_libbson(stdx::string_view s, uint32_t* len_out = nullptr) {
@@ -40,7 +39,7 @@ BSONCXX_INLINE char* make_copy_for_libbson(stdx::string_view s, uint32_t* len_ou
     return copy;
 }
 
-BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_binary& binary, bson_value_t* v) {
+BSONCXX_INLINE void convert_to_libbson(const b_binary& binary, bson_value_t* v) {
     v->value_type = BSON_TYPE_BINARY;
 
     v->value.v_binary.subtype = static_cast<bson_subtype_t>(binary.sub_type);
@@ -49,64 +48,63 @@ BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_binary& binary, b
     std::memcpy(v->value.v_binary.data, binary.bytes, binary.size);
 }
 
-BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_string& str, bson_value_t* v) {
+BSONCXX_INLINE void convert_to_libbson(const b_string& str, bson_value_t* v) {
     v->value_type = BSON_TYPE_UTF8;
     v->value.v_utf8.str = make_copy_for_libbson(str.value, &(v->value.v_utf8.len));
 }
 
-BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_double& val, bson_value_t* v) {
+BSONCXX_INLINE void convert_to_libbson(const b_double& val, bson_value_t* v) {
     v->value_type = BSON_TYPE_DOUBLE;
     v->value.v_double = val.value;
 }
 
-BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_int32& val, bson_value_t* v) {
+BSONCXX_INLINE void convert_to_libbson(const b_int32& val, bson_value_t* v) {
     v->value_type = BSON_TYPE_INT32;
     v->value.v_int32 = val.value;
 }
 
-BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_int64& val, bson_value_t* v) {
+BSONCXX_INLINE void convert_to_libbson(const b_int64& val, bson_value_t* v) {
     v->value_type = BSON_TYPE_INT64;
     v->value.v_int64 = val.value;
 }
 
-BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_undefined&, bson_value_t* v) {
+BSONCXX_INLINE void convert_to_libbson(const b_undefined&, bson_value_t* v) {
     v->value_type = BSON_TYPE_UNDEFINED;
 }
 
-BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_oid& val, bson_value_t* v) {
+BSONCXX_INLINE void convert_to_libbson(const b_oid& val, bson_value_t* v) {
     v->value_type = BSON_TYPE_OID;
     std::memcpy(&v->value.v_oid.bytes, val.value.bytes(), val.value.k_oid_length);
 }
 
-BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_decimal128& decimal,
-                                       bson_value_t* v) {
+BSONCXX_INLINE void convert_to_libbson(const b_decimal128& decimal, bson_value_t* v) {
     v->value_type = BSON_TYPE_DECIMAL128;
 
     v->value.v_decimal128.high = decimal.value.high();
     v->value.v_decimal128.low = decimal.value.low();
 }
 
-BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_bool& val, bson_value_t* v) {
+BSONCXX_INLINE void convert_to_libbson(const b_bool& val, bson_value_t* v) {
     v->value_type = BSON_TYPE_BOOL;
     v->value.v_bool = val.value;
 }
 
-BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_date& date, bson_value_t* v) {
+BSONCXX_INLINE void convert_to_libbson(const b_date& date, bson_value_t* v) {
     v->value_type = BSON_TYPE_DATE_TIME;
     v->value.v_datetime = date.value.count();
 }
 
-BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_null&, bson_value_t* v) {
+BSONCXX_INLINE void convert_to_libbson(const b_null&, bson_value_t* v) {
     v->value_type = BSON_TYPE_NULL;
 }
 
-BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_regex& regex, bson_value_t* v) {
+BSONCXX_INLINE void convert_to_libbson(const b_regex& regex, bson_value_t* v) {
     v->value_type = BSON_TYPE_REGEX;
     v->value.v_regex.options = make_copy_for_libbson(regex.options);
     v->value.v_regex.regex = make_copy_for_libbson(regex.regex);
 }
 
-BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_dbpointer& db, bson_value_t* v) {
+BSONCXX_INLINE void convert_to_libbson(const b_dbpointer& db, bson_value_t* v) {
     v->value_type = BSON_TYPE_DBPOINTER;
 
     v->value.v_dbpointer.collection =
@@ -115,17 +113,17 @@ BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_dbpointer& db, bs
     std::memcpy((v->value.v_dbpointer.oid.bytes), db.value.bytes(), db.value.k_oid_length);
 }
 
-BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_code& code, bson_value_t* v) {
+BSONCXX_INLINE void convert_to_libbson(const b_code& code, bson_value_t* v) {
     v->value_type = BSON_TYPE_CODE;
     v->value.v_code.code = make_copy_for_libbson(code.code, &(v->value.v_code.code_len));
 }
 
-BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_symbol& symbol, bson_value_t* v) {
+BSONCXX_INLINE void convert_to_libbson(const b_symbol& symbol, bson_value_t* v) {
     v->value_type = BSON_TYPE_SYMBOL;
     v->value.v_symbol.symbol = make_copy_for_libbson(symbol.symbol, &(v->value.v_symbol.len));
 }
 
-BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_codewscope& code, bson_value_t* v) {
+BSONCXX_INLINE void convert_to_libbson(const b_codewscope& code, bson_value_t* v) {
     v->value_type = BSON_TYPE_CODEWSCOPE;
 
     // Copy the code
@@ -143,21 +141,21 @@ BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_codewscope& code,
     }
 }
 
-BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_timestamp& t, bson_value_t* v) {
+BSONCXX_INLINE void convert_to_libbson(const b_timestamp& t, bson_value_t* v) {
     v->value_type = BSON_TYPE_TIMESTAMP;
     v->value.v_timestamp.timestamp = t.timestamp;
     v->value.v_timestamp.increment = t.increment;
 }
 
-BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_minkey&, bson_value_t* v) {
+BSONCXX_INLINE void convert_to_libbson(const b_minkey&, bson_value_t* v) {
     v->value_type = BSON_TYPE_MINKEY;
 }
 
-BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_maxkey&, bson_value_t* v) {
+BSONCXX_INLINE void convert_to_libbson(const b_maxkey&, bson_value_t* v) {
     v->value_type = BSON_TYPE_MAXKEY;
 }
 
-BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_document& doc, bson_value_t* v) {
+BSONCXX_INLINE void convert_to_libbson(const b_document& doc, bson_value_t* v) {
     v->value_type = BSON_TYPE_DOCUMENT;
 
     v->value.v_doc.data_len = (uint32_t)doc.value.length();
@@ -169,7 +167,7 @@ BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_document& doc, bs
     }
 }
 
-BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_array& arr, bson_value_t* v) {
+BSONCXX_INLINE void convert_to_libbson(const b_array& arr, bson_value_t* v) {
     v->value_type = BSON_TYPE_ARRAY;
     // The bson_value_t struct does not have a separate union
     // member for arrays. They are handled the same as the document
@@ -189,7 +187,7 @@ BSONCXX_INLINE void convert_to_libbson(const bsoncxx::types::b_array& arr, bson_
 BSONCXX_INLINE void convert_to_libbson(bson_value_t* v, const bson_value::view& bson_view) {
     switch (bson_view.type()) {
 #define BSONCXX_ENUM(name, val)              \
-    case bsoncxx::type::k_##name: {          \
+    case bsoncxx::v_noabi::type::k_##name: { \
         auto value = bson_view.get_##name(); \
         convert_to_libbson(value, v);        \
         break;                               \
@@ -201,7 +199,7 @@ BSONCXX_INLINE void convert_to_libbson(bson_value_t* v, const bson_value::view& 
     }
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_binary* out) {
+BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_binary* out) {
     bson_subtype_t subtype = v->value.v_binary.subtype;
     std::uint32_t len = v->value.v_binary.data_len;
     const std::uint8_t* binary = v->value.v_binary.data;
@@ -209,126 +207,124 @@ BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_bina
     *out = {static_cast<binary_sub_type>(subtype), len, binary};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_string* out) {
+BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_string* out) {
     uint32_t len = v->value.v_utf8.len;
     const char* val = v->value.v_utf8.str;
 
-    *out = bsoncxx::types::b_string{stdx::string_view{val, len}};
+    *out = b_string{stdx::string_view{val, len}};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_double* out) {
-    *out = bsoncxx::types::b_double{v->value.v_double};
+BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_double* out) {
+    *out = b_double{v->value.v_double};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_int32* out) {
-    *out = bsoncxx::types::b_int32{v->value.v_int32};
+BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_int32* out) {
+    *out = b_int32{v->value.v_int32};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_int64* out) {
-    *out = bsoncxx::types::b_int64{v->value.v_int64};
+BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_int64* out) {
+    *out = b_int64{v->value.v_int64};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t*, bsoncxx::types::b_undefined* out) {
-    *out = bsoncxx::types::b_undefined{};
+BSONCXX_INLINE void convert_from_libbson(bson_value_t*, b_undefined* out) {
+    *out = b_undefined{};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_oid* out) {
+BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_oid* out) {
     const bson_oid_t* boid = &(v->value.v_oid);
     oid val_oid(reinterpret_cast<const char*>(boid->bytes), sizeof(boid->bytes));
-    *out = bsoncxx::types::b_oid{std::move(val_oid)};
+    *out = b_oid{std::move(val_oid)};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_decimal128* out) {
+BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_decimal128* out) {
     bson_decimal128_t d128 = v->value.v_decimal128;
-    *out = bsoncxx::types::b_decimal128{decimal128{d128.high, d128.low}};
+    *out = b_decimal128{decimal128{d128.high, d128.low}};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_bool* out) {
-    *out = bsoncxx::types::b_bool{v->value.v_bool};
+BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_bool* out) {
+    *out = b_bool{v->value.v_bool};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_date* out) {
-    *out = bsoncxx::types::b_date{std::chrono::milliseconds{v->value.v_datetime}};
+BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_date* out) {
+    *out = b_date{std::chrono::milliseconds{v->value.v_datetime}};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t*, bsoncxx::types::b_null* out) {
-    *out = bsoncxx::types::b_null{};
+BSONCXX_INLINE void convert_from_libbson(bson_value_t*, b_null* out) {
+    *out = b_null{};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_regex* out) {
+BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_regex* out) {
     const char* options = v->value.v_regex.options;
     const char* regex = v->value.v_regex.regex;
-    *out = bsoncxx::types::b_regex{regex, options ? options : stdx::string_view{}};
+    *out = b_regex{regex, options ? options : stdx::string_view{}};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_dbpointer* out) {
+BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_dbpointer* out) {
     uint32_t collection_len = v->value.v_dbpointer.collection_len;
     const char* collection = v->value.v_dbpointer.collection;
     const bson_oid_t* boid = &(v->value.v_dbpointer.oid);
 
     oid oid{reinterpret_cast<const char*>(boid->bytes), sizeof(boid->bytes)};
 
-    *out =
-        bsoncxx::types::b_dbpointer{stdx::string_view{collection, collection_len}, std::move(oid)};
+    *out = b_dbpointer{stdx::string_view{collection, collection_len}, std::move(oid)};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_code* out) {
+BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_code* out) {
     uint32_t len = v->value.v_code.code_len;
     const char* code = v->value.v_code.code;
 
-    *out = bsoncxx::types::b_code{stdx::string_view{code, len}};
+    *out = b_code{stdx::string_view{code, len}};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_symbol* out) {
+BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_symbol* out) {
     uint32_t len = v->value.v_symbol.len;
     const char* symbol = v->value.v_symbol.symbol;
 
-    *out = bsoncxx::types::b_symbol{stdx::string_view{symbol, len}};
+    *out = b_symbol{stdx::string_view{symbol, len}};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_codewscope* out) {
+BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_codewscope* out) {
     uint32_t code_len = v->value.v_codewscope.code_len;
     const uint8_t* scope_ptr = v->value.v_codewscope.scope_data;
     uint32_t scope_len = v->value.v_codewscope.scope_len;
     const char* code = v->value.v_codewscope.code;
     document::view view(scope_ptr, scope_len);
 
-    *out = bsoncxx::types::b_codewscope{stdx::string_view{code, code_len}, view};
+    *out = b_codewscope{stdx::string_view{code, code_len}, view};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_timestamp* out) {
+BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_timestamp* out) {
     uint32_t timestamp = v->value.v_timestamp.timestamp;
     uint32_t increment = v->value.v_timestamp.increment;
     *out = {increment, timestamp};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t*, bsoncxx::types::b_minkey* out) {
-    *out = bsoncxx::types::b_minkey{};
+BSONCXX_INLINE void convert_from_libbson(bson_value_t*, b_minkey* out) {
+    *out = b_minkey{};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t*, bsoncxx::types::b_maxkey* out) {
-    *out = bsoncxx::types::b_maxkey{};
+BSONCXX_INLINE void convert_from_libbson(bson_value_t*, b_maxkey* out) {
+    *out = b_maxkey{};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_document* out) {
+BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_document* out) {
     const std::uint8_t* buf = v->value.v_doc.data;
     std::uint32_t len = v->value.v_doc.data_len;
 
-    *out = bsoncxx::types::b_document{document::view{buf, len}};
+    *out = b_document{document::view{buf, len}};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_array* out) {
+BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_array* out) {
     // The bson_value_t struct does not have a separate union
     // member for arrays. They are handled the same as the document
     // BSON type.
     const std::uint8_t* buf = v->value.v_doc.data;
     std::uint32_t len = v->value.v_doc.data_len;
 
-    *out = bsoncxx::types::b_array{array::view{buf, len}};
+    *out = b_array{array::view{buf, len}};
 }
 
 }  // namespace types
-}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/private/postlude.hh>

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/private/convert.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/private/convert.hh
@@ -24,9 +24,10 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
+namespace v_noabi {
 namespace types {
 
-BSONCXX_INLINE char* make_copy_for_libbson(stdx::string_view s, uint32_t* len_out = nullptr) {
+inline char* make_copy_for_libbson(stdx::string_view s, uint32_t* len_out = nullptr) {
     // Append a nul byte to the end of the string
     char* copy = (char*)bson_malloc0(s.length() + 1);
     std::memcpy(copy, s.data(), s.length());
@@ -39,7 +40,7 @@ BSONCXX_INLINE char* make_copy_for_libbson(stdx::string_view s, uint32_t* len_ou
     return copy;
 }
 
-BSONCXX_INLINE void convert_to_libbson(const b_binary& binary, bson_value_t* v) {
+inline void convert_to_libbson(const b_binary& binary, bson_value_t* v) {
     v->value_type = BSON_TYPE_BINARY;
 
     v->value.v_binary.subtype = static_cast<bson_subtype_t>(binary.sub_type);
@@ -48,63 +49,63 @@ BSONCXX_INLINE void convert_to_libbson(const b_binary& binary, bson_value_t* v) 
     std::memcpy(v->value.v_binary.data, binary.bytes, binary.size);
 }
 
-BSONCXX_INLINE void convert_to_libbson(const b_string& str, bson_value_t* v) {
+inline void convert_to_libbson(const b_string& str, bson_value_t* v) {
     v->value_type = BSON_TYPE_UTF8;
     v->value.v_utf8.str = make_copy_for_libbson(str.value, &(v->value.v_utf8.len));
 }
 
-BSONCXX_INLINE void convert_to_libbson(const b_double& val, bson_value_t* v) {
+inline void convert_to_libbson(const b_double& val, bson_value_t* v) {
     v->value_type = BSON_TYPE_DOUBLE;
     v->value.v_double = val.value;
 }
 
-BSONCXX_INLINE void convert_to_libbson(const b_int32& val, bson_value_t* v) {
+inline void convert_to_libbson(const b_int32& val, bson_value_t* v) {
     v->value_type = BSON_TYPE_INT32;
     v->value.v_int32 = val.value;
 }
 
-BSONCXX_INLINE void convert_to_libbson(const b_int64& val, bson_value_t* v) {
+inline void convert_to_libbson(const b_int64& val, bson_value_t* v) {
     v->value_type = BSON_TYPE_INT64;
     v->value.v_int64 = val.value;
 }
 
-BSONCXX_INLINE void convert_to_libbson(const b_undefined&, bson_value_t* v) {
+inline void convert_to_libbson(const b_undefined&, bson_value_t* v) {
     v->value_type = BSON_TYPE_UNDEFINED;
 }
 
-BSONCXX_INLINE void convert_to_libbson(const b_oid& val, bson_value_t* v) {
+inline void convert_to_libbson(const b_oid& val, bson_value_t* v) {
     v->value_type = BSON_TYPE_OID;
     std::memcpy(&v->value.v_oid.bytes, val.value.bytes(), val.value.k_oid_length);
 }
 
-BSONCXX_INLINE void convert_to_libbson(const b_decimal128& decimal, bson_value_t* v) {
+inline void convert_to_libbson(const b_decimal128& decimal, bson_value_t* v) {
     v->value_type = BSON_TYPE_DECIMAL128;
 
     v->value.v_decimal128.high = decimal.value.high();
     v->value.v_decimal128.low = decimal.value.low();
 }
 
-BSONCXX_INLINE void convert_to_libbson(const b_bool& val, bson_value_t* v) {
+inline void convert_to_libbson(const b_bool& val, bson_value_t* v) {
     v->value_type = BSON_TYPE_BOOL;
     v->value.v_bool = val.value;
 }
 
-BSONCXX_INLINE void convert_to_libbson(const b_date& date, bson_value_t* v) {
+inline void convert_to_libbson(const b_date& date, bson_value_t* v) {
     v->value_type = BSON_TYPE_DATE_TIME;
     v->value.v_datetime = date.value.count();
 }
 
-BSONCXX_INLINE void convert_to_libbson(const b_null&, bson_value_t* v) {
+inline void convert_to_libbson(const b_null&, bson_value_t* v) {
     v->value_type = BSON_TYPE_NULL;
 }
 
-BSONCXX_INLINE void convert_to_libbson(const b_regex& regex, bson_value_t* v) {
+inline void convert_to_libbson(const b_regex& regex, bson_value_t* v) {
     v->value_type = BSON_TYPE_REGEX;
     v->value.v_regex.options = make_copy_for_libbson(regex.options);
     v->value.v_regex.regex = make_copy_for_libbson(regex.regex);
 }
 
-BSONCXX_INLINE void convert_to_libbson(const b_dbpointer& db, bson_value_t* v) {
+inline void convert_to_libbson(const b_dbpointer& db, bson_value_t* v) {
     v->value_type = BSON_TYPE_DBPOINTER;
 
     v->value.v_dbpointer.collection =
@@ -113,17 +114,17 @@ BSONCXX_INLINE void convert_to_libbson(const b_dbpointer& db, bson_value_t* v) {
     std::memcpy((v->value.v_dbpointer.oid.bytes), db.value.bytes(), db.value.k_oid_length);
 }
 
-BSONCXX_INLINE void convert_to_libbson(const b_code& code, bson_value_t* v) {
+inline void convert_to_libbson(const b_code& code, bson_value_t* v) {
     v->value_type = BSON_TYPE_CODE;
     v->value.v_code.code = make_copy_for_libbson(code.code, &(v->value.v_code.code_len));
 }
 
-BSONCXX_INLINE void convert_to_libbson(const b_symbol& symbol, bson_value_t* v) {
+inline void convert_to_libbson(const b_symbol& symbol, bson_value_t* v) {
     v->value_type = BSON_TYPE_SYMBOL;
     v->value.v_symbol.symbol = make_copy_for_libbson(symbol.symbol, &(v->value.v_symbol.len));
 }
 
-BSONCXX_INLINE void convert_to_libbson(const b_codewscope& code, bson_value_t* v) {
+inline void convert_to_libbson(const b_codewscope& code, bson_value_t* v) {
     v->value_type = BSON_TYPE_CODEWSCOPE;
 
     // Copy the code
@@ -141,21 +142,21 @@ BSONCXX_INLINE void convert_to_libbson(const b_codewscope& code, bson_value_t* v
     }
 }
 
-BSONCXX_INLINE void convert_to_libbson(const b_timestamp& t, bson_value_t* v) {
+inline void convert_to_libbson(const b_timestamp& t, bson_value_t* v) {
     v->value_type = BSON_TYPE_TIMESTAMP;
     v->value.v_timestamp.timestamp = t.timestamp;
     v->value.v_timestamp.increment = t.increment;
 }
 
-BSONCXX_INLINE void convert_to_libbson(const b_minkey&, bson_value_t* v) {
+inline void convert_to_libbson(const b_minkey&, bson_value_t* v) {
     v->value_type = BSON_TYPE_MINKEY;
 }
 
-BSONCXX_INLINE void convert_to_libbson(const b_maxkey&, bson_value_t* v) {
+inline void convert_to_libbson(const b_maxkey&, bson_value_t* v) {
     v->value_type = BSON_TYPE_MAXKEY;
 }
 
-BSONCXX_INLINE void convert_to_libbson(const b_document& doc, bson_value_t* v) {
+inline void convert_to_libbson(const b_document& doc, bson_value_t* v) {
     v->value_type = BSON_TYPE_DOCUMENT;
 
     v->value.v_doc.data_len = (uint32_t)doc.value.length();
@@ -167,7 +168,7 @@ BSONCXX_INLINE void convert_to_libbson(const b_document& doc, bson_value_t* v) {
     }
 }
 
-BSONCXX_INLINE void convert_to_libbson(const b_array& arr, bson_value_t* v) {
+inline void convert_to_libbson(const b_array& arr, bson_value_t* v) {
     v->value_type = BSON_TYPE_ARRAY;
     // The bson_value_t struct does not have a separate union
     // member for arrays. They are handled the same as the document
@@ -184,7 +185,7 @@ BSONCXX_INLINE void convert_to_libbson(const b_array& arr, bson_value_t* v) {
 //
 // Helper to convert without caller being aware of the underlying bson type.
 //
-BSONCXX_INLINE void convert_to_libbson(bson_value_t* v, const bson_value::view& bson_view) {
+inline void convert_to_libbson(bson_value_t* v, const bson_value::view& bson_view) {
     switch (bson_view.type()) {
 #define BSONCXX_ENUM(name, val)              \
     case bsoncxx::v_noabi::type::k_##name: { \
@@ -199,7 +200,7 @@ BSONCXX_INLINE void convert_to_libbson(bson_value_t* v, const bson_value::view& 
     }
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_binary* out) {
+inline void convert_from_libbson(bson_value_t* v, b_binary* out) {
     bson_subtype_t subtype = v->value.v_binary.subtype;
     std::uint32_t len = v->value.v_binary.data_len;
     const std::uint8_t* binary = v->value.v_binary.data;
@@ -207,59 +208,59 @@ BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_binary* out) {
     *out = {static_cast<binary_sub_type>(subtype), len, binary};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_string* out) {
+inline void convert_from_libbson(bson_value_t* v, b_string* out) {
     uint32_t len = v->value.v_utf8.len;
     const char* val = v->value.v_utf8.str;
 
     *out = b_string{stdx::string_view{val, len}};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_double* out) {
+inline void convert_from_libbson(bson_value_t* v, b_double* out) {
     *out = b_double{v->value.v_double};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_int32* out) {
+inline void convert_from_libbson(bson_value_t* v, b_int32* out) {
     *out = b_int32{v->value.v_int32};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_int64* out) {
+inline void convert_from_libbson(bson_value_t* v, b_int64* out) {
     *out = b_int64{v->value.v_int64};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t*, b_undefined* out) {
+inline void convert_from_libbson(bson_value_t*, b_undefined* out) {
     *out = b_undefined{};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_oid* out) {
+inline void convert_from_libbson(bson_value_t* v, b_oid* out) {
     const bson_oid_t* boid = &(v->value.v_oid);
     oid val_oid(reinterpret_cast<const char*>(boid->bytes), sizeof(boid->bytes));
     *out = b_oid{std::move(val_oid)};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_decimal128* out) {
+inline void convert_from_libbson(bson_value_t* v, b_decimal128* out) {
     bson_decimal128_t d128 = v->value.v_decimal128;
     *out = b_decimal128{decimal128{d128.high, d128.low}};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_bool* out) {
+inline void convert_from_libbson(bson_value_t* v, b_bool* out) {
     *out = b_bool{v->value.v_bool};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_date* out) {
+inline void convert_from_libbson(bson_value_t* v, b_date* out) {
     *out = b_date{std::chrono::milliseconds{v->value.v_datetime}};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t*, b_null* out) {
+inline void convert_from_libbson(bson_value_t*, b_null* out) {
     *out = b_null{};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_regex* out) {
+inline void convert_from_libbson(bson_value_t* v, b_regex* out) {
     const char* options = v->value.v_regex.options;
     const char* regex = v->value.v_regex.regex;
     *out = b_regex{regex, options ? options : stdx::string_view{}};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_dbpointer* out) {
+inline void convert_from_libbson(bson_value_t* v, b_dbpointer* out) {
     uint32_t collection_len = v->value.v_dbpointer.collection_len;
     const char* collection = v->value.v_dbpointer.collection;
     const bson_oid_t* boid = &(v->value.v_dbpointer.oid);
@@ -269,21 +270,21 @@ BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_dbpointer* out) {
     *out = b_dbpointer{stdx::string_view{collection, collection_len}, std::move(oid)};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_code* out) {
+inline void convert_from_libbson(bson_value_t* v, b_code* out) {
     uint32_t len = v->value.v_code.code_len;
     const char* code = v->value.v_code.code;
 
     *out = b_code{stdx::string_view{code, len}};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_symbol* out) {
+inline void convert_from_libbson(bson_value_t* v, b_symbol* out) {
     uint32_t len = v->value.v_symbol.len;
     const char* symbol = v->value.v_symbol.symbol;
 
     *out = b_symbol{stdx::string_view{symbol, len}};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_codewscope* out) {
+inline void convert_from_libbson(bson_value_t* v, b_codewscope* out) {
     uint32_t code_len = v->value.v_codewscope.code_len;
     const uint8_t* scope_ptr = v->value.v_codewscope.scope_data;
     uint32_t scope_len = v->value.v_codewscope.scope_len;
@@ -293,28 +294,28 @@ BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_codewscope* out) {
     *out = b_codewscope{stdx::string_view{code, code_len}, view};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_timestamp* out) {
+inline void convert_from_libbson(bson_value_t* v, b_timestamp* out) {
     uint32_t timestamp = v->value.v_timestamp.timestamp;
     uint32_t increment = v->value.v_timestamp.increment;
     *out = {increment, timestamp};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t*, b_minkey* out) {
+inline void convert_from_libbson(bson_value_t*, b_minkey* out) {
     *out = b_minkey{};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t*, b_maxkey* out) {
+inline void convert_from_libbson(bson_value_t*, b_maxkey* out) {
     *out = b_maxkey{};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_document* out) {
+inline void convert_from_libbson(bson_value_t* v, b_document* out) {
     const std::uint8_t* buf = v->value.v_doc.data;
     std::uint32_t len = v->value.v_doc.data_len;
 
     *out = b_document{document::view{buf, len}};
 }
 
-BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_array* out) {
+inline void convert_from_libbson(bson_value_t* v, b_array* out) {
     // The bson_value_t struct does not have a separate union
     // member for arrays. They are handled the same as the document
     // BSON type.
@@ -325,6 +326,7 @@ BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, b_array* out) {
 }
 
 }  // namespace types
+}  // namespace v_noabi
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/private/postlude.hh>

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/private/convert.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/private/convert.hh
@@ -24,7 +24,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace types {
 
 BSONCXX_INLINE char* make_copy_for_libbson(stdx::string_view s, uint32_t* len_out = nullptr) {
@@ -328,7 +328,7 @@ BSONCXX_INLINE void convert_from_libbson(bson_value_t* v, bsoncxx::types::b_arra
 }
 
 }  // namespace types
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/private/postlude.hh>

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/validate.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/validate.cpp
@@ -19,7 +19,8 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace wip {
+namespace v_noabi {
+
 struct validator::impl {
     bool _check_utf8{false};
     bool _check_utf8_allow_null{false};
@@ -104,5 +105,5 @@ stdx::optional<document::view> BSONCXX_CALL validate(const std::uint8_t* data,
     return document::view{data, length};
 }
 
-}  // namespace wip
+}  // namespace v_noabi
 }  // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/validate.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/validate.cpp
@@ -19,7 +19,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 struct validator::impl {
     bool _check_utf8{false};
     bool _check_utf8_allow_null{false};
@@ -104,5 +104,5 @@ stdx::optional<document::view> BSONCXX_CALL validate(const std::uint8_t* data,
     return document::view{data, length};
 }
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx

--- a/src/bsoncxx/test/to_string.hh
+++ b/src/bsoncxx/test/to_string.hh
@@ -29,7 +29,7 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 inline std::string to_string(types::bson_value::view_or_value val) {
     switch (val.view().type()) {
         case bsoncxx::type::k_string:
@@ -90,7 +90,7 @@ inline std::string to_string(types::bson_value::view_or_value val) {
     }
 }
 
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/private/postlude.hh>

--- a/src/bsoncxx/test/to_string.hh
+++ b/src/bsoncxx/test/to_string.hh
@@ -29,22 +29,24 @@
 #include <bsoncxx/config/private/prelude.hh>
 
 namespace bsoncxx {
-inline namespace wip {
-inline std::string to_string(types::bson_value::view_or_value val) {
+
+inline std::string to_string(bsoncxx::v_noabi::types::bson_value::view_or_value val) {
+    using type = bsoncxx::v_noabi::type;
+
     switch (val.view().type()) {
-        case bsoncxx::type::k_string:
+        case type::k_string:
             return string::to_string(val.view().get_string().value);
-        case bsoncxx::type::k_int32:
+        case type::k_int32:
             return std::to_string(val.view().get_int32().value);
-        case bsoncxx::type::k_int64:
+        case type::k_int64:
             return std::to_string(val.view().get_int64().value);
-        case bsoncxx::type::k_document:
+        case type::k_document:
             return to_json(val.view().get_document().value);
-        case bsoncxx::type::k_array:
+        case type::k_array:
             return to_json(val.view().get_array().value);
-        case bsoncxx::type::k_oid:
+        case type::k_oid:
             return val.view().get_oid().value.to_string();
-        case bsoncxx::type::k_binary: {
+        case type::k_binary: {
             const auto& binary = val.view().get_binary();
             std::stringstream ss;
             ss << std::hex;
@@ -54,43 +56,42 @@ inline std::string to_string(types::bson_value::view_or_value val) {
             }
             return ss.str();
         }
-        case bsoncxx::type::k_bool:
+        case type::k_bool:
             return val.view().get_bool().value ? "true" : "false";
-        case bsoncxx::type::k_code:
+        case type::k_code:
             return string::to_string(val.view().get_code().code);
-        case bsoncxx::type::k_codewscope:
+        case type::k_codewscope:
             return "code={" + string::to_string(val.view().get_codewscope().code) + "}, scope={" +
                    to_json(val.view().get_codewscope().scope) + "}";
-        case bsoncxx::type::k_date:
+        case type::k_date:
             return std::to_string(val.view().get_date().value.count());
-        case bsoncxx::type::k_double:
+        case type::k_double:
             return std::to_string(val.view().get_double());
-        case bsoncxx::type::k_null:
+        case type::k_null:
             return "null";
-        case bsoncxx::type::k_undefined:
+        case type::k_undefined:
             return "undefined";
-        case bsoncxx::type::k_timestamp:
+        case type::k_timestamp:
             return "timestamp={" + std::to_string(val.view().get_timestamp().timestamp) +
                    "}, increment={" + std::to_string(val.view().get_timestamp().increment) + "}";
-        case bsoncxx::type::k_regex:
+        case type::k_regex:
             return "regex={" + string::to_string(val.view().get_regex().regex) + "}, options={" +
                    string::to_string(val.view().get_regex().options) + "}";
-        case bsoncxx::type::k_minkey:
+        case type::k_minkey:
             return "minkey";
-        case bsoncxx::type::k_maxkey:
+        case type::k_maxkey:
             return "maxkey";
-        case bsoncxx::type::k_decimal128:
+        case type::k_decimal128:
             return val.view().get_decimal128().value.to_string();
-        case bsoncxx::type::k_symbol:
+        case type::k_symbol:
             return string::to_string(val.view().get_symbol().symbol);
-        case bsoncxx::type::k_dbpointer:
+        case type::k_dbpointer:
             return val.view().get_dbpointer().value.to_string();
         default:
             return "?";  // Match bsoncxx::v_noabi::to_string(bsoncxx::v_noabi::type) behavior.
     }
 }
 
-}  // namespace wip
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/private/postlude.hh>

--- a/src/bsoncxx/test/to_string.hh
+++ b/src/bsoncxx/test/to_string.hh
@@ -86,7 +86,7 @@ inline std::string to_string(types::bson_value::view_or_value val) {
         case bsoncxx::type::k_dbpointer:
             return val.view().get_dbpointer().value.to_string();
         default:
-            return "?";  // Match bsoncxx::to_string(bsoncxx::type) behavior.
+            return "?";  // Match bsoncxx::v_noabi::to_string(bsoncxx::v_noabi::type) behavior.
     }
 }
 

--- a/src/bsoncxx/test/type_traits.test.cpp
+++ b/src/bsoncxx/test/type_traits.test.cpp
@@ -11,6 +11,7 @@
 #endif
 
 namespace {
+
 namespace tt = bsoncxx::detail;
 
 template <typename Result, typename Expect>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stdx.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stdx.hpp
@@ -18,9 +18,9 @@
 
 // "Forward-declare" the `bsoncxx::stdx` namespace to permit the using-declaration below.
 namespace bsoncxx {
-inline namespace v_noabi {
+inline namespace wip {
 namespace stdx {}
-}  // namespace v_noabi
+}  // namespace wip
 }  // namespace bsoncxx
 
 namespace mongocxx {

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stdx.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stdx.hpp
@@ -18,9 +18,7 @@
 
 // "Forward-declare" the `bsoncxx::stdx` namespace to permit the using-declaration below.
 namespace bsoncxx {
-inline namespace wip {
 namespace stdx {}
-}  // namespace wip
 }  // namespace bsoncxx
 
 namespace mongocxx {
@@ -28,7 +26,7 @@ inline namespace v_noabi {
 namespace stdx {
 
 // We adopt all the bsoncxx polyfills
-using namespace ::bsoncxx::stdx;
+using namespace bsoncxx::stdx;
 
 }  // namespace stdx
 }  // namespace v_noabi

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/encrypt.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/encrypt.cpp
@@ -100,9 +100,9 @@ struct scoped_bson_value {
     auto convert(const T& value)
         // Use trailing return type syntax to SFINAE without triggering GCC -Wignored-attributes
         // warnings due to using decltype within template parameters.
-        -> decltype(::bsoncxx::types::convert_to_libbson(std::declval<const T&>(),
-                                                         std::declval<bson_value_t*>())) {
-        ::bsoncxx::types::convert_to_libbson(value, &this->value);
+        -> decltype(bsoncxx::v_noabi::types::convert_to_libbson(std::declval<const T&>(),
+                                                                std::declval<bson_value_t*>())) {
+        bsoncxx::v_noabi::types::convert_to_libbson(value, &this->value);
     }
 
     template <typename T>
@@ -112,7 +112,7 @@ struct scoped_bson_value {
 
     explicit scoped_bson_value(const bsoncxx::types::bson_value::view& view) {
         // Argument order is reversed for bsoncxx::types::bson_value::view.
-        ::bsoncxx::types::convert_to_libbson(&this->value, view);
+        bsoncxx::v_noabi::types::convert_to_libbson(&this->value, view);
     }
 
     ~scoped_bson_value() {

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/encrypt.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/encrypt.cpp
@@ -100,9 +100,9 @@ struct scoped_bson_value {
     auto convert(const T& value)
         // Use trailing return type syntax to SFINAE without triggering GCC -Wignored-attributes
         // warnings due to using decltype within template parameters.
-        -> decltype(bsoncxx::types::convert_to_libbson(std::declval<const T&>(),
-                                                       std::declval<bson_value_t*>())) {
-        bsoncxx::types::convert_to_libbson(value, &this->value);
+        -> decltype(::bsoncxx::types::convert_to_libbson(std::declval<const T&>(),
+                                                         std::declval<bson_value_t*>())) {
+        ::bsoncxx::types::convert_to_libbson(value, &this->value);
     }
 
     template <typename T>
@@ -112,7 +112,7 @@ struct scoped_bson_value {
 
     explicit scoped_bson_value(const bsoncxx::types::bson_value::view& view) {
         // Argument order is reversed for bsoncxx::types::bson_value::view.
-        bsoncxx::types::convert_to_libbson(&this->value, view);
+        ::bsoncxx::types::convert_to_libbson(&this->value, view);
     }
 
     ~scoped_bson_value() {

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client_encryption.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client_encryption.hh
@@ -59,9 +59,9 @@ class client_encryption::impl {
         auto convert(const T& value)
             // Use trailing return type syntax to SFINAE without triggering GCC -Wignored-attributes
             // warnings due to using decltype within template parameters.
-            -> decltype(bsoncxx::types::convert_to_libbson(std::declval<const T&>(),
-                                                           std::declval<bson_value_t*>())) {
-            bsoncxx::types::convert_to_libbson(value, &this->value);
+            -> decltype(::bsoncxx::types::convert_to_libbson(std::declval<const T&>(),
+                                                             std::declval<bson_value_t*>())) {
+            ::bsoncxx::types::convert_to_libbson(value, &this->value);
         }
 
         template <typename T>
@@ -71,7 +71,7 @@ class client_encryption::impl {
 
         explicit scoped_bson_value(const bsoncxx::types::bson_value::view& view) {
             // Argument order is reversed for bsoncxx::types::bson_value::view.
-            bsoncxx::types::convert_to_libbson(&this->value, view);
+            ::bsoncxx::types::convert_to_libbson(&this->value, view);
         }
 
         ~scoped_bson_value() {

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client_encryption.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client_encryption.hh
@@ -59,9 +59,9 @@ class client_encryption::impl {
         auto convert(const T& value)
             // Use trailing return type syntax to SFINAE without triggering GCC -Wignored-attributes
             // warnings due to using decltype within template parameters.
-            -> decltype(::bsoncxx::types::convert_to_libbson(std::declval<const T&>(),
-                                                             std::declval<bson_value_t*>())) {
-            ::bsoncxx::types::convert_to_libbson(value, &this->value);
+            -> decltype(bsoncxx::v_noabi::types::convert_to_libbson(
+                std::declval<const T&>(), std::declval<bson_value_t*>())) {
+            bsoncxx::v_noabi::types::convert_to_libbson(value, &this->value);
         }
 
         template <typename T>
@@ -71,7 +71,7 @@ class client_encryption::impl {
 
         explicit scoped_bson_value(const bsoncxx::types::bson_value::view& view) {
             // Argument order is reversed for bsoncxx::types::bson_value::view.
-            ::bsoncxx::types::convert_to_libbson(&this->value, view);
+            bsoncxx::v_noabi::types::convert_to_libbson(&this->value, view);
         }
 
         ~scoped_bson_value() {

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client_encryption.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client_encryption.hh
@@ -143,7 +143,7 @@ class client_encryption::impl {
             throw_exception<operation_exception>(error);
         }
 
-        return bsoncxx::types::bson_value::make_owning_bson(keyid.get());
+        return bsoncxx::v_noabi::types::bson_value::make_owning_bson(keyid.get());
     }
 
     bsoncxx::types::bson_value::value encrypt(bsoncxx::types::bson_value::view value,
@@ -162,7 +162,7 @@ class client_encryption::impl {
             throw_exception<operation_exception>(error);
         }
 
-        return bsoncxx::types::bson_value::make_owning_bson(ciphertext.get());
+        return bsoncxx::v_noabi::types::bson_value::make_owning_bson(ciphertext.get());
     }
 
     bsoncxx::document::value encrypt_expression(bsoncxx::document::view_or_value expr,
@@ -195,7 +195,7 @@ class client_encryption::impl {
             throw_exception<operation_exception>(error);
         }
 
-        return bsoncxx::types::bson_value::make_owning_bson(decrypted_value.get());
+        return bsoncxx::v_noabi::types::bson_value::make_owning_bson(decrypted_value.get());
     }
 
     result::rewrap_many_datakey rewrap_many_datakey(bsoncxx::document::view_or_value filter,

--- a/src/mongocxx/test/spec/operation.cpp
+++ b/src/mongocxx/test/spec/operation.cpp
@@ -318,7 +318,7 @@ document::value operation_runner::_run_delete_many(document::view operation) {
     }
 
     if (arguments["hint"]) {
-        if (arguments["hint"].type() == bsoncxx::v_noabi::type::k_string)
+        if (arguments["hint"].type() == bsoncxx::wip::type::k_string)
             options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
@@ -355,7 +355,7 @@ document::value operation_runner::_run_delete_one(document::view operation) {
     }
 
     if (arguments["hint"]) {
-        if (arguments["hint"].type() == bsoncxx::v_noabi::type::k_string)
+        if (arguments["hint"].type() == bsoncxx::wip::type::k_string)
             options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
@@ -392,14 +392,14 @@ document::value operation_runner::_run_find_one_and_delete(document::view operat
     }
 
     if (arguments["hint"]) {
-        if (arguments["hint"].type() == bsoncxx::v_noabi::type::k_string)
+        if (arguments["hint"].type() == bsoncxx::wip::type::k_string)
             options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
     }
 
     if (arguments["hint"]) {
-        if (arguments["hint"].type() == bsoncxx::v_noabi::type::k_string)
+        if (arguments["hint"].type() == bsoncxx::wip::type::k_string)
             options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
@@ -461,7 +461,7 @@ document::value operation_runner::_run_find_one_and_replace(document::view opera
     }
 
     if (arguments["hint"]) {
-        if (arguments["hint"].type() == bsoncxx::v_noabi::type::k_string)
+        if (arguments["hint"].type() == bsoncxx::wip::type::k_string)
             options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
@@ -521,7 +521,7 @@ document::value operation_runner::_run_find_one_and_update(document::view operat
     }
 
     if (arguments["hint"]) {
-        if (arguments["hint"].type() == bsoncxx::v_noabi::type::k_string)
+        if (arguments["hint"].type() == bsoncxx::wip::type::k_string)
             options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
@@ -677,7 +677,7 @@ document::value operation_runner::_run_replace_one(document::view operation) {
     }
 
     if (arguments["hint"]) {
-        if (arguments["hint"].type() == bsoncxx::v_noabi::type::k_string)
+        if (arguments["hint"].type() == bsoncxx::wip::type::k_string)
             options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
@@ -745,7 +745,7 @@ document::value operation_runner::_run_update_many(document::view operation) {
     }
 
     if (arguments["hint"]) {
-        if (arguments["hint"].type() == bsoncxx::v_noabi::type::k_string)
+        if (arguments["hint"].type() == bsoncxx::wip::type::k_string)
             options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
@@ -837,7 +837,7 @@ document::value operation_runner::_run_update_one(document::view operation) {
     }
 
     if (arguments["hint"]) {
-        if (arguments["hint"].type() == bsoncxx::v_noabi::type::k_string)
+        if (arguments["hint"].type() == bsoncxx::wip::type::k_string)
             options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
@@ -996,7 +996,7 @@ document::value operation_runner::_run_bulk_write(document::view operation) {
             auto update_one = _build_update_model<model::update_one>(request_arguments);
 
             if (request_arguments["hint"]) {
-                if (request_arguments["hint"].type() == bsoncxx::v_noabi::type::k_string)
+                if (request_arguments["hint"].type() == bsoncxx::wip::type::k_string)
                     update_one.hint(hint{request_arguments["hint"].get_string().value});
                 else
                     update_one.hint(hint{request_arguments["hint"].get_document().value});
@@ -1019,7 +1019,7 @@ document::value operation_runner::_run_bulk_write(document::view operation) {
             auto update_many = _build_update_model<model::update_many>(request_arguments);
 
             if (request_arguments["hint"]) {
-                if (request_arguments["hint"].type() == bsoncxx::v_noabi::type::k_string)
+                if (request_arguments["hint"].type() == bsoncxx::wip::type::k_string)
                     update_many.hint(hint{request_arguments["hint"].get_string().value});
                 else
                     update_many.hint(hint{request_arguments["hint"].get_document().value});
@@ -1043,7 +1043,7 @@ document::value operation_runner::_run_bulk_write(document::view operation) {
             document::view replacement = request_arguments["replacement"].get_document().value;
             model::replace_one replace_one(filter, replacement);
             if (request_arguments["hint"]) {
-                if (request_arguments["hint"].type() == bsoncxx::v_noabi::type::k_string)
+                if (request_arguments["hint"].type() == bsoncxx::wip::type::k_string)
                     replace_one.hint(hint{request_arguments["hint"].get_string().value});
                 else
                     replace_one.hint(hint{request_arguments["hint"].get_document().value});
@@ -1066,7 +1066,7 @@ document::value operation_runner::_run_bulk_write(document::view operation) {
             document::view filter = request_arguments["filter"].get_document().value;
             model::delete_one delete_one(filter);
             if (request_arguments["hint"]) {
-                if (request_arguments["hint"].type() == bsoncxx::v_noabi::type::k_string)
+                if (request_arguments["hint"].type() == bsoncxx::wip::type::k_string)
                     delete_one.hint(hint{request_arguments["hint"].get_string().value});
                 else
                     delete_one.hint(hint{request_arguments["hint"].get_document().value});
@@ -1081,7 +1081,7 @@ document::value operation_runner::_run_bulk_write(document::view operation) {
             document::view filter = request_arguments["filter"].get_document().value;
             model::delete_many delete_many(filter);
             if (request_arguments["hint"]) {
-                if (request_arguments["hint"].type() == bsoncxx::v_noabi::type::k_string)
+                if (request_arguments["hint"].type() == bsoncxx::wip::type::k_string)
                     delete_many.hint(hint{request_arguments["hint"].get_string().value});
                 else
                     delete_many.hint(hint{request_arguments["hint"].get_document().value});
@@ -1459,12 +1459,11 @@ document::value operation_runner::run(document::view operation) {
         auto cursor = client[_db->name()][_coll->name()].list_indexes();
 
         REQUIRE(cursor.end() ==
-                std::find_if(cursor.begin(),
-                             cursor.end(),
-                             [operation](bsoncxx::v_noabi::document::view doc) {
-                                 return (doc["name"].get_string() ==
-                                         operation["arguments"]["index"].get_string());
-                             }));
+                std::find_if(
+                    cursor.begin(), cursor.end(), [operation](bsoncxx::wip::document::view doc) {
+                        return (doc["name"].get_string() ==
+                                operation["arguments"]["index"].get_string());
+                    }));
 
         return empty_document;
     } else if (key.compare("assertIndexExists") == 0) {
@@ -1474,12 +1473,11 @@ document::value operation_runner::run(document::view operation) {
         auto cursor = client[db][collection].list_indexes();
 
         REQUIRE(cursor.end() !=
-                std::find_if(cursor.begin(),
-                             cursor.end(),
-                             [operation](bsoncxx::v_noabi::document::view doc) {
-                                 return (doc["name"].get_string() ==
-                                         operation["arguments"]["index"].get_string());
-                             }));
+                std::find_if(
+                    cursor.begin(), cursor.end(), [operation](bsoncxx::wip::document::view doc) {
+                        return (doc["name"].get_string() ==
+                                operation["arguments"]["index"].get_string());
+                    }));
 
         return empty_document;
     } else if (key.compare("targetedFailPoint") == 0) {

--- a/src/mongocxx/test/spec/operation.cpp
+++ b/src/mongocxx/test/spec/operation.cpp
@@ -1458,12 +1458,11 @@ document::value operation_runner::run(document::view operation) {
         client client{uri{}};
         auto cursor = client[_db->name()][_coll->name()].list_indexes();
 
-        REQUIRE(cursor.end() ==
-                std::find_if(
-                    cursor.begin(), cursor.end(), [operation](bsoncxx::wip::document::view doc) {
-                        return (doc["name"].get_string() ==
-                                operation["arguments"]["index"].get_string());
-                    }));
+        REQUIRE(
+            cursor.end() ==
+            std::find_if(cursor.begin(), cursor.end(), [operation](bsoncxx::document::view doc) {
+                return (doc["name"].get_string() == operation["arguments"]["index"].get_string());
+            }));
 
         return empty_document;
     } else if (key.compare("assertIndexExists") == 0) {
@@ -1472,12 +1471,11 @@ document::value operation_runner::run(document::view operation) {
         auto collection = operation["arguments"]["collection"].get_string().value;
         auto cursor = client[db][collection].list_indexes();
 
-        REQUIRE(cursor.end() !=
-                std::find_if(
-                    cursor.begin(), cursor.end(), [operation](bsoncxx::wip::document::view doc) {
-                        return (doc["name"].get_string() ==
-                                operation["arguments"]["index"].get_string());
-                    }));
+        REQUIRE(
+            cursor.end() !=
+            std::find_if(cursor.begin(), cursor.end(), [operation](bsoncxx::document::view doc) {
+                return (doc["name"].get_string() == operation["arguments"]["index"].get_string());
+            }));
 
         return empty_document;
     } else if (key.compare("targetedFailPoint") == 0) {

--- a/src/mongocxx/test/spec/operation.cpp
+++ b/src/mongocxx/test/spec/operation.cpp
@@ -318,7 +318,7 @@ document::value operation_runner::_run_delete_many(document::view operation) {
     }
 
     if (arguments["hint"]) {
-        if (arguments["hint"].type() == bsoncxx::wip::type::k_string)
+        if (arguments["hint"].type() == bsoncxx::type::k_string)
             options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
@@ -355,7 +355,7 @@ document::value operation_runner::_run_delete_one(document::view operation) {
     }
 
     if (arguments["hint"]) {
-        if (arguments["hint"].type() == bsoncxx::wip::type::k_string)
+        if (arguments["hint"].type() == bsoncxx::type::k_string)
             options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
@@ -392,14 +392,14 @@ document::value operation_runner::_run_find_one_and_delete(document::view operat
     }
 
     if (arguments["hint"]) {
-        if (arguments["hint"].type() == bsoncxx::wip::type::k_string)
+        if (arguments["hint"].type() == bsoncxx::type::k_string)
             options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
     }
 
     if (arguments["hint"]) {
-        if (arguments["hint"].type() == bsoncxx::wip::type::k_string)
+        if (arguments["hint"].type() == bsoncxx::type::k_string)
             options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
@@ -461,7 +461,7 @@ document::value operation_runner::_run_find_one_and_replace(document::view opera
     }
 
     if (arguments["hint"]) {
-        if (arguments["hint"].type() == bsoncxx::wip::type::k_string)
+        if (arguments["hint"].type() == bsoncxx::type::k_string)
             options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
@@ -521,7 +521,7 @@ document::value operation_runner::_run_find_one_and_update(document::view operat
     }
 
     if (arguments["hint"]) {
-        if (arguments["hint"].type() == bsoncxx::wip::type::k_string)
+        if (arguments["hint"].type() == bsoncxx::type::k_string)
             options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
@@ -677,7 +677,7 @@ document::value operation_runner::_run_replace_one(document::view operation) {
     }
 
     if (arguments["hint"]) {
-        if (arguments["hint"].type() == bsoncxx::wip::type::k_string)
+        if (arguments["hint"].type() == bsoncxx::type::k_string)
             options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
@@ -745,7 +745,7 @@ document::value operation_runner::_run_update_many(document::view operation) {
     }
 
     if (arguments["hint"]) {
-        if (arguments["hint"].type() == bsoncxx::wip::type::k_string)
+        if (arguments["hint"].type() == bsoncxx::type::k_string)
             options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
@@ -837,7 +837,7 @@ document::value operation_runner::_run_update_one(document::view operation) {
     }
 
     if (arguments["hint"]) {
-        if (arguments["hint"].type() == bsoncxx::wip::type::k_string)
+        if (arguments["hint"].type() == bsoncxx::type::k_string)
             options.hint(hint{arguments["hint"].get_string().value});
         else
             options.hint(hint{arguments["hint"].get_document().value});
@@ -996,7 +996,7 @@ document::value operation_runner::_run_bulk_write(document::view operation) {
             auto update_one = _build_update_model<model::update_one>(request_arguments);
 
             if (request_arguments["hint"]) {
-                if (request_arguments["hint"].type() == bsoncxx::wip::type::k_string)
+                if (request_arguments["hint"].type() == bsoncxx::type::k_string)
                     update_one.hint(hint{request_arguments["hint"].get_string().value});
                 else
                     update_one.hint(hint{request_arguments["hint"].get_document().value});
@@ -1019,7 +1019,7 @@ document::value operation_runner::_run_bulk_write(document::view operation) {
             auto update_many = _build_update_model<model::update_many>(request_arguments);
 
             if (request_arguments["hint"]) {
-                if (request_arguments["hint"].type() == bsoncxx::wip::type::k_string)
+                if (request_arguments["hint"].type() == bsoncxx::type::k_string)
                     update_many.hint(hint{request_arguments["hint"].get_string().value});
                 else
                     update_many.hint(hint{request_arguments["hint"].get_document().value});
@@ -1043,7 +1043,7 @@ document::value operation_runner::_run_bulk_write(document::view operation) {
             document::view replacement = request_arguments["replacement"].get_document().value;
             model::replace_one replace_one(filter, replacement);
             if (request_arguments["hint"]) {
-                if (request_arguments["hint"].type() == bsoncxx::wip::type::k_string)
+                if (request_arguments["hint"].type() == bsoncxx::type::k_string)
                     replace_one.hint(hint{request_arguments["hint"].get_string().value});
                 else
                     replace_one.hint(hint{request_arguments["hint"].get_document().value});
@@ -1066,7 +1066,7 @@ document::value operation_runner::_run_bulk_write(document::view operation) {
             document::view filter = request_arguments["filter"].get_document().value;
             model::delete_one delete_one(filter);
             if (request_arguments["hint"]) {
-                if (request_arguments["hint"].type() == bsoncxx::wip::type::k_string)
+                if (request_arguments["hint"].type() == bsoncxx::type::k_string)
                     delete_one.hint(hint{request_arguments["hint"].get_string().value});
                 else
                     delete_one.hint(hint{request_arguments["hint"].get_document().value});
@@ -1081,7 +1081,7 @@ document::value operation_runner::_run_bulk_write(document::view operation) {
             document::view filter = request_arguments["filter"].get_document().value;
             model::delete_many delete_many(filter);
             if (request_arguments["hint"]) {
-                if (request_arguments["hint"].type() == bsoncxx::wip::type::k_string)
+                if (request_arguments["hint"].type() == bsoncxx::type::k_string)
                     delete_many.hint(hint{request_arguments["hint"].get_string().value});
                 else
                     delete_many.hint(hint{request_arguments["hint"].get_document().value});

--- a/src/mongocxx/test/spec/unified_tests/operations.cpp
+++ b/src/mongocxx/test/spec/unified_tests/operations.cpp
@@ -276,7 +276,7 @@ document::value list_indexes(entity::map& map, client_session* session, const st
 template <typename Model>
 void add_hint_to_model(Model model, document::view doc) {
     if (doc["hint"]) {
-        if (doc["hint"].type() == bsoncxx::v_noabi::type::k_string)
+        if (doc["hint"].type() == bsoncxx::wip::type::k_string)
             model.hint(hint{doc["hint"].get_string().value});
         else
             model.hint(hint{doc["hint"].get_document().value});
@@ -308,7 +308,7 @@ T _build_update_model(document::view arguments) {
 
 template <typename Model>
 void set_hint(Model& model, const mongocxx::document::element& hint) {
-    if (hint.type() == bsoncxx::v_noabi::type::k_string) {
+    if (hint.type() == bsoncxx::wip::type::k_string) {
         model.hint(mongocxx::hint(hint.get_string().value));
     } else {
         model.hint(mongocxx::hint(hint.get_document().value));
@@ -541,7 +541,7 @@ document::value replace_one(collection& coll, client_session* session, document:
     }
 
     if (const auto hint = arguments["hint"]) {
-        if (hint.type() == bsoncxx::v_noabi::type::k_string)
+        if (hint.type() == bsoncxx::wip::type::k_string)
             options.hint(mongocxx::hint(hint.get_string().value));
         else
             options.hint(mongocxx::hint(hint.get_document().value));
@@ -824,7 +824,7 @@ document::value find_one_and_delete(collection& coll,
     }
 
     if (const auto hint = arguments["hint"]) {
-        if (hint.type() == bsoncxx::v_noabi::type::k_string)
+        if (hint.type() == bsoncxx::wip::type::k_string)
             options.hint(mongocxx::hint(hint.get_string().value));
         else
             options.hint(mongocxx::hint(hint.get_document().value));
@@ -877,7 +877,7 @@ document::value find_one_and_replace(collection& coll,
     }
 
     if (const auto hint = arguments["hint"]) {
-        if (hint.type() == bsoncxx::v_noabi::type::k_string)
+        if (hint.type() == bsoncxx::wip::type::k_string)
             options.hint(mongocxx::hint(hint.get_string().value));
         else
             options.hint(mongocxx::hint(hint.get_document().value));
@@ -947,7 +947,7 @@ document::value find_one_and_update(collection& coll,
     }
 
     if (const auto hint = arguments["hint"]) {
-        if (hint.type() == bsoncxx::v_noabi::type::k_string)
+        if (hint.type() == bsoncxx::wip::type::k_string)
             options.hint(mongocxx::hint(hint.get_string().value));
         else
             options.hint(mongocxx::hint(hint.get_document().value));
@@ -1227,7 +1227,7 @@ document::value delete_one(collection& coll, client_session* session, document::
     }
 
     if (const auto hint = arguments["hint"]) {
-        if (hint.type() == bsoncxx::v_noabi::type::k_string)
+        if (hint.type() == bsoncxx::wip::type::k_string)
             options.hint(mongocxx::hint(hint.get_string().value));
         else
             options.hint(mongocxx::hint(hint.get_document().value));
@@ -1272,7 +1272,7 @@ document::value delete_many(collection& coll, client_session* session, document:
     }
 
     if (const auto hint = arguments["hint"]) {
-        if (hint.type() == bsoncxx::v_noabi::type::k_string) {
+        if (hint.type() == bsoncxx::wip::type::k_string) {
             options.hint(mongocxx::hint(hint.get_string().value));
         } else {
             options.hint(mongocxx::hint(hint.get_document().value));
@@ -1360,7 +1360,7 @@ document::value update_one(collection& coll, client_session* session, document::
     }
 
     if (const auto hint = arguments["hint"]) {
-        if (arguments["hint"].type() == bsoncxx::v_noabi::type::k_string)
+        if (arguments["hint"].type() == bsoncxx::wip::type::k_string)
             options.hint(mongocxx::hint(hint.get_string().value));
         else
             options.hint(mongocxx::hint(hint.get_document().value));
@@ -1432,7 +1432,7 @@ document::value update_many(collection& coll, document::view operation) {
     }
 
     if (const auto hint = arguments["hint"]) {
-        if (hint.type() == bsoncxx::v_noabi::type::k_string)
+        if (hint.type() == bsoncxx::wip::type::k_string)
             options.hint(mongocxx::hint(hint.get_string().value));
         else
             options.hint(mongocxx::hint(hint.get_document().value));
@@ -1518,7 +1518,7 @@ document::value count_documents(collection& coll,
     }
 
     if (const auto hint = arguments["hint"]) {
-        if (hint.type() == bsoncxx::v_noabi::type::k_string) {
+        if (hint.type() == bsoncxx::wip::type::k_string) {
             options.hint(mongocxx::hint(hint.get_string().value));
         } else {
             options.hint(mongocxx::hint(hint.get_document().value));

--- a/src/mongocxx/test/spec/unified_tests/operations.cpp
+++ b/src/mongocxx/test/spec/unified_tests/operations.cpp
@@ -276,7 +276,7 @@ document::value list_indexes(entity::map& map, client_session* session, const st
 template <typename Model>
 void add_hint_to_model(Model model, document::view doc) {
     if (doc["hint"]) {
-        if (doc["hint"].type() == bsoncxx::wip::type::k_string)
+        if (doc["hint"].type() == bsoncxx::type::k_string)
             model.hint(hint{doc["hint"].get_string().value});
         else
             model.hint(hint{doc["hint"].get_document().value});
@@ -308,7 +308,7 @@ T _build_update_model(document::view arguments) {
 
 template <typename Model>
 void set_hint(Model& model, const mongocxx::document::element& hint) {
-    if (hint.type() == bsoncxx::wip::type::k_string) {
+    if (hint.type() == bsoncxx::type::k_string) {
         model.hint(mongocxx::hint(hint.get_string().value));
     } else {
         model.hint(mongocxx::hint(hint.get_document().value));
@@ -541,7 +541,7 @@ document::value replace_one(collection& coll, client_session* session, document:
     }
 
     if (const auto hint = arguments["hint"]) {
-        if (hint.type() == bsoncxx::wip::type::k_string)
+        if (hint.type() == bsoncxx::type::k_string)
             options.hint(mongocxx::hint(hint.get_string().value));
         else
             options.hint(mongocxx::hint(hint.get_document().value));
@@ -824,7 +824,7 @@ document::value find_one_and_delete(collection& coll,
     }
 
     if (const auto hint = arguments["hint"]) {
-        if (hint.type() == bsoncxx::wip::type::k_string)
+        if (hint.type() == bsoncxx::type::k_string)
             options.hint(mongocxx::hint(hint.get_string().value));
         else
             options.hint(mongocxx::hint(hint.get_document().value));
@@ -877,7 +877,7 @@ document::value find_one_and_replace(collection& coll,
     }
 
     if (const auto hint = arguments["hint"]) {
-        if (hint.type() == bsoncxx::wip::type::k_string)
+        if (hint.type() == bsoncxx::type::k_string)
             options.hint(mongocxx::hint(hint.get_string().value));
         else
             options.hint(mongocxx::hint(hint.get_document().value));
@@ -947,7 +947,7 @@ document::value find_one_and_update(collection& coll,
     }
 
     if (const auto hint = arguments["hint"]) {
-        if (hint.type() == bsoncxx::wip::type::k_string)
+        if (hint.type() == bsoncxx::type::k_string)
             options.hint(mongocxx::hint(hint.get_string().value));
         else
             options.hint(mongocxx::hint(hint.get_document().value));
@@ -1227,7 +1227,7 @@ document::value delete_one(collection& coll, client_session* session, document::
     }
 
     if (const auto hint = arguments["hint"]) {
-        if (hint.type() == bsoncxx::wip::type::k_string)
+        if (hint.type() == bsoncxx::type::k_string)
             options.hint(mongocxx::hint(hint.get_string().value));
         else
             options.hint(mongocxx::hint(hint.get_document().value));
@@ -1272,7 +1272,7 @@ document::value delete_many(collection& coll, client_session* session, document:
     }
 
     if (const auto hint = arguments["hint"]) {
-        if (hint.type() == bsoncxx::wip::type::k_string) {
+        if (hint.type() == bsoncxx::type::k_string) {
             options.hint(mongocxx::hint(hint.get_string().value));
         } else {
             options.hint(mongocxx::hint(hint.get_document().value));
@@ -1360,7 +1360,7 @@ document::value update_one(collection& coll, client_session* session, document::
     }
 
     if (const auto hint = arguments["hint"]) {
-        if (arguments["hint"].type() == bsoncxx::wip::type::k_string)
+        if (arguments["hint"].type() == bsoncxx::type::k_string)
             options.hint(mongocxx::hint(hint.get_string().value));
         else
             options.hint(mongocxx::hint(hint.get_document().value));
@@ -1432,7 +1432,7 @@ document::value update_many(collection& coll, document::view operation) {
     }
 
     if (const auto hint = arguments["hint"]) {
-        if (hint.type() == bsoncxx::wip::type::k_string)
+        if (hint.type() == bsoncxx::type::k_string)
             options.hint(mongocxx::hint(hint.get_string().value));
         else
             options.hint(mongocxx::hint(hint.get_document().value));
@@ -1518,7 +1518,7 @@ document::value count_documents(collection& coll,
     }
 
     if (const auto hint = arguments["hint"]) {
-        if (hint.type() == bsoncxx::wip::type::k_string) {
+        if (hint.type() == bsoncxx::type::k_string) {
             options.hint(mongocxx::hint(hint.get_string().value));
         } else {
             options.hint(mongocxx::hint(hint.get_document().value));


### PR DESCRIPTION
## Description

This PR partially resolves CXX-2790. Verified by [this patch](https://spruce.mongodb.com/version/656a2f2e2fbabecf068a967f).

Although this PR and description is focused only on the bsoncxx library, many points equally apply to the mongocxx library. A followup PR will apply the same refactor to mongocxx.

This PR _SHOULD NOT_ break source or binary compatibility. Verified by [this patch](https://spruce.mongodb.com/version/656e327930661569ac9735dd/tasks) (pending ABI compatibility check scripts); specifically, the source compatibility report uploaded by the `abi-compliance-check` task. Concerning the added/removed `bsoncxx::detail` symbols, see the section below regarding type traits.

## Context

The following distinctions must be defined first:

* A _binary-breaking change_ requires bumping the ABI version number due to a _change_ or _removal_ of a symbol in the stable ABI.
* A _binary-incompatible feature_ may be an _addition_ of a symbol to the stable ABI, thus does NOT necessarily require bumping the ABI version number.
* A _source-breaking change_ requires bumping the API major version number due to a _change_ or _removal_ of an entity in the API.
* A _source-incompatible feature_ may be an _addition_ of an entity to the API, thus does NOT necessarily require bumping the API major version number.

For example, given the following initial state (assume no other overloads exist):

```cpp
namespace bsoncxx {
  inline namespace vA {
    std::int32_t foo();
  }
}
```

The following introduces a potentially source-incompatible, binary-incompatible feature _without_ being a source-breaking or binary-breaking change (it is purely additive):

```cpp
namespace bsoncxx {
  inline namespace vA {
    std::int32_t foo(); // Old, deprecated.
  }

  namespace vB {
    std::int64_t foo(); // New!
  }
}
```

Source code that refers to `bsoncxx::foo` or `bsoncxx::vA::foo` continue to compile with the new library release. Binaries that expect the symbol `bsoncxx::vA::foo` continue to link with the new library release. **This type of change allows library maintainers to introduce new features without concern for breaking source or binary compatibility.**

By contrast, the following is a non-binary-breaking, potentially source-breaking change:

```cpp
namespace bsoncxx {
  namespace vA {
    std::int32_t foo(); // Old, deprecated.
  }

  inline namespace vB {
    std::int64_t foo(); // New!
  }
}
```

Source code that refers to `bsoncxx::vA::foo` continue to compile with the new library release, and binaries that expect the symbol `bsoncxx::vA::foo` continue to link with the new library release. However, the meaning of source code referring to `bsoncxx::foo` has changed: it now refers to `bsoncxx::vB::foo` instead of `bsoncxx::vA::foo`. **This type of change allows users to benefit from binary-incompatible features without requiring binary-breaking changes**.

The important takeway from these examples is that potentially source-breaking changes can be introduced as binary-incompatible features _without_ necessarily breaking source or binary compatibility. This allows forward-progress of the library interface and provides users the Quality of Experience (QoE) of being able to benefit from incremental upgrades, while also providing incremental backward _and_ forward compatibility in the case of source-incompatible changes via explicit ABI namespace qualification: a user may opt-into using a potentially source-incompatible feature `bsoncxx::vB::foo` early, or may opt-out of a potentially source-breaking change by continuing to use `bsoncxx::vA::foo` instead.

## Inline ABI Namespaces

The bsoncxx library was originally designed with the intent of controlling binary compatibility via a `BSONCXX_ABI_VERSION` variable. Both the `SOVERSION` and the ABI namespace were defined in terms of this variable, such that when the ABI version number is bumped from `A` to `B`, the inline ABI namespace within which all bsoncxx entities are declared is also renamed from `vA` to `vB`. This has the effect of migrating the _entirety_ of the bsoncxx library from the `vA` to the `vB` namespace alongside the bumped `SOVERSION`.

This design was considered undesirable as, in practice, it does not easily allow for the type of changes described above. This is due to the fact that an inline namespace cannot be redeclared as non-inline, and a non-inline namespace cannot be redeclared as inline. This means bsoncxx library maintainers are forced into an _all-or-nothing_ approach to binary compatibility when considering potentially source-breaking changes:

```cpp
namespace bsoncxx {
  // Cannot declare as non-inline without affecting *all* entities within the
  // namespace.
  inline namespace vA {
    std::int32_t foo(); // Cannot selectively "undeclare" this entity in the
                        // root namespace.

    void bar(); // Unrelated entities in the inline namespace are forcibly
                // involved in root namespace declaration considerations.
  }
}
```

This limitation discourages both backward _and_ forward compatibility in three major ways:

* Because the current `vA::foo` cannot be selectively "undeclared" in the root namespace, `bsoncxx::foo` cannot refer to `vB::foo` without forcing an ABI version bump. This means users are unable to benefit from the addition of `vB::foo` unless they explicitly qualify their references with `vB`, which largely limits the utility of providing root namespace declarations (can only be exercised during binary-breaking releases, which are expected to be very infrequent).

```cpp
namespace bsoncxx {
  inline namespace vA {
    std::int32_t foo(); // Cannot "undeclare" `vA::foo` in root namespace.
  }

  /* inline */ // error: conflicts with `vA::foo`.
  namespace vB {
    std::int32_t foo();
  }

  /* using vB::foo; */ // error: conflicts with `vA::foo`.
}
```

* Because the ABI version bump is fundamentally linked to the redeclaration of ABI namespaces as (not-)inline, binary-incompatible changes are naturally forced into being treated like they are binary-breaking changes. `vA::foo` cannot be declared within a non-inline `vA` namespace until the `vA` -> `vB` rename is already in-progress. Therefore, preserving binary-compatibility with `vA::foo` -> implies preserving `vA` as the inline ABI namespace -> implies preserving the current ABI version number.

```cpp
namespace bsoncxx {
  inline namespace vB {
    std::int64_t foo(); // Even if possible...
  }

  namespace vA {
    std::int32_t foo(); // ... cannot declare/define this...
  }

  inline namespace vA {
    void bar(); // ... while any instance of an inline `vA` still exists.
  }
}
```

* Because the inline ABI namespace is _renamed_ `vA` to `vB` in the process of an ABI version bump, all entities in the `vA` namespace are redeclared in the `vB` namespace regardless of their intended ABI version compatibility. This inevitably triggers a conflict between the intended `vB::foo` and the former `vA::foo` (now incorrectly renamed to `vB::foo`) during the ABI version number bump. Library maintainers must then go through the laborous effort of identifying and resolving these conflicts _at the time of_ the ABI version bump (this cannot be mitigated beforehand other than via "TODO" documentation). The difficulty of this process is proportional to the number of conflicting `vB` symbols _and_ the number of `vA` symbols that must be removed or redeclared (furthermore, these two sets of symbols are _not_ 1-to-1!).

```cpp
namespace bsoncxx {
  inline namespace vA {
    class X; // Not immediately clear which entities
    class Y; // are intended to be removed during the
    class Z; // transition to vB.
  }

  namespace vB {
    class X; // Not immediately clear which entities
    class Y; // are intended to replace *or* be replaced
    class Z; // by a counterpart in `vA`.
  }
}
```

These three bullet points overlap under a common theme: binary-incompatible features are _a major pain_ to maintain even if they do not immediately break binary-compatibility.

## Using-Declarations

To address the issues with inline namespaces above, this PR follows up on https://github.com/mongodb/mongo-cxx-driver/pull/1034 (CXX-2750) by proposing the use of _using-declarations_ as the method to redeclare ABI namespace entities in the root namespace:

```cpp
namespace bsoncxx {
  namespace vA {
    std::int32_t foo();
    void bar();
  }

  namespace vB {
    std::int64_t foo();
  }

  using vA::foo; // Consider effect of updating to `vB::foo`.
  using vA::bar;
}
```

This method is believed to address all of the issues described above:

* The introduction of binary-incompatible changes in `vB` has no immediate effect or conflict with existing symbols in `vA` (it is not all-or-nothing).
* All symbols associated with a given ABI version `vA` are always declared in the appropriate namespace and can be maintained independently from symbols in `vB` (no namespace renaming shenanigans).
* Root namespace declarations can be independently controlled per-symbol, permitting incremental potentially source-breaking changes without forcing binary-breaking changes (API major/minor version bumps are independent from ABI version bumps).

This method facilitates both forward and backward compatibility, allows maintainers more freedom of design, and makes upgrades more accessible to users. The combination of all the above allows maintainers to selectively and incrementally migrate entities from `vA` to `vB`, without breaking source or binary compatibility while minimizing code duplication.

Furthermore, this refactor is NOT a source or binary breaking change. The identity of symbols remains unchanged, as all symbols are is still declared within their original ABI namespace (`bsoncxx::v_noabi::X` is still `bsoncxx::v_noabi::X`). All references (or lack thereof) to root namespace declarations, formerly imported via inline namespaces, are now fulfilled by the explicit using-declarations. Even argument-dependent lookup (ADL) should not be affected by this refactor given correct all the relevant using-declarations are implemented.

## Changes

The volume of diffs in this PR is large, but the patterns applied are fairly simple in nature.

### Replace `inline namespace v_noabi` with `namespace v_noabi`

The primary intent of this PR. All instances of `inline namespace` in the bsoncxx library are refactored to be non-inline. Due to the all-or-nothing nature of inline namespaces, this PR is forced to apply this refactor to _all_ instances simulatenously.

### Add Using-Declarations for Public Interfaces

All entities intended to be part of the public API are redeclared in the corresponding root namespace via a using-declaration. For example, for `bsoncxx::document::value`, the forward header looks as follows:

```cpp
namespace bsoncxx {
  namespace v_noabi {
    namespace document {
      class value;
    }
  }
}

namespace bsoncxx {
  namespace document {
    using ::bsoncxx::v_noabi::document::value;
  }
}
```

And the normal header looks as follows:

```cpp
namespace bsoncxx {
  namespace v_noabi {
    namespace document {
      class value { ... };

      BSONCXX_INLINE bool operator==(const value& lhs, const value& rhs) { ... }
      BSONCXX_INLINE bool operator!=(const value& lhs, const value& rhs) { ... }
    }
  }
}

namespace bsoncxx {
  namespace document {
    using ::bsoncxx::v_noabi::document::operator==;
    using ::bsoncxx::v_noabi::document::operator!=;
  }
}
```

Note: "hidden friends" do not require a using-declaration in the root namespace, as by-design they can only be found via ADL. This applies to functions and operator overloads such as `bsoncxx::document::view::operator==` that do not have an explicit declaration in namespace scope.

The completely separate redeclaration of the `bsoncxx` namespace is intentional to ensure the root namespace declarations are easily identifiable and grouped together. It should be plainly obvious at all times that any given entity declared in the root namespace is referring to the entity declared in _this_ specific ABI namespace. It was deemed undesirable for this information to be mixed within ABI-specific declarations and definitions. Thus all headers now follow this approximate pattern:

```cpp
#pragma once

#include <...>

#include <bsoncxx/config/prelude.hpp>

// ABI namespace declarations and definitions.
namespace bsoncxx {
  namespace vA {
    ...
  }
}

// Root namespace using-declarations.
namespace bsoncxx {
  using bsoncxx::vA::...;
}

#include <bsoncxx/config/postlude.hpp>
```

Note, this also has the additional side-effect of providing an interface boundary to better control exposure of public vs. private/implementation interfaces by the selective using-declaration of ABI namespace entities. For example, it is assumed (note: this assumption may be incorrect) that `bsoncxx::v_noabi::types::is_bson_view_compatible` in `bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp` is not intended to be part of the public API, thus it is not included in the using-declarations below, preventing its accidental/unintended use (there is no `bsoncxx::types::is_bson_view_compatible`).

Furthermore, the impact of using-declarations and using-directives used within the `v_noabi` namespaces in public headers can be somewhat mitigated in the future by being excluded in their root namespace counterparts. Their removal is not done in this PR to ensure source-compatibility, but `// Deprecated.` comments have been added to discourage their continued dependence/use.

### ABI Interface Stability

In library interface and implementation (headers and sources), all references to `bsoncxx::X` have been refactored to either exclude the root namespace qualifier entirely (e.g. just `X`) or to be fully qualified with the ABI namespace included (e.g. `::bsoncxx::v_noabi::X`). This is a coding style that should be enforced via code review going forward: **entities within an ABI namespace MUST NOT be defined in terms of root namespace declarations**. This is to ensure that any interface defined in terms of ABI namespace `vA` will never be inadvertently affected by the upgrade of a root namespace declaration `vA` -> `vB`.

For example:

```cpp
namespace bsoncxx {
  namespace vA {
    struct X;
  }

  namespace vB {
    struct X;
  }
}

namespace bsoncxx {
  using ::bsoncxx::vA::X; // Updating this to `bsoncxx::vB::X`...
}

namespace bsoncxx {
  namespace vA {
    void foo(bsoncxx::X const& x); // ... MUST NOT change the meaning of this
                                   // ABI-specific declaration (unintended)!
  }
}

```

Applying this rule consistently throughout the bsoncxx library contributed most to the volume of diffs in this PR.

### Private and Test Interfaces

Private and test interfaces, by-design, should not affect the ABI, thus are not subject to ABI stability requirements or concerns as described above. Therefore, private and test interfaces have (mostly) been redeclared without being associated with an ABI namespace, simply due to it not being necessary (e.g. `bsoncxx/private/helpers.hh`). However, if convenient, they may still be declared within an ABI namespace (e.g. `bsoncxx/types/private/convert.hh`).

This PR takes this opportunity to replace instances of `BSONCXX_INLINE` in private and test headers with a simple `inline` to avoid conflating the macro's intended usage as documenting "a public API member that is _not_ a member of the stable ABI". This takes advantage of the CMake target property `VISIBILITY_INLINES_HIDDEN` being set to `ON` in the bsoncxx library CMake configuration.

### Type Traits

The `type_traits.hpp` header is the sole exception to the rules described above. It was observed that the use of type traits are, [with one sole exception](https://github.com/mongodb/mongo-cxx-driver/blob/5f2077f98140ea656983ea5881de31d73bb3f735/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp#L92) (arguably a bug; it should be declared `BSONCXX_INLINE`), exclusively used in interfaces declared `BSONCXX_INLINE`, `inline`, or private, indicating they are _not_ guaranteed ABI-stability. To both document and encourage this pattern, the type traits defined in `bsoncxx/stdx/type_traits.hpp` are _not_ declared in an ABI namespace, as the interfaces they are used for are not intended to affect the ABI.

To further enforce this expectation, note the addition of an `abi-prohibited-symbols` task in [this patch](https://spruce.mongodb.com/version/656e327930661569ac9735dd/tasks) (pending ABI compatibility check scripts) which greps for any mention of `bsoncxx::detail` in the exported dynamic symbol table, per `nm --demangle --dynamic --defined-only --extern-only --just-symbols`.

### Doxygen Documentation

A notable casualty of this PR is that, shockingly, Doxygen does not yet understand how to identify using-declarations (https://github.com/doxygen/doxygen/issues/3760). This means documentation of root namespace declarations are completely gone following this PR (Doxygen effectively behaves as if they do not exist). This presents a documentation problem for how to communicate what entities are declared in the root namespace. The current Doxygen pages in release 3.9.0 have the ideal behavior (root namespace entities redirect to `v_noabi` entities and inherit their documentation). An acceptable workaround for this issue has not yet been identified.

This is not too severe an issue at the moment, as the only ABI namespace is the `v_noabi` namespace, thus all root namespace declarations only refer to `v_noabi` namespace entities, and all current CXX Driver users are familiar with the existence of the root namespace declarations. However, this issue will need to be addressed before any `v1` namespace entities are introduced to avoid confusion.
