### PR TITLE
CXX-2967 Document the Stable ABI Compatibility Policy

### DIFF
--- a/docs/content/mongocxx-v3/api-abi-versioning.md
+++ b/docs/content/mongocxx-v3/api-abi-versioning.md
@@ -113,7 +113,7 @@ cmake -S example -B example-build -D bsoncxx_ROOT="$INSTALLDIR"
 Although the CXX Driver also provides pkg-config files, users are strongly encouraged to use CMake package config files instead.
 
 The name of the pkg-config file for bsoncxx libraries is also controlled by `BSONCXX_OUTPUT_NAME` and follow the pattern `lib<basename>.pc`.
-Because the CXX Driver does not install pkg-config files to typical pkg-config system directories, the `PKG_CONFIG_PATH` environment variable may need to be used to augment pkg-config's search path, e.g.:
+The `PKG_CONFIG_PATH` environment variable may need to be used to augment pkg-config's search path, e.g.:
 
 ```bash
 bsoncxx_cflags="$(PKG_CONFIG_PATH="$INSTALLDIR" pkg-config --cflags "libbsoncxx >= 1.2.3")"
@@ -237,7 +237,7 @@ ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/
 
 ### Static Libraries (MSVC Only)
 
-The name of static libraries use the same pattern as regular (non-MSVC) static library behavior described above, but uses `static` as `<abi-version-number>` and the library output name as-if it were the basename.
+The name of static libraries use the same pattern as MSVC shared library behavior described above, but uses `static` as the `<abi-version-number>` and the library output name as-if it were the basename.
 
 For example, the following install prefix directory contains the expected shared _and_ static library files for a bsoncxx library (the bin directory is included to account for `.dll` files):
 

--- a/docs/content/mongocxx-v3/api-abi-versioning.md
+++ b/docs/content/mongocxx-v3/api-abi-versioning.md
@@ -186,9 +186,9 @@ ${CMAKE_INSTALL_PREFIX}/
 
 The CMake package config files are the same as the regular (non-MSVC) shared library behavior described above.
 
-**NOTE:** CMake automatically handles selection of libraries according to build type, but does not enforce build type consistency when only one build type is installed. Installing _both_ debug and release configurations on Windows highly recommended for this reason. This does not extend to _all_ build configuration parameters.
+**NOTE:** CMake automatically handles selection of libraries according to build type, but does not enforce build type consistency when only one build type is installed. Installing _both_ Debug and Release configurations on Windows is highly recommended for this reason. (This note only applies to the build type configuration parameter).
 
-The name of the pkg-config file for CXX Driver libraries is the same as the regular (non-MSVC) shared library behavior described above.
+The name of the pkg-config file for CXX Driver libraries is the same as that for the regular (non-MSVC) shared library behavior described above.
 However, when `ENABLE_ABI_TAG_IN_PKGCONFIG_FILENAMES=ON`, the library output name is used as-if it were the basename for pkg-config files.
 For example, to obtain flags for the shared library `bsoncxx-v_noabi-rhs-x64-v142-md.dll`, the pkg-config command may look as follows when `ENABLE_ABI_TAG_IN_PKGCONFIG_FILENAMES=OFF` (the default):
 
@@ -202,7 +202,7 @@ or as follows when `ENABLE_ABI_TAG_IN_PKGCONFIG_FILENAMES=ON`:
 pkg-config --cflags "libbsoncxx-v_noabi-rhs-x64-v142-md"
 ```
 
-Setting `ENABLE_ABI_TAG_IN_PKGCONFIG_FILENAMES=ON` is recommended when expected parallel installation of the bsoncxx library with different build configurations (e.g. Debug vs. Release).
+Setting `ENABLE_ABI_TAG_IN_PKGCONFIG_FILENAMES=ON` is recommended when parallel installation of CXX Driver libraries with different build configurations (e.g. Debug vs. Release) is expected.
 However, using CMake package config files instead is most recommended.
 
 ### Static Libraries

--- a/docs/content/mongocxx-v3/api-abi-versioning.md
+++ b/docs/content/mongocxx-v3/api-abi-versioning.md
@@ -6,122 +6,252 @@ title = "API and ABI versioning"
   parent="mongocxx3"
 +++
 
+For brevity, this page may describe properties and features as-if they only apply to the bsoncxx library.
+Unless stated otherwise, one may assume the properties and features described are similarly applicable to the mongocxx library.
+
 ## API Versioning
 
-* We use [semantic versioning](http://semver.org/).
-* bsoncxx and mongocxx both define corresponding CMake variables for MAJOR, MINOR, and PATCH.
+See [API Versioning]({{< relref "policies/api-versioning" >}}).
 
 ## ABI Versioning
 
-* Both bsoncxx and mongocxx both have a single scalar ABI version.
-* Only bump ABI version on **incompatible** ABI change (not for ABI additions).
-* **We stay on ABI version \_noabi (without bumping for incompatible changes) until ABI is stable.**
+See [ABI Versioning]({{< relref "policies/abi-versioning" >}}).
 
-## Parallel Header Installation
+## Header File Structure
 
-* For mongocxx, install all headers to `$PREFIX/mongocxx/v$ABI/`.
-* For bsoncxx, install all headers to `$PREFIX/bsoncxx/v$ABI/`.
-* We install a pkg-config file to shield consumers from this complexity.
+The public header files of the bsoncxx library are organized by ABI namespace:
 
-## Sonames and symlinks
+```
+${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/
+└── bsoncxx/
+    ├── v_noabi/bsoncxx/
+    │   └── ...
+    ├── v1/bsoncxx/
+    │   └── ...
+    ├── v2/bsoncxx/
+    │   └── ...
+    └── vN/bsoncxx/
+        └── ...
+```
 
-*Note that below examples are given for libmongocxx, but also apply to libbsoncxx*
+For forward compatibility, a public header file in an ABI namespace directory `vA` may include a header file in a _newer_ ABI namespace directory `vB`, where `A < B`.
+Such forward compatibility include directives, when supported, will be explicitly documented.
+For any given public API entity, we recommend including its corresponding header from the _latest_ ABI namespace directory whenever available.
 
-*DSO = Dynamic Shared Object, to use Ulrich Drepper's terminology*
+**IMPORTANT:** For backward compatibility, the `bsoncxx/v_noabi/` ABI namespace directory is added to include paths such that `#include <bsoncxx/example.hpp>` is equivalent to `#include <bsoncxx/v_noabi/bsoncxx/example.hpp>`. Relying on this behavior is discouraged: we recommend explicitly including `#include <bsoncxx/v_noabi/bsoncxx/example.hpp>` instead.
 
-### Windows (MSVC only)
+**NOTE:** The stability of an _undocumented_ include directive is not supported.
 
-Since version 3.10.0, the physical filename for CXX Driver libraries is different
-from other platforms when built with the MSVC toolchain on Windows
-(even when the CMake generator is not Visual Studio).
+Package files are installed to subdirectories in `${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/`.
+Users are strongly encouraged to use these package files to obtain bsoncxx library header (as well for linking and the setting of compile flags).
+Manual configuration of include paths to obtain bsoncxx header files is not recommended.
+Package files are described further below.
+
+In all cases, **CMake package config files are the recommended method for importing CXX Driver libraries.**
+
+## Library Filenames
+
+The filename and presence of symlinks depends on the platform and toolchain used to build the library, as well as the library type (shared vs. static).
+
+### Shared Libraries
+
+**IMPORTANT:** Shared libraries on Windows when configured with the MSVC toolchain on Windows are treated differently due to Windows-specific special considerations. See "Shared Libraries (MSVC Only)" below.
+
+The "real name" of shared libraries use the following pattern:
+
+```
+lib<basename>.so.<api-version-number>
+```
+
+where:
+
+* `<basename>` corresponds to the `BSONCXX_OUTPUT_BASENAME` CMake configuration variable (`MONGOCXX_OUTPUT_BASENAME` for the mongocxx library). By default, this is set to `bsoncxx` and `mongocxx`. The basename of a static library is suffixed with `-static`.
+* `<api-version-number>` is the MAJOR, MINOR, and PATCH version for the given build configuration, corresponding to the `BUILD_VERSION` CMake configuration variable. (Note: explicitly setting this configuration variable should not be necessary in regular use of the CXX Driver.)
+* API version number extensions are _not_ included in the real name (e.g. the `-alpha` in `1.2.3-alpha`).
+
+Examples of expected library real names include:
+
+```
+libbsoncxx.so.1.0.0
+libbsoncxx.so.2.3.4
+```
+
+CMake's `SOVERSION` target property and "namelink" behavior is used to also install symlinks to the library directory consistent with the Linux soname convention.
+These symlinks include the ABI version number as part of the library soname.
+
+For example, the following lib directory contains the expected library files for a bsoncxx library with API version `1.2.3` and ABI version `10`, where `a -> b` indicates `a` is a symlink to `b`:
+
+```
+${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/
+├── libbsoncxx.so.1.2.3
+├── libbsoncxx.so.10 -> libbsoncxx.so.1.2.3
+├── libbsoncxx.so -> libbsoncxx.so.10
+├── cmake/bsoncxx-1.2.3/
+│   ├── bsoncxx-config.cmake
+│   └── ...
+└── pkgconfig/
+    └── libbsoncxx.pc
+```
+
+The name of the CMake package for bsoncxx libraries is controlled by `BSONCXX_OUTPUT_BASENAME` (`MONGOCXX_OUTPUT_BASENAME` for mongocxx libraries).
+They should be imported according to CMake's [Config Mode Search Procedure](https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-search-procedure).
+For example, assuming the CXX Driver was installed to a prefix `$INSTALLDIR`:
+
+```bash
+# The CMake package may be imported via CMAKE_PREFIX_PATH (recommended)...
+cmake -S example -B example-build -D CMAKE_PREFIX_PATH="$INSTALLDIR"
+
+# Or via <PackageName>_ROOT (assuming BSONCXX_OUTPUT_NAME=bsoncxx)...
+cmake -S example -B example-build -D bsoncxx_ROOT="$INSTALLDIR"
+
+# Or via `PATHS` in the `find_package()` command... or etc.
+# find_package(bsoncxx CONFIG REQUIRED PATHS "$INSTALLDIR")
+```
+
+**NOTE:** The C Driver is a required dependency of CXX Driver. The CMake package config files for the C Driver may also need to be imported using the same (or similar) approach to satisfy this dependency.
+
+Although the CXX Driver also provides pkg-config files, users are strongly encouraged to use CMake package config files instead.
+
+The name of the pkg-config file for bsoncxx libraries is also controlled by `BSONCXX_OUTPUT_NAME` and follow the pattern `lib<basename>.pc`.
+Because the CXX Driver does not install pkg-config files to typical pkg-config system directories, the `PKG_CONFIG_PATH` environment variable may need to be used to augment pkg-config's search path, e.g.:
+
+```bash
+bsoncxx_cflags="$(PKG_CONFIG_PATH="$INSTALLDIR" pkg-config --cflags "libbsoncxx >= 1.2.3")"
+bsoncxx_ldflags="$(PKG_CONFIG_PATH="$INSTALLDIR" pkg-config --libs "libbsoncxx >= 1.2.3")"
+
+g++ $bsoncxx_cflags -c example-a.cpp
+g++ $bsoncxx_cflags -c example-b.cpp
+g++ $bsoncxx_ldflags -o example example-a.o example-b.o
+```
+
+### Shared Libraries (MSVC Only)
+
+Since version 3.10.0, the shared libraries when built with the MSVC toolchain on Windows (even when the CMake generator is not Visual Studio) use a different naming scheme from other platforms.
 To restore prior behavior, which is similar to other platforms, set `ENABLE_ABI_TAG_IN_LIBRARY_FILENAMES=OFF`.
 
-* Physical filename for a DSO is `mongocxx-$ABI-$TAG.dll`
-* Physical filename for a static library is `mongocxx-static-$TAG.lib`
+The name of shared libraries (aka the "output name") use the following pattern (file extension excluded):
 
-Where `$TAG` is a triplet of letters indicating:
+```
+<basename>-v<abi-version-number>-<abi-tag>
+```
+
+where:
+
+* `<basename>` corresponds to the `BSONCXX_OUTPUT_BASENAME` CMake configuration variable (`MONGOCXX_OUTPUT_BASENAME` for the mongocxx library). By default, this is set to `bsoncxx` and `mongocxx`. The basename of a static library is suffixed with `-static`.
+* `<abi-version-number>` corresponds to the current ABI version number.
+* `<abi-tag>` describes known properties that affect the binary compatibility of the shared library.
+
+The `<abi-tag>` is a triplet of letters indicating:
 
 * Build Type
 * mongoc Link Type
 * Polyfill Library
 
 followed by a suffix describing the toolset and runtime library used to build the library.
+The exact contents of the suffix depend on the build configuration.
 
-Some examples of common DSO filenames expected to be generated include:
+Examples of expected library filenames (with a brief description of notable features) include:
 
-* `mongocxx-v_noabi-rhs-x64-v142-md.dll` (release build configuration)
-* `mongocxx-v_noabi-dhs-x64-v142-mdd.dll` (debug build configuration)
-* `mongocxx-v_noabi-rts-x64-v142-md.dll` (link with mongoc statically)
-* `mongocxx-v_noabi-rhi-x64-v142-md.dll` (bsoncxx polyfill library)
-* `mongocxx-v_noabi-rhm-x64-v142-md.dll` (mnmlstc/core polyfill library)
-* `mongocxx-v_noabi-rhb-x64-v142-md.dll` (Boost polyfill library)
+* `bsoncxx-v_noabi-rhs-x64-v142-md.dll` (release build configuration)
+* `bsoncxx-v_noabi-dhs-x64-v142-mdd.dll` (debug build configuration)
+* `bsoncxx-v_noabi-rts-x64-v142-md.dll` (link with mongoc static libraries)
+* `bsoncxx-v_noabi-rhi-x64-v142-md.dll` (bsoncxx as polyfill library)
+* `bsoncxx-v_noabi-rhm-x64-v142-md.dll` (mnmlstc/core as polyfill library)
+* `bsoncxx-v_noabi-rhb-x64-v142-md.dll` (Boost as polyfill library)
+* `bsoncxx-v1-rhs-x64-v142-md.dll`      (ABI version number 1)
+* `bsoncxx-v2-rhs-x64-v142-md.dll`      (ABI version number 2)
 
-This allows libraries built with different build configurations (and different runtime library requirements) to be built and installed without conflicting with each other.
+**NOTE:** This example also applies to the companion `.lib` file.
 
+This naming scheme allows the bsoncxx library to be built and installed with different build configurations (e.g. Debug vs. Release) and different runtime library requirements (e.g. MultiThreadedDLL vs. MultiThreadedDebugDLL) in parallel and without conflict.
 See references to `ENABLE_ABI_TAG_IN_LIBRARY_FILENAMES` and related code in the CMake configuration for more details.
 
-### Other Platforms (Linux, MacOS)
-
-* Physical filename for a DSO is `libmongocxx.so.$MAJOR.$MINOR.$PATCH`
-
-Note that the physical filename is disconnected from ABI version/soname.
-This looks a bit strange, but allows multiple versions of the library with
-the same ABI version to be installed on the same system.
-
-* soname for a DSO is `libmongocxx.$ABI`
-
-We provide a soname symlink that links to the physical DSO.  We also
-provide a dev symlink that links to the soname symlink of the highest ABI
-version of the library installed.
-
-## Inline namespaces
-
-* We provide inline namespace macros for both mongocxx and bsoncxx.
-* This allows multiple, ABI incompatible versions of the library to be linked into the same application.
-* The name of the namespace is `v$ABI`. We create them from ABI version to maintain forwards compatibibility.
-
-
-## Deprecation
-
-Occasionally we will phase features out of use in the driver.
-In the release that marks a feature as deprecated we offer several transition options:
-
-1. The original method, marked with `MONGOCXX_DEPRECATED`. This
-will raise deprecation warnings when compiled.
-2. A variant of the feature suffixed with `_deprecated`. This will require only small
-code changes and will not raise deprecation warnings.
-3. A new feature that provides alternate functionality.
-The new feature may not be a drop-in replacement for the deprecated feature and
-switching to it may require code changes. In the rare case where we
-remove a feature without replacing it, this third option will not be available.
-
-In the following release, the original feature marked with `MONGOCXX_DEPRECATED` and its
-suffixed `_deprecated` equivalent will be removed.
-
-```c++
-// release 1 with a supported feature
-void do_thing();
-
-// release 2 where the feature is deprecated in favor of a new feature
-MONGOCXX_DEPRECATED void do_thing();
-void do_thing_deprecated();
-void do_new_thing();
-
-// release 3 where the original feature is removed
-void do_new_thing();
-```
-
-In the case of a feature rename we do not offer a suffixed `_deprecated` variant,
-as one can simply switch to using the new name with the same amount of effort.
+For example, the following install prefix directory contains the expected debug _and_ release library files for a bsoncxx library with API version `1.2.3` and ABI version `10` (the bin directory is included to account for `.dll` files):
 
 ```
-// release 1 with a supported feature
-void do_thing();
+${CMAKE_INSTALL_PREFIX}/
+├── ${CMAKE_INSTALL_BINDIR}/
+│   ├── bsoncxx-v10-dhs-x64-v142-mdd.dll
+│   └── bsoncxx-v10-rhs-x64-v142-md.dll
+└── ${CMAKE_INSTALL_LIBDIR}/
+    ├── bsoncxx-v10-dhs-x64-v142-mdd.lib
+    ├── bsoncxx-v10-rhs-x64-v142-md.lib
+    ├── cmake/bsoncxx-1.2.3/
+    │   ├── bsoncxx-config.cmake
+    │   └── ...
+    └── pkgconfig/
+        ├── libbsoncxx-v10-dhs-x64-v142-mdd.pc
+        └── libbsoncxx-v10-rhs-x64-v142-md.pc
+```
 
-// release 2 where the feature name is renamed
-MONGOCXX_DEPRECATED void do_thing();
-void do_stuff();
+The CMake package config files are the same as the regular (non-MSVC) shared library behavior described above.
 
-// release 3 where the original feature name is removed
-void do_stuff();
+**NOTE:** CMake automatically handles selection of libraries according to build type, but does not enforce build type consistency when only one build type is installed. Installing _both_ debug and release configurations on Windows highly recommended for this reason. This does not extend to _all_ build configuration parameters.
+
+The name of the pkg-config file for CXX Driver libraries is the same as the regular (non-MSVC) shared library behavior described above.
+However, when `ENABLE_ABI_TAG_IN_PKGCONFIG_FILENAMES=ON`, the library output name is used as-if it were the basename for pkg-config files.
+For example, to obtain flags for the shared library `bsoncxx-v_noabi-rhs-x64-v142-md.dll`, the pkg-config command may look as follows when `ENABLE_ABI_TAG_IN_PKGCONFIG_FILENAMES=OFF` (the default):
+
+```bash
+pkg-config --cflags "libbsoncxx"
+```
+
+or as follows when `ENABLE_ABI_TAG_IN_PKGCONFIG_FILENAMES=ON`:
+
+```bash
+pkg-config --cflags "libbsoncxx-v_noabi-rhs-x64-v142-md"
+```
+
+Setting `ENABLE_ABI_TAG_IN_PKGCONFIG_FILENAMES=ON` is recommended when expected parallel installation of the bsoncxx library with different build configurations (e.g. Debug vs. Release).
+However, using CMake package config files instead is most recommended.
+
+### Static Libraries
+
+Static libraries use a simple filename pattern:
+
+```
+lib<basename>-static.a
+```
+
+No API or ABI version information is included in the name of static library files.
+
+Shared vs. static library selection for CMake package config files is handled via CMake targets.
+
+Shared vs. static library selection for pkg-config files is handled by adding the `-static` suffix to the library basename, e.g. `lib<basename>-static.pc`.
+
+For example, the following library directory contains the expected shared _and_ static library files for a bsoncxx library:
+
+```
+${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/
+├── libbsoncxx.so.1.2.3
+├── libbsoncxx.so.10 -> libbsoncxx.so.1.2.3
+├── libbsoncxx.so -> libbsoncxx.so.10
+├── libbsoncxx-static.a
+├── cmake/bsoncxx-1.2.3/
+│   ├── bsoncxx-config.cmake
+│   └── ...
+└── pkgconfig/
+    ├── libbsoncxx.pc
+    └── libbsoncxx-static.pc
+```
+
+### Static Libraries (MSVC Only)
+
+The name of static libraries use the same pattern as regular (non-MSVC) static library behavior described above, but uses `static` as `<abi-version-number>` and the library output name as-if it were the basename.
+
+For example, the following install prefix directory contains the expected shared _and_ static library files for a bsoncxx library (the bin directory is included to account for `.dll` files):
+
+```
+${CMAKE_INSTALL_PREFIX}/
+├── ${CMAKE_INSTALL_BINDIR}/
+│   └── bsoncxx-v10-rhs-x64-v142-md.dll
+└── ${CMAKE_INSTALL_LIBDIR}/
+    ├── bsoncxx-v10-rhs-x64-v142-md.lib
+    ├── bsoncxx-static-dhs-x64-v142-mdd.lib
+    ├── cmake/bsoncxx-1.2.3/
+    │   ├── bsoncxx-config.cmake
+    │   └── ...
+    └── pkgconfig/
+        ├── libbsoncxx-v10-rhs-x64-v142-md.pc
+        └── libbsoncxx-static-rhs-x64-v142-md.pc
 ```

--- a/docs/content/mongocxx-v3/api-abi-versioning.md
+++ b/docs/content/mongocxx-v3/api-abi-versioning.md
@@ -108,7 +108,7 @@ cmake -S example -B example-build -D bsoncxx_ROOT="$INSTALLDIR"
 # find_package(bsoncxx CONFIG REQUIRED PATHS "$INSTALLDIR")
 ```
 
-**NOTE:** The C Driver is a required dependency of CXX Driver. The CMake package config files for the C Driver may also need to be imported using the same (or similar) approach to satisfy this dependency.
+**NOTE:** The C Driver is a required dependency for the CXX Driver. The CMake package config files for the C Driver may also need to be imported using the same (or similar) approach to satisfy this dependency.
 
 Although the CXX Driver also provides pkg-config files, users are strongly encouraged to use CMake package config files instead.
 

--- a/docs/content/mongocxx-v3/policies/abi-versioning.md
+++ b/docs/content/mongocxx-v3/policies/abi-versioning.md
@@ -79,8 +79,8 @@ For example, all of the following redeclarations may be present simultaneously:
 * `bsoncxx::example::baz` -> `bsoncxx::v2::example::baz`
 
 Root namespace redeclarations are designed to allow for the addition of binary incompatible symbols in `vB` without breaking binary compatibility of `vA` symbols.
-They faciliate the deprecation of stable ABI symbols while providing the opportunity for a clean transition from `vA` to `vB` without breaking binary compatibility.
-They allow user code to opt into "redeclaration upgrades" that reduces require changes to source code when transitioning from `vA` to `vB`.
+They facilitate the deprecation of stable ABI symbols while providing the opportunity for a clean transition from `vA` to `vB` without breaking binary compatibility.
+They allow user code to opt into "redeclaration upgrades" that reduces required changes to source code when transitioning from `vA` to `vB`.
 
 These redeclaration upgrades are intended to support a clean transition away from deprecated, to-be-removed ABI symbols across releases.
 Accordingly, users are encouraged to use the root namespace declarations by default to opt into these upgrades.

--- a/docs/content/mongocxx-v3/policies/abi-versioning.md
+++ b/docs/content/mongocxx-v3/policies/abi-versioning.md
@@ -5,3 +5,104 @@ title = "ABI Versioning"
   weight = 33
   parent="mongocxx3/policies"
 +++
+
+The CXX Driver uses Ulrich Drepper's guide to "Defining Stability", the Linux shared library "soname" convention, and the CMake `SOVERSION` target property for ABI versioning.
+
+Per [Ulrich Drepper](https://www.cs.dartmouth.edu/~sergey/cs258/ABI/UlrichDrepper-How-To-Write-Shared-Libraries.pdf):
+
+> The definition of stability should therefore use the _documented_ interface as the basis. Legitimate uses of interfaces should not be affected by changes in the implementation; using interfaces in an undefined way void the warranty. The same is true for using completely undocumented, internal symbols. Those must not be used at all.
+
+Per [The Linux Documentation Project](https://tldp.org/HOWTO/Program-Library-HOWTO/shared-libraries.html):
+
+> Every shared library has a special name called the \`\`soname''. The soname has the prefix \`\`lib'', the name of the library, the phrase \`\`.so'', followed by a period and a version number that is incremented whenever the interface changes (as a special exception, the lowest-level C libraries don't start with \`\`lib''). A fully-qualified soname includes as a prefix the directory it's in; on a working system a fully-qualified soname is simply a symbolic link to the shared library's \`\`real name''.
+
+Per [CMake documentation](https://cmake.org/cmake/help/latest/prop_tgt/SOVERSION.html):
+
+> For shared libraries `VERSION` and `SOVERSION` can be used to specify the build version and ABI version respectively. When building or installing appropriate symlinks are created if the platform supports symlinks and the linker supports so-names. If only one of both is specified the missing is assumed to have the same version number.
+
+For purposes of ABI versioning, we distinguish between the _stable ABI_ and the _unstable ABI_.
+
+The ABI version number bumped whenever there is a backward incompatible change to the stable ABI as defined below.
+
+**IMPORTANT:** Only the stability of the stable ABI is communicated by the ABI version number. Backward (in)compatible changes to the unstable ABI are not communicated by the ABI version number.
+
+**NOTE:** The ABI versioning policy is only applicable to _shared libraries_. It does not apply to static libraries.
+
+## Binary Compatibility
+
+An _ABI namespace_ is declared within the library's root namespace (see [Source Compatibility]({{< relref "api-versioning#source-compatibility" >}})), prefixed with the letter `v` and followed by either an integer or `_noabi`.
+
+Examples of ABI namespaces include (relative to the global namespace scope):
+
+* `bsoncxx::v_noabi`
+* `bsoncxx::v1`
+* `bsoncxx::v2`
+* `bsoncxx::v99`
+
+An _unstable ABI namespace_ is a namespace with the name `v_noabi`. Any other ABI namespace is a _stable ABI namespace_. The root namespace is not an ABI namespace.
+
+The _stable ABI_ is the set of exported symbols that are used by the public API and declared in a stable ABI namespace, with the following exceptions:
+
+* The symbol or corresponding public API entities are explicitly documented as experimental or not yet prepared for ABI stability.
+* The entity is not declared within an ABI namespace.
+
+Including these exceptions, all other exported symbols are considered to be part of the _unstable ABI_.
+
+If there is a symbol that _should_ be exported or part of the stable ABI, but is currently not, please submit a bug report.
+
+**IMPORTANT:** Direct use of exported symbols that bypasses the public API is not supported. All exported symbols (stable or unstable) must be used via the public API. If there is a symbol that _should_ be exported or part of the stable ABI, but is currently not, please submit a bug report.
+
+**IMPORTANT:** A symbol only needs to be _used by_ the public API (even indirectly) to be considered part of the stable ABI. An exported symbol that has _never_ been used by any public API entity in _any_ prior release is not considered part of the stable ABI (see note above).
+
+**NOTE:** The _behavior_ of a stable ABI symbol is not considered part of the stable ABI. The stability of documented behavior is communicated by the API version number, not the ABI version number.
+
+**NOTE:** Some entities that are part of the public API may not be part of the stable ABI (e.g. inline functions, inline variables, and template instantiations of functions and variables). Conversely, some entities that are part of the ABI may not be part of the public API (e.g. an exported private member function). See [API Versioning]({{< relref "api-versioning" >}}).
+
+## Build System Compatibility
+
+The stable ABI policy concerning properties of the build system is mostly to that for the public API (see [Build System Compatibility]({{< relref "/api-versioning#build-system-compatibility" >}})) with the following differences:
+
+* Instead of properties that directly impact the public API, properties that directly impact the stable ABI, are considered part of the stable ABI.
+* **The soname is considered part of the stable ABI**. This means, in contrast to the public API, `BSONCXX_OUTPUT_NAME` is considered part of the stable ABI, as it directly impacts the soname of the resulting bsoncxx shared library.
+* The "soname" is not applicable on Windows. See [Shared Libraries (MSVC Only)]({{< relref "../api-abi-versioning#shared-libraries-msvc-only" >}}).
+
+**NOTE:** We support the the stability of the public API _per build configuration_. We do not support compatibility of the public API _across_ different build configurations. For example, a shared library generated with `BSONCXX_OUTPUT_NAME=bsoncxx` is not expected to be compatible with a program compiled against a stable ABI produced using a build configuration with `BSONCXX_OUTPUT_NAME=bsoncxx-custom-basename`. (This is particularly important when using multi-config generators such as Visual Studio!)
+
+## Root Namespace Redeclarations
+
+The root namespace provides "redeclarations" of entities declared in an ABI namespace. The ABI namespace may differ across entities being redeclared.
+
+For example, all of the following redeclarations may be present simultaneously:
+
+* `bsoncxx::example::foo` -> `bsoncxx::v_noabi::example::foo`
+* `bsoncxx::example::bar` -> `bsoncxx::v1::example::bar`
+* `bsoncxx::example::baz` -> `bsoncxx::v2::example::baz`
+
+Root namespace redeclarations are designed to allow for the addition of binary incompatible symbols in `vB` without breaking binary compatibility of `vA` symbols.
+They faciliate the deprecation of stable ABI symbols while providing the opportunity for a clean transition from `vA` to `vB` without breaking binary compatibility.
+They allow user code to opt into "redeclaration upgrades" that reduces require changes to source code when transitioning from `vA` to `vB`.
+
+These redeclaration upgrades are intended to support a clean transition away from deprecated, to-be-removed ABI symbols across releases.
+Accordingly, users are encouraged to use the root namespace declarations by default to opt into these upgrades.
+However, users may need to use explicit ABI namespace qualifiers when referencing CXX Driver entities in their own stable ABIs depending on their own stability policy.
+
+The following compatibility table describes when the API major version number or ABI version number must be bumped due to an incompatible change:
+
+| Change Type | Source Compatible | Binary Compatible |
+| - | - | - |
+| Add a new `vB` symbol | Yes | Yes |
+| Upgrade a redeclaration from `vA` to `vB` | Maybe (1) | Yes |
+| Remove a `vA` symbol (from the public API) | No | Maybe (2) |
+| Remove a `vA` symbol (from the stable ABI) | Maybe (2) | No |
+
+* (1): A `vB` entity could be 100% source compatible with the `vA` API despite requiring use of a new, incompatible stable ABI symbol.
+* (2): A stable ABI symbol could be removed from the public API (e.g. via documentation or removal from public headers) while still providing an exported symbol definition for backward compatibility. This is probably unlikely to happen, but if it does, it be a rare case where the source and binary incompatible changes can be split into separate releases.
+
+**IMPORTANT:** The integer used by an ABI namespace does _NOT_ directly correspond to an ABI version number. The ABI version number is bumped whenever _any_ binary incompatible change occurs, even when it is the removal of a _single_ symbol from the stable ABI. An ABI version number bump from `A` to `B` does _NOT_ imply the deprecation or removal of symbols declared in the ABI namespace `vA` (if one exists).
+
+## Deprecation and Removal
+
+The policy for deprecation and removal of symbols in the stable ABI is the same as that for the public API: see [Deprecation and Removal]({{< relref "api-versioning#deprecation-and-removal" >}}).
+
+A release containing binary incompatible changes will bump the ABI version number rather than the API major version number.
+However, it is likely that when the ABI version number is bumped, the API major version number will also be bumped, as most binary incompatible changes will likely also be a source incompatible change.

--- a/docs/content/mongocxx-v3/policies/abi-versioning.md
+++ b/docs/content/mongocxx-v3/policies/abi-versioning.md
@@ -68,7 +68,7 @@ The stable ABI policy concerning properties of the build system is mostly the sa
 * **The soname is considered part of the stable ABI**. This means, in contrast to the public API, `BSONCXX_OUTPUT_NAME` is considered part of the stable ABI, as it directly impacts the soname of the resulting bsoncxx shared library.
 * The "soname" is not applicable on Windows. See [Shared Libraries (MSVC Only)]({{< relref "../api-abi-versioning#shared-libraries-msvc-only" >}}).
 
-**NOTE:** We support the the stability of the public API _per build configuration_. We do not support compatibility of the public API _across_ different build configurations. For example, a shared library generated with `BSONCXX_OUTPUT_NAME=bsoncxx` is not expected to be compatible with a program compiled against a stable ABI produced using a build configuration with `BSONCXX_OUTPUT_NAME=bsoncxx-custom-basename`. (This is particularly important when using multi-config generators such as Visual Studio!)
+**NOTE:** We support the stability of the stable ABI _per build configuration_. We do not support compatibility of the stable ABI _across_ different build configurations. For example, a shared library generated with `BSONCXX_OUTPUT_NAME=bsoncxx` is not expected to be compatible with a program compiled against a stable ABI produced using a build configuration with `BSONCXX_OUTPUT_NAME=bsoncxx-custom-basename`. (This is particularly important when using multi-config generators such as Visual Studio!)
 
 ## Root Namespace Redeclarations
 

--- a/docs/content/mongocxx-v3/policies/abi-versioning.md
+++ b/docs/content/mongocxx-v3/policies/abi-versioning.md
@@ -22,7 +22,7 @@ Per [CMake documentation](https://cmake.org/cmake/help/latest/prop_tgt/SOVERSION
 
 For purposes of ABI versioning, we distinguish between the _stable ABI_ and the _unstable ABI_.
 
-The ABI version number bumped whenever there is a backward incompatible change to the stable ABI as defined below.
+The ABI version number is bumped whenever there is a backward incompatible change to the stable ABI as defined below.
 
 **IMPORTANT:** Only the stability of the stable ABI is communicated by the ABI version number. Backward (in)compatible changes to the unstable ABI are not communicated by the ABI version number.
 
@@ -56,13 +56,13 @@ If there is a symbol that _should_ be exported or part of the stable ABI, but is
 
 **NOTE:** The _behavior_ of a stable ABI symbol is not considered part of the stable ABI. The stability of documented behavior is communicated by the API version number, not the ABI version number.
 
-**NOTE:** Some entities that are part of the public API may not be part of the stable ABI (e.g. inline functions, inline variables, and template instantiations of functions and variables). Conversely, some entities that are part of the ABI may not be part of the public API (e.g. an exported private member function). See [API Versioning]({{< relref "api-versioning" >}}).
+**NOTE:** Some entities that are part of the public API may not be part of the stable ABI (e.g. inline functions, inline variables, and template instantiations of functions and variables). Conversely, some entities that are part of the stable ABI may not be part of the public API (e.g. an exported private member function). See [API Versioning]({{< relref "api-versioning" >}}).
 
 ## Build System Compatibility
 
-The stable ABI policy concerning properties of the build system is mostly to that for the public API (see [Build System Compatibility]({{< relref "/api-versioning#build-system-compatibility" >}})) with the following differences:
+The stable ABI policy concerning properties of the build system is mostly the same as that for the public API (see [Build System Compatibility]({{< relref "/api-versioning#build-system-compatibility" >}})) with the following differences:
 
-* Instead of properties that directly impact the public API, properties that directly impact the stable ABI, are considered part of the stable ABI.
+* Instead of properties that directly impact the public API, properties that directly impact the stable ABI are considered part of the stable ABI.
 * **The soname is considered part of the stable ABI**. This means, in contrast to the public API, `BSONCXX_OUTPUT_NAME` is considered part of the stable ABI, as it directly impacts the soname of the resulting bsoncxx shared library.
 * The "soname" is not applicable on Windows. See [Shared Libraries (MSVC Only)]({{< relref "../api-abi-versioning#shared-libraries-msvc-only" >}}).
 
@@ -96,7 +96,7 @@ The following compatibility table describes when the API major version number or
 | Remove a `vA` symbol (from the stable ABI) | Maybe (2) | No |
 
 * (1): A `vB` entity could be 100% source compatible with the `vA` API despite requiring use of a new, incompatible stable ABI symbol.
-* (2): A stable ABI symbol could be removed from the public API (e.g. via documentation or removal from public headers) while still providing an exported symbol definition for backward compatibility. This is probably unlikely to happen, but if it does, it be a rare case where the source and binary incompatible changes can be split into separate releases.
+* (2): A stable ABI symbol could be removed from the public API (e.g. via documentation or removal from public headers) while still providing an exported symbol definition for backward compatibility. This is probably unlikely to happen, but if it does, it would be a rare case where the source and binary incompatible changes can be split into separate releases.
 
 **IMPORTANT:** The integer used by an ABI namespace does _NOT_ directly correspond to an ABI version number. The ABI version number is bumped whenever _any_ binary incompatible change occurs, even when it is the removal of a _single_ symbol from the stable ABI. An ABI version number bump from `A` to `B` does _NOT_ imply the deprecation or removal of symbols declared in the ABI namespace `vA` (if one exists).
 
@@ -105,4 +105,4 @@ The following compatibility table describes when the API major version number or
 The policy for deprecation and removal of symbols in the stable ABI is the same as that for the public API: see [Deprecation and Removal]({{< relref "api-versioning#deprecation-and-removal" >}}).
 
 A release containing binary incompatible changes will bump the ABI version number rather than the API major version number.
-However, it is likely that when the ABI version number is bumped, the API major version number will also be bumped, as most binary incompatible changes will likely also be a source incompatible change.
+However, it is likely that when the ABI version number is bumped, the API major version number will also be bumped, as a binary incompatible change is likely to also be a source incompatible change.

--- a/docs/content/mongocxx-v3/policies/abi-versioning.md
+++ b/docs/content/mongocxx-v3/policies/abi-versioning.md
@@ -48,6 +48,8 @@ The _stable ABI_ is the set of exported symbols that are used by the public API 
 
 Including these exceptions, all other exported symbols are considered to be part of the _unstable ABI_.
 
+Only symbols whose corresponding API entity is explicitly declared with an export macro are exported, as controlled by the [`CXX_VISIBILITY_PRESET`](https://cmake.org/cmake/help/latest/prop_tgt/LANG_VISIBILITY_PRESET.html) target property. Additionally, entities that are declared `inline`, either explicitly (e.g. with `inline`) or implicitly (e.g. member function definitions in class definitions, variable/function template instantiations, etc.) are _not_ exported, as controlled by the [`VISIBILITY_INLINES_HIDDEN`](https://cmake.org/cmake/help/latest/prop_tgt/VISIBILITY_INLINES_HIDDEN.html) target property.
+
 If there is a symbol that _should_ be exported or part of the stable ABI, but is currently not, please submit a bug report.
 
 **IMPORTANT:** Direct use of exported symbols that bypasses the public API is not supported. All exported symbols (stable or unstable) must be used via the public API. If there is a symbol that _should_ be exported or part of the stable ABI, but is currently not, please submit a bug report.

--- a/docs/content/mongocxx-v3/policies/abi-versioning.md
+++ b/docs/content/mongocxx-v3/policies/abi-versioning.md
@@ -1,0 +1,7 @@
++++
+date = "2024-02-26T00:00:00+00:00"
+title = "ABI Versioning"
+[menu.main]
+  weight = 33
+  parent="mongocxx3/policies"
++++

--- a/docs/content/mongocxx-v3/policies/abi-versioning.md
+++ b/docs/content/mongocxx-v3/policies/abi-versioning.md
@@ -56,7 +56,7 @@ If there is a symbol that _should_ be exported or part of the stable ABI, but is
 
 **IMPORTANT:** A symbol only needs to be _used by_ the public API (even indirectly) to be considered part of the stable ABI. An exported symbol that has _never_ been used by any public API entity in _any_ prior release is not considered part of the stable ABI (see note above).
 
-**NOTE:** The _behavior_ of a stable ABI symbol is not considered part of the stable ABI. The stability of documented behavior is communicated by the API version number, not the ABI version number.
+**IMPORTANT:** The _behavior_ of a stable ABI symbol is also part of the stable ABI. This is to ensure consistent and compatible runtime behavior between shared libraries with the same ABI version number. The behavior _must_ be consistent with the documentation of one or more public API entities that uses the symbol (even indirectly) such that there is no observable change in public API behavior (within the scope of what is explicitly documented) across releases with the same ABI version number.
 
 **NOTE:** Some entities that are part of the public API may not be part of the stable ABI (e.g. inline functions, inline variables, and template instantiations of functions and variables). Conversely, some entities that are part of the stable ABI may not be part of the public API (e.g. an exported private member function). See [API Versioning]({{< relref "api-versioning" >}}).
 

--- a/docs/content/mongocxx-v3/policies/api-versioning.md
+++ b/docs/content/mongocxx-v3/policies/api-versioning.md
@@ -1,0 +1,7 @@
++++
+date = "2024-02-26T00:00:00+00:00"
+title = "API Versioning"
+[menu.main]
+  weight = 33
+  parent="mongocxx3/policies"
++++

--- a/docs/content/mongocxx-v3/policies/api-versioning.md
+++ b/docs/content/mongocxx-v3/policies/api-versioning.md
@@ -5,3 +5,90 @@ title = "API Versioning"
   weight = 33
   parent="mongocxx3/policies"
 +++
+
+The CXX Driver uses Semantic Versioning (aka SemVer) for API versioning.
+
+Per the [SemVer specification](http://semver.org/):
+
+> Given a version number MAJOR.MINOR.PATCH, increment the:
+> 1. MAJOR version when you make incompatible API changes
+> 2. MINOR version when you add functionality in a backward compatible manner
+> 3. PATCH version when you make backward compatible bug fixes
+
+For purposes of API versioning, we distinguish between the _public API_ and the _private API_:
+
+> For this system to work, you first need to declare a public API. This may consist of documentation or be enforced by the code itself. Regardless, it is important that this API be clear and precise. Once you identify your public API, you communicate changes to it with specific increments to your version number.
+
+The API version number is updated according to SemVer and the definition of the public API below.
+
+**IMPORTANT:** Only the stability of the public API is communicated by the API version number. Backward (in)compatible changes to the private API are not communicated by the API version number.
+
+## Source Compatibility
+
+A _public header file_ is installed to the include directory for any given CMake build configuration. Any other header file is a _private header file_.
+
+A library's _root namespace_ is declared in the global namespace scope, e.g. `bsoncxx`.
+All entities owned by the library are declared within the library's root namespace.
+Preprocessor macros owned by the library are prefixed with the library name instead, e.g. `BSONCXX_EXAMPLE_MACRO`.
+
+The _public API_ is the set of _documented_ entities that are declared or defined in a public header file within the library's root namespace, with the following exceptions:
+
+* The entity is explicitly documented as private or not intended for public use.
+* The entity is declared in a `detail` namespace.
+
+Including these exceptions, all other entities are considered to be part of the _private API_.
+
+If there is an entity that _should_ be documented, but is currently not, please submit a bug report.
+
+**IMPORTANT:** The _documented_ behavior of a public entity is also considered part of the public API.
+Behavior that is not documented is considered library-level undefined behavior and is not supported.
+If there is behavior that _should_ be documented but is currently not, please submit a bug report.
+
+**NOTE:** Some entities that are part of the public API may not be part of the stable ABI. Conversely, some symbols that are part of the stable ABI may not be part of the public API. See [ABI Versioning Policy]({{< relref "abi-versioning#binary-compatibility" >}}).
+
+## Build System Compatibility
+
+Although the public API depends on the configuration of the build system, the build system itself is **_NOT_** part of the public API.
+
+Properties of the build system include:
+
+* CMake configuration variables and corresponding behavior (with some exceptions: see below).
+* The name, location, and contents of:
+  * CMake source files (e.g. under `${PROJECT_SOURCE_DIR}`).
+  * CMake binary files (e.g. under `${PROJECT_BINARY_DIR}`).
+  * Installed library files (e.g. under `{CMAKE_INSTALL_LIBDIR}`).
+  * Installed package files (e.g. under `{CMAKE_INSTALL_LIBDIR}/pkgconfig`).
+
+However, build system configuration variables that directly impact the public API are considered part of the public API.
+
+For example, C++17 polyfills declared in the `bsoncxx::stdx` namespace depend on configuration variables that determine the polyfill library used, e.g. `CMAKE_CXX_STANDARD`, `BSONCXX_POLY_USE_STD`, etc..
+A build configuration using `CMAKE_CXX_STANDARD=17` produces a public API where `bsoncxx::stdx::optional<T> == std::optional<T>`.
+Because changing the type of `bsoncxx::stdx::optional<T>` such that it is no longer equivalent to `std::optional<T>` is a breaking change to the public API, changing the polyfill library selection behavior of `CMAKE_CXX_STANDARD` is also a breaking change to the public API.
+Therefore, `CMAKE_CXX_STANDARD` is considered part of the public API.
+
+On the other hand, `BSONCXX_OUTPUT_NAME` controls the `<basename>` used to generate library and package filenames.
+Changing the name of a library or package file does not directly impact the public API (even if existing projects or applications may fail to configure, build, or link due to unexpected filenames).
+Therefore, `BSONCXX_OUTPUT_NAME` is _not_ considered part of the public API.
+
+**NOTE:** We support the the stability of the public API _per build configuration_. We do not support compatibility of the public API _across_ different build configurations. For example, a public API produced using a build configuration with `CMAKE_BUILD_TYPE=Debug` is not expected to be compatible with a program compiled against a public API produced using a build configuration with `CMAKE_BUILD_TYPE=Release`. (This is particularly important when using multi-config generators such as Visual Studio!)
+
+## Root Namespace Redeclarations
+
+The API of CXX Driver libraries uses root namespace redeclarations of ABI namespace entities to facilitate incremental changes to the ABI: see [Root Namespace Redeclarations]({{< relref "abi-versioning#root-namespace-redeclarations" >}}).
+
+Entities that are not part of the stable ABI or the public API may be declared in the root namespace without being a member of any particular ABI namespace (e.g. `bsoncxx::detail`).
+
+## Deprecation and Removal
+
+Before making a backward incompatible change, the existing entity or behavior will first be deprecated in a minor release.
+The backward incompatible change will be finalized in a major release that changes or removes the deprecated entity or behavior.
+
+When able, the backward incompatible entity or behavior will be provided alongside its deprecated counterpart to provide an opportunity for a clean transition in the minor release.
+Users are strongly encouraged to apply the clean transition when such an opportunity is provided: please do not continue to use deprecated entities or behavior.
+(Note: providing a clean transition path in a minor release may not always be possible.)
+
+A deprecated entity or behavior will be documented using one or more of the following methods (not exhaustive):
+
+* Use a `*_DEPRECATED` macro in the declaration of the entity.
+* Include "deprecated" in the name of the entity.
+* Explicitly document an entity or behavior as deprecated.

--- a/docs/content/mongocxx-v3/policies/api-versioning.md
+++ b/docs/content/mongocxx-v3/policies/api-versioning.md
@@ -61,7 +61,7 @@ Properties of the build system include:
 
 However, build system configuration variables that directly impact the public API are considered part of the public API.
 
-For example, C++17 polyfills declared in the `bsoncxx::stdx` namespace depend on configuration variables that determine the polyfill library used, e.g. `CMAKE_CXX_STANDARD`, `BSONCXX_POLY_USE_STD`, etc..
+For example, C++17 polyfills declared in the `bsoncxx::stdx` namespace depend on configuration variables that determine the polyfill library used, e.g. `CMAKE_CXX_STANDARD`, `BSONCXX_POLY_USE_STD`, etc.
 A build configuration using `CMAKE_CXX_STANDARD=17` produces a public API where `bsoncxx::stdx::optional<T> == std::optional<T>`.
 Because changing the type of `bsoncxx::stdx::optional<T>` such that it is no longer equivalent to `std::optional<T>` is a breaking change to the public API, changing the polyfill library selection behavior of `CMAKE_CXX_STANDARD` is also a breaking change to the public API.
 Therefore, `CMAKE_CXX_STANDARD` is considered part of the public API.

--- a/docs/content/mongocxx-v3/policies/api-versioning.md
+++ b/docs/content/mongocxx-v3/policies/api-versioning.md
@@ -70,7 +70,7 @@ On the other hand, `BSONCXX_OUTPUT_NAME` controls the `<basename>` used to gener
 Changing the name of a library or package file does not directly impact the public API (even if existing projects or applications may fail to configure, build, or link due to unexpected filenames).
 Therefore, `BSONCXX_OUTPUT_NAME` is _not_ considered part of the public API.
 
-**NOTE:** We support the the stability of the public API _per build configuration_. We do not support compatibility of the public API _across_ different build configurations. For example, a public API produced using a build configuration with `CMAKE_BUILD_TYPE=Debug` is not expected to be compatible with a program compiled against a public API produced using a build configuration with `CMAKE_BUILD_TYPE=Release`. (This is particularly important when using multi-config generators such as Visual Studio!)
+**NOTE:** We support the stability of the public API _per build configuration_. We do not support compatibility of the public API _across_ different build configurations. For example, a public API produced using a build configuration with `CMAKE_BUILD_TYPE=Debug` is not expected to be compatible with a program compiled against a public API produced using a build configuration with `CMAKE_BUILD_TYPE=Release`. (This is particularly important when using multi-config generators such as Visual Studio!)
 
 ## Root Namespace Redeclarations
 


### PR DESCRIPTION
Resolves CXX-2967. This is a documentation-only PR.

Running `hugo server` in the `docs` directory to live-preview the changes in a web browser is recommended.

This PR aims to expand and clarify our API and ABI compatibility policies. This will serve as a reference for all stable ABI changes going forward. This should be established before we set the ABI version number to its first integer value and commit to ABI stability. The API compatibility policy is updated accordingly.

Notable points include:

* Explicit definitions of what constitutes the "public API" and "stable ABI" for which we are committed to communicating compatibility for with the API and ABI version numbers respectively (see quotes from SemVer and Drepper).
  * Exclude most build system properties from the public API (e.g. library and package filenames) while making an effort to keep sensible ones included (e.g. `CMAKE_CXX_STANDARD`).
  * Include the soname as part of the stable ABI (e.g. library filename), except on Windows (where the soname convention doesn't apply).
  * Exclude entities and symbols explicitly documented as "private", "experimental", etc. so features can be added and developed without immediately committing to stability (or so they can be "soft-removed" via documentation without physically breaking compatibility).
* Describe the expected evolution of the API and ABI, including deprecation and removal, and when a given change requires updating the API and ABI version numbers.
* Document the existence and purpose of root namespace redeclarations w.r.t. ABI namespaces as well as the ABI namespace directory structure of public headers.
* Improve tips for using CMake package config and pkg-config files, strongly recommending use of CMake package config files, as well as discouraging manual configuration (although not outright declaring it unsupported).
* Improve MSVC-only documentation to cover package files and static libraries.

The stable ABI compatibility policy should be compatible with shared library versioning policies for mainstream package distributions. Both the ABI and API stability policy should be consistent with established practice for the CXX Driver, but refined to clearly set boundaries on what we consider in-scope and out-of-scope w.r.t. stability (such as build system properties).