### PR TITLE
Fix broken link

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -9,15 +9,6 @@ publishdir = "../build/hugo"
 [blackfriday]
   plainIdAnchors = true
 
-
-# Update versions in mongodb.toml as well
-[[menu.main]]
-    name = "mongocxx (v3)"
-    pre = "<i class='fa fa-arrow-right'></i>"
-    weight = 30
-    identifier = "mongocxx3"
-    url = "/mongocxx-v3/"
-
 [[menu.main]]
     name = "legacy (v1)"
     pre = "<i class='fa fa-arrow-right'></i>"

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -8,7 +8,7 @@ type = "index"
 
 This is the legacy site for the Mongo C++ Driver documentation. See the new
 [MongoDB C++ Driver
-documentation](https://www.mongodb.com/docs/languages/cpp/drivers/current/).
+documentation](https://www.mongodb.com/docs/languages/cpp/).
 
 For documentation of the legacy C++ driver (versions older than 3.0), see the
 [Legacy C++ Driver documentation](https://mongocxx.org/legacy-v1/).


### PR DESCRIPTION
Fix broken redirect link on https://mongocxx.org and removes a no-longer-relevant sidebar link.