### PR TITLE
Add ABI compatibility tasks to EVG config (CXX-641, CXX-2746)

### DIFF
--- a/.evergreen/abi-compliance-check-setup.sh
+++ b/.evergreen/abi-compliance-check-setup.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+declare working_dir
+working_dir="$(pwd)"
+
+export PATH
+PATH="${working_dir:?}/install/bin:${PATH:-}"
+
+# Install prefix to use for ABI compatibility scripts.
+[[ -d "${working_dir}/install" ]]
+
+declare parallel_level
+parallel_level="$(("$(nproc)" + 1))"
+
+# Obtain abi-compliance-checker.
+echo "Fetching abi-compliance-checker..."
+[[ -d checker ]] || {
+  git clone -b "2.3" --depth 1 https://github.com/lvc/abi-compliance-checker.git checker
+  pushd checker
+  make -j "${parallel_level:?}" --no-print-directory install prefix="${working_dir:?}/install"
+  popd # checker
+} >/dev/null
+echo "Fetching abi-compliance-checker... done."
+
+# Obtain ctags.
+echo "Fetching ctags..."
+[[ -d ctags ]] || {
+  git clone -b "v6.0.0" --depth 1 https://github.com/universal-ctags/ctags.git ctags
+  pushd ctags
+  ./autogen.sh
+  ./configure --prefix="${working_dir}/install"
+  make -j "${parallel_level:?}"
+  make install
+  popd # ctags
+} >/dev/null
+echo "Fetching ctags... done."
+
+command -V abi-compliance-checker

--- a/.evergreen/abi-compliance-check-test.sh
+++ b/.evergreen/abi-compliance-check-test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+declare working_dir
+working_dir="$(pwd)"
+
+declare base current
+base="$(cat base-commit.txt)"
+current="$(cat current-commit.txt)"
+
+export PATH
+PATH="${working_dir:?}/install/bin:${PATH:-}"
+
+# Remove 'r' prefix in version string.
+declare old_ver new_ver
+old_ver="${base:1}-base"
+new_ver="${current:1}-current"
+
+command -V abi-compliance-checker >/dev/null
+
+mkdir cxx-abi cxx-noabi
+
+cat >cxx-abi/old.xml <<DOC
+<version>
+  ${old_ver:?}
+</version>
+
+<headers>
+  ../install/old/include/bsoncxx/
+  ../install/old/include/mongocxx/
+</headers>
+
+<skip_headers>
+  /v_noabi/
+</skip_headers>
+
+<libs>
+  ../install/old/lib
+</libs>
+
+<add_include_paths>
+  ../install/old/include/
+</add_include_paths>
+
+<skip_including>
+  bsoncxx/enums/
+  /config/
+</skip_including>
+DOC
+
+cat >cxx-abi/new.xml <<DOC
+<version>
+  ${new_ver:?}
+</version>
+
+<headers>
+  ../install/new/include/mongocxx/
+  ../install/new/include/bsoncxx/
+</headers>
+
+<skip_headers>
+  /v_noabi/
+</skip_headers>
+
+<libs>
+  ../install/new/lib
+</libs>
+
+<add_include_paths>
+  ../install/new/include/
+</add_include_paths>
+
+<skip_including>
+  bsoncxx/enums/
+  /config/
+</skip_including>
+DOC
+
+cat >cxx-noabi/old.xml <<DOC
+<version>
+  ${old_ver:?}
+</version>
+
+<headers>
+  ../install/old/include/bsoncxx/v_noabi
+  ../install/old/include/mongocxx/v_noabi
+</headers>
+
+<libs>
+  ../install/old/lib
+</libs>
+
+<add_include_paths>
+  ../install/old/include/
+</add_include_paths>
+
+<skip_including>
+  bsoncxx/enums/
+  /config/
+</skip_including>
+DOC
+
+cat >cxx-noabi/new.xml <<DOC
+<version>
+  ${new_ver:?}
+</version>
+
+<headers>
+  ../install/new/include/bsoncxx/v_noabi
+  ../install/new/include/mongocxx/v_noabi
+</headers>
+
+<libs>
+  ../install/new/lib
+</libs>
+
+<add_include_paths>
+  ../install/new/include/
+</add_include_paths>
+
+<skip_including>
+  bsoncxx/enums/
+  /config/
+</skip_including>
+DOC
+
+# Allow task to upload the HTML report despite failed status.
+echo "Generating stable ABI report..."
+pushd cxx-abi
+if ! abi-compliance-checker -lib mongo-cxx-driver -old old.xml -new new.xml; then
+  : # CXX-2812: enable code below once stable ABI symbols exist in the base commit libraries.
+  # declare status
+  # status='{"status":"failed", "type":"test", "should_continue":true, "desc":"abi-compliance-checker emitted one or more errors"}'
+  # curl -sS -d "${status:?}" -H "Content-Type: application/json" -X POST localhost:2285/task_status || true
+fi
+popd # cxx-abi
+echo "Generating stable ABI report... done."
+
+# Also create a report for the unstable ABI. Errors are expected and OK.
+echo "Generating unstable ABI report..."
+pushd cxx-noabi
+abi-compliance-checker -lib mongo-cxx-driver -old old.xml -new new.xml || true
+popd # cxx-noabi
+echo "Generating unstable ABI report... done."

--- a/.evergreen/abi-prohibited-symbols-test.sh
+++ b/.evergreen/abi-prohibited-symbols-test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+command -V nm >/dev/null
+
+declare -a libs
+libs=(
+  install/new/lib/libbsoncxx.so
+  install/new/lib/libmongocxx.so
+)
+
+for lib in "${libs[@]}"; do
+  [[ -f "${lib:?}" ]] || {
+    echo "error: missing ${lib:?}"
+    exit 1
+  } 1>&2
+done
+
+# Patterns for library symbols to check.
+match_pattern=(
+  -e '(bsoncxx|mongocxx)::'
+)
+
+# Patterns for bad symbols.
+bad_pattern=(
+  -e '(bsoncxx|mongocxx)::(.+::)?detail::'
+  -e '(bsoncxx|mongocxx)::(.+::)?test::'
+)
+
+# Ensure implementation details do not leak into the ABI.
+mapfile -t bad_symbols < <(
+  nm --demangle --dynamic --defined-only --extern-only --just-symbols "${libs[@]}" |
+    grep -E "${match_pattern[@]}" |
+    grep -E "${bad_pattern[@]}"
+)
+
+# Print list of bad symbols.
+(("${#bad_symbols[*]}" == 0)) || {
+  echo "error: found ${#bad_symbols[@]} prohibited symbols in exported ABI:"
+  printf " - %s\n" "${bad_symbols[@]}"
+  exit 1
+} 1>&2

--- a/.evergreen/abi-stability-setup.sh
+++ b/.evergreen/abi-stability-setup.sh
@@ -5,8 +5,6 @@ set -o pipefail
 
 : "${cxx_standard:?}" # Set by abi-stability-checks-* build variant definition.
 
-: "${is_patch:-}" # Set by EVG for patch builds.
-
 command -V git >/dev/null
 
 # Files prepared by EVG config.
@@ -73,10 +71,7 @@ CFLAGS="-g -Og"
 CXXFLAGS="-g -Og"
 
 # Build and install the base commit first.
-if [[ "${is_patch:-}" == "true" ]]; then
-  # Patch builds treat diffs relative to base commit as staged changes.
-  git -C mongo-cxx-driver stash push -u
-fi
+git -C mongo-cxx-driver stash push -u
 git -C mongo-cxx-driver reset --hard "${base:?}"
 
 # Install old (base) to install/old.
@@ -99,9 +94,7 @@ echo "Building old libraries... done."
 
 # Restore all pending changes.
 git -C mongo-cxx-driver reset --hard "HEAD@{1}"
-if [[ "${is_patch:-}" == "true" ]]; then
-  git -C mongo-cxx-driver stash pop
-fi
+git -C mongo-cxx-driver stash pop -q || true # Only patch builds have stashed changes.
 
 # Install new (current) to install/new.
 echo "Building new libraries..."

--- a/.evergreen/abi-stability-setup.sh
+++ b/.evergreen/abi-stability-setup.sh
@@ -81,7 +81,7 @@ git -C mongo-cxx-driver reset --hard "${base:?}"
 
 # Install old (base) to install/old.
 echo "Building old libraries..."
-[[ -d install/old ]] || {
+{
   "${cmake_binary:?}" \
     -S mongo-cxx-driver \
     -B build/old \
@@ -105,7 +105,7 @@ fi
 
 # Install new (current) to install/new.
 echo "Building new libraries..."
-[[ -d install/new ]] || {
+{
   "${cmake_binary:?}" \
     -S mongo-cxx-driver \
     -B build/new \

--- a/.evergreen/abi-stability-setup.sh
+++ b/.evergreen/abi-stability-setup.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+: "${cxx_standard:?}" # Set by abi-stability-checks-* build variant definition.
+
+command -V git >/dev/null
+
+# Files prepared by EVG config.
+[[ -d "mongoc" ]] || {
+  echo "missing mongoc" 1>&2
+  exit 1
+}
+[[ -d "mongo-cxx-driver" ]] || {
+  echo "missing mongo-cxx-driver" 1>&2
+  exit 1
+}
+
+declare working_dir
+working_dir="$(pwd)"
+
+declare cmake_binary
+# shellcheck source=/dev/null
+. ./mongoc/.evergreen/scripts/find-cmake-latest.sh
+cmake_binary="$(find_cmake_latest)"
+command -V "${cmake_binary:?}"
+
+# To use a different base commit, replace `--abbrev 0` with the intended commit.
+# Note: EVG treat all changes relative to the EVG base commit as staged changes!
+declare base current
+base="$(git -C mongo-cxx-driver describe --tags --abbrev=0)"
+current="$(git -C mongo-cxx-driver describe --tags)"
+
+echo "Old Version (Base): ${base:?}"
+echo "New Version (Current): ${current:?}"
+
+printf "%s" "${base:?}" >base-commit.txt
+printf "%s" "${current:?}" >current-commit.txt
+
+# Remove 'r' prefix in version string.
+declare old_ver new_ver
+old_ver="${base:1}"
+new_ver="${current:1}"
+
+declare parallel_level
+parallel_level="$(("$(nproc)" + 1))"
+
+# Use Ninja if available.
+if command -V ninja; then
+  export CMAKE_GENERATOR
+  CMAKE_GENERATOR="Ninja"
+else
+  export CMAKE_BUILD_PARALLEL_LEVEL
+  CMAKE_BUILD_PARALLEL_LEVEL="${parallel_level:?}"
+fi
+
+# Use ccache if available.
+if command -V ccache; then
+  export CMAKE_C_COMPILER_LAUNCHER CMAKE_CXX_COMPILER_LAUNCHER
+  CMAKE_C_COMPILER_LAUNCHER="ccache"
+  CMAKE_CXX_COMPILER_LAUNCHER="ccache"
+fi
+
+# Install prefix to use for ABI compatibility scripts.
+mkdir -p "${working_dir}/install"
+
+# As encouraged by ABI compatibility checkers.
+export CFLAGS CXXFLAGS
+CFLAGS="-g -Og"
+CXXFLAGS="-g -Og"
+
+# Build and install the base commit first.
+git -C mongo-cxx-driver stash push -u
+git -C mongo-cxx-driver reset --hard "${base:?}"
+
+# Install old (base) to install/old.
+echo "Building old libraries..."
+[[ -d install/old ]] || {
+  "${cmake_binary:?}" \
+    -S mongo-cxx-driver \
+    -B build/old \
+    -DCMAKE_INSTALL_PREFIX="install/old" \
+    -DCMAKE_PREFIX_PATH="${working_dir:?}/mongoc" \
+    -DBUILD_VERSION="${old_ver:?}-base" \
+    -DCMAKE_CXX_STANDARD="${cxx_standard:?}"
+  "${cmake_binary:?}" --build build/old
+  "${cmake_binary:?}" --install build/old
+} &>old.log || {
+  cat old.log 1>&2
+  exit 1
+}
+echo "Building old libraries... done."
+
+# Restore all pending changes.
+git -C mongo-cxx-driver reset --hard "HEAD@{1}"
+git -C mongo-cxx-driver stash pop
+
+# Install new (current) to install/new.
+echo "Building new libraries..."
+[[ -d install/new ]] || {
+  "${cmake_binary:?}" \
+    -S mongo-cxx-driver \
+    -B build/new \
+    -DCMAKE_INSTALL_PREFIX="install/new" \
+    -DCMAKE_PREFIX_PATH="${working_dir:?}/mongoc" \
+    -DBUILD_VERSION="${new_ver:?}-current" \
+    -DCMAKE_CXX_STANDARD="${cxx_standard:?}"
+  "${cmake_binary:?}" --build build/new
+  "${cmake_binary:?}" --install build/new
+} &>new.log || {
+  cat new.log 1>&2
+  exit 1
+}
+echo "Building new libraries... done."

--- a/.evergreen/abidiff-setup.sh
+++ b/.evergreen/abidiff-setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+declare working_dir
+working_dir="$(pwd)"
+
+export PATH
+PATH="${working_dir:?}/install/bin:${PATH:-}"
+
+# Install prefix to use for ABI compatibility scripts.
+[[ -d "${working_dir}/install" ]]
+
+if command -V abidiff 2>/dev/null; then
+  exit # Already available.
+fi
+
+# Expected to be run on Ubuntu.
+echo "Installing abigail-tools..."
+sudo apt-get install -q -y abigail-tools >/dev/null
+echo "Installing abigail-tools... done."
+
+command -V abidiff

--- a/.evergreen/abidiff-test.sh
+++ b/.evergreen/abidiff-test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+declare working_dir
+working_dir="$(pwd)"
+
+export PATH
+PATH="${working_dir:?}/install/bin:${PATH:-}"
+
+declare -a common_flags
+flags=(
+  --headers-dir1 install/old/include
+  --headers-dir2 install/new/include
+  --non-reachable-types
+  --fail-no-debug-info
+)
+
+declare -a abi_flags=("${common_flags[@]}" --suppressions cxx-abi/abignore)
+declare -a noabi_flags=("${common_flags[@]}" --suppressions cxx-noabi/abignore)
+
+command -V abidiff >/dev/null
+
+mkdir cxx-abi cxx-noabi
+
+cat >cxx-abi/abignore <<DOC
+[suppress_type]
+name_not_regexp = ^(bsoncxx|mongocxx)::v[[:digit:]]+::
+
+[suppress_function]
+name_not_regexp = ^(bsoncxx|mongocxx)::v[[:digit:]]+::
+
+[suppress_variable]
+name_not_regexp = ^(bsoncxx|mongocxx)::v[[:digit:]]+::
+DOC
+
+cat >cxx-noabi/abignore <<DOC
+[suppress_type]
+name_regexp = ^(bsoncxx|mongocxx)::v[[:digit:]]+::
+
+[suppress_function]
+name_regexp = ^(bsoncxx|mongocxx)::v[[:digit:]]+::
+
+[suppress_variable]
+name_regexp = ^(bsoncxx|mongocxx)::v[[:digit:]]+::
+DOC
+
+# Allow task to upload the diff reports despite failed status.
+echo "Comparing stable ABI for bsoncxx..."
+if ! abidiff "${abi_flags[@]}" install/old/lib/libbsoncxx.so install/new/lib/libbsoncxx.so &>cxx-abi/bsoncxx.txt; then
+  declare status
+  status='{"status":"failed", "type":"test", "should_continue":true, "desc":"abidiff returned an error for bsoncxx (stable)"}'
+  curl -sS -d "${status:?}" -H "Content-Type: application/json" -X POST localhost:2285/task_status || true
+  :
+fi
+echo "Comparing stable ABI for bsoncxx... done."
+
+# Allow task to upload the diff reports despite failed status.
+echo "Comparing stable ABI for mongocxx..."
+if ! abidiff "${abi_flags[@]}" install/old/lib/libmongocxx.so install/new/lib/libmongocxx.so &>cxx-abi/mongocxx.txt; then
+  declare status
+  status='{"status":"failed", "type":"test", "should_continue":true, "desc":"abidiff returned an error for mongocxx (stable)"}'
+  curl -sS -d "${status:?}" -H "Content-Type: application/json" -X POST localhost:2285/task_status || true
+  :
+fi
+echo "Comparing stable ABI for mongocxx... done."
+
+echo "Comparing unstable ABI for bsoncxx..."
+abidiff "${noabi_flags[@]}" install/old/lib/libbsoncxx.so install/new/lib/libbsoncxx.so &>cxx-noabi/bsoncxx.txt || true
+echo "Comparing unstable ABI for bsoncxx... done."
+
+echo "Comparing unstable ABI for mongocxx..."
+abidiff "${noabi_flags[@]}" install/old/lib/libmongocxx.so install/new/lib/libmongocxx.so &>cxx-noabi/mongocxx.txt || true
+echo "Comparing unstable ABI for mongocxx... done."
+
+# Ensure files have content even when abidiff produces no output.
+printf "\n" >>cxx-abi/bsoncxx.txt
+printf "\n" >>cxx-abi/mongocxx.txt
+printf "\n" >>cxx-noabi/bsoncxx.txt
+printf "\n" >>cxx-noabi/mongocxx.txt

--- a/.evergreen/abidiff-test.sh
+++ b/.evergreen/abidiff-test.sh
@@ -52,7 +52,6 @@ if ! abidiff "${abi_flags[@]}" install/old/lib/libbsoncxx.so install/new/lib/lib
   declare status
   status='{"status":"failed", "type":"test", "should_continue":true, "desc":"abidiff returned an error for bsoncxx (stable)"}'
   curl -sS -d "${status:?}" -H "Content-Type: application/json" -X POST localhost:2285/task_status || true
-  :
 fi
 echo "Comparing stable ABI for bsoncxx... done."
 
@@ -62,7 +61,6 @@ if ! abidiff "${abi_flags[@]}" install/old/lib/libmongocxx.so install/new/lib/li
   declare status
   status='{"status":"failed", "type":"test", "should_continue":true, "desc":"abidiff returned an error for mongocxx (stable)"}'
   curl -sS -d "${status:?}" -H "Content-Type: application/json" -X POST localhost:2285/task_status || true
-  :
 fi
 echo "Comparing stable ABI for mongocxx... done."
 

--- a/.mci.yml
+++ b/.mci.yml
@@ -56,6 +56,103 @@ variables:
 #######################################
 
 functions:
+    "abi-compliance-check":
+        - command: subprocess.exec
+          type: setup
+          params:
+            binary: bash
+            args: [mongo-cxx-driver/.evergreen/abi-compliance-check-setup.sh]
+        - command: subprocess.exec
+          type: test
+          params:
+            binary: bash
+            args: [mongo-cxx-driver/.evergreen/abi-compliance-check-test.sh]
+        - command: s3.put
+          type: system
+          params:
+            aws_key: ${aws_key}
+            aws_secret: ${aws_secret}
+            bucket: mciuploads
+            content_type: text/html
+            display_name: "ABI Compliance Check (Stable): "
+            local_files_include_filter: cxx-abi/compat_reports/**/compat_report.html
+            permissions: public-read
+            remote_file: mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/abi-compliance-check/abi/
+        - command: s3.put
+          type: system
+          params:
+            aws_key: ${aws_key}
+            aws_secret: ${aws_secret}
+            bucket: mciuploads
+            content_type: text/plain
+            display_name: "ABI Compliance Check (Stable): "
+            local_files_include_filter: cxx-abi/logs/**/log.txt
+            permissions: public-read
+            remote_file: mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/abi-compliance-check/abi/
+        - command: s3.put
+          type: system
+          params:
+            aws_key: ${aws_key}
+            aws_secret: ${aws_secret}
+            bucket: mciuploads
+            content_type: text/html
+            display_name: "ABI Compliance Check (Unstable): "
+            local_files_include_filter: cxx-noabi/compat_reports/**/compat_report.html
+            permissions: public-read
+            remote_file: mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/abi-compliance-check/noabi/
+        - command: s3.put
+          type: system
+          params:
+            aws_key: ${aws_key}
+            aws_secret: ${aws_secret}
+            bucket: mciuploads
+            content_type: text/plain
+            display_name: "ABI Compliance Check (Unstable): "
+            local_files_include_filter: cxx-noabi/logs/**/log.txt
+            permissions: public-read
+            remote_file: mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/abi-compliance-check/noabi/
+
+    "abidiff":
+        - command: subprocess.exec
+          type: setup
+          params:
+            binary: bash
+            args: [mongo-cxx-driver/.evergreen/abidiff-setup.sh]
+        - command: subprocess.exec
+          type: test
+          params:
+            binary: bash
+            args: [mongo-cxx-driver/.evergreen/abidiff-test.sh]
+        - command: s3.put
+          type: system
+          params:
+            aws_key: ${aws_key}
+            aws_secret: ${aws_secret}
+            bucket: mciuploads
+            content_type: text/plain
+            display_name: "abidiff (Stable): "
+            local_files_include_filter: cxx-abi/*.txt
+            permissions: public-read
+            remote_file: mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/abidiff/abi/
+        - command: s3.put
+          type: system
+          params:
+            aws_key: ${aws_key}
+            aws_secret: ${aws_secret}
+            bucket: mciuploads
+            content_type: text/plain
+            display_name: "abidiff (Unstable): "
+            local_files_include_filter: cxx-noabi/*.txt
+            permissions: public-read
+            remote_file: mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/abidiff/noabi/
+
+    "abi-prohibited-symbols":
+        - command: subprocess.exec
+          type: test
+          params:
+            binary: bash
+            args: [mongo-cxx-driver/.evergreen/abi-prohibited-symbols-test.sh]
+
     "setup":
         - command: shell.exec
           params:
@@ -563,6 +660,22 @@ post:
 #######################################
 
 tasks:
+    - name: abi-compliance-check
+      tags: ["abi-stability", "abi-compliance-check"]
+      run_on: "ubuntu2204-large"
+      commands:
+        - func: "abi-compliance-check"
+    - name: abidiff
+      tags: ["abi-stability", "abidiff"]
+      run_on: "ubuntu2204-large"
+      commands:
+        - func: "abidiff"
+    - name: abi-prohibited-symbols
+      tags: ["abi-stability", "abi-prohibited-symbols"]
+      run_on: "ubuntu2204-large"
+      commands:
+        - func: "abi-prohibited-symbols"
+
     - name: lint
       run_on: ubuntu1804-large
       commands:
@@ -987,6 +1100,27 @@ tasks:
               ./build/src/mongocxx/test/test_driver "atlas search indexes prose tests"
 
 task_groups:
+  - name: tg-abi-stability
+    max_hosts: -1
+    setup_task_can_fail_task: true
+    setup_task:
+      - command: git.get_project
+        params:
+          directory: "mongo-cxx-driver"
+      - func: install_c_driver
+      - command: subprocess.exec
+        params:
+          binary: bash
+          args: [mongo-cxx-driver/.evergreen/abi-stability-setup.sh]
+          include_expansions_in_env: [cxx_standard]
+    tasks: [".abi-stability"]
+    teardown_task_can_fail_task: true
+    teardown_task:
+      - command: subprocess.exec
+        params:
+          binary: bash
+          args: [-c, rm -rf *]
+
   - name: test_atlas_task_group_search_indexes
     setup_group:
       - func: "setup"
@@ -1023,6 +1157,29 @@ task_groups:
 #######################################
 
 buildvariants:
+    ##########################
+    #  ABI Stability Checks  #
+    ##########################
+    - name: abi-stability-polyfill
+      display_name: "ABI Stability Checks (polyfill)"
+      expansions:
+        cxx_standard: 11 # Use a polyfill library.
+      tasks:
+        - "tg-abi-stability"
+      display_tasks:
+        - name: "ABI Stability Checks (polyfill)"
+          execution_tasks: [".abi-stability"]
+
+    - name: abi-stability-stdlib
+      display_name: "ABI Stability Checks (stdlib)"
+      expansions:
+        cxx_standard: 17 # Use the stdlib.
+      tasks:
+        - "tg-abi-stability"
+      display_tasks:
+        - name: "ABI Stability Checks (stdlib)"
+          execution_tasks: [".abi-stability"]
+
     #######################################
     #  Standard MongoDB Integration Tests #
     #######################################

--- a/.mci.yml
+++ b/.mci.yml
@@ -1112,9 +1112,7 @@ task_groups:
         params:
           binary: bash
           args: [mongo-cxx-driver/.evergreen/abi-stability-setup.sh]
-          include_expansions_in_env:
-            - cxx_standard
-            - is_patch
+          include_expansions_in_env: [cxx_standard]
     tasks: [".abi-stability"]
     teardown_task_can_fail_task: true
     teardown_task:

--- a/.mci.yml
+++ b/.mci.yml
@@ -1112,7 +1112,9 @@ task_groups:
         params:
           binary: bash
           args: [mongo-cxx-driver/.evergreen/abi-stability-setup.sh]
-          include_expansions_in_env: [cxx_standard]
+          include_expansions_in_env:
+            - cxx_standard
+            - is_patch
     tasks: [".abi-stability"]
     teardown_task_can_fail_task: true
     teardown_task:


### PR DESCRIPTION
## Description

This PR resolves both CXX-641 and CXX-2746. Verified by [this patch](https://spruce.mongodb.com/version/65a98804e3c3315314baed3e).

This PR proposes adding three tasks to the CXX Driver EVG config:

- abi-compliance-check: uses [abi-compliance-checker](https://lvc.github.io/abi-compliance-checker/) to generate binary and source compatibility reports.
- abidiff: uses [abidiff](https://sourceware.org/libabigail/manual/abidiff.html) to generate detailed binary compatibility reports.
- abi-prohibited-symbols: uses [nm](https://sourceware.org/binutils/docs/binutils/nm.html) and `grep` to detect symbols that should not be present in the ABI.

These three tasks are run by two build variants: one testing the CXX Driver libraries configured to use a polyfill library (currently mnmlstc/core by default), and one configured to use the C++17 standard library.

## The abi-stability Task Group

This PR uses an EVG task group to select and run the ABI stability tasks.

A task group allow one to define "pre" and "post" commands unique to the task group in the form of "setup" and "teardown" tasks. These overrule the global "pre" and "post" commands, providing better separation of concerns. On the other hand, tasks in a task group may potentially reuse the same host, which may include whatever contents remain after running the prior task. To avoid unexpected filesystem conflicts and encourage reproducibility, the teardown task simply removes _all_ contents in the default directory with `rm -rf *`.

The setup task fetches the CXX Driver sources, installs the C Driver, then runs `abi-stability-setup.sh`. The setup script requires only one externally-provided environment, `cxx_standard`, to control selection of the polyfill library via `CMAKE_CXX_STANDARD`. Beyond some conveniences such as Ninja generator selection and enabling ccache support, the "base" and "current" state of the CXX Driver repository are built and installed into separate prefixes using the exact same build configuration, with the sole exception of the C++ standard requested. The separate prefixes are then used by the ABI stability tasks for comparison and testing.

The "base commit" is the latest tag reachable from the "current commit", obtained via `git describe --tags --abbrev=0`. For this PR, this is the 3.9.0 release. The "current commit" is the latest commit in a PR or waterfall build, or the base commit + staged changes in an EVG patch build. This means the generated reports will be comparing the current state of the CXX Driver against the most recent release version (including patch releases, when a patch release tag is reachable from the current commit).

The unstable and stable ABIs are tested separately. If a binary-incompatible change is detected for a stable ABI symbol, the task will fail. If a binary-incompatible change is detected for an unstable ABI symbol, the task will not fail. This is to allow generating informative reports for the unstable ABI independent of the state of the stable ABI, e.g. to track ongoing and upcoming work for CXX-2625, CXX-2796, and CXX-2797 (the unstable ABI reports with stdlib should not report incompatibilities once CXX-2796 is resolved).

The polyfill and stdlib configurations are also tested as separate build variants. This is to ensure the build system correctly configures the CXX Driver libraries to use the C++17 standard library features when available, and to ensure our pre-C++17 polyfill library alternatives do not affect post-C++17 compatibility. For example, the ongoing changes made for CXX-2625 are currently reflected in the stdlib abi-compliance-check [source compatibility report](https://mciuploads.s3.amazonaws.com/mongo-cxx-driver/master/5b743b105e13c4437b18d8245db8e3d83c351c88/65a98804e3c3315314baed3e/cxx_driver_abi_stability_stdlib_patch_5b743b105e13c4437b18d8245db8e3d83c351c88_65a98804e3c3315314baed3e_24_01_18_20_20_21/0/abi-compliance-check/noabi/compat_report.html) as high/medium severity issues. Once C++17 support is restored by CXX-2796, this report should return to a much cleaner state.

## abi-compliance-check

The `abi-compliance-checker` tool requires the set intersection of the symbols being checked to be non-empty: at least one common symbol must be present in the old and new libraries. This means the stable ABI cannot be tested yet due to the set of symbols being empty. Once stable ABI symbols are present in _both_ the current and base commits being compared, the commented-out commands can be enabled: this pending task is tracked by CXX-2812.

The HTML compatibility reports describe both binary and source compatibility. The source compatibility reports in particular are expected to be a useful tool independent of ABI compatibility tests and informing the release of minor vs. major versions.

Both the `abi-compliance-checker` tool and its required `ctags` tool are build from source to obtain suitably recent versions, as the system-provided binary was observed to be susceptible to confusing runtime bugs.

## abidiff

The `abidiff` tool provides a very detailed report comparing both definite and indirect potential ABI incompatibility issues. This tool is obtained via the system package manager.

## abi-prohibited-symbols

This task greps for any symbols in the `bsoncxx` or `mongocxx` namespaces that are also members of a `detail` or `test` namespace. If such a symbol is found, suggesting leak of implementation details or test-specific interfaces into the ABI, this task will fail.

## Task Status via HTTP Endpoint

The `curl` commands in the `*-test.sh` scripts is to allow for the following `s3.put` commands to upload the generated reports before marking the task as failed. Normally, when a command within a task fails, the remaining commands are not executed; this is to circumvent that usual behavior. If this is seen as too confusing or complicated to maintain, a `[[ -f error_occurred.txt ]]` check _after_ the `s3.put` commands can be used instead.

## Display Tasks

The "display tasks" EVG feature is used to reduce verbosity of the EVG results page. This also allows for the uploaded files to be conveniently grouped by display task, e.g. see all the reports for the [polyfill](https://spruce.mongodb.com/task/cxx_driver_abi_stability_polyfill_display_ABI_Stability_Checks_(polyfill)_patch_5b743b105e13c4437b18d8245db8e3d83c351c88_65a98804e3c3315314baed3e_24_01_18_20_20_21/files) and [stdlib](https://spruce.mongodb.com/task/cxx_driver_abi_stability_stdlib_display_ABI_Stability_Checks_(stdlib)_patch_5b743b105e13c4437b18d8245db8e3d83c351c88_65a98804e3c3315314baed3e_24_01_18_20_20_21/files) variant tasks each on a single page.