### PR TITLE
Update CHANGELOG with CXX-2971 and CXX-2977

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changes prior to 3.9.0 are documented as [release notes on GitHub](https://github.com/mongodb/mongo-cxx-driver/releases).
 
+## 3.10.1 [Unreleased]
+
+### Fixed
+
+- (MSVC only) The name of the libbsoncxx package in the "Requires" field of the libmongocxx pkg-config file incorrectly used the library output name instead of the pkg-config package name when `ENABLE_ABI_TAG_IN_PKGCONFIG_FILENAMES=OFF`.
+- (MSVC only) The translation of the `MSVC_RUNTIME_LIBRARY` target property into an ABI tag parameter in library and package filenames did not account for generator expressions.
+
 ## 3.10.0
 
 ### Added


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1103 and https://github.com/mongodb/mongo-cxx-driver/pull/1106 that adds corresponding changelog entries for 3.10.1.