### PR TITLE
CXX-3008 add instructions to examine Snyk reports during release

### DIFF
--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -21,7 +21,7 @@ by changes in the new release.
 
 ## Check Coverity
 
-Ensure there are no new, unexpected, or high severity issues on Coverity.
+Ensure there are no new or unexpected issues with High severity or greater.
 
 ## Update etc/purls.txt
 
@@ -36,6 +36,14 @@ podman login artifactory.corp.mongodb.com --username cpp-driver
 # Output: "... writing sbom to file"
 podman run -it --rm -v "$(pwd):$(pwd)" artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0 update -p "$(pwd)/etc/purls.txt" -i "$(pwd)/etc/cyclonedx.sbom.json" -o "$(pwd)/etc/cyclonedx.sbom.json"
 ```
+
+## Check Snyk
+
+Inspect the list of issues in the latest report for the mongodb/mongo-cxx-driver target in [Snyk](https://app.snyk.io/).
+
+Examine the latest report and ensure there are no new or unexpected fixable issues with High severity or greater.
+
+Deactivate any projects that will not be relevant in the upcoming release. Remove any projects that are not relevant to the current release.
 
 ## Check fixVersions in Jira
 

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -1,9 +1,31 @@
-# Required for release script.
-Click
-GitPython
-PyGithub
+# Required packages for the release script.
+click==8.1.7
+GitPython==3.1.43
+PyGithub==2.3.0
+cryptography==42.0.7
+
 # Pin `jira` to apply fix of https://github.com/pycontribs/jira/commit/010223289eb66663aaafb70447397038efb2d40d.
 # This avoids the `signature_method_rejected` error described in https://github.com/pycontribs/jira/pull/1643.
 # TODO: replace the following line with `jira` once there is a release of `jira` containing the fix.
-git+https://github.com/pycontribs/jira.git@010223289eb66663aaafb70447397038efb2d40d
-cryptography
+jira @ git+https://github.com/pycontribs/jira.git@010223289eb66663aaafb70447397038efb2d40d
+
+# Dependencies of required packages above.
+certifi==2024.2.2
+cffi==1.16.0
+charset-normalizer==3.3.2
+defusedxml==0.7.1
+Deprecated==1.2.14
+gitdb==4.0.11
+idna==3.7
+oauthlib==3.2.2
+packaging==24.0
+pycparser==2.22
+PyJWT==2.8.0
+PyNaCl==1.5.0
+requests==2.32.2
+requests-oauthlib==2.0.0
+requests-toolbelt==1.0.0
+smmap==5.0.1
+typing_extensions==4.11.0
+urllib3==2.2.1
+wrapt==1.16.0


### PR DESCRIPTION
Related to CXX-3008. Additionally updates `etc/requirements.txt` with output of `pip freeze` to ensure dependencies are pinned, which should resolve some open Snyk issues.