### PR TITLE
CXX-3008 Add post-release instructions for Silk, Snyk, and patch release tags

### DIFF
--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -318,7 +318,7 @@ The new branch should be continuously tested on Evergreen. Update the "Display N
 
 After creating the new minor release branch in the prior step, update Silk and Snyk to trach the new release branch.
 
-For Silk, see the [silk-create-asset-group.sh script](https://github.com/mongodb/libmongocrypt/blob/master/etc/silk-create-asset-group.sh) in the C Driver as reference for the commands to run against the Silk API. Use `mongo-cxx-driver` as the name and prefix in place of `mongo-c-driver` accordingly.
+For Silk, use the [create-silk-asset-group.py script](https://github.com/mongodb/mongo-c-driver/blob/master/tools/create-silk-asset-group.py) in the C Driver to create a new Silk asset group. Use `mongo-cxx-driver` as the name and prefix in place of `mongo-c-driver` accordingly.
 
 For Snyk, configure and build the CXX Driver with `BSONCXX_POLY_USE_MNMLSTC=ON` (force download of mnmlstc/core sources) and no `CMAKE_PREFIX_PATH` entry to a C Driver installation (force download of C Driver sources), then run:
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -75,7 +75,7 @@ podman pull artifactory.corp.mongodb.com/release-tools-container-registry-public
 
 # Output: "... writing sbom to file"
 podman run \
-  --env-file "$HOME/.secrets/silk-creds.txt"
+  --env-file "$HOME/.secrets/silk-creds.txt" \
   -it --rm -v "$(pwd):/pwd" \
   artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0 \
   download --silk-asset-group "mongo-cxx-driver" -o "/pwd/etc/augmented.sbom.json"

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -46,11 +46,7 @@ podman pull artifactory.corp.mongodb.com/release-tools-container-registry-public
 
 # Output: "... writing sbom to file"
 podman run \
-  --env-file <(
-    printf "%s\n" \
-      "SILK_CLIENT_ID=${SILK_CLIENT_ID:?}" \
-      "SILK_CLIENT_SECRET=${SILK_CLIENT_SECRET:?}"
-  ) \
+  --env-file "$HOME/.secrets/silk-creds.txt" \
   -it --rm -v "$(pwd):/pwd" \
   artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0 \
   update -p "/pwd/etc/purls.txt" -i "/pwd/etc/cyclonedx.sbom.json" -o "/pwd/etc/cyclonedx.sbom.json"
@@ -79,11 +75,7 @@ podman pull artifactory.corp.mongodb.com/release-tools-container-registry-public
 
 # Output: "... writing sbom to file"
 podman run \
-  --env-file <(
-    printf "%s\n" \
-      "SILK_CLIENT_ID=${SILK_CLIENT_ID:?}" \
-      "SILK_CLIENT_SECRET=${SILK_CLIENT_SECRET:?}"
-  ) \
+  --env-file "$HOME/.secrets/silk-creds.txt"
   -it --rm -v "$(pwd):/pwd" \
   artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0 \
   download --silk-asset-group "mongo-cxx-driver" -o "/pwd/etc/augmented.sbom.json"
@@ -229,6 +221,11 @@ The following credentials are required. Ask for these from a team member if nece
   ```bash
   GRS_CONFIG_USER1_USERNAME=<username>
   GRS_CONFIG_USER1_PASSWORD=<password>
+  ```
+- Silk credentials. Save these to `~/.secrets/silk-creds.txt`:
+  ```bash
+  SILK_CLIENT_ID=<client_id>
+  SILK_CLIENT_SECRET=<client_secret>
   ```
 - Snyk credentials. Save these to `~/.secrets/snyk-creds.txt`:
   ```bash

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -320,7 +320,7 @@ After creating the new minor release branch in the prior step, update Silk and S
 
 For Silk, see the [silk-create-asset-group.sh script](https://github.com/mongodb/libmongocrypt/blob/master/etc/silk-create-asset-group.sh) in the C Driver as reference for the commands to run against the Silk API. Use `mongo-cxx-driver` as the name and prefix in place of `mongo-c-driver` accordingly.
 
-For Snyk, configure and build the CXX Driver with `BSONCXX_POLY_USE_MNMLSTC=ON` (force download of mnmlstc/core sources) and `CMAKE_PREFIX_PATH=""` (force download of C Driver sources), then run:
+For Snyk, configure and build the CXX Driver with `BSONCXX_POLY_USE_MNMLSTC=ON` (force download of mnmlstc/core sources) and no `CMAKE_PREFIX_PATH` entry to a C Driver installation (force download of C Driver sources), then run:
 
 ```bash
 # Snyk credentials. Ask for these from a team member.
@@ -401,6 +401,17 @@ pushed.
    - Switch back to the branch with documentation updates: `git checkout post-release-changes`.
 - Wait a few minutes and verify mongocxx.org has updated.
 
+## Merge the release branch back into `master` if necessary
+
+If this is a patch release on a minor release branch, create a pull request on GitHub to merge the latest state of the `releases/rX.Y` branch containing the new release tag `rX.Y.Z` into the `master` branch. Use the "Create a merge commit" option when merging this pull request.
+
+> [IMPORTANT]
+> Use the "Create a merge commit" option when merging this pull request!
+
+Do **NOT** delete the release branch after merge.
+
+Verify correct repo state by running `git describe --tags --abbrev=0` on the post-merge `master` branch, which should return the patch release tag `rX.Y.Z`. Adding the `--first-parent` flag should return the last minor release tag `rX.Y.0`.
+
 ## Update CHANGELOG.md post-release ...
 
 CHANGELOG.md on the `master` branch contains sections for every release. This is intended to ease searching for changes among all releases.
@@ -446,7 +457,9 @@ Ensure there are `[Unreleased]` sections for the next minor and patch releases. 
 <!-- Contains published release notes -->
 ```
 
-Commit the change. Create a PR from the `post-release-changes` branch to merge to `master`.
+Commit the change.
+
+Create a PR from the `post-release-changes` branch to merge to `master`.
 
 ## Homebrew
 This requires a macOS machine.


### PR DESCRIPTION
Adds additional steps following creation of a new release branch `releases/vX.Y` to ensure Silk and Snyk are aware of, and continue analyzing, the release branch.

Silk commands defer to scripts in the C Driver introduced by https://github.com/mongodb/mongo-c-driver/pull/1619 to minimize redundancy. The CXX Driver will ideally adopt and reuse the same scripts as those used by libmongocrypt and the C Driver.

Snyk commands use the changes proposed in https://github.com/mongodb/libmongocrypt/pull/820 as reference. Note: Snyk does not appear to be able to detect the mnmlstc/core library despite `--detection-depth`, so a [Snyk support ticket](https://support.snyk.io/hc/en-us/requests/new) may be necessary.

Additionally, a new "merge back into `master`" branch is added to release instructions to ensure patch release tags are reachable from the latest commit in `master`. This enables support for accurate `git describe --tags` results as is used by Coverity nightly snapshot labels, abi-compliance-checker HTML compatibility reports, and eventually the `calc_release_version.py` script (significant simplifications incoming). This step is not expected to affect the current implementation of `calc_release_version.py`: it should continue to return the correct latest tag as intended.