### PR TITLE
CXX-3043 Address additional Ro3/Ro5 violations

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
@@ -39,20 +39,28 @@ class array : public sub_array {
     ///
     /// Default constructor
     ///
-    BSONCXX_INLINE array() : sub_array(&_core), _core(true) {}
+    array() : sub_array(&_core), _core(true) {}
+
+    ///
+    /// Destructor
+    ///
+    ~array() = default;
 
     ///
     /// Move constructor
     ///
-    BSONCXX_INLINE array(array&& arr) noexcept : sub_array(&_core), _core(std::move(arr._core)) {}
+    array(array&& arr) noexcept : sub_array(&_core), _core(std::move(arr._core)) {}
 
     ///
     /// Move assignment operator
     ///
-    BSONCXX_INLINE array& operator=(array&& arr) noexcept {
+    array& operator=(array&& arr) noexcept {
         _core = std::move(arr._core);
         return *this;
     }
+
+    array(const array&) = delete;
+    array& operator=(const array&) = delete;
 
     ///
     /// @return A view of the BSON array.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
@@ -75,6 +75,8 @@ class value {
     ///
     explicit value(document::view view);
 
+    ~value() = default;
+
     value(const value&);
     value& operator=(const value&);
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/index_view.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/index_view.hh
@@ -274,8 +274,15 @@ class index_view::impl {
             mongoc_server_description_destroy(sd);
         }
 
-        scoped_server_description(scoped_server_description&&) = delete;
-        scoped_server_description& operator=(scoped_server_description&&) = delete;
+        scoped_server_description(scoped_server_description&& other) : sd(other.sd) {
+            other.sd = nullptr;
+        }
+
+        scoped_server_description& operator=(scoped_server_description&& other) {
+            sd = other.sd;
+            other.sd = nullptr;
+            return *this;
+        }
 
         scoped_server_description(const scoped_server_description&) = delete;
         scoped_server_description& operator=(const scoped_server_description&) = delete;

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/index_view.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/index_view.hh
@@ -269,9 +269,17 @@ class index_view::impl {
     class scoped_server_description {
        public:
         explicit scoped_server_description(mongoc_server_description_t* sd) : sd(sd) {}
+
         ~scoped_server_description() {
             mongoc_server_description_destroy(sd);
         }
+
+        scoped_server_description(scoped_server_description&&) = delete;
+        scoped_server_description& operator=(scoped_server_description&&) = delete;
+
+        scoped_server_description(const scoped_server_description&) = delete;
+        scoped_server_description& operator=(const scoped_server_description&) = delete;
+
         mongoc_server_description_t* sd;
     };
 };


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1142 which addresses a few more instances of Ro3/Ro5 violations which were missed in the prior PR.