### PR TITLE
CXX-2783 use Docker image to run `mongohouse`

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -193,18 +193,17 @@ functions:
                 cd drivers-evergreen-tools
                 export DRIVERS_TOOLS=$(pwd)
 
-                sh .evergreen/atlas_data_lake/build-mongohouse-local.sh
+                sh .evergreen/atlas_data_lake/pull-mongohouse-image.sh
 
     "run_mongohouse":
         command: shell.exec
         params:
             shell: bash
-            background: true
             script: |
                 cd drivers-evergreen-tools
                 export DRIVERS_TOOLS=$(pwd)
 
-                sh .evergreen/atlas_data_lake/run-mongohouse-local.sh
+                sh .evergreen/atlas_data_lake/run-mongohouse-image.sh
 
     "test_mongohouse":
         command: shell.exec

--- a/.mci.yml
+++ b/.mci.yml
@@ -240,6 +240,7 @@ functions:
                 fi
 
                 export MONGOHOUSE_TESTS_PATH="$(pwd)/../data/mongohouse"
+                export RUN_MONGOHOUSE_TESTS=ON
 
                 ulimit -c unlimited || true
 

--- a/.mci.yml
+++ b/.mci.yml
@@ -211,7 +211,21 @@ functions:
             shell: bash
             working_dir: "mongo-cxx-driver"
             script: |
-                echo "testing that mongohouse is running..."
+                echo "Waiting for mongohouse to start..."
+                wait_for_mongohouse() {
+                    for _ in $(seq 300); do
+                        # Exit code 7: "Failed to connect to host".
+                        if curl -s localhost:$1; (("$?" != 7)); then
+                            return 0
+                        else
+                            sleep 1
+                        fi
+                    done
+                    echo "Could not detect mongohouse on port $1" 1>&2
+                    return 1
+                }
+                wait_for_mongohouse 27017 || exit
+                echo "Waiting for mongohouse to start... done."
                 ps aux | grep mongohouse
 
                 cd build

--- a/.mci.yml
+++ b/.mci.yml
@@ -1853,7 +1853,6 @@ buildvariants:
       display_name: "Mongohouse Test"
       expansions:
           build_type: "Release"
-          mongodb_version: "latest"
       run_on: ubuntu2204-small
       tasks:
           - name: test_mongohouse

--- a/.mci.yml
+++ b/.mci.yml
@@ -193,7 +193,7 @@ functions:
                 cd drivers-evergreen-tools
                 export DRIVERS_TOOLS=$(pwd)
 
-                sh .evergreen/atlas_data_lake/pull-mongohouse-image.sh
+                bash .evergreen/atlas_data_lake/pull-mongohouse-image.sh
 
     "run_mongohouse":
         command: shell.exec
@@ -203,7 +203,7 @@ functions:
                 cd drivers-evergreen-tools
                 export DRIVERS_TOOLS=$(pwd)
 
-                sh .evergreen/atlas_data_lake/run-mongohouse-image.sh
+                bash .evergreen/atlas_data_lake/run-mongohouse-image.sh
 
     "test_mongohouse":
         command: shell.exec

--- a/.mci.yml
+++ b/.mci.yml
@@ -1854,7 +1854,7 @@ buildvariants:
       expansions:
           build_type: "Release"
           mongodb_version: "latest"
-      run_on: ubuntu2004-test
+      run_on: ubuntu2204-small
       tasks:
           - name: test_mongohouse
 

--- a/src/mongocxx/test/spec/util.cpp
+++ b/src/mongocxx/test/spec/util.cpp
@@ -123,19 +123,7 @@ bool should_skip_spec_test(const client& client, document::view test) {
         return false;
     }
 
-    std::string server_version;
-    try {
-        server_version = test_util::get_server_version(client);
-    } catch (const operation_exception& e) {
-        // Mongohouse does not support serverStatus, so if we get an error from
-        // serverStatus, exit this logic early and run the test.
-        std::string message = e.what();
-        if (message.find("command serverStatus is unsupported") != std::string::npos) {
-            return false;
-        }
-
-        throw e;
-    }
+    std::string server_version = test_util::get_server_version(client);
 
     std::string topology = test_util::get_topology(client);
 

--- a/src/mongocxx/test/spec/util.cpp
+++ b/src/mongocxx/test/spec/util.cpp
@@ -116,6 +116,13 @@ bool should_skip_spec_test(const client& client, document::view test) {
         return true;
     }
 
+    auto run_mongohouse_tests = std::getenv("RUN_MONGOHOUSE_TESTS");
+    if (run_mongohouse_tests && std::string(run_mongohouse_tests) == "ON") {
+        // mongohoused does not return `version` field in response to serverStatus.
+        // Exit early to run the test.
+        return false;
+    }
+
     std::string server_version;
     try {
         server_version = test_util::get_server_version(client);


### PR DESCRIPTION
# Summary

Similar to https://github.com/mongodb/mongo-c-driver/pull/1517, this PR uses the mongohouse Docker image added in DRIVERS-2543 to fix `test_mongohouse` task.

Verified with this patch build: https://spruce.mongodb.com/version/65aeae81c9ec44ca5f410888

# Background & Motivation

DRIVERS-2543 adds scripts to use the Docker image maintained by the Atlas Data Lake team. https://github.com/mongodb-labs/drivers-evergreen-tools/commit/95ad5f3708b2ecb8cfcbc9005743ea92e9f81027 removed `run-mongohouse-local.sh` from drivers-evergreen-tools.

A new `RUN_MONGOHOUSE_TESTS` environment variable is passed to the test runner to conditionally run the `serverStatus` command. mongohoused does not return an expected `version` field in the response to `serverStatus`:

```
AtlasDataFederation test> db.runCommand({serverStatus: 1})
{ ok: 1, host: 'localhost' }
```
The test `mongohoused` uses a [local store](https://github.com/10gen/mongohouse/blob/3512649c2684920d66292cf8faf1ade20ea5347a/testdata/config/external/drivers/config.yaml#L57). I expect this does not requiring a running `mongod` or `mongos`. I expect the version check is not applicable.