### PR TITLE
CXX-2977 Support generator expressions in MSVC_RUNTIME_LIBRARY

### DIFF
--- a/cmake/BsoncxxUtil.cmake
+++ b/cmake/BsoncxxUtil.cmake
@@ -93,10 +93,11 @@ function(bsoncxx_add_library TARGET OUTPUT_NAME LINK_TYPE)
             if(1)
                 get_target_property(runtime ${TARGET} MSVC_RUNTIME_LIBRARY)
 
+                set(runtime_str "")
+
                 if(runtime)
                     # MSVC_RUNTIME_LIBRARY may contain generator expressions.
                     # Therefore the comparison must be evaluated during the build generation step.
-                    set(runtime_str "")
                     string(APPEND runtime_str "$<$<STREQUAL:${runtime},MultiThreaded>:mt>")
                     string(APPEND runtime_str "$<$<STREQUAL:${runtime},MultiThreadedDebug>:mtd>")
                     string(APPEND runtime_str "$<$<STREQUAL:${runtime},MultiThreadedDLL>:md>")

--- a/cmake/BsoncxxUtil.cmake
+++ b/cmake/BsoncxxUtil.cmake
@@ -94,15 +94,13 @@ function(bsoncxx_add_library TARGET OUTPUT_NAME LINK_TYPE)
                 get_target_property(runtime ${TARGET} MSVC_RUNTIME_LIBRARY)
 
                 if(runtime)
-                    if(runtime STREQUAL "MultiThreaded")
-                        set(runtime_str "mt")
-                    elseif(runtime STREQUAL "MultiThreadedDebug")
-                        set(runtime_str "mtd")
-                    elseif(runtime STREQUAL "MultiThreadedDLL")
-                        set(runtime_str "md")
-                    elseif(runtime STREQUAL "MultiThreadedDebugDLL")
-                        set(runtime_str "mdd")
-                    endif()
+                    # MSVC_RUNTIME_LIBRARY may contain generator expressions.
+                    # Therefore the comparison must be evaluated during the build generation step.
+                    set(runtime_str "")
+                    string(APPEND runtime_str "$<$<STREQUAL:${runtime},MultiThreaded>:mt>")
+                    string(APPEND runtime_str "$<$<STREQUAL:${runtime},MultiThreadedDebug>:mtd>")
+                    string(APPEND runtime_str "$<$<STREQUAL:${runtime},MultiThreadedDLL>:md>")
+                    string(APPEND runtime_str "$<$<STREQUAL:${runtime},MultiThreadedDebugDLL>:mdd>")
                 else()
                     # Per CMake documentation: if MSVC_RUNTIME_LIBRARY is not set, then
                     # CMake uses the default value MultiThreaded$<$<CONFIG:Debug>:Debug>DLL


### PR DESCRIPTION
Resolves CXX-2977.

https://github.com/mongodb/mongo-cxx-driver/pull/1081 failed to account for the possibility of generator expressions in `MSVC_RUNTIME_LIBRARY` (either set directly or via `CMAKE_MSVC_RUNTIME_LIBRARY`). This caused the series of `if()`/`elseif()` when `MSVC_RUNTIME_LIBRARY` is not-empty to fallthrough all string-comparison cases and produce output names with a trailing `-` and no runtime library property, e.g. `mongocxx-v_noabi-dhs-x64-v143-.dll`.

This PR adds support for generator expressions by deferring the evaluation of the string comparison to the build generation step via the `$<STREQUAL:str1,str2>` generator expression.