### PR TITLE
CXX-2785 use read concern majority in test

### DIFF
--- a/src/mongocxx/test/search_index_view.cpp
+++ b/src/mongocxx/test/search_index_view.cpp
@@ -235,7 +235,7 @@ TEST_CASE("atlas search indexes prose tests", "") {
 
         // Apply non-default read concern.
         auto nondefault_rc = mongocxx::read_concern();
-        nondefault_rc.acknowledge_level(mongocxx::read_concern::level::k_local);
+        nondefault_rc.acknowledge_level(mongocxx::read_concern::level::k_majority);
         coll.read_concern(nondefault_rc);
 
         auto siv = coll.search_indexes();


### PR DESCRIPTION
# Summary

This is a follow-up to https://github.com/mongodb/mongo-cxx-driver/pull/1055 to use `majority` read concern instead of `local`.

# Background & Motivation

The test expects that applying a read concern to the command results in an error from Atlas. It was discovered in the specification PR (https://github.com/mongodb/specifications/pull/1474#discussion_r1423258678) that `local` is accepted for the `aggregate` with `$listSearchIndexes`. To avoid a false positive test, the test now uses read concern `majority`. If the driver incorrectly applies the read concern, Atlas returns the error: `$listSearchIndexes cannot run with a readConcern other than 'local'. Current readConcern: majority`.