### PR TITLE
Replace SSH git clone commands with HTTPS equivalents

### DIFF
--- a/.evergreen/compile.sh
+++ b/.evergreen/compile.sh
@@ -41,7 +41,7 @@ cmake_binary="$(find_cmake_latest)"
 command -v "$cmake_binary"
 
 if [ ! -d ../drivers-evergreen-tools ]; then
-  git clone --depth 1 git@github.com:mongodb-labs/drivers-evergreen-tools.git ../drivers-evergreen-tools
+  git clone --depth 1 https://github.com/mongodb-labs/drivers-evergreen-tools.git ../drivers-evergreen-tools
 fi
 # shellcheck source=/dev/null
 . ../drivers-evergreen-tools/.evergreen/find-python3.sh

--- a/.mci.yml
+++ b/.mci.yml
@@ -188,7 +188,7 @@ functions:
             shell: bash
             script: |
                 if [ ! -d "drivers-evergreen-tools" ]; then
-                    git clone git@github.com:mongodb-labs/drivers-evergreen-tools.git
+                    git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git
                 fi
                 cd drivers-evergreen-tools
                 export DRIVERS_TOOLS=$(pwd)
@@ -255,7 +255,7 @@ functions:
                 set -o errexit
                 set -o pipefail
                 if [ ! -d "drivers-evergreen-tools" ]; then
-                    git clone git@github.com:mongodb-labs/drivers-evergreen-tools.git
+                    git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git
                 fi
                 cd drivers-evergreen-tools
                 # The legacy shell is only present in server 5.0 builds and earlier,
@@ -404,7 +404,7 @@ functions:
           script: |-
             set -o errexit
             if [ ! -d "drivers-evergreen-tools" ]; then
-                git clone git@github.com:mongodb-labs/drivers-evergreen-tools.git --depth=1
+                git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git --depth=1
             fi
             echo "DRIVERS_TOOLS: $(pwd)/drivers-evergreen-tools" > det-expansion.yml
       # Set DRIVERS_TOOLS expansion.


### PR DESCRIPTION
Consistently replaces all instances of SSH git clone commands in scripts (not in documentation) with HTTPS equivalents as a proactive measure concerning upcoming updates to EVG. Verified by [this patch](https://spruce.mongodb.com/version/66296ff6d5113000076d3a63).