### PR TITLE
CXX-2039 Add VS2019 support and migrate VS2017 tasks to windows-vsCurrent distro

### DIFF
--- a/.evergreen/compile.sh
+++ b/.evergreen/compile.sh
@@ -28,23 +28,6 @@ set -o pipefail
 : "${USE_SANITIZER_UBSAN:-}"
 : "${USE_STATIC_LIBS:-}"
 
-# Add MSBuild.exe to path.
-if [[ "${OSTYPE:?}" == "cygwin" ]]; then
-  case "${generator:-}" in
-  *2015*)
-    PATH="/cygdrive/c/cmake/bin:/cygdrive/c/Program Files (x86)/MSBuild/14.0/Bin:$PATH"
-    ;;
-  *2017*)
-    PATH="/cygdrive/c/cmake/bin:/cygdrive/c/Program Files (x86)/Microsoft Visual Studio/2017/Professional/MSBuild/15.0/Bin:$PATH"
-    ;;
-  *)
-    echo "missing explicit CMake Generator on Windows distro" 1>&2
-    exit 1
-    ;;
-  esac
-fi
-export PATH
-
 mongoc_prefix="$(pwd)/../mongoc"
 echo "mongoc_prefix=${mongoc_prefix:?}"
 

--- a/.evergreen/compile.sh
+++ b/.evergreen/compile.sh
@@ -107,7 +107,7 @@ case "${OSTYPE:?}" in
 cygwin)
   case "${generator:-}" in
   *2015*) cmake_flags+=("-DBOOST_ROOT=C:/local/boost_1_60_0") ;;
-  *2017*) cmake_flags+=("-DCMAKE_CXX_STANDARD=17") ;;
+  *2017*|*2019*) cmake_flags+=("-DCMAKE_CXX_STANDARD=17") ;;
   *)
     echo "missing explicit CMake Generator on Windows distro" 1>&2
     exit 1

--- a/.evergreen/compile.sh
+++ b/.evergreen/compile.sh
@@ -19,6 +19,7 @@ set -o pipefail
 : "${ENABLE_CODE_COVERAGE:-}"
 : "${ENABLE_TESTS:-}"
 : "${generator:-}"
+: "${platform:-}"
 : "${REQUIRED_CXX_STANDARD:-}"
 : "${RUN_DISTCHECK:-}"
 : "${USE_POLYFILL_BOOST:-}"
@@ -142,6 +143,7 @@ darwin* | linux*)
   ;;
 esac
 export CMAKE_GENERATOR="${generator:?}"
+export CMAKE_GENERATOR_PLATFORM="${platform:-}"
 
 if [[ "${USE_POLYFILL_STD_EXPERIMENTAL:-}" == "ON" ]]; then
   cmake_flags+=(

--- a/.evergreen/install_c_driver.sh
+++ b/.evergreen/install_c_driver.sh
@@ -83,14 +83,17 @@ if [[ "${OSTYPE}" == darwin* ]]; then
   }
 fi
 
+
 # Default CMake generator to use if not already provided.
-declare cmake_generator
+declare CMAKE_GENERATOR CMAKE_GENERATOR_PLATFORM
 if [[ "${OSTYPE:?}" == "cygwin" ]]; then
-  cmake_generator=${generator:-"Visual Studio 14 2015 Win64"}
+  CMAKE_GENERATOR="${generator:-"Visual Studio 14 2015"}"
+  CMAKE_GENERATOR_PLATFORM="${platform:-"x64"}"
 else
-  cmake_generator=${generator:-"Unix Makefiles"}
+  CMAKE_GENERATOR="${generator:-"Unix Makefiles"}"
+  CMAKE_GENERATOR_PLATFORM="${platform:-""}"
 fi
-: "${cmake_generator:?}"
+export CMAKE_GENERATOR CMAKE_GENERATOR_PLATFORM
 
 declare -a configure_flags=(
   "-DCMAKE_BUILD_TYPE=Debug"
@@ -131,7 +134,7 @@ fi
 # Install libmongoc.
 {
   echo "Installing C Driver into ${mongoc_dir}..." 1>&2
-  "${cmake_binary}" -S "${mongoc_idir}" -B "${mongoc_idir}" -G "${cmake_generator}" "${configure_flags[@]}"
+  "${cmake_binary}" -S "${mongoc_idir}" -B "${mongoc_idir}" "${configure_flags[@]}"
   "${cmake_binary}" --build "${mongoc_idir}" --config Debug --target install -- "${compile_flags[@]}"
   echo "Installing C Driver into ${mongoc_dir}... done." 1>&2
 } >/dev/null

--- a/.evergreen/test.sh
+++ b/.evergreen/test.sh
@@ -23,6 +23,7 @@ set -o pipefail
 : "${generator:-}"
 : "${lib_dir:-}"
 : "${MONGODB_API_VERSION:-}"
+: "${platform:-}"
 : "${TEST_WITH_ASAN:-}"
 : "${TEST_WITH_UBSAN:-}"
 : "${TEST_WITH_VALGRIND:-}"
@@ -313,6 +314,8 @@ fi
 export PKG_CONFIG_PATH
 
 # Environment variables used by example projects.
+export CMAKE_GENERATOR="${generator:-}"
+export CMAKE_GENERATOR_PLATFORM="${platform:-}"
 export BUILD_TYPE="${build_type:?}"
 export CXXFLAGS="${example_projects_cxxflags}"
 export LDFLAGS="${example_projects_ldflags}"

--- a/.mci.yml
+++ b/.mci.yml
@@ -45,6 +45,11 @@ variables:
             generator: Visual Studio 15 2017
             platform: x64
             example_projects_cxx_standard: 17
+        integration_matrix_expansions_windows_vs2019: &integration_matrix_expansions_windows_vs2019
+            build_type: "Debug" # Same for Windows and Linux
+            generator: Visual Studio 16 2019
+            platform: x64
+            example_projects_cxx_standard: 17
 
 #######################################
 #            Functions                #
@@ -1132,6 +1137,62 @@ buildvariants:
           <<: *integration_matrix_expansions_windows_vs2017
       <<: *integration_matrix_tasks_single
 
+    - name: integration-vs2019-latest-single
+      display_name: "Windows (VS 2019) Debug (MongoDB Latest)"
+      run_on: windows-vsCurrent-large
+      expansions:
+          mongodb_version: "latest"
+          <<: *integration_matrix_expansions_windows_vs2019
+      <<: *integration_matrix_tasks_single
+
+    - name: integration-vs2019-7.0-single
+      display_name: "Windows (VS 2019) Debug (MongoDB 7.0)"
+      run_on: windows-vsCurrent-large
+      expansions:
+          mongodb_version: "7.0"
+          <<: *integration_matrix_expansions_windows_vs2019
+      <<: *integration_matrix_tasks_single
+
+    - name: integration-vs2019-6.0-single
+      display_name: "Windows (VS 2019) Debug (MongoDB 6.0)"
+      run_on: windows-vsCurrent-large
+      expansions:
+          mongodb_version: "6.0"
+          <<: *integration_matrix_expansions_windows_vs2019
+      <<: *integration_matrix_tasks_single
+
+    - name: integration-vs2019-5.0-single
+      display_name: "Windows (VS 2019) Debug (MongoDB 5.0)"
+      run_on: windows-vsCurrent-large
+      expansions:
+          mongodb_version: "5.0"
+          <<: *integration_matrix_expansions_windows_vs2019
+      <<: *integration_matrix_tasks_single
+
+    - name: integration-vs2019-4.4-single
+      display_name: "Windows (VS 2019) Debug (MongoDB 4.4)"
+      run_on: windows-vsCurrent-large
+      expansions:
+          mongodb_version: "4.4"
+          <<: *integration_matrix_expansions_windows_vs2019
+      <<: *integration_matrix_tasks_single
+
+    - name: integration-vs2019-4.2-single
+      display_name: "Windows (VS 2019) Debug (MongoDB 4.2)"
+      run_on: windows-vsCurrent-large
+      expansions:
+          mongodb_version: "4.2"
+          <<: *integration_matrix_expansions_windows_vs2019
+      <<: *integration_matrix_tasks_single
+
+    - name: integration-vs2019-4.0-single
+      display_name: "Windows (VS 2019) Debug (MongoDB 4.0)"
+      run_on: windows-vsCurrent-large
+      expansions:
+          mongodb_version: "4.0"
+          <<: *integration_matrix_expansions_windows_vs2019
+      <<: *integration_matrix_tasks_single
+
     - name: integration-ubuntu2004-latest-replica
       display_name: "Ubuntu 20.04 Debug replica set (MongoDB Latest)"
       run_on: ubuntu2004-large
@@ -1260,6 +1321,14 @@ buildvariants:
           <<: *integration_matrix_expansions_windows_vs2017
       <<: *integration_matrix_auth_tasks_single
 
+    - name: integration-auth-vs2019-latest-single
+      display_name: "Windows (VS 2019) Debug Latest Auth"
+      run_on: windows-vsCurrent-large
+      expansions:
+          mongodb_version: "latest"
+          <<: *integration_matrix_expansions_windows_vs2019
+      <<: *integration_matrix_auth_tasks_single
+
     - name: integration-versioned-api-ubuntu2004-latest-single
       display_name: "Ubuntu 20.04 Debug Latest Versioned API"
       run_on: ubuntu2004-large
@@ -1274,6 +1343,14 @@ buildvariants:
       expansions:
           mongodb_version: "latest"
           <<: *integration_matrix_expansions_windows_vs2017
+      <<: *integration_matrix_versioned_api_tasks_single
+
+    - name: integration-versioned-api-vs2019-latest-single
+      display_name: "Windows (VS 2019) Debug Latest Versioned API"
+      run_on: windows-vsCurrent-large
+      expansions:
+          mongodb_version: "latest"
+          <<: *integration_matrix_expansions_windows_vs2019
       <<: *integration_matrix_versioned_api_tasks_single
 
     - name: integration-mongocryptd-ubuntu2004-latest

--- a/.mci.yml
+++ b/.mci.yml
@@ -1082,62 +1082,6 @@ buildvariants:
           <<: *integration_matrix_expansions_linux
       <<: *integration_matrix_tasks_single
 
-    - name: integration-vs2017-latest-single
-      display_name: "Windows (VS 2017) Debug (MongoDB Latest)"
-      run_on: windows-vsCurrent-large
-      expansions:
-          mongodb_version: "latest"
-          <<: *integration_matrix_expansions_windows_vs2017
-      <<: *integration_matrix_tasks_single
-
-    - name: integration-vs2017-7.0-single
-      display_name: "Windows (VS 2017) Debug (MongoDB 7.0)"
-      run_on: windows-vsCurrent-large
-      expansions:
-          mongodb_version: "7.0"
-          <<: *integration_matrix_expansions_windows_vs2017
-      <<: *integration_matrix_tasks_single
-
-    - name: integration-vs2017-6.0-single
-      display_name: "Windows (VS 2017) Debug (MongoDB 6.0)"
-      run_on: windows-vsCurrent-large
-      expansions:
-          mongodb_version: "6.0"
-          <<: *integration_matrix_expansions_windows_vs2017
-      <<: *integration_matrix_tasks_single
-
-    - name: integration-vs2017-5.0-single
-      display_name: "Windows (VS 2017) Debug (MongoDB 5.0)"
-      run_on: windows-vsCurrent-large
-      expansions:
-          mongodb_version: "5.0"
-          <<: *integration_matrix_expansions_windows_vs2017
-      <<: *integration_matrix_tasks_single
-
-    - name: integration-vs2017-4.4-single
-      display_name: "Windows (VS 2017) Debug (MongoDB 4.4)"
-      run_on: windows-vsCurrent-large
-      expansions:
-          mongodb_version: "4.4"
-          <<: *integration_matrix_expansions_windows_vs2017
-      <<: *integration_matrix_tasks_single
-
-    - name: integration-vs2017-4.2-single
-      display_name: "Windows (VS 2017) Debug (MongoDB 4.2)"
-      run_on: windows-vsCurrent-large
-      expansions:
-          mongodb_version: "4.2"
-          <<: *integration_matrix_expansions_windows_vs2017
-      <<: *integration_matrix_tasks_single
-
-    - name: integration-vs2017-4.0-single
-      display_name: "Windows (VS 2017) Debug (MongoDB 4.0)"
-      run_on: windows-vsCurrent-large
-      expansions:
-          mongodb_version: "4.0"
-          <<: *integration_matrix_expansions_windows_vs2017
-      <<: *integration_matrix_tasks_single
-
     - name: integration-vs2019-latest-single
       display_name: "Windows (VS 2019) Debug (MongoDB Latest)"
       run_on: windows-vsCurrent-large
@@ -1336,14 +1280,6 @@ buildvariants:
       expansions:
           mongodb_version: "latest"
           <<: *integration_matrix_expansions_linux
-      <<: *integration_matrix_versioned_api_tasks_single
-
-    - name: integration-versioned-api-vs2017-latest-single
-      display_name: "Windows (VS 2017) Debug Latest Versioned API"
-      run_on: windows-vsCurrent-large
-      expansions:
-          mongodb_version: "latest"
-          <<: *integration_matrix_expansions_windows_vs2017
       <<: *integration_matrix_versioned_api_tasks_single
 
     - name: integration-versioned-api-vs2019-latest-single

--- a/.mci.yml
+++ b/.mci.yml
@@ -402,6 +402,7 @@ functions:
                   - generator
                   - lib_dir
                   - MONGODB_API_VERSION
+                  - platform
                   - TEST_WITH_ASAN
                   - TEST_WITH_UBSAN
                   - TEST_WITH_VALGRIND

--- a/.mci.yml
+++ b/.mci.yml
@@ -1076,7 +1076,7 @@ buildvariants:
 
     - name: integration-vs2017-latest-single
       display_name: "Windows (VS 2017) Debug (MongoDB Latest)"
-      run_on: windows-64-vs2017-large
+      run_on: windows-vsCurrent-large
       expansions:
           mongodb_version: "latest"
           <<: *integration_matrix_expansions_windows
@@ -1084,7 +1084,7 @@ buildvariants:
 
     - name: integration-vs2017-7.0-single
       display_name: "Windows (VS 2017) Debug (MongoDB 7.0)"
-      run_on: windows-64-vs2017-large
+      run_on: windows-vsCurrent-large
       expansions:
           mongodb_version: "7.0"
           <<: *integration_matrix_expansions_windows
@@ -1092,7 +1092,7 @@ buildvariants:
 
     - name: integration-vs2017-6.0-single
       display_name: "Windows (VS 2017) Debug (MongoDB 6.0)"
-      run_on: windows-64-vs2017-large
+      run_on: windows-vsCurrent-large
       expansions:
           mongodb_version: "6.0"
           <<: *integration_matrix_expansions_windows
@@ -1100,7 +1100,7 @@ buildvariants:
 
     - name: integration-vs2017-5.0-single
       display_name: "Windows (VS 2017) Debug (MongoDB 5.0)"
-      run_on: windows-64-vs2017-large
+      run_on: windows-vsCurrent-large
       expansions:
           mongodb_version: "5.0"
           <<: *integration_matrix_expansions_windows
@@ -1108,7 +1108,7 @@ buildvariants:
 
     - name: integration-vs2017-4.4-single
       display_name: "Windows (VS 2017) Debug (MongoDB 4.4)"
-      run_on: windows-64-vs2017-large
+      run_on: windows-vsCurrent-large
       expansions:
           mongodb_version: "4.4"
           <<: *integration_matrix_expansions_windows
@@ -1116,7 +1116,7 @@ buildvariants:
 
     - name: integration-vs2017-4.2-single
       display_name: "Windows (VS 2017) Debug (MongoDB 4.2)"
-      run_on: windows-64-vs2017-large
+      run_on: windows-vsCurrent-large
       expansions:
           mongodb_version: "4.2"
           <<: *integration_matrix_expansions_windows
@@ -1124,7 +1124,7 @@ buildvariants:
 
     - name: integration-vs2017-4.0-single
       display_name: "Windows (VS 2017) Debug (MongoDB 4.0)"
-      run_on: windows-64-vs2017-large
+      run_on: windows-vsCurrent-large
       expansions:
           mongodb_version: "4.0"
           <<: *integration_matrix_expansions_windows
@@ -1252,7 +1252,7 @@ buildvariants:
 
     - name: integration-auth-vs2017-latest-single
       display_name: "Windows (VS 2017) Debug Latest Auth"
-      run_on: windows-64-vs2017-large
+      run_on: windows-vsCurrent-large
       expansions:
           mongodb_version: "latest"
           <<: *integration_matrix_expansions_windows
@@ -1268,7 +1268,7 @@ buildvariants:
 
     - name: integration-versioned-api-vs2017-latest-single
       display_name: "Windows (VS 2017) Debug Latest Versioned API"
-      run_on: windows-64-vs2017-large
+      run_on: windows-vsCurrent-large
       expansions:
           mongodb_version: "latest"
           <<: *integration_matrix_expansions_windows

--- a/.mci.yml
+++ b/.mci.yml
@@ -42,7 +42,8 @@ variables:
             ENABLE_CODE_COVERAGE: ON
         integration_matrix_expansions_windows: &integration_matrix_expansions_windows
             build_type: "Debug" # Same for Windows and Linux
-            generator: Visual Studio 15 2017 Win64
+            generator: Visual Studio 15 2017
+            platform: x64
             example_projects_cxx_standard: 17
 
 #######################################
@@ -348,6 +349,7 @@ functions:
                   - ENABLE_CODE_COVERAGE
                   - ENABLE_TESTS
                   - generator
+                  - platform
                   - REQUIRED_CXX_STANDARD
                   - RUN_DISTCHECK
                   - USE_POLYFILL_BOOST
@@ -1833,7 +1835,8 @@ buildvariants:
       expansions:
           build_type: "Release"
           mongodb_version: "4.2"
-          generator: Visual Studio 14 2015 Win64
+          generator: Visual Studio 14 2015
+          platform: x64
       run_on:
           - windows-64-vs2015-compile
       tasks:
@@ -1848,7 +1851,8 @@ buildvariants:
       expansions:
           build_type: "Debug"
           mongodb_version: "4.2"
-          generator: Visual Studio 14 2015 Win64
+          generator: Visual Studio 14 2015
+          platform: x64
       run_on:
           - windows-64-vs2015-compile
       tasks:
@@ -1860,7 +1864,8 @@ buildvariants:
       display_name: "Windows (VS 2015) Debug (MongoDB 4.2)"
       expansions:
           build_type: "Debug"
-          generator: Visual Studio 14 2015 Win64
+          generator: Visual Studio 14 2015
+          platform: x64
           mongodb_version: "4.2"
       run_on:
          - windows-64-vs2015-compile

--- a/.mci.yml
+++ b/.mci.yml
@@ -40,7 +40,7 @@ variables:
         integration_matrix_expansions_linux: &integration_matrix_expansions_linux
             build_type: "Debug"
             ENABLE_CODE_COVERAGE: ON
-        integration_matrix_expansions_windows: &integration_matrix_expansions_windows
+        integration_matrix_expansions_windows_vs2017: &integration_matrix_expansions_windows_vs2017
             build_type: "Debug" # Same for Windows and Linux
             generator: Visual Studio 15 2017
             platform: x64
@@ -1081,7 +1081,7 @@ buildvariants:
       run_on: windows-vsCurrent-large
       expansions:
           mongodb_version: "latest"
-          <<: *integration_matrix_expansions_windows
+          <<: *integration_matrix_expansions_windows_vs2017
       <<: *integration_matrix_tasks_single
 
     - name: integration-vs2017-7.0-single
@@ -1089,7 +1089,7 @@ buildvariants:
       run_on: windows-vsCurrent-large
       expansions:
           mongodb_version: "7.0"
-          <<: *integration_matrix_expansions_windows
+          <<: *integration_matrix_expansions_windows_vs2017
       <<: *integration_matrix_tasks_single
 
     - name: integration-vs2017-6.0-single
@@ -1097,7 +1097,7 @@ buildvariants:
       run_on: windows-vsCurrent-large
       expansions:
           mongodb_version: "6.0"
-          <<: *integration_matrix_expansions_windows
+          <<: *integration_matrix_expansions_windows_vs2017
       <<: *integration_matrix_tasks_single
 
     - name: integration-vs2017-5.0-single
@@ -1105,7 +1105,7 @@ buildvariants:
       run_on: windows-vsCurrent-large
       expansions:
           mongodb_version: "5.0"
-          <<: *integration_matrix_expansions_windows
+          <<: *integration_matrix_expansions_windows_vs2017
       <<: *integration_matrix_tasks_single
 
     - name: integration-vs2017-4.4-single
@@ -1113,7 +1113,7 @@ buildvariants:
       run_on: windows-vsCurrent-large
       expansions:
           mongodb_version: "4.4"
-          <<: *integration_matrix_expansions_windows
+          <<: *integration_matrix_expansions_windows_vs2017
       <<: *integration_matrix_tasks_single
 
     - name: integration-vs2017-4.2-single
@@ -1121,7 +1121,7 @@ buildvariants:
       run_on: windows-vsCurrent-large
       expansions:
           mongodb_version: "4.2"
-          <<: *integration_matrix_expansions_windows
+          <<: *integration_matrix_expansions_windows_vs2017
       <<: *integration_matrix_tasks_single
 
     - name: integration-vs2017-4.0-single
@@ -1129,7 +1129,7 @@ buildvariants:
       run_on: windows-vsCurrent-large
       expansions:
           mongodb_version: "4.0"
-          <<: *integration_matrix_expansions_windows
+          <<: *integration_matrix_expansions_windows_vs2017
       <<: *integration_matrix_tasks_single
 
     - name: integration-ubuntu2004-latest-replica
@@ -1257,7 +1257,7 @@ buildvariants:
       run_on: windows-vsCurrent-large
       expansions:
           mongodb_version: "latest"
-          <<: *integration_matrix_expansions_windows
+          <<: *integration_matrix_expansions_windows_vs2017
       <<: *integration_matrix_auth_tasks_single
 
     - name: integration-versioned-api-ubuntu2004-latest-single
@@ -1273,7 +1273,7 @@ buildvariants:
       run_on: windows-vsCurrent-large
       expansions:
           mongodb_version: "latest"
-          <<: *integration_matrix_expansions_windows
+          <<: *integration_matrix_expansions_windows_vs2017
       <<: *integration_matrix_versioned_api_tasks_single
 
     - name: integration-mongocryptd-ubuntu2004-latest

--- a/docs/content/mongocxx-v3/installation/windows.md
+++ b/docs/content/mongocxx-v3/installation/windows.md
@@ -67,7 +67,7 @@ On Windows, the C++ driver is configured as follows (adjusting the path of the C
 
 ```sh
 'C:\Program Files (x86)\CMake\bin\cmake.exe' .. \
-     -G "Visual Studio 14 2015 Win64"           \
+     -G "Visual Studio 14 2015" -A "x64"        \
     -DBOOST_ROOT=C:\local\boost_1_60_0          \
     -DCMAKE_INSTALL_PREFIX=C:\mongo-cxx-driver
 ```
@@ -81,7 +81,7 @@ To build with Visual Studio 2017 without a C++17 polyfill, configure as follows:
 
 ```sh
 'C:\Program Files (x86)\CMake\bin\cmake.exe' .. \
-    -G "Visual Studio 15 2017 Win64"            \
+    -G "Visual Studio 15 2017" -A "x64"         \
     -DCMAKE_CXX_STANDARD=17                     \
     -DCMAKE_INSTALL_PREFIX=C:\mongo-cxx-driver  \
 ```
@@ -94,7 +94,7 @@ To build versions 3.7.0 and older without a C++17 polyfill, it is necessary to c
 
 ```sh
 'C:\Program Files (x86)\CMake\bin\cmake.exe' .. \
-    -G "Visual Studio 15 2017 Win64"            \
+    -G "Visual Studio 15 2017" -A "x64"         \
     -DCMAKE_CXX_STANDARD=17                     \
     -DCMAKE_CXX_FLAGS="/Zc:__cplusplus /EHsc"   \
     -DCMAKE_INSTALL_PREFIX=C:\mongo-cxx-driver  \

--- a/examples/projects/bsoncxx/cmake/shared/build.sh
+++ b/examples/projects/bsoncxx/cmake/shared/build.sh
@@ -13,10 +13,10 @@ if [ -z "$MSVC" ]; then
     "$CMAKE" --build . --target run
 else
     if [ "$CXX_STANDARD" = "17" ]; then
-        "$CMAKE" -G "Visual Studio 15 2017 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
+        "$CMAKE" -G "Visual Studio 15 2017" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
     else
         # Boost is needed for pre-17 Windows polyfill.
-        "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
+        "$CMAKE" -G "Visual Studio 14 2015" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
     fi
     "$CMAKE" --build . --target run --config "${BUILD_TYPE}" -- /verbosity:minimal
 fi

--- a/examples/projects/bsoncxx/cmake/static/build.sh
+++ b/examples/projects/bsoncxx/cmake/static/build.sh
@@ -13,10 +13,10 @@ if [ -z "$MSVC" ]; then
     "$CMAKE" --build . --target run
 else
     if [ "$CXX_STANDARD" = "17" ]; then
-        "$CMAKE" -G "Visual Studio 15 2017 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
+        "$CMAKE" -G "Visual Studio 15 2017" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
     else
         # Boost is needed for pre-17 Windows polyfill.
-        "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
+        "$CMAKE" -G "Visual Studio 14 2015" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
     fi
     "$CMAKE" --build . --target run --config "${BUILD_TYPE}" -- /verbosity:minimal
 fi

--- a/examples/projects/mongocxx/cmake/shared/build.sh
+++ b/examples/projects/mongocxx/cmake/shared/build.sh
@@ -13,10 +13,10 @@ if [ -z "$MSVC" ]; then
     "$CMAKE" --build . --target run
 else
     if [ "$CXX_STANDARD" = "17" ]; then
-        "$CMAKE" -G "Visual Studio 15 2017 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
+        "$CMAKE" -G "Visual Studio 15 2017" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
     else
         # Boost is needed for pre-17 Windows polyfill.
-        "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
+        "$CMAKE" -G "Visual Studio 14 2015" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
     fi
     "$CMAKE" --build . --target run --config "${BUILD_TYPE}" -- /verbosity:minimal
 fi

--- a/examples/projects/mongocxx/cmake/static/build.sh
+++ b/examples/projects/mongocxx/cmake/static/build.sh
@@ -13,10 +13,10 @@ if [ -z "$MSVC" ]; then
     "$CMAKE" --build . --target run
 else
     if [ "$CXX_STANDARD" = "17" ]; then
-        "$CMAKE" -G "Visual Studio 15 2017 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
+        "$CMAKE" -G "Visual Studio 15 2017" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
     else
         # Boost is needed for pre-17 Windows polyfill.
-        "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
+        "$CMAKE" -G "Visual Studio 14 2015" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DBOOST_ROOT=c:/local/boost_1_60_0 ..
     fi
     "$CMAKE" --build . --target run --config "${BUILD_TYPE}" -- /verbosity:minimal
 fi


### PR DESCRIPTION
Resolves CXX-2039. Verified by [this patch](https://spruce.mongodb.com/version/65a6d7943066150d92e11de2).

This PR primarily consists of three steps:

* Move existing VS 2017 tasks from `windows-64-vs2017` to `windows-vsCurrent`.
* Rename VS 2017 fields/properties to accomodate multiple VS versions.
* Extend VS 2017 tasks to VS 2019 (simple duplication).

This should also address the spurious "cygheap base mismatch detected" failures on Evergreen due to BUILD-17907, which were frequently observed on the `windows-64-vs2017` distro (VS 2015 tasks thankfully seem to be unaffected?).

As part of this effort, several drive-by improvements are made to the EVG config and scripts:

* Use `CMAKE_GENERATOR_PLATFORM` or `-A` to specify the [generator platform](https://cmake.org/cmake/help/v3.15/variable/CMAKE_GENERATOR_PLATFORM.html#variable:CMAKE_GENERATOR_PLATFORM) rather than the `Win64` generator suffix (which only exists for pre-CMake 3.1 compatibility and is not supported by the VS 2019 generator or newer). Documentation and examples were updated accordingly.
* Drop obsolete MSBuild path handlers (toolchain detection is handled by the "latest" CMake binary, and build system invocation is handled by the toolchain-independent `cmake --build` command).
* Ensure CMake generator and platform preferences are also communicated to example projects via CMake environment variables.

This PR initially proposes a simple duplication of the existing VS 2017 tasks with VS 2019 instead. If preferable, the set of tasks and coverage between the VS 2017 and VS 2019 tasks can be adjusted to reduce redundancy.

Note: this PR does not extend C++20 compile coverage to VS 2019, nor does it extend test coverage to VS 2022 (which is available on the new distro).