### PR TITLE
Re-enable the Alpine build

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -612,9 +612,8 @@ functions:
             set -o errexit
             set -o pipefail
             set -x
-            # TODO: Re-enable Alpine test once MONGOCRYPT-601 is released.
-            # echo "Building Alpine Docker image"
-            # make -C extras/docker/alpine3.19 nocachebuild test
+            echo "Building Alpine Docker image"
+            make -C extras/docker/alpine3.19 nocachebuild test
             echo "Building Debian Docker image"
             make -C extras/docker/bookworm nocachebuild test
             echo "Building Red Hat UBI Docker image"


### PR DESCRIPTION
The fix for the bug that broke the Alpine build has been merged, therefore we can now re-enable the build for Alpine Linux.