### PR TITLE
CXX-3043 Address Coverity warnings for Ro3/Ro5 violations

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value.hpp
@@ -76,8 +76,8 @@ class value {
     value(const value&);
     value& operator=(const value&);
 
-    value(value&&) noexcept = default;
-    value& operator=(value&&) noexcept = default;
+    value(value&&) = default;
+    value& operator=(value&&) = default;
 
     ///
     /// Get a view over the document owned by this value.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
@@ -54,6 +54,9 @@ class array : public sub_array {
         return *this;
     }
 
+    array(const array&) = delete;
+    array& operator=(const array&) = delete;
+
     ///
     /// @return A view of the BSON array.
     ///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
@@ -42,6 +42,8 @@ class document : public sub_document {
     ///
     BSONCXX_INLINE document() : sub_document(&_core), _core(false) {}
 
+    ~document() = default;
+
     ///
     /// Move constructor
     ///
@@ -55,6 +57,9 @@ class document : public sub_document {
         _core = std::move(doc._core);
         return *this;
     }
+
+    document(const document&) = delete;
+    document& operator=(const document&) = delete;
 
     ///
     /// @return A view of the BSON document.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
@@ -32,10 +32,6 @@ namespace builder {
 struct concatenate_doc {
     document::view_or_value doc;
 
-    // MSVC seems to need a hint that it should always
-    // inline this destructor.
-    BSONCXX_INLINE ~concatenate_doc() = default;
-
     ///
     /// Conversion operator that provides a view of the wrapped concatenate
     /// document.
@@ -63,10 +59,6 @@ struct concatenate_doc {
 ///
 struct concatenate_array {
     array::view_or_value array;
-
-    // MSVC seems to need a hint that it should always
-    // inline this destructor.
-    BSONCXX_INLINE ~concatenate_array() = default;
 
     ///
     /// Conversion operator that provides a view of the wrapped concatenate

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
@@ -59,6 +59,9 @@ class core {
 
     ~core();
 
+    core(const core&) = delete;
+    core& operator=(const core&) = delete;
+
     ///
     /// Appends a key passed as a non-owning stdx::string_view.
     ///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
@@ -75,11 +75,13 @@ class value {
     ///
     explicit value(document::view view);
 
+    ~value() = default;
+
     value(const value&);
     value& operator=(const value&);
 
-    value(value&&) noexcept = default;
-    value& operator=(value&&) noexcept = default;
+    value(value&&) = default;
+    value& operator=(value&&) = default;
 
     ///
     /// Constructor used for serialization of user objects. This uses argument-dependent lookup

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
@@ -45,7 +45,7 @@ class view_or_value : public bsoncxx::v_noabi::view_or_value<stdx::string_view, 
     ///
     /// Default constructor, equivalent to using an empty string.
     ///
-    BSONCXX_INLINE view_or_value() = default;
+    view_or_value() = default;
 
     ///
     /// Construct a string::view_or_value using a null-terminated const char *.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value.hpp
@@ -47,10 +47,15 @@ class view_or_value {
                   "View type must be default constructible");
 
     ///
+    /// Destroys a view_or_value.
+    ///
+    ~view_or_value() = default;
+
+    ///
     /// Default-constructs a view_or_value. This is equivalent to constructing a
     /// view_or_value with a default-constructed View.
     ///
-    BSONCXX_INLINE view_or_value() = default;
+    view_or_value() = default;
 
     ///
     /// Construct a view_or_value from a View. When constructed with a View,

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/itoa.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/itoa.hh
@@ -27,6 +27,11 @@ class BSONCXX_TEST_API itoa {
    public:
     explicit itoa(uint32_t i = 0);
 
+    ~itoa() = default;
+
+    itoa(itoa&& rhs) = delete;
+    itoa& operator=(itoa&&) = delete;
+
     itoa(const itoa& rhs) = delete;
     itoa& operator=(const itoa&) = delete;
 

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/stack.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/stack.hh
@@ -55,6 +55,12 @@ class stack {
         }
     }
 
+    stack(stack&&) = delete;
+    stack& operator=(stack&&) = delete;
+
+    stack(const stack&) = delete;
+    stack& operator=(const stack&) = delete;
+
     bool empty() const {
         return _is_empty;
     }

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
@@ -96,6 +96,9 @@ class client {
     ///
     ~client();
 
+    client(const client&) = delete;
+    client& operator=(const client&) = delete;
+
     ///
     /// Returns true if the client is valid, meaning it was not default constructed
     /// or moved from.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
@@ -53,17 +53,17 @@ class client_encryption {
     ///
     /// Destroys a client_encryption.
     ///
-    ~client_encryption() noexcept;
+    ~client_encryption();
 
     ///
     /// Move-constructs a client_encryption object.
     ///
-    client_encryption(client_encryption&&);
+    client_encryption(client_encryption&&) noexcept;
 
     ///
     /// Move-assigns a client_encryption object.
     ///
-    client_encryption& operator=(client_encryption&&);
+    client_encryption& operator=(client_encryption&&) noexcept;
 
     client_encryption(const client_encryption&) = delete;
     client_encryption& operator=(const client_encryption&) = delete;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
@@ -60,6 +60,9 @@ class cursor {
     ///
     ~cursor();
 
+    cursor(const cursor&) = delete;
+    cursor& operator=(const cursor&) = delete;
+
     ///
     /// A cursor::iterator that points to the beginning of any available
     /// results.  If begin() is called more than once, the cursor::iterator

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_failed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_failed_event.hpp
@@ -43,6 +43,12 @@ class command_failed_event {
     ///
     ~command_failed_event();
 
+    command_failed_event(command_failed_event&&) = default;
+    command_failed_event& operator=(command_failed_event&&) = default;
+
+    command_failed_event(const command_failed_event&) = default;
+    command_failed_event& operator=(const command_failed_event&) = default;
+
     ///
     /// Returns the server’s reply to the failed operation.
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_started_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_started_event.hpp
@@ -43,6 +43,12 @@ class command_started_event {
     ///
     ~command_started_event();
 
+    command_started_event(command_started_event&&) = default;
+    command_started_event& operator=(command_started_event&&) = default;
+
+    command_started_event(const command_started_event&) = default;
+    command_started_event& operator=(const command_started_event&) = default;
+
     ///
     /// Returns the command that has been started.
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_succeeded_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_succeeded_event.hpp
@@ -43,6 +43,12 @@ class command_succeeded_event {
     ///
     ~command_succeeded_event();
 
+    command_succeeded_event(command_succeeded_event&&) = default;
+    command_succeeded_event& operator=(command_succeeded_event&&) = default;
+
+    command_succeeded_event(const command_succeeded_event&) = default;
+    command_succeeded_event& operator=(const command_succeeded_event&) = default;
+
     ///
     /// Returns the server reply for the succeeded operation.
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event.hpp
@@ -42,6 +42,12 @@ class heartbeat_failed_event {
     ///
     ~heartbeat_failed_event();
 
+    heartbeat_failed_event(heartbeat_failed_event&&) = default;
+    heartbeat_failed_event& operator=(heartbeat_failed_event&&) = default;
+
+    heartbeat_failed_event(const heartbeat_failed_event&) = default;
+    heartbeat_failed_event& operator=(const heartbeat_failed_event&) = default;
+
     ///
     /// Returns the failed operation's error message.
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event.hpp
@@ -42,6 +42,13 @@ class heartbeat_started_event {
     ///
     ~heartbeat_started_event();
 
+    heartbeat_started_event(heartbeat_started_event&&) = default;
+    MONGOCXX_INLINE heartbeat_started_event& operator=(heartbeat_started_event&&) noexcept =
+        default;
+
+    heartbeat_started_event(const heartbeat_started_event&) = default;
+    heartbeat_started_event& operator=(const heartbeat_started_event&) = default;
+
     ///
     /// Returns the host name.
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event.hpp
@@ -43,8 +43,7 @@ class heartbeat_started_event {
     ~heartbeat_started_event();
 
     heartbeat_started_event(heartbeat_started_event&&) = default;
-    MONGOCXX_INLINE heartbeat_started_event& operator=(heartbeat_started_event&&) noexcept =
-        default;
+    heartbeat_started_event& operator=(heartbeat_started_event&&) noexcept = default;
 
     heartbeat_started_event(const heartbeat_started_event&) = default;
     heartbeat_started_event& operator=(const heartbeat_started_event&) = default;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event.hpp
@@ -41,6 +41,12 @@ class heartbeat_succeeded_event {
     ///
     ~heartbeat_succeeded_event();
 
+    heartbeat_succeeded_event(heartbeat_succeeded_event&&) = default;
+    heartbeat_succeeded_event& operator=(heartbeat_succeeded_event&&) = default;
+
+    heartbeat_succeeded_event(const heartbeat_succeeded_event&) = default;
+    heartbeat_succeeded_event& operator=(const heartbeat_succeeded_event&) = default;
+
     ///
     /// Returns the server reply for the succeeded operation.
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_changed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_changed_event.hpp
@@ -42,6 +42,12 @@ class server_changed_event {
     ///
     ~server_changed_event();
 
+    server_changed_event(server_changed_event&&) = default;
+    server_changed_event& operator=(server_changed_event&&) = default;
+
+    server_changed_event(const server_changed_event&) = default;
+    server_changed_event& operator=(const server_changed_event&) = default;
+
     ///
     /// Returns the server host name.
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_closed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_closed_event.hpp
@@ -43,6 +43,12 @@ class server_closed_event {
     ///
     ~server_closed_event();
 
+    server_closed_event(server_closed_event&&) = default;
+    server_closed_event& operator=(server_closed_event&&) = default;
+
+    server_closed_event(const server_closed_event&) = default;
+    server_closed_event& operator=(const server_closed_event&) = default;
+
     ///
     /// Returns the server host name.
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_description.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_description.hpp
@@ -37,6 +37,12 @@ class server_description {
     ///
     ~server_description();
 
+    server_description(server_description&&) = default;
+    server_description& operator=(server_description&&) = default;
+
+    server_description(const server_description&) = default;
+    server_description& operator=(const server_description&) = default;
+
     ///
     /// An opaque id, unique to this server for this mongocxx::v_noabi::client or
     /// mongocxx::v_noabi::pool.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_opening_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_opening_event.hpp
@@ -42,6 +42,12 @@ class server_opening_event {
     ///
     ~server_opening_event();
 
+    server_opening_event(server_opening_event&&) = default;
+    server_opening_event& operator=(server_opening_event&&) = default;
+
+    server_opening_event(const server_opening_event&) = default;
+    server_opening_event& operator=(const server_opening_event&) = default;
+
     ///
     /// Returns the server host name.
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_changed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_changed_event.hpp
@@ -41,6 +41,12 @@ class topology_changed_event {
     ///
     ~topology_changed_event();
 
+    topology_changed_event(topology_changed_event&&) = default;
+    topology_changed_event& operator=(topology_changed_event&&) = default;
+
+    topology_changed_event(const topology_changed_event&) = default;
+    topology_changed_event& operator=(const topology_changed_event&) = default;
+
     ///
     /// An opaque id, unique to this topology for this mongocxx::v_noabi::client or
     /// mongocxx::v_noabi::pool.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_closed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_closed_event.hpp
@@ -40,6 +40,12 @@ class topology_closed_event {
     ///
     ~topology_closed_event();
 
+    topology_closed_event(topology_closed_event&&) = default;
+    topology_closed_event& operator=(topology_closed_event&&) = default;
+
+    topology_closed_event(const topology_closed_event&) = default;
+    topology_closed_event& operator=(const topology_closed_event&) = default;
+
     ///
     /// An opaque id, unique to this topology for this mongocxx::v_noabi::client or
     /// mongocxx::v_noabi::pool.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description.hpp
@@ -119,6 +119,12 @@ class topology_description {
     ///
     ~topology_description();
 
+    topology_description(topology_description&&) = default;
+    topology_description& operator=(topology_description&&) = default;
+
+    topology_description(const topology_description&) = default;
+    topology_description& operator=(const topology_description&) = default;
+
     ///
     /// The topology type: "Unknown", "Sharded", "ReplicaSetNoPrimary", "ReplicaSetWithPrimary", or
     /// "Single".

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_opening_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_opening_event.hpp
@@ -40,6 +40,12 @@ class topology_opening_event {
     ///
     ~topology_opening_event();
 
+    topology_opening_event(topology_opening_event&&) = default;
+    topology_opening_event& operator=(topology_opening_event&&) = default;
+
+    topology_opening_event(const topology_opening_event&) = default;
+    topology_opening_event& operator=(const topology_opening_event&) = default;
+
     ///
     /// An opaque id, unique to this topology for this mongocxx::v_noabi::client or
     /// mongocxx::v_noabi::pool.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_model.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_model.hpp
@@ -53,7 +53,10 @@ class index_model {
     ///
     index_model(const index_model&);
 
-    index_model& operator=(const index_model&) = delete;
+    ///
+    /// Copy assigns an index_model.
+    ///
+    index_model& operator=(const index_model&) = default;
 
     ///
     /// Destroys an index_model.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view.hpp
@@ -42,6 +42,9 @@ class index_view {
 
     ~index_view();
 
+    index_view(const index_view&) = delete;
+    index_view& operator=(const index_view&) = delete;
+
     ///
     /// @{
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/instance.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/instance.hpp
@@ -107,6 +107,9 @@ class instance {
     ///
     ~instance();
 
+    instance(const instance&) = delete;
+    instance& operator=(const instance&) = delete;
+
     ///
     /// Returns the current unique instance of the driver. If an instance was explicitly created,
     /// that will be returned. If no instance has yet been created, a default instance will be

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline.hpp
@@ -60,6 +60,9 @@ class pipeline {
     ///
     ~pipeline();
 
+    pipeline(const pipeline&) = delete;
+    pipeline& operator=(const pipeline&) = delete;
+
     ///
     /// Adds new fields to documents.
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
@@ -67,6 +67,12 @@ class pool {
     ///
     ~pool();
 
+    pool(pool&&) = delete;
+    pool& operator=(pool&&) = delete;
+
+    pool(const pool&) = delete;
+    pool& operator=(const pool&) = delete;
+
     ///
     /// An entry is a handle on a @c client object acquired via the pool. Similar to
     /// std::unique_ptr.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_many.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_many.hpp
@@ -40,10 +40,12 @@ class insert_many {
 
     insert_many(result::bulk_write result, bsoncxx::v_noabi::array::value inserted_ids);
 
-    insert_many(const insert_many&);
-    insert_many(insert_many&&) = default;
+    ~insert_many() = default;
 
+    insert_many(const insert_many&);
     insert_many& operator=(const insert_many&);
+
+    insert_many(insert_many&&) = default;
     insert_many& operator=(insert_many&&) = default;
 
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
@@ -83,6 +83,9 @@ class uri {
     ///
     ~uri();
 
+    uri(const uri&) = delete;
+    uri& operator=(const uri&) = delete;
+
     ///
     /// Returns the authentication mechanism from the uri.
     ///

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client_encryption.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client_encryption.cpp
@@ -27,9 +27,9 @@ using mongocxx::libbson::scoped_bson_t;
 client_encryption::client_encryption(options::client_encryption opts)
     : _impl(stdx::make_unique<impl>(std::move(opts))) {}
 
-client_encryption::~client_encryption() noexcept = default;
-client_encryption::client_encryption(client_encryption&&) = default;
-client_encryption& client_encryption::operator=(client_encryption&&) = default;
+client_encryption::~client_encryption() = default;
+client_encryption::client_encryption(client_encryption&&) noexcept = default;
+client_encryption& client_encryption::operator=(client_encryption&&) noexcept = default;
 
 bsoncxx::v_noabi::types::bson_value::value client_encryption::create_data_key(
     std::string kms_provider, const options::data_key& opts) {

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/database.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/database.cpp
@@ -55,6 +55,12 @@ class collection_names {
         bson_strfreev(_names);
     }
 
+    collection_names(collection_names&&) noexcept = delete;
+    collection_names& operator=(collection_names&&) noexcept = delete;
+
+    collection_names(const collection_names&) = delete;
+    collection_names& operator=(const collection_names&) = delete;
+
     const char* operator[](const std::size_t i) const {
         return _names[i];
     };

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/instance.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/instance.cpp
@@ -126,6 +126,12 @@ class instance::impl {
 #endif
     }
 
+    impl(impl&&) noexcept = delete;
+    impl& operator=(impl&&) noexcept = delete;
+
+    impl(const impl&) = delete;
+    impl& operator=(const impl&) = delete;
+
     const std::unique_ptr<logger> _user_logger;
 };
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/private/transaction.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/private/transaction.hh
@@ -51,8 +51,10 @@ class transaction::impl {
         return *this;
     }
 
-    impl(impl&&) noexcept = default;
-    impl& operator=(impl&&) noexcept = default;
+    ~impl() = default;
+
+    impl(impl&&) = default;
+    impl& operator=(impl&&) = default;
 
     void read_concern(const mongocxx::v_noabi::read_concern& rc) {
         libmongoc::transaction_opts_set_read_concern(_transaction_opt_t.get(),

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/bulk_write.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/bulk_write.hh
@@ -30,6 +30,12 @@ class bulk_write::impl {
         libmongoc::bulk_operation_destroy(operation_t);
     }
 
+    impl(impl&&) = delete;
+    impl& operator=(impl&&) = delete;
+
+    impl(const impl&) = delete;
+    impl& operator=(const impl&) = delete;
+
     mongoc_bulk_operation_t* operation_t;
 };
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client.hh
@@ -33,6 +33,12 @@ class client::impl {
         libmongoc::client_destroy(client_t);
     }
 
+    impl(impl&&) = delete;
+    impl& operator=(impl&&) = delete;
+
+    impl(const impl&) = delete;
+    impl& operator=(const impl&) = delete;
+
     mongoc_client_t* client_t;
     std::list<bsoncxx::v_noabi::string::view_or_value> tls_options;
     options::apm listeners;

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/cursor.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/cursor.hh
@@ -43,6 +43,12 @@ class cursor::impl {
         libmongoc::cursor_destroy(cursor_t);
     }
 
+    impl(impl&&) = delete;
+    impl& operator=(impl&&) = delete;
+
+    impl(const impl&) = delete;
+    impl& operator=(const impl&) = delete;
+
     bool has_started() const {
         return status >= state::k_started;
     }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/index_view.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/index_view.hh
@@ -43,14 +43,6 @@ class index_view::impl {
     impl(mongoc_collection_t* collection, mongoc_client_t* client)
         : _coll{collection}, _client{client} {}
 
-    impl(const impl& i) = default;
-
-    impl(impl&& i) = default;
-
-    ~impl() = default;
-
-    impl& operator=(const impl& i) = default;
-
     std::string get_index_name_from_keys(bsoncxx::v_noabi::document::view_or_value keys) {
         libbson::scoped_bson_t keys_bson{keys};
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/pool.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/pool.hh
@@ -33,6 +33,12 @@ class pool::impl {
         libmongoc::client_pool_destroy(client_pool_t);
     }
 
+    impl(impl&&) = delete;
+    impl& operator=(impl&&) = delete;
+
+    impl(const impl&) = delete;
+    impl& operator=(const impl&) = delete;
+
     mongoc_client_pool_t* client_pool_t;
     std::list<bsoncxx::v_noabi::string::view_or_value> tls_options;
     options::apm listeners;

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/read_concern.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/read_concern.hh
@@ -30,6 +30,12 @@ class read_concern::impl {
         libmongoc::read_concern_destroy(read_concern_t);
     }
 
+    impl(impl&&) = delete;
+    impl& operator=(impl&&) = delete;
+
+    impl(const impl&) = delete;
+    impl& operator=(const impl&) = delete;
+
     ::mongoc_read_concern_t* read_concern_t;
 };
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/read_preference.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/read_preference.hh
@@ -30,6 +30,12 @@ class read_preference::impl {
         libmongoc::read_prefs_destroy(read_preference_t);
     }
 
+    impl(impl&&) = delete;
+    impl& operator=(impl&&) = delete;
+
+    impl(const impl&) = delete;
+    impl& operator=(const impl&) = delete;
+
     mongoc_read_prefs_t* read_preference_t;
 };
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/uri.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/uri.hh
@@ -28,6 +28,10 @@ class uri::impl {
     ~impl() {
         libmongoc::uri_destroy(uri_t);
     }
+    impl(impl&&) = delete;
+    impl& operator=(impl&&) = delete;
+    impl(const impl&) = delete;
+    impl& operator=(const impl&) = delete;
     mongoc_uri_t* uri_t;
 };
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/write_concern.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/write_concern.hh
@@ -30,6 +30,12 @@ class write_concern::impl {
         libmongoc::write_concern_destroy(write_concern_t);
     }
 
+    impl(impl&&) = delete;
+    impl& operator=(impl&&) = delete;
+
+    impl(const impl&) = delete;
+    impl& operator=(const impl&) = delete;
+
     mongoc_write_concern_t* write_concern_t;
 };
 


### PR DESCRIPTION
Resolves CXX-3043. Verified by [this patch](https://spruce.mongodb.com/version/665dfca13ef01a0007f9530f).

This PR _explicitly_ defaults or deletes special member functions (SMFs) which are currently _implicitly_ defaulted or deleted, in accordance with the Rule of All or Nothing. This addresses multiple Coverity issues as well as a few `-Wdeprecated-copy-with-*` Clang warnings (depending on implicit default of copy SMFs given a user-declared dtor, copy ctor, or copy assign op).

This PR should NOT change either the API or the ABI. This PR should NOT change the behavior at either compile-time or runtime, with exactly one exception: `index_model`'s explicitly deleted copy assignment operator is now defaulted. It is unclear why this function was deleted when all other SMFs are (out-of-line) defaulted. This change is not expected to break user code.

Some additional notes worth mentioning:

- `= default` within class definition does not require `(BSONCXX|MONGOCXX)_INLINE` per `VISIBILITY_INLINES_HIDDEN=ON`, as class member functions defined within the class definition are implicitly `inline` (even with `= default`), so all instances of such redundant inline macro usage are removed for consistency.
- The quoted bug with [inline dtor default definition behavior for VS2015](https://github.com/mongodb/mongo-cxx-driver/commit/025ebb2df0a8c8ee2e100dce55a78aae7b4481b4) in `concatenate.hpp` is no longer an issue (AFAICT).
- Removed redundant explicit `noexcept` for defaulted/deleted SMFs. This is only applicable to SFMs that are defaulted _on first declaration_, thus SMFs defaulted out-of-line still require explicit `noexcept`.
- Deleted SMFs that are unnecessary/unused internally (i.e. impl classes).
- Inconsistencies in inline vs. out-of-line SMF defaults are expected to be resolved in the near future via v1 namespace interfaces. This PR favors avoiding the introduction of new ABI symbols; if consistency is preferred, new (explicitly defaulted) SMFs can be defined out-of-line instead (this can also be done in a followup PR).