### PR TITLE
Update links and docker image references

### DIFF
--- a/extras/docker/README.md
+++ b/extras/docker/README.md
@@ -16,6 +16,7 @@ is also known as
 
 ## Tags
 
+- [3.10.1-redhat-ubi-9.4](https://github.com/mongodb/mongo-cxx-driver/blob/76ffc364af1e13b9f04aedd7956de7550bd1aacc/extras/docker/redhat-ubi-9.4/Dockerfile)
 - [3.10.1-redhat-ubi-9.3](https://github.com/mongodb/mongo-cxx-driver/blob/0532dc531ef64521a5aa2339f5835bb2d9f6f964/extras/docker/redhat-ubi-9.3/Dockerfile)
 - [3.10.0-redhat-ubi-9.3](https://github.com/mongodb/mongo-cxx-driver/blob/7fa047f64b476b7b7c422afc9b92eafde41f3412/extras/docker/redhat-ubi-9.3/Dockerfile)
 - [3.9.0-redhat-ubi-9.3](https://github.com/mongodb/mongo-cxx-driver/blob/fe02b0dbb930d0fb28ca704bc5cfc0b31160d860/extras/docker/redhat-ubi-9.3/Dockerfile)
@@ -34,7 +35,7 @@ instance for
 Next, create a `Dockerfile` like so.
 ```Dockerfile
 # Dockerfile
-FROM mongodb/mongo-cxx-driver:3.10.1-redhat-ubi-9.3
+FROM mongodb/mongo-cxx-driver:3.10.1-redhat-ubi-9.4
 
 WORKDIR /build
 
@@ -163,7 +164,7 @@ instance for
 Next, create a `Dockerfile` like so.
 ```Dockerfile
 # Dockerfile
-FROM mongodb/mongo-cxx-driver:3.10.1-redhat-ubi-9.3
+FROM mongodb/mongo-cxx-driver:3.10.1-redhat-ubi-9.4
 
 WORKDIR /build
 


### PR DESCRIPTION
Update links and docker image references to point to the latest Dockerfile which uses Red Hat UBI 9.4 as a base image.