### PR TITLE
Include post-release updates to `CHANGELOG.md` in release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changes prior to 3.9.0 are documented as [release notes on GitHub](https://github.com/mongodb/mongo-cxx-driver/releases).
 
-## 3.11.0 [Unreleased]
-
-<!-- Will contain entries for the 3.11.0 release. -->
-
 ## 3.10.1 [Unreleased]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changes prior to 3.9.0 are documented as [release notes on GitHub](https://github.com/mongodb/mongo-cxx-driver/releases).
 
+## 3.11.0 [Unreleased]
+
 ## 3.10.1 [Unreleased]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ## 3.11.0 [Unreleased]
 
-(TODO: add entries for the 3.11.0 release)
+<!-- Will contain entries for the 3.11.0 release. -->
 
 ## 3.10.1 [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ## 3.11.0 [Unreleased]
 
-## 3.10.1 [Unreleased]
-
 ### Fixed
 
 - (MSVC only) The name of the libbsoncxx package in the "Requires" field of the libmongocxx pkg-config file incorrectly used the library output name instead of the pkg-config package name when `ENABLE_ABI_TAG_IN_PKGCONFIG_FILENAMES=OFF`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ## 3.11.0 [Unreleased]
 
+(TODO: add entries for the 3.11.0 release)
+
+## 3.10.1 [Unreleased]
+
 ### Fixed
 
 - (MSVC only) The name of the libbsoncxx package in the "Requires" field of the libmongocxx pkg-config file incorrectly used the library output name instead of the pkg-config package name when `ENABLE_ABI_TAG_IN_PKGCONFIG_FILENAMES=OFF`.

--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -496,9 +496,10 @@ def get_jira_project_versions(auth_jira):
 def get_all_issues_for_version(auth_jira, release_version):
     """
     Return a list of all issues in the project assigned to the given release.
+    Excludes the ticket created to track the release itself.
     """
 
-    jql_query = 'project={} and fixVersion={} ORDER BY issueKey ASC'\
+    jql_query = 'project={} and fixVersion={} and (labels IS EMPTY OR labels != release) ORDER BY issueKey ASC'\
             .format(str(CXX_PROJ_ID), release_version)
     return auth_jira.search_issues(jql_query, maxResults=0)
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -38,11 +38,43 @@ Update Jira ticket types and titles as appropriate.
 User-facing issues should generally be either "Bug" or "New Feature".
 Non-user facing issues should generally be "Task" tickets.
 
-## Update CHANGELOG.md
+## Update CHANGELOG.md pre-release ...
 
-Check Jira for tickets closed in this fix version. Update CHANGELOG.md
-with notable changes not already mentioned. Update CHANGELOG.md to remove
-the text `[Unreleased]` for the title of this release. Commit this change.
+### ... for a minor release (e.g. `1.2.0`)
+
+Check out the `master` branch. Create a new branch to contain changelog updates: `git checkout -b pre-release-changes`. This branch will be used to create a PR.
+
+Check Jira for tickets closed in this fix version. Update CHANGELOG.md with notable changes not already mentioned. Remove `[Unreleased]` from the version being released.
+
+Check if there is an `[Unreleased]` section for a patch version (e.g. `1.1.4 [Unreleased]`). The C++ driver does not typically do patch releases for previously released minor versions. If the previous patch release is no longer planned, move the patch release entries into the minor release section and remove the patch release section. If you are unsure whether the patch release is planned, ask in the #dbx-c-cxx channel.
+
+Example (if `1.2.0` is being released):
+```md
+## 1.2.0 [Unreleased]
+### Fixed
+- Fixes A <!-- Unreleased fix on master branch -->
+## 1.1.4 [Unreleased]
+### Fixed
+- Fixes B <!-- Unreleased fix on `releases/v1.1` branch. B is implicity fixed on 1.2.0. Change was cherry-picked from master. -->
+```
+
+Becomes:
+```md
+## 1.2.0
+### Fixed
+- Fixes A
+- Fixes B <!-- 1.1.4 is no longer planned. Document B in 1.2.0 -->
+```
+
+Commit with a message like `Update CHANGELOG for <version>`. Create a PR. Once the PR is merged, proceed with the rest of the releease.
+
+### ... for a patch release (e.g. `1.2.3`)
+
+Check out the release branch (e.g. `releases/v1.2`).
+
+Check Jira for tickets closed in this fix version. Update CHANGELOG.md with notable changes not already mentioned. Remove `[Unreleased]` from the version being released.
+
+Commit with a message like `Update CHANGELOG for <version>`. Push the change.
 
 
 ## Clone and set up environment

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -214,7 +214,7 @@ to request the build team create new Evergreen project to track the
 Documentation generation must be run after the release tag has been made and
 pushed.
 
-- Checkout the master branch.
+- Checkout the master branch. Create a new branch to contain documentation updates: `git checkout -b post-release-changes`. This branch will be used to create a PR later.
 - Edit `etc/apidocmenu.md` and add the released version in the `mongocxx` column
   following the established pattern. If this is a minor release (x.y.0), revise
   the entire document as needed.
@@ -253,53 +253,50 @@ pushed.
     stable release branch.
   - Commit and push the symlink change:
     `git commit -am "Update symlink for r1.2.3"`
+   - Switch back to the branch with documentation updates: `git checkout post-release-changes`.
 - Wait a few minutes and verify mongocxx.org has updated.
 - Checkout the master branch. Push the commit containing changes to `etc/` and
   `docs/`. This may require pushing the commit to a fork of the C++ Driver
   repository and creating a pull request.
 
-## Update CHANGELOG.md for next release
+## Update CHANGELOG.md post-release ...
 
 CHANGELOG.md on the `master` branch contains sections for every release. This is intended to ease searching for changes among all releases.
 CHANGELOG.md on a release branch (e.g. `releases/v1.2`) contains entries for patch releases of the minor version number tracked by the release branch (e.g. for 1.2.1, 1.2.2, 1.2.3, etc.), as well as all entries prior to the initial minor release (e.g. before 1.2.0).
 
-### For a minor release (e.g. r1.2.0):
+### ... on the `master` branch
 
-Open a PR to the master branch to add a new empty `[Unreleased]` section to the CHANGELOG.md for the next minor release and next patch release. Example:
+Check out the `post-release-changes` branch created before.
+
+Ensure `[Unreleased]` is removed from the recently released section.
+
+Ensure there are `[Unreleased]` sections for the next minor and patch releases. Example (if `1.2.3` was just released):
 
 ```md
 ## 1.3.0 [Unreleased]
-
-<!-- Will contain entries for 1.3.0 release. -->
-
-## 1.2.1 [Unreleased]
-
-<!-- Will contain entries for 1.2.1 release. Entries are implicitly included in 1.3.0 release. -->
-
-```
-
-Open a PR to the release branch (e.g. `releases/v1.2`) to add a new empty `[Unreleased]` section to the CHANGELOG.md for the next patch release. Example:
-
-```md
-## 1.2.1 [Unreleased]
-
-<!-- Will contain entries for 1.2.1 release. -->
-```
-
-### For a patch release (e.g. r1.2.3):
-
-Open a PR to the `master` branch to remove `[Unreleased]` from the recently released version, and add a `[Unreleased]` section for the next patch release. Example:
-```md
+<!-- Will contain entries for the next minor release -->
 ## 1.2.4 [Unreleased]
-<!-- Will contain entries for 1.2.4 release. -->
+<!-- Will contain entries for the next patch release -->
 ## 1.2.3
+<!-- Contains published release notes -->
+```
 
-Open a PR to the release branch (e.g. `releases/v1.2`) branch to add a new empty `[Unreleased]` section to the CHANGELOG.md for the next patch release. Example:
+Commit the change. Create a PR from the `post-release-changes` branch to merge to `master`.
+
+### ... on the release branch
+
+Check out the release branch (e.g. `releases/v1.2`).
+
+Update CHANGELOG.md to add an `[Unreleased]` section for the next patch release. Example (if `1.2.3` was just released):
 
 ```md
 ## 1.2.4 [Unreleased]
-<!-- Will contain entries for 1.2.4 release. -->
+<!-- Will contain entries for the next patch release -->
+## 1.2.3
+<!-- Contains published release notes -->
 ```
+
+Commit and push this change to the release branch (no PR necessary for release branch).
 
 ## Homebrew
 This requires a macOS machine.

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -194,6 +194,21 @@ git reset --hard r1.2.3
 git push -f origin releases/stable
 ```
 
+## Branch if necessary
+
+If doing a new minor release `x.y.0` (e.g. a `1.2.0` release), create branch
+`releases/vx.y`  (e.g `releases/v3.8`).
+
+Push the new branch:
+
+```
+git push --set-upstream origin releases/v3.8
+```
+
+The new branch should be continuously tested on Evergreen. Create a BUILD ticket
+to request the build team create new Evergreen project to track the
+`releases/vx.y` branch (see BUILD-5666 for an example).
+
 ## Generate and Publish Documentation
 
 Documentation generation must be run after the release tag has been made and
@@ -317,21 +332,6 @@ under `Product & Driver Announcements` with the tag `cxx`.
 See this
 [example announcement](https://www.mongodb.com/community/forums/t/mongodb-c-11-driver-3-9-0-released/252724)
 of the stable release of 3.9.0.
-
-## Branch if necessary
-
-If doing a new minor release `x.y.0` (e.g. a `1.2.0` release), create branch
-`releases/vx.y`  (e.g `releases/v3.8`).
-
-Push the new branch:
-
-```
-git push --set-upstream origin releases/v3.8
-```
-
-The new branch should be continuously tested on Evergreen. Create a BUILD ticket
-to request the build team create new Evergreen project to track the
-`releases/vx.y` branch (see BUILD-5666 for an example).
 
 ## Docker Image Build and Publish
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -63,8 +63,9 @@ the instructions. If doing a patch release (e.g. releasing rX.Y.Z with non-zero
 `Z`), check out the corresponding release branch, which should be an existing
 `releases/vX.Y` branch.
 
-Check Jira for tickets closed in this fix version. Consider updating CHANGELOG.md
-with notable changes not already mentioned.
+Check Jira for tickets closed in this fix version. Update CHANGELOG.md
+with notable changes not already mentioned. Update CHANGELOG.md to remove
+the text `[Unreleased]` for the title of this release. Commit this change.
 
 Create a tag for the commit to serve as the release (or release candidate):
 
@@ -206,6 +207,32 @@ pushed.
 - Checkout the master branch. Push the commit containing changes to `etc/` and
   `docs/`. This may require pushing the commit to a fork of the C++ Driver
   repository and creating a pull request.
+
+## Update CHANGELOG.md for next release
+
+### For a minor release (e.g. r1.2.0):
+
+Open a PR to the master branch to add a new empty `[Unreleased]` section to the CHANGELOG.md for the next minor release. Example:
+
+```md
+## 1.3.0 [Unreleased]
+```
+
+Open a PR to the release branch (e.g. `releases/v1.2`) to add a new empty `[Unreleased]` section to the CHANGELOG.md for the next patch release. Example:
+
+```md
+## 1.2.1 [Unreleased]
+```
+
+### For a patch release (e.g. r1.2.3):
+
+Open a PR to the `master` branch to add the notes of the recent release (`r1.2.3`) to the `master` branch. This is intended to keep release notes for all releases in master for easier searching.
+
+Open a PR to the release branch (e.g. `releases/v1.2`) branch to add a new empty `[Unreleased]` section to the CHANGELOG.md for the next patch release. Example:
+
+```md
+## 1.2.4 [Unreleased]
+```
 
 ## Homebrew
 This requires a macOS machine.

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -255,9 +255,6 @@ pushed.
     `git commit -am "Update symlink for r1.2.3"`
    - Switch back to the branch with documentation updates: `git checkout post-release-changes`.
 - Wait a few minutes and verify mongocxx.org has updated.
-- Checkout the master branch. Push the commit containing changes to `etc/` and
-  `docs/`. This may require pushing the commit to a fork of the C++ Driver
-  repository and creating a pull request.
 
 ## Update CHANGELOG.md post-release ...
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -42,7 +42,7 @@ Non-user facing issues should generally be "Task" tickets.
 
 ### ... for a minor release (e.g. `1.2.0`)
 
-Create a new branch on the master branch. This branch will contain changelog updates prior to release: `git checkout -b pre-release-changes master`.
+Create a new branch to contain changelog updates from the master branch: `git checkout -b pre-release-changes master`. This branch will be used to create a PR.
 
 Check Jira for tickets closed in this fix version. Update CHANGELOG.md with notable changes not already mentioned. Remove `[Unreleased]` from the version being released.
 
@@ -212,7 +212,7 @@ The new branch should be continuously tested on Evergreen. Update the "Display N
 Documentation generation must be run after the release tag has been made and
 pushed.
 
-- Checkout the master branch. Create a new branch to contain documentation updates: `git checkout -b post-release-changes`. This branch will be used to create a PR later.
+- Create a new branch to contain documentation updates from master: `git checkout -b post-release-changes master`. This branch will be used to create a PR later.
 - Edit `etc/apidocmenu.md` and add the released version in the `mongocxx` column
   following the established pattern. If this is a minor release (X.Y.0), revise
   the entire document as needed.

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -46,7 +46,7 @@ Create a new branch to contain changelog updates from the master branch: `git ch
 
 Check Jira for tickets closed in this fix version. Update CHANGELOG.md with notable changes not already mentioned. Remove `[Unreleased]` from the version being released.
 
-Check if there is an `[Unreleased]` section for a patch version (e.g. `1.1.4 [Unreleased]`). The C++ driver does not typically do patch releases for previously released minor versions. If the previous patch release is no longer planned, move the patch release entries into the minor release section and remove the patch release section. If you are unsure whether the patch release is planned, ask in the #dbx-c-cxx channel.
+Check if there is an `[Unreleased]` section for a patch version (e.g. `1.1.4 [Unreleased]`). Normally, the C++ Driver does not release patches for old minor versions. If an unreleased patch release section is no longer applicable, move its entries into the minor release section (as needed) and remove the patch release section. If you are unsure whether the patch release is planned, ask in the #dbx-c-cxx channel.
 
 Example (if `1.2.0` is being released):
 ```md

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -246,7 +246,7 @@ pushed.
 ## Update CHANGELOG.md for next release
 
 CHANGELOG.md on the `master` branch contains sections for every release. This is intended to ease searching for changes among all releases.
-CHANGELOG.md on a release branch (e.g. `releases/v1.2`) contains entries for all prior releases, and all patch releases on the `releases/v1.2` branch.
+CHANGELOG.md on a release branch (e.g. `releases/v1.2`) contains entries for patch releases of the minor version number tracked by the release branch (e.g. for 1.2.1, 1.2.2, 1.2.3, etc.), as well as all entries prior to the initial minor release (e.g. before 1.2.0).
 
 ### For a minor release (e.g. r1.2.0):
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -268,7 +268,7 @@ CHANGELOG.md on a release branch (e.g. `releases/v1.2`) contains entries for pat
 
 ### ... on the `master` branch
 
-Check out the `post-release-changes` branch created before.
+Check out the `post-release-changes` branch created before editing and generating documentation.
 
 Ensure `[Unreleased]` is removed from the recently released section. Ensure the contents of the recently released section match the published release notes.
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -77,7 +77,7 @@ Commit with a message like `Update CHANGELOG for <version>`. Create a PR for the
 
 ### ... for a patch release (e.g. `1.2.3`)
 
-Check out the release branch (e.g. `releases/v1.2`).
+Check out the existing release branch (e.g. `releases/v1.2`).
 
 Check Jira for tickets closed in this fix version. Update CHANGELOG.md with notable changes not already mentioned. Remove `[Unreleased]` from the version being released.
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -38,6 +38,13 @@ Update Jira ticket types and titles as appropriate.
 User-facing issues should generally be either "Bug" or "New Feature".
 Non-user facing issues should generally be "Task" tickets.
 
+## Update CHANGELOG.md
+
+Check Jira for tickets closed in this fix version. Update CHANGELOG.md
+with notable changes not already mentioned. Update CHANGELOG.md to remove
+the text `[Unreleased]` for the title of this release. Commit this change.
+
+
 ## Clone and set up environment
 
 Do a fresh clone, to avoid local git branches or IDE files from interfering.
@@ -62,10 +69,6 @@ stay on the master branch. You will create a new `releases/vX.Y` branch later in
 the instructions. If doing a patch release (e.g. releasing rX.Y.Z with non-zero
 `Z`), check out the corresponding release branch, which should be an existing
 `releases/vX.Y` branch.
-
-Check Jira for tickets closed in this fix version. Update CHANGELOG.md
-with notable changes not already mentioned. Update CHANGELOG.md to remove
-the text `[Unreleased]` for the title of this release. Commit this change.
 
 Create a tag for the commit to serve as the release (or release candidate):
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -265,7 +265,7 @@ CHANGELOG.md on a release branch (e.g. `releases/v1.2`) contains entries for pat
 
 Check out the `post-release-changes` branch created before.
 
-Ensure `[Unreleased]` is removed from the recently released section.
+Ensure `[Unreleased]` is removed from the recently released section. Ensure the contents of the recently released section match the published release notes.
 
 Ensure there are `[Unreleased]` sections for the next minor and patch releases. Example (if `1.2.3` was just released):
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -300,7 +300,7 @@ Commit and push this change to the release branch (no PR necessary for release b
 
 ## Homebrew
 This requires a macOS machine.
-If this is a stable release, update the [mongo-cxx-driver](https://github.com/Homebrew/homebrew-core/blob/master/Formula/mongo-cxx-driver.rb) homebrew formula, using: `brew bump-formula-pr --url <tarball url>`
+If this is a stable release, update the [mongo-cxx-driver](https://github.com/Homebrew/homebrew-core/blob/master/Formula/mongo-cxx-driver.rb) homebrew formula, using: `brew bump-formula-pr mongo-cxx-driver --url <tarball url>`
 
 Example:
 `brew bump-formula-pr mongo-cxx-driver --url https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.7.3/mongo-cxx-driver-r3.7.3.tar.gz`

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -38,11 +38,6 @@ Update Jira ticket types and titles as appropriate.
 User-facing issues should generally be either "Bug" or "New Feature".
 Non-user facing issues should generally be "Task" tickets.
 
-## Update CHANGELOG.md
-
-Check Jira for tickets closed in this fix version. Consider updating CHANGELOG.md
-with notable changes not already mentioned.
-
 ## Clone and set up environment
 
 Do a fresh clone, to avoid local git branches or IDE files from interfering.
@@ -67,6 +62,9 @@ stay on the master branch. You will create a new `releases/vX.Y` branch later in
 the instructions. If doing a patch release (e.g. releasing rX.Y.Z with non-zero
 `Z`), check out the corresponding release branch, which should be an existing
 `releases/vX.Y` branch.
+
+Check Jira for tickets closed in this fix version. Consider updating CHANGELOG.md
+with notable changes not already mentioned.
 
 Create a tag for the commit to serve as the release (or release candidate):
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -212,26 +212,40 @@ pushed.
 
 ### For a minor release (e.g. r1.2.0):
 
-Open a PR to the master branch to add a new empty `[Unreleased]` section to the CHANGELOG.md for the next minor release. Example:
+Open a PR to the master branch to add a new empty `[Unreleased]` section to the CHANGELOG.md for the next minor release and next patch release. Example:
 
 ```md
 ## 1.3.0 [Unreleased]
+
+<!-- Will contain entries for 1.3.0 release. -->
+
+## 1.2.1 [Unreleased]
+
+<!-- Will contain entries for 1.2.1 release. Entries are implicitly included in 1.3.0 release. -->
+
 ```
 
 Open a PR to the release branch (e.g. `releases/v1.2`) to add a new empty `[Unreleased]` section to the CHANGELOG.md for the next patch release. Example:
 
 ```md
 ## 1.2.1 [Unreleased]
+
+<!-- Will contain entries for 1.2.1 release. -->
 ```
 
 ### For a patch release (e.g. r1.2.3):
 
-Open a PR to the `master` branch to add the notes of the recent release (`r1.2.3`) to the `master` branch. This is intended to keep release notes for all releases in master for easier searching.
+Open a PR to the `master` branch to remove `[Unreleased]` from the recently released version, and add a `[Unreleased]` section for the next patch release. Example:
+```md
+## 1.2.4 [Unreleased]
+<!-- Will contain entries for 1.2.4 release. -->
+## 1.2.3
 
 Open a PR to the release branch (e.g. `releases/v1.2`) branch to add a new empty `[Unreleased]` section to the CHANGELOG.md for the next patch release. Example:
 
 ```md
 ## 1.2.4 [Unreleased]
+<!-- Will contain entries for 1.2.4 release. -->
 ```
 
 ## Homebrew

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -197,7 +197,7 @@ git push -f origin releases/stable
 ## Branch if necessary
 
 If doing a new minor release `X.Y.0` (e.g. a `1.2.0` release), create branch
-`releases/vX.Y` (e.g `releases/v1.2`).
+`releases/vX.Y` (e.g `releases/v1.2`): `git checkout -b releases/v1.2 master`
 
 Push the new branch:
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -210,6 +210,9 @@ pushed.
 
 ## Update CHANGELOG.md for next release
 
+CHANGELOG.md on the `master` branch contains sections for every release. This is intended to ease searching for changes among all releases.
+CHANGELOG.md on a release branch (e.g. `releases/v1.2`) contains entries for all prior releases, and all patch releases on the `releases/v1.2` branch.
+
 ### For a minor release (e.g. r1.2.0):
 
 Open a PR to the master branch to add a new empty `[Unreleased]` section to the CHANGELOG.md for the next minor release and next patch release. Example:

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -51,17 +51,24 @@ Check if there is an `[Unreleased]` section for a patch version (e.g. `1.1.4 [Un
 Example (if `1.2.0` is being released):
 ```md
 ## 1.2.0 [Unreleased]
+
 ### Fixed
+
 - Fixes A <!-- Unreleased fix on master branch -->
+
 ## 1.1.4 [Unreleased]
+
 ### Fixed
+
 - Fixes B <!-- Unreleased fix on `releases/v1.1` branch. B is implicity fixed on 1.2.0. Change was cherry-picked from master. -->
 ```
 
 Becomes:
 ```md
 ## 1.2.0
+
 ### Fixed
+
 - Fixes A
 - Fixes B <!-- 1.1.4 is no longer planned. Document B in 1.2.0 -->
 ```
@@ -269,10 +276,15 @@ Ensure there are `[Unreleased]` sections for the next minor and patch releases. 
 
 ```md
 ## 1.3.0 [Unreleased]
+
 <!-- Will contain entries for the next minor release -->
+
 ## 1.2.4 [Unreleased]
+
 <!-- Will contain entries for the next patch release -->
+
 ## 1.2.3
+
 <!-- Contains published release notes -->
 ```
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -219,7 +219,7 @@ The new branch should be continuously tested on Evergreen. Update the "Display N
 Documentation generation must be run after the release tag has been made and
 pushed.
 
-- Create a new branch to contain documentation updates from master: `git checkout -b post-release-changes master`. This branch will be used to create a PR later.
+- Create and checkout a new branch to contain documentation updates from master: `git checkout -b post-release-changes master`. This branch will be used to create a PR later.
 - Edit `etc/apidocmenu.md` and add the released version in the `mongocxx` column
   following the established pattern. If this is a minor release (X.Y.0), revise
   the entire document as needed.

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -274,8 +274,11 @@ Update CHANGELOG.md to add an `[Unreleased]` section for the next patch release.
 
 ```md
 ## 1.2.4 [Unreleased]
+
 <!-- Will contain entries for the next patch release -->
+
 ## 1.2.3
+
 <!-- Contains published release notes -->
 ```
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -197,12 +197,12 @@ git push -f origin releases/stable
 ## Branch if necessary
 
 If doing a new minor release `x.y.0` (e.g. a `1.2.0` release), create branch
-`releases/vx.y`  (e.g `releases/v3.8`).
+`releases/vx.y`  (e.g `releases/v1.2`).
 
 Push the new branch:
 
 ```
-git push --set-upstream origin releases/v3.8
+git push --set-upstream origin releases/v1.2
 ```
 
 The new branch should be continuously tested on Evergreen. Create a BUILD ticket

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -205,9 +205,7 @@ Push the new branch:
 git push --set-upstream origin releases/v1.2
 ```
 
-The new branch should be continuously tested on Evergreen. Create a BUILD ticket
-to request the build team create new Evergreen project to track the
-`releases/vx.y` branch (see BUILD-5666 for an example).
+The new branch should be continuously tested on Evergreen. Update the "Display Name" and "Branch Name" of the [mongo-cxx-driver-latest-release Evergreen project](https://spruce.mongodb.com/project/mongo-cxx-driver-latest-release/settings/general) to refer to the new release branch.
 
 ## Generate and Publish Documentation
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -196,8 +196,8 @@ git push -f origin releases/stable
 
 ## Branch if necessary
 
-If doing a new minor release `x.y.0` (e.g. a `1.2.0` release), create branch
-`releases/vx.y`  (e.g `releases/v1.2`).
+If doing a new minor release `X.Y.0` (e.g. a `1.2.0` release), create branch
+`releases/vX.Y` (e.g `releases/v1.2`).
 
 Push the new branch:
 
@@ -214,7 +214,7 @@ pushed.
 
 - Checkout the master branch. Create a new branch to contain documentation updates: `git checkout -b post-release-changes`. This branch will be used to create a PR later.
 - Edit `etc/apidocmenu.md` and add the released version in the `mongocxx` column
-  following the established pattern. If this is a minor release (x.y.0), revise
+  following the established pattern. If this is a minor release (X.Y.0), revise
   the entire document as needed.
 - Edit `docs/content/_index.md` and `README.md` to match.
 - Edit the `Installing the MongoDB C driver` section of

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -66,7 +66,7 @@ Becomes:
 - Fixes B <!-- 1.1.4 is no longer planned. Document B in 1.2.0 -->
 ```
 
-Commit with a message like `Update CHANGELOG for <version>`. Create a PR. Once the PR is merged, proceed with the rest of the releease.
+Commit with a message like `Update CHANGELOG for <version>`. Create a PR. Once the PR is merged, proceed with the rest of the release. The `pre-release-changes` branch may be deleted.
 
 ### ... for a patch release (e.g. `1.2.3`)
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -266,6 +266,21 @@ pushed.
 CHANGELOG.md on the `master` branch contains sections for every release. This is intended to ease searching for changes among all releases.
 CHANGELOG.md on a release branch (e.g. `releases/v1.2`) contains entries for patch releases of the minor version number tracked by the release branch (e.g. for 1.2.1, 1.2.2, 1.2.3, etc.), as well as all entries prior to the initial minor release (e.g. before 1.2.0).
 
+### ... on the release branch
+
+Check out the release branch (e.g. `releases/v1.2`).
+
+Update CHANGELOG.md to add an `[Unreleased]` section for the next patch release. Example (if `1.2.3` was just released):
+
+```md
+## 1.2.4 [Unreleased]
+<!-- Will contain entries for the next patch release -->
+## 1.2.3
+<!-- Contains published release notes -->
+```
+
+Commit and push this change to the release branch (no PR necessary for release branch).
+
 ### ... on the `master` branch
 
 Check out the `post-release-changes` branch created before editing and generating documentation.
@@ -289,21 +304,6 @@ Ensure there are `[Unreleased]` sections for the next minor and patch releases. 
 ```
 
 Commit the change. Create a PR from the `post-release-changes` branch to merge to `master`.
-
-### ... on the release branch
-
-Check out the release branch (e.g. `releases/v1.2`).
-
-Update CHANGELOG.md to add an `[Unreleased]` section for the next patch release. Example (if `1.2.3` was just released):
-
-```md
-## 1.2.4 [Unreleased]
-<!-- Will contain entries for the next patch release -->
-## 1.2.3
-<!-- Contains published release notes -->
-```
-
-Commit and push this change to the release branch (no PR necessary for release branch).
 
 ## Homebrew
 This requires a macOS machine.

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -42,7 +42,7 @@ Non-user facing issues should generally be "Task" tickets.
 
 ### ... for a minor release (e.g. `1.2.0`)
 
-Check out the `master` branch. Create a new branch to contain changelog updates: `git checkout -b pre-release-changes`. This branch will be used to create a PR.
+Create a new branch on the master branch. This branch will contain changelog updates prior to release: `git checkout -b pre-release-changes master`.
 
 Check Jira for tickets closed in this fix version. Update CHANGELOG.md with notable changes not already mentioned. Remove `[Unreleased]` from the version being released.
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -73,7 +73,7 @@ Becomes:
 - Fixes B <!-- 1.1.4 is no longer planned. Document B in 1.2.0 -->
 ```
 
-Commit with a message like `Update CHANGELOG for <version>`. Create a PR. Once the PR is merged, proceed with the rest of the release. The `pre-release-changes` branch may be deleted.
+Commit with a message like `Update CHANGELOG for <version>`. Create a PR for the `pre-release-changes` branch which contains the commits made up to this point. Once the PR is merged, proceed with the rest of the release. The `pre-release-changes` branch may be deleted.
 
 ### ... for a patch release (e.g. `1.2.3`)
 


### PR DESCRIPTION
# Summary

This PR is intended to specify consistent updates the `CHANGELOG.md` when releasing:
- Tag the commit updating `CHANGELOG.md`
- Add `[Unreleased]` sections for subsequent releases after a release.

As a drive-by improvement `make_release.py` is updated to ignore the "Release `<version>`" ticket when checking for open tickets.

This PR is associated with: ~~https://github.com/mongodb/mongo-cxx-driver/pull/1108~~ https://github.com/mongodb/mongo-cxx-driver/pull/1107 to add a CHANGELOG.md entry for the upcoming 3.10.1 release.

# Background & Motivation

There are no instructions for updating CHANGELOG.md after a release. This resulted in a follow-up PR to update CHANGELOG.md with the 3.10.0 section: https://github.com/mongodb/mongo-cxx-driver/pull/1105

