### PR TITLE
Allow ccache to reuse results across build directories

### DIFF
--- a/.evergreen/abi-stability-setup.sh
+++ b/.evergreen/abi-stability-setup.sh
@@ -62,7 +62,7 @@ if command -V ccache 2>/dev/null; then
 
   # Allow reuse of ccache compilation results between different build directories.
   export CCACHE_BASEDIR CCACHE_NOHASHDIR
-  CCACHE_BASEDIR="$(pwd)"
+  CCACHE_BASEDIR="$(pwd)/mongo-cxx-driver"
   CCACHE_NOHASHDIR=1
 fi
 

--- a/.evergreen/abi-stability-setup.sh
+++ b/.evergreen/abi-stability-setup.sh
@@ -56,10 +56,14 @@ else
 fi
 
 # Use ccache if available.
-if command -V ccache; then
-  export CMAKE_C_COMPILER_LAUNCHER CMAKE_CXX_COMPILER_LAUNCHER
-  CMAKE_C_COMPILER_LAUNCHER="ccache"
-  CMAKE_CXX_COMPILER_LAUNCHER="ccache"
+if command -V ccache 2>/dev/null; then
+  export CMAKE_C_COMPILER_LAUNCHER=ccache
+  export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+  # Allow reuse of ccache compilation results between different build directories.
+  export CCACHE_BASEDIR CCACHE_NOHASHDIR
+  CCACHE_BASEDIR="$(pwd)"
+  CCACHE_NOHASHDIR=1
 fi
 
 # Install prefix to use for ABI compatibility scripts.

--- a/.evergreen/compile.sh
+++ b/.evergreen/compile.sh
@@ -67,10 +67,18 @@ CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
 export CMAKE_BUILD_PARALLEL_LEVEL
 
 # Use ccache if available.
-if command -v ccache >/dev/null; then
-  echo "Enabling ccache as CMake compiler launcher"
-  export CMAKE_C_COMPILER_LAUNCHER=ccache
+if command -V ccache 2>/dev/null; then
   export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+
+  # Allow reuse of ccache compilation results between different build directories.
+  export CCACHE_BASEDIR CCACHE_NOHASHDIR
+  CCACHE_BASEDIR="$(pwd)"
+  CCACHE_NOHASHDIR=1
+  # Allow reuse of ccache compilation results between different build directories.
+  export CCACHE_BASEDIR CCACHE_NOHASHDIR
+  CCACHE_BASEDIR="$(pwd)"
+  CCACHE_NOHASHDIR=1
 fi
 
 cmake_build_opts=()

--- a/.evergreen/install_c_driver.sh
+++ b/.evergreen/install_c_driver.sh
@@ -83,7 +83,6 @@ if [[ "${OSTYPE}" == darwin* ]]; then
   }
 fi
 
-
 # Default CMake generator to use if not already provided.
 declare CMAKE_GENERATOR CMAKE_GENERATOR_PLATFORM
 if [[ "${OSTYPE:?}" == "cygwin" ]]; then
@@ -129,6 +128,17 @@ if [[ "${BSON_EXTRA_ALIGNMENT:-}" == "1" ]]; then
   configure_flags+=("-DENABLE_EXTRA_ALIGNMENT=ON")
 else
   configure_flags+=("-DENABLE_EXTRA_ALIGNMENT=OFF")
+fi
+
+# Use ccache if available.
+if command -V ccache 2>/dev/null; then
+  export CMAKE_C_COMPILER_LAUNCHER=ccache
+  export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+  # Allow reuse of ccache compilation results between different build directories.
+  export CCACHE_BASEDIR CCACHE_NOHASHDIR
+  CCACHE_BASEDIR="${mongoc_idir}"
+  CCACHE_NOHASHDIR=1
 fi
 
 # Install libmongoc.

--- a/.mci.yml
+++ b/.mci.yml
@@ -962,11 +962,21 @@ tasks:
             rsync -aq --exclude='examples/add_subdirectory' $(readlink -f ../..) .
             [ -d build ] || mkdir build
             . ./mongo-c-driver/.evergreen/scripts/find-cmake-latest.sh
-            export CMAKE
-            CMAKE="$(find_cmake_latest)"
-            command -v "$CMAKE"
-            $CMAKE -S . -B build -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF
-            $CMAKE --build build
+            export cmake_binary
+            cmake_binary="$(find_cmake_latest)"
+            # Use ccache if available.
+            if command -V ccache 2>/dev/null; then
+              export CMAKE_C_COMPILER_LAUNCHER=ccache
+              export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+              # Allow reuse of ccache compilation results between different build directories.
+              export CCACHE_BASEDIR CCACHE_NOHASHDIR
+              CCACHE_BASEDIR="$(pwd)"
+              CCACHE_NOHASHDIR=1
+            fi
+            command -v "$cmake_binary"
+            "$cmake_binary" -S . -B build -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF
+            "$cmake_binary" --build build
             ./build/hello_mongocxx
 
     - name: debian-package-build


### PR DESCRIPTION
The CXX Driver equivalent of changes in https://github.com/mongodb/mongo-c-driver/pull/1522. Verified by [this patch](https://spruce.mongodb.com/version/65b1705357e85a2a383b69fd).

The only caveat is that the CXX Driver does not have its own ccache detect-and-use routine a la CCache.cmake in the C Driver, so each instance of setting the ccache environment variables is preceeded by a test for `ccache` being present.

For consistency, other instances of the ccache test have been changed to use the same `command -V` method, which prints the path to the ccache binary when present in an informative manner (e.g. `ccache is /usr/bin/ccache`) in lieu of the explicit message that was being used prior.