### PR TITLE
CXX-2803 Fix build type for mongocxx library's ABI tag

### DIFF
--- a/cmake/MongocxxUtil.cmake
+++ b/cmake/MongocxxUtil.cmake
@@ -31,17 +31,12 @@ function(mongocxx_add_library TARGET OUTPUT_NAME LINK_TYPE)
             string(APPEND abi_tag "-v${soversion}")
         endif()
 
-        # Build type. Inherit from bsoncxx.
-        if(1)
-            get_target_property(build_type ${bsoncxx_target} INTERFACE_BSONCXX_ABI_TAG_BUILD_TYPE)
-
-            set_target_properties(${TARGET} PROPERTIES
-                BSONCXX_ABI_TAG_BUILD_TYPE ${build_type}
-                INTERFACE_BSONCXX_ABI_TAG_BUILD_TYPE ${build_type}
-            )
-
-            string(APPEND abi_tag "-${build_type}")
-        endif()
+        # Build type (same as bsoncxx):
+        # - 'd' for debug.
+        # - 'r' for release (including RelWithDebInfo and MinSizeRel).
+        # - 'u' for unknown (e.g. to allow user-defined configurations).
+        # Compatibility is handled via CMake's IMPORTED_CONFIGURATIONS rather than interface properties.
+        string(APPEND abi_tag "-$<IF:$<CONFIG:Debug>,d,$<IF:$<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>,$<CONFIG:MinSizeRel>>,r,u>>")
 
         # Link type with libmongoc. Inherit from bsoncxx.
         if(1)


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1081 (CXX-2803).

Overlooked the removal of `INTERFACE_BSONCXX_ABI_TAG_BUILD_TYPE` in https://github.com/mongodb/mongo-cxx-driver/pull/1081/commits/73e40df285a188e442d63fdd2fb383eb1025299c impacting the derivation of the build type in MongocxxUtil.cmake, e.g.:

```
# There is no INTERFACE_BSONCXX_ABI_TAG_BUILD_TYPE property.
mongocxx-v_noabi-build_type-NOTFOUNDhs-x64-v142-mdd
```

This PR fixes the ABI tag such that the build type for mongocxx is consistent with bsoncxx.