### PR TITLE
Fix broken links

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Build-Depends: debhelper (>= 11),
                doxygen
 Standards-Version: 4.6.2
 Section: libs
-Homepage: http://mongocxx.org/
+Homepage: https://mongocxx.org/
 Vcs-Git: https://github.com/mongodb/mongo-cxx-driver.git
 Vcs-Browser: https://github.com/mongodb/mongo-cxx-driver/tree/master
 

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,4 +1,4 @@
-baseurl = "http://mongocxx.org"
+baseurl = "https://mongocxx.org"
 languageCode = "en-us"
 title = "MongoDB C++ Driver Manual"
 theme = "mongodb"

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -30,7 +30,7 @@ publishdir = "../build/hugo"
     pre = "<i class='fa fa-file-text-o'></i>"
     weight = 90
     identifier = "apiDocs"
-    url = "https://mongodb.github.io/mongo-cxx-driver/api/current"
+    url = "https://mongocxx.org/api/current"
 
 [[menu.main]]
     name = "Contributing"

--- a/docs/content/mongocxx-v3/configuration.md
+++ b/docs/content/mongocxx-v3/configuration.md
@@ -9,7 +9,7 @@ title = "Configuring the mongocxx driver"
 In the mongocxx driver, most configuration is done via the [connection
 URI](https://www.mongodb.com/docs/manual/reference/connection-string/).  Some
 additional connection options are possible via the
-[mongocxx::options::client]({{< api3ref classmongocxx_1_1options_1_1client
+[mongocxx::options::client]({{< api3ref classmongocxx_1_1v__noabi_1_1options_1_1client
 >}}) class.
 
 ## Configuring TLS/SSL
@@ -21,7 +21,7 @@ To enable TLS (SSL), set `tls=true` in the URI:
 By default, mongocxx will verify server certificates against the local
 system CA list.  You can override that either by specifying different settings in
 the connection string, or by creating a
-[mongocxx::options::tls]({{< api3ref classmongocxx_1_1options_1_1tls >}})
+[mongocxx::options::tls]({{< api3ref classmongocxx_1_1v__noabi_1_1options_1_1tls >}})
 object and passing it to `tls_opts` on mongocxx::options::client.
 
 For example, to use a custom CA or to disable certificate validation,
@@ -109,7 +109,7 @@ See the MongoDB server
 for more information about determining the subject name from the
 certificate.
 
-The PEM file can also be specified using the [mongocxx::options::tls]({{< api3ref classmongocxx_1_1options_1_1tls >}}) class, see the first "Configuring TLS/SSL" example above.
+The PEM file can also be specified using the [mongocxx::options::tls]({{< api3ref classmongocxx_1_1v__noabi_1_1options_1_1tls >}}) class, see the first "Configuring TLS/SSL" example above.
 
 ### Kerberos (GSSAPI)
 

--- a/docs/content/mongocxx-v3/tutorial.md
+++ b/docs/content/mongocxx-v3/tutorial.md
@@ -212,7 +212,7 @@ auto insert_one_result = collection.insert_one(make_document(kvp("i", 0)));
 ```
 
 `insert_one_result` is an optional [`mongocxx::result::insert_one`]({{< api3ref
-classmongocxx_1_1v__noabi_1_1result_1_1insert_one >}}). In this example, `insert_one_result`
+classmongocxx_1_1v__noabi_1_1result_1_1insert__one >}}). In this example, `insert_one_result`
 is expected to be set. The default behavior for write operations is to wait for
 a reply from the server. This may be overriden by setting an unacknowledged
 [`mongocxx::write_concern`]({{< api3ref classmongocxx_1_1v__noabi_1_1write__concern >}}).

--- a/docs/content/mongocxx-v3/tutorial.md
+++ b/docs/content/mongocxx-v3/tutorial.md
@@ -174,7 +174,7 @@ auto doc_value = make_document(
 
 This `bsoncxx::document::value` type is a read-only object owning
 its own memory. To use it, you must obtain a
-[`bsoncxx::document::view`]({{< api3ref classbsoncxx_1_1document_1_1view >}}) using
+[`bsoncxx::document::view`]({{< api3ref classbsoncxx_1_1v__noabi_1_1document_1_1view >}}) using
 the `view()` method:
 
 ```c++
@@ -183,7 +183,7 @@ auto doc_view = doc_value.view();
 
 You can access fields within this document view using `operator[]`,
 which will return a
-[`bsoncxx::document::element`]({{< api3ref classbsoncxx_1_1document_1_1element >}})
+[`bsoncxx::document::element`]({{< api3ref classbsoncxx_1_1v__noabi_1_1document_1_1element >}})
 instance. For example, the following will extract the `name` field whose
 value is a string:
 
@@ -197,7 +197,7 @@ assert(0 == name.compare("MongoDB"));
 If the value in the `name` field is not a string and you do not
 include a type guard as seen in the preceding example, this code will
 throw an instance of
-[`bsoncxx::exception`]({{< api3ref classbsoncxx_1_1exception >}}).
+[`bsoncxx::exception`]({{< api3ref classbsoncxx_1_1v__noabi_1_1exception >}}).
 
 ## Insert Documents
 
@@ -280,7 +280,7 @@ To query the collection, use the collection’s `find()` and
 `find()` will return an instance of
 [`mongocxx::cursor`]({{< api3ref classmongocxx_1_1v__noabi_1_1cursor >}}),
 while `find_one()` will return an instance of
-`std::optional<`[`bsoncxx::document::value`]({{< api3ref classbsoncxx_1_1document_1_1value >}})`>`
+`std::optional<`[`bsoncxx::document::value`]({{< api3ref classbsoncxx_1_1v__noabi_1_1document_1_1value >}})`>`
 
 You can call either method with an empty document to query all documents
 in a collection, or pass a filter to query for documents that match the

--- a/docs/content/mongocxx-v3/tutorial.md
+++ b/docs/content/mongocxx-v3/tutorial.md
@@ -63,15 +63,15 @@ c++ --std=c++11 <input>.cpp
 ## Make a Connection
 
 **IMPORTANT**: Before making any connections, you need to create one and only
-one instance of [`mongocxx::instance`]({{< api3ref classmongocxx_1_1instance >}}).
+one instance of [`mongocxx::instance`]({{< api3ref classmongocxx_1_1v__noabi_1_1instance >}}).
 This instance must exist for the entirety of your program.
 
 To connect to a running MongoDB instance, use the
-[`mongocxx::client`]({{< api3ref classmongocxx_1_1client >}})
+[`mongocxx::client`]({{< api3ref classmongocxx_1_1v__noabi_1_1client >}})
 class.
 
 You must specify the host to connect to using a
-[`mongocxx::uri`]({{< api3ref classmongocxx_1_1uri >}}) instance containing a
+[`mongocxx::uri`]({{< api3ref classmongocxx_1_1v__noabi_1_1uri >}}) instance containing a
 [MongoDB URI](https://www.mongodb.com/docs/manual/reference/connection-string/),
 and pass that into the `mongocxx::client` constructor.  For details regarding
 supported URI options see the documentation for the version of libmongoc used
@@ -96,10 +96,10 @@ mongocxx::client client(uri);
 
 ## Access a Database
 
-Once you have a [`mongocxx::client`]({{< api3ref classmongocxx_1_1client >}})
+Once you have a [`mongocxx::client`]({{< api3ref classmongocxx_1_1v__noabi_1_1client >}})
 instance connected to a MongoDB deployment, use either the
 `database()` method or `operator[]` to obtain a
-[`mongocxx::database`]({{< api3ref classmongocxx_1_1database >}})
+[`mongocxx::database`]({{< api3ref classmongocxx_1_1v__noabi_1_1database >}})
 instance.
 
 If the database you request does not exist, MongoDB creates it when you
@@ -114,9 +114,9 @@ auto db = client["mydb"];
 ## Access a Collection
 
 Once you have a
-[`mongocxx::database`]({{< api3ref classmongocxx_1_1database >}})
+[`mongocxx::database`]({{< api3ref classmongocxx_1_1v__noabi_1_1database >}})
 instance, use either the `collection()` method or `operator[]` to obtain a
-[`mongocxx::collection`]({{< api3ref classmongocxx_1_1collection >}})
+[`mongocxx::collection`]({{< api3ref classmongocxx_1_1v__noabi_1_1collection >}})
 instance.
 
 If the collection you request does not exist, MongoDB creates it when
@@ -204,7 +204,7 @@ throw an instance of
 ### Insert One Document
 
 To insert a single document into the collection, use a
-[`mongocxx::collection`]({{< api3ref classmongocxx_1_1collection >}})
+[`mongocxx::collection`]({{< api3ref classmongocxx_1_1v__noabi_1_1collection >}})
 instance's `insert_one()` method to insert `{ "i": 0 }`:
 
 ```c++
@@ -212,10 +212,10 @@ auto insert_one_result = collection.insert_one(make_document(kvp("i", 0)));
 ```
 
 `insert_one_result` is an optional [`mongocxx::result::insert_one`]({{< api3ref
-classmongocxx_1_1result_1_1insert_one >}}). In this example, `insert_one_result`
+classmongocxx_1_1v__noabi_1_1result_1_1insert_one >}}). In this example, `insert_one_result`
 is expected to be set. The default behavior for write operations is to wait for
 a reply from the server. This may be overriden by setting an unacknowledged
-[`mongocxx::write_concern`]({{< api3ref classmongocxx_1_1write__concern >}}).
+[`mongocxx::write_concern`]({{< api3ref classmongocxx_1_1v__noabi_1_1write__concern >}}).
 
 ```c++
 assert(insert_one_result);  // Acknowledged writes return results.
@@ -226,7 +226,7 @@ MongoDB automatically adds an `_id` field to the inserted document.
 
 You can obtain this value using the `inserted_id()` method of the
 returned
-[`mongocxx::result::insert_one`]({{< api3ref classmongocxx_1_1result_1_1insert__one >}})
+[`mongocxx::result::insert_one`]({{< api3ref classmongocxx_1_1v__noabi_1_1result_1_1insert__one >}})
 instance.
 
 ```c++
@@ -237,7 +237,7 @@ assert(doc_id.type() == bsoncxx::type::k_oid);
 ### Insert Multiple Documents
 
 To insert multiple documents to the collection, use a
-[`mongocxx::collection`]({{< api3ref classmongocxx_1_1collection >}}) instance's
+[`mongocxx::collection`]({{< api3ref classmongocxx_1_1v__noabi_1_1collection >}}) instance's
 `insert_many()` method, which takes a list of documents to insert.
 
 The following example inserts the documents `{ "i": 1 }` and `{ "i": 2 }`.
@@ -262,7 +262,7 @@ MongoDB automatically adds a `_id` field to the inserted documents.
 
 You can obtain this value using the `inserted_ids()` method of the
 returned
-[`mongocxx::result::insert_many`]({{< api3ref classmongocxx_1_1result_1_1insert__many >}})
+[`mongocxx::result::insert_many`]({{< api3ref classmongocxx_1_1v__noabi_1_1result_1_1insert__many >}})
 instance.
 
 ```c++
@@ -278,7 +278,7 @@ To query the collection, use the collection’s `find()` and
 `find_one` methods.
 
 `find()` will return an instance of
-[`mongocxx::cursor`]({{< api3ref classmongocxx_1_1cursor >}}),
+[`mongocxx::cursor`]({{< api3ref classmongocxx_1_1v__noabi_1_1cursor >}}),
 while `find_one()` will return an instance of
 `std::optional<`[`bsoncxx::document::value`]({{< api3ref classbsoncxx_1_1document_1_1value >}})`>`
 
@@ -369,7 +369,7 @@ To update documents in a collection, you can use the collection’s
 `update_one()` and `update_many()` methods.
 
 The update methods return an instance of
-`std::optional<`[`mongocxx::result::update`]({{< api3ref classmongocxx_1_1result_1_1update >}})`>`,
+`std::optional<`[`mongocxx::result::update`]({{< api3ref classmongocxx_1_1v__noabi_1_1result_1_1update >}})`>`,
 which provides information about the operation including the number of
 documents modified by the update.
 
@@ -411,7 +411,7 @@ To delete documents from a collection, you can use a collection’s
 `delete_one()` and `delete_many()` methods.
 
 The delete methods return an instance of
-`std::optional<`[`mongocxx::result::delete`]({{< api3ref classmongocxx_1_1result_1_1delete__result >}})`>`,
+`std::optional<`[`mongocxx::result::delete`]({{< api3ref classmongocxx_1_1v__noabi_1_1result_1_1delete__result >}})`>`,
 which contains the number of documents deleted.
 
 ### Delete a Single Document
@@ -447,7 +447,7 @@ assert(delete_many_result->deleted_count() == 2);
 To create an [index](https://www.mongodb.com/docs/manual/indexes/) on a
 field or set of fields, pass an index specification document to the
 `create_index()` method of a
-[`mongocxx::collection`]({{< api3ref classmongocxx_1_1collection >}}) instance. An
+[`mongocxx::collection`]({{< api3ref classmongocxx_1_1v__noabi_1_1collection >}}) instance. An
 index key specification document contains the fields to index and the
 index type for each field:
 

--- a/docs/content/mongocxx-v3/working-with-bson.md
+++ b/docs/content/mongocxx-v3/working-with-bson.md
@@ -25,8 +25,8 @@ use each.  For more information and example code, see our
 The bsoncxx library offers four interfaces for building BSON: one-off
 functions, a basic builder, a list builder and a stream-based builder.
 
-[`bsoncxx::builder::basic::document`](https://github.com/mongodb/mongo-cxx-driver/blob/master/src/bsoncxx/builder/basic/document.hpp)<br/>
-[`bsoncxx::builder::stream::document`](https://github.com/mongodb/mongo-cxx-driver/blob/master/src/bsoncxx/builder/stream/document.hpp)
+[`bsoncxx::builder::basic::document`](https://github.com/mongodb/mongo-cxx-driver/blob/master/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp)<br/>
+[`bsoncxx::builder::stream::document`](https://github.com/mongodb/mongo-cxx-driver/blob/master/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp)
 
 The various methods of creating BSON documents and arrays are all
 equivalent. All interfaces will provide the same results, the choice of
@@ -175,7 +175,7 @@ for (auto && e : {1, 2, 3}) {
 
 ### <a name="value">Owning BSON Documents (values)</a>
 
-[`bsoncxx::document::value`](https://github.com/mongodb/mongo-cxx-driver/blob/master/src/bsoncxx/document/value.hpp)
+[`bsoncxx::document::value`](https://github.com/mongodb/mongo-cxx-driver/blob/master/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp)
 
 This type represents an actual BSON document, one that owns its buffer of
 data.  These documents can be constructed from a builder by calling
@@ -200,7 +200,7 @@ bsoncxx::document::value one_line = bsoncxx::builder::stream::document{} << "fin
 
 ### <a name="view">Non-owning BSON Documents (views)</a>
 
-[`bsoncxx::document::view`](https://github.com/mongodb/mongo-cxx-driver/blob/master/src/bsoncxx/document/view.hpp)
+[`bsoncxx::document::view`](https://github.com/mongodb/mongo-cxx-driver/blob/master/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view.hpp)
 
 This type is a view into an owning `bsoncxx::document::value`.
 
@@ -232,7 +232,7 @@ auto cursor2 = collection2.find(query_value.view());
 
 ### <a name="view_or_value">Optionally-owning BSON Documents (view_or_value)</a>
 
-Many driver methods take a document::view_or_value parameter, for example, [`run_command`](https://github.com/mongodb/mongo-cxx-driver/blob/master/src/mongocxx/database.hpp#L83-L92):
+Many driver methods take a document::view_or_value parameter, for example, [`run_command`](https://github.com/mongodb/mongo-cxx-driver/blob/master/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp#L144-L153):
 
 ```
 bsoncxx::document::value run_command(bsoncxx::document::view_or_value command);
@@ -297,7 +297,7 @@ bsoncxx::document::view dangling_view = temp_builder.extract().view(); // Bad!!
 
 ### <a name="print">Printing BSON Documents</a>
 
-[`bsoncxx::to_json()`](https://github.com/mongodb/mongo-cxx-driver/blob/master/src/bsoncxx/json.hpp#L28-L36)
+[`bsoncxx::to_json()`](https://github.com/mongodb/mongo-cxx-driver/blob/master/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp#L39-L55)
 
 The bsoncxx library comes with a convenience method to convert BSON
 documents to strings for easy inspection:
@@ -307,7 +307,7 @@ bsoncxx::document::value = document{} << "I am" << "a BSON document" << finalize
 std::cout << bsoncxx::to_json(doc.view()) << std::endl;
 ```
 
-There is an analogous method, [from_json()](https://github.com/mongodb/mongo-cxx-driver/blob/master/src/bsoncxx/json.hpp#L60-L68), to build document::values out of existing JSON strings.
+There is an analogous method, [from_json()](https://github.com/mongodb/mongo-cxx-driver/blob/master/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp#L57-L67), to build document::values out of existing JSON strings.
 
 ### <a name="fields">Getting Fields out of BSON Documents</a>
 

--- a/docs/content/mongocxx-v3/working-with-bson.md
+++ b/docs/content/mongocxx-v3/working-with-bson.md
@@ -335,7 +335,7 @@ This feature is shown in more detail in [this example](https://github.com/mongod
 
 The [BSON specification](http://bsonspec.org/spec.html) provides a list
 of supported types.  These are represented in C++ using the
-[b_xxx](https://mongodb.github.io/mongo-cxx-driver/api/current/classes.html#letter_B)
+[b_xxx](https://mongocxx.org/api/current/classes.html#letter_B)
 type wrappers.
 
 Some BSON types don't necessarily have a native representation to wrap and

--- a/docs/data/mongodb.toml
+++ b/docs/data/mongodb.toml
@@ -2,6 +2,6 @@
 githubRepo = "mongo-cxx-driver"
 githubBranch = "master"
 highlightTheme = "idea.css"
-api3Url = "https://mongodb.github.io/mongo-cxx-driver/api/mongocxx-v3"
-api1Url = "https://mongodb.github.io/mongo-cxx-driver/api/legacy-v1"
+api3Url = "https://mongocxx.org/api/mongocxx-v3"
+api1Url = "https://mongocxx.org/api/legacy-v1"
 

--- a/docs/themes/mongodb/theme.toml
+++ b/docs/themes/mongodb/theme.toml
@@ -2,11 +2,11 @@ name = "MongoDB"
 license = "Creative Commons Attribution NonCommercial ShareAlike 3.0 Unported"
 licenselink = "http://creativecommons.org/licenses/by-nc-sa/3.0/"
 description = "A standalone mongodb docs theme, for individual driver homepages"
-homepage = "https://mongodb.github.io/mongo-cxx-driver"
+homepage = "https://mongocxx.org/"
 
 [author]
   name = "MongoDB C++ driver authors"
-  homepage = "https://mongodb.github.io/mongo-cxx-driver"
+  homepage = "https://mongocxx.org/"
 
 [original]
   name = "MongoDB Docs"

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@
 ## Building code examples
 
 1. Run `git clone https://github.com/mongodb/mongo-cxx-driver && cd mongo-cxx-driver/build`
-2. Follow the instructions [here](https://mongodb.github.io/mongo-cxx-driver/mongocxx-v3/installation/) to install the driver
+2. Follow the instructions [here](https://mongocxx.org/mongocxx-v3/installation/) to install the driver
 3. Run `make examples`
 4. cd `examples/mongocxx`
 5. Start up `mongod` running on the default port (i.e. 27017)
@@ -16,6 +16,6 @@
 ## Building project examples
 
 1. Install `libmongoc` and `mongocxx` following the [installation
-   instructions](https://mongodb.github.io/mongo-cxx-driver/mongocxx-v3/installation/)
+   instructions](https://mongocxx.org/mongocxx-v3/installation/)
 2. Change to one of the project example directories, e.g. `examples/projects/cmake/mongocxx/shared`
 3. Run `./build.sh`

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
@@ -36,7 +36,7 @@ namespace stream {
 /// a BSON array.
 ///
 /// @note Use of the stream builder is discouraged. See
-/// https://mongodb.github.io/mongo-cxx-driver/mongocxx-v3/working-with-bson/#stream-builder for
+/// https://mongocxx.org/mongocxx-v3/working-with-bson/#stream-builder for
 /// more details.
 ///
 class array : public array_context<> {

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
@@ -34,7 +34,7 @@ namespace stream {
 /// a BSON document.
 ///
 /// @note Use of the stream builder is discouraged. See
-/// https://mongodb.github.io/mongo-cxx-driver/mongocxx-v3/working-with-bson/#stream-builder for
+/// https://mongocxx.org/mongocxx-v3/working-with-bson/#stream-builder for
 /// more details.
 ///
 class document : public key_context<> {

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp
@@ -60,7 +60,7 @@ struct open_array_type {
 ///
 /// A stream manipulator to open a subarray.
 ///
-/// @see https://mongodb.github.io/mongo-cxx-driver/mongocxx-v3/working-with-bson/#builders for help
+/// @see https://mongocxx.org/mongocxx-v3/working-with-bson/#builders for help
 /// building arrays in loops.
 ///
 constexpr open_array_type open_array;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
@@ -56,7 +56,7 @@ inline namespace v_noabi {
 /// @endcode
 ///
 /// Note that client is not thread-safe. See
-/// https://mongodb.github.io/mongo-cxx-driver/mongocxx-v3/thread-safety/ for more details.
+/// https://mongocxx.org/mongocxx-v3/thread-safety/ for more details.
 class client {
    public:
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
@@ -38,7 +38,7 @@ inline namespace v_noabi {
 /// or snapshots.
 ///
 /// Note that client_session is not thread-safe. See
-/// https://mongodb.github.io/mongo-cxx-driver/mongocxx-v3/thread-safety/ for more details.
+/// https://mongocxx.org/mongocxx-v3/thread-safety/ for more details.
 ///
 /// @see
 /// https://www.mongodb.com/docs/manual/core/read-isolation-consistency-recency/#causal-consistency


### PR DESCRIPTION
# Summary

Fix broken links in Hugo documentation.

This PR includes additional drive-by improvements:

- replace `http://mongocxx.org` with `https://mongocxx.org`
- replace `mongodb.github.io` with `mongocxx.org`


# Background & Motivation

https://github.com/mongodb/mongo-cxx-driver/pull/1039 replaced use of the inline namespace macros with `inline namespace v_noabi`. I expect this changed the Doxygen page links include the namespace:

Example:
- In 3.8.1: https://mongocxx.org/api/mongocxx-3.8.1/classbsoncxx_1_1oid.html
- In 3.9.0: https://mongocxx.org/api/mongocxx-3.9.0/classbsoncxx_1_1v__noabi_1_1oid.html

This PR is intended as a short-term solution to fix the broken links. Further investigation may be needed to restore links omitting the namespace.

https://github.com/mongodb/mongo-cxx-driver/pull/1026 changed the directory structure. I expect this resulted in broken links to GitHub source pages:

- In 3.8.1: https://github.com/mongodb/mongo-cxx-driver/blob/r3.8.1/src/mongocxx/database.hpp
- In 3.9.1: https://github.com/mongodb/mongo-cxx-driver/blob/r3.9.0/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp

Broken links were checked by building docs with `cmake --build cmake-build --target hugo` and running [find_broken_links.py](https://gist.github.com/kevinAlbs/4ca2bfc2835a0df2cadb167282796f69).