### PR TITLE
document minimum CMake as 3.15

### DIFF
--- a/docs/content/mongocxx-v3/installation/_index.md
+++ b/docs/content/mongocxx-v3/installation/_index.md
@@ -11,7 +11,7 @@ title = "Installing the mongocxx driver"
 
 - Any standard Unix platform, or Windows 7 SP1+
 - A compiler that supports C++11 (gcc, clang, or Visual Studio)
-- [CMake](https://cmake.org) 3.2 or later
+- [CMake](https://cmake.org) 3.15 or later
 - [boost](https://www.boost.org) headers (optional)
 
 If you encounter build failures or other problems with a platform configuration


### PR DESCRIPTION
Update documented required CMake to 3.15. 3.15 became the new minimum in C++ driver 3.9.0 as part of https://github.com/mongodb/mongo-cxx-driver/pull/1019.