### PR TITLE
CXX-2818 Minor improvements to EVG config (codecov, xtrace)

### DIFF
--- a/.evergreen/test.sh
+++ b/.evergreen/test.sh
@@ -109,14 +109,22 @@ else
   # export environment variables for encryption tests
   set +o errexit
 
-  # Avoid printing credentials in logs.
-  set +o xtrace
-
   echo "Setting temporary credentials..."
   pushd "${DRIVERS_TOOLS:?}/.evergreen/csfle"
-  export AWS_SECRET_ACCESS_KEY="${cse_aws_secret_access_key:?}"
-  export AWS_ACCESS_KEY_ID="${cse_aws_access_key_id:?}"
-  export AWS_DEFAULT_REGION="us-east-1"
+  {
+    # DEVPROD-4630: use BASH_XTRACEFD instead:
+    #     exec {BASH_XTRACEFD}>/dev/null
+    is_xtrace_set="$([[ "$-" == *x* ]] && echo 1)"
+    set +o xtrace
+
+    export AWS_SECRET_ACCESS_KEY="${cse_aws_secret_access_key:?}"
+    export AWS_ACCESS_KEY_ID="${cse_aws_access_key_id:?}"
+    export AWS_DEFAULT_REGION="us-east-1"
+
+    # DEVPROD-4630: use BASH_XTRACEFD instead:
+    #     unset BASH_XTRACEFD
+    [[ "${old_trace_opt:-}" == 1 ]] && set -o xtrace
+  }
   echo "Running activate-kmstlsvenv.sh..."
   # shellcheck source=/dev/null
   . ./activate-kmstlsvenv.sh
@@ -135,18 +143,29 @@ else
     exit 1
   fi
 
-  export MONGOCXX_TEST_CSFLE_TLS_CA_FILE=${DRIVERS_TOOLS:?}/.evergreen/x509gen/ca.pem
-  export MONGOCXX_TEST_CSFLE_TLS_CERTIFICATE_KEY_FILE=${DRIVERS_TOOLS:?}/.evergreen/x509gen/client.pem
-  export MONGOCXX_TEST_AWS_TEMP_ACCESS_KEY_ID="$CSFLE_AWS_TEMP_ACCESS_KEY_ID"
-  export MONGOCXX_TEST_AWS_TEMP_SECRET_ACCESS_KEY="$CSFLE_AWS_TEMP_SECRET_ACCESS_KEY"
-  export MONGOCXX_TEST_AWS_TEMP_SESSION_TOKEN="$CSFLE_AWS_TEMP_SESSION_TOKEN"
-  export MONGOCXX_TEST_AWS_SECRET_ACCESS_KEY="${cse_aws_secret_access_key:?}"
-  export MONGOCXX_TEST_AWS_ACCESS_KEY_ID="${cse_aws_access_key_id:?}"
-  export MONGOCXX_TEST_AZURE_TENANT_ID="${cse_azure_tenant_id:?}"
-  export MONGOCXX_TEST_AZURE_CLIENT_ID="${cse_azure_client_id:?}"
-  export MONGOCXX_TEST_AZURE_CLIENT_SECRET="${cse_azure_client_secret:?}"
-  export MONGOCXX_TEST_GCP_EMAIL="${cse_gcp_email:?}"
-  export MONGOCXX_TEST_GCP_PRIVATEKEY="${cse_gcp_privatekey:?}"
+  {
+    # DEVPROD-4630: use BASH_XTRACEFD instead:
+    #     exec {BASH_XTRACEFD}>/dev/null
+    is_xtrace_set="$([[ "$-" == *x* ]] && echo 1)"
+    set +o xtrace
+
+    export MONGOCXX_TEST_CSFLE_TLS_CA_FILE=${DRIVERS_TOOLS:?}/.evergreen/x509gen/ca.pem
+    export MONGOCXX_TEST_CSFLE_TLS_CERTIFICATE_KEY_FILE=${DRIVERS_TOOLS:?}/.evergreen/x509gen/client.pem
+    export MONGOCXX_TEST_AWS_TEMP_ACCESS_KEY_ID="$CSFLE_AWS_TEMP_ACCESS_KEY_ID"
+    export MONGOCXX_TEST_AWS_TEMP_SECRET_ACCESS_KEY="$CSFLE_AWS_TEMP_SECRET_ACCESS_KEY"
+    export MONGOCXX_TEST_AWS_TEMP_SESSION_TOKEN="$CSFLE_AWS_TEMP_SESSION_TOKEN"
+    export MONGOCXX_TEST_AWS_SECRET_ACCESS_KEY="${cse_aws_secret_access_key:?}"
+    export MONGOCXX_TEST_AWS_ACCESS_KEY_ID="${cse_aws_access_key_id:?}"
+    export MONGOCXX_TEST_AZURE_TENANT_ID="${cse_azure_tenant_id:?}"
+    export MONGOCXX_TEST_AZURE_CLIENT_ID="${cse_azure_client_id:?}"
+    export MONGOCXX_TEST_AZURE_CLIENT_SECRET="${cse_azure_client_secret:?}"
+    export MONGOCXX_TEST_GCP_EMAIL="${cse_gcp_email:?}"
+    export MONGOCXX_TEST_GCP_PRIVATEKEY="${cse_gcp_privatekey:?}"
+
+    # DEVPROD-4630: use BASH_XTRACEFD instead:
+    #     unset BASH_XTRACEFD
+    [[ "${old_trace_opt:-}" == 1 ]] && set -o xtrace
+  }
 
   set -o errexit
 

--- a/.evergreen/test.sh
+++ b/.evergreen/test.sh
@@ -123,7 +123,7 @@ else
 
     # DEVPROD-4630: use BASH_XTRACEFD instead:
     #     unset BASH_XTRACEFD
-    [[ "${old_trace_opt:-}" == 1 ]] && set -o xtrace
+    [[ "${is_xtrace_set:-}" == 1 ]] && set -o xtrace
   }
   echo "Running activate-kmstlsvenv.sh..."
   # shellcheck source=/dev/null
@@ -164,7 +164,7 @@ else
 
     # DEVPROD-4630: use BASH_XTRACEFD instead:
     #     unset BASH_XTRACEFD
-    [[ "${old_trace_opt:-}" == 1 ]] && set -o xtrace
+    [[ "${is_xtrace_set:-}" == 1 ]] && set -o xtrace
   }
 
   set -o errexit

--- a/.evergreen/upload-code-coverage.sh
+++ b/.evergreen/upload-code-coverage.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+: "${codecov_token:?}"
+
+: "${ENABLE_CODE_COVERAGE:-}"
+
+set -o errexit
+set -o pipefail
+
+# Nothing to do if code coverage was not enabled.
+if [[ "${ENABLE_CODE_COVERAGE:-}" != "ON" ]]; then
+  exit 0
+fi
+
+# Note: coverage is currently only enabled on the ubuntu-1804 distro.
+# This script does not support MacOS, Windows, or non-x86_64 distros.
+# Update accordingly if code coverage is expanded to other distros.
+curl -Os https://uploader.codecov.io/latest/linux/codecov
+chmod +x codecov
+
+# -Z: Exit with a non-zero value if error.
+# -g: Run with gcov support.
+# -t: Codecov upload token.
+# perl: filter verbose "Found" list and "Processing" messages.
+./codecov -Zgt "${codecov_token:?}" | perl -lne 'print if not m|(^.*\.gcov(\.\.\.)?$)|'

--- a/.mci.yml
+++ b/.mci.yml
@@ -596,30 +596,12 @@ functions:
             display_name: "mongodb-logs.tar.gz"
 
     "upload code coverage":
-      - command: shell.exec
+      - command: subprocess.exec
         params:
-          shell: bash
+          binary: bash
           working_dir: "mongo-cxx-driver"
-          script: |
-            set -o errexit
-            set -o pipefail
-
-            # Nothing to do if code coverage was not enabled.
-            if [[ "${ENABLE_CODE_COVERAGE}" != "ON" ]]; then
-              exit 0
-            fi
-
-            # Note: coverage is currently only enabled on the ubuntu-1804 distro.
-            # This script does not support MacOS, Windows, or non-x86_64 distros.
-            # Update accordingly if code coverage is expanded to other distros.
-            curl -Os https://uploader.codecov.io/latest/linux/codecov
-            chmod +x codecov
-
-            # -Z: Exit with a non-zero value if error.
-            # -g: Run with gcov support.
-            # -t: Codecov upload token.
-            # perl: filter verbose "Found" list and "Processing" messages.
-            ./codecov -Zgt "${codecov_token}" | perl -lne 'print if not m|(^.*\.gcov(\.\.\.)?$)|'
+          args: [-c, .evergreen/upload-code-coverage.sh]
+          include_expansions_in_env: [codecov_token]
 
     "docker-image-build":
       - command: shell.exec


### PR DESCRIPTION
Partially addresses CXX-2818. See ticket for details. Verified by [this patch](https://spruce.mongodb.com/version/65c650ea2fbabec21a9ed4bd).

Drive-by investigation of xtrace handling led to [DEVPROD-4630](https://jira.mongodb.org/browse/DEVPROD-4630). Currently, no task other than `docker-image-build` seems to enable xtrace, but a small improvement to temporary xtrace disable routines were applied nevertheless.