### PR TITLE
Add etc/ssdlc_compliance_report.md (CXX-3013, CXX-3024, and CXX-3039)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ else()
 endif()
 
 if(NEED_DOWNLOAD_C_DRIVER)
-    message(STATUS "No Mongo C Driver path provided via CMAKE_PREFIX_PATH, will download C driver version ${LIBMONGOC_DOWNLOAD_VERSION} from the internet.")
+    message(STATUS "No MongoDB C Driver path provided via CMAKE_PREFIX_PATH, will download C driver version ${LIBMONGOC_DOWNLOAD_VERSION} from the internet.")
     include(FetchMongoC)
 endif()
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -6,7 +6,7 @@ type = "index"
 
 # MongoDB C++ Driver
 
-This is the legacy site for the Mongo C++ Driver documentation. See the new
+This is the legacy site for the MongoDB C++ Driver documentation. See the new
 [MongoDB C++ Driver
 documentation](https://www.mongodb.com/docs/languages/cpp/).
 

--- a/docs/content/legacy-v1/configuration.md
+++ b/docs/content/legacy-v1/configuration.md
@@ -84,7 +84,7 @@ configure them at the call site:
 using mongo::client::initialize;
 using mongo::client::Options;
 
-// Configure the mongo C++ client driver, enabling SSL and setting
+// Configure the MongoDB C++ Driver, enabling SSL and setting
 // the SSL Certificate Authority file to "mycafile".
 Status status = initialize(
     Options().setSSLMode(Options::kSSLRequired).setSSLCAFile("mycafile")

--- a/etc/generate-uninstall.cmd
+++ b/etc/generate-uninstall.cmd
@@ -45,7 +45,7 @@ set prefix=%prefix:"=%
 
 echo.@echo off
 echo.
-echo.REM Mongo C++ Driver uninstall program, generated with CMake
+echo.REM MongoDB C++ Driver uninstall program, generated with CMake
 echo.
 echo.REM Copyright 2018-present MongoDB, Inc.
 echo.REM

--- a/etc/generate-uninstall.sh
+++ b/etc/generate-uninstall.sh
@@ -61,7 +61,7 @@ fi
 
 
 printf "#!/bin/sh\n"
-printf "# MongoDB C Driver uninstall program, generated with CMake"
+printf "# MongoDB C++ Driver uninstall program, generated with CMake"
 printf "\n"
 printf "# Copyright 2018-present MongoDB, Inc.\n"
 printf "#\n"

--- a/etc/generate-uninstall.sh
+++ b/etc/generate-uninstall.sh
@@ -61,7 +61,7 @@ fi
 
 
 printf "#!/bin/sh\n"
-printf "# Mongo C Driver uninstall program, generated with CMake"
+printf "# MongoDB C Driver uninstall program, generated with CMake"
 printf "\n"
 printf "# Copyright 2018-present MongoDB, Inc.\n"
 printf "#\n"
@@ -110,4 +110,3 @@ printf "(rmdir \"%s\" 2>/dev/null && printf \"\\\n\") || printf \" ... not remov
 printf "\n"
 printf "# Return to the directory from which the program was called\n"
 printf "cd \${save_pwd}\n"
-

--- a/etc/ssdlc_compliance_report.md
+++ b/etc/ssdlc_compliance_report.md
@@ -1,0 +1,40 @@
+# Mongo C++ Driver SSDLC Compliance Report
+
+## Release Creator
+
+- See [C/CXX Release Info](https://docs.google.com/spreadsheets/d/1yHfGmDnbA5-Qt8FX4tKWC5xk9AhzYZx1SKF4AD36ecY/edit?usp=sharing).
+
+## Process Document
+
+- See [go/how-we-develop-software-doc](http://go/how-we-develop-software-doc).
+
+## Tool used to track third party vulnerabilities
+
+- See [Silk](https://us1.app.silk.security/inventory/asset-group/mongodb____DedupedAssetGroup____60640b8853771efe3af5f78ea37af5d1cdd190df).
+- See [C++ Driver - SSDLC Reports](https://drive.google.com/drive/folders/1q9RI55trFzHlh8McALSIAbT6ugyn8zlO) for release-specific reports.
+
+## Third-Party Dependency Information
+
+- See [etc/augmented.sbom.json](https://github.com/mongodb/mongo-cxx-driver/blob/master/etc/augmented.sbom.json) within the release tarball.
+- See [etc/third_party_vulnerabilities.md](https://github.com/mongodb/mongo-cxx-driver/blob/master/etc/third_party_vulnerabilities.md) within the release tarball.
+- See [C++ Driver - SSDLC Reports](https://drive.google.com/drive/folders/1q9RI55trFzHlh8McALSIAbT6ugyn8zlO) for release-specific reports.
+
+## Static Analysis Findings
+
+- See [C++ Driver - SSDLC Reports](https://drive.google.com/drive/folders/1q9RI55trFzHlh8McALSIAbT6ugyn8zlO) for release-specific reports.
+
+## Security Testing Report
+
+- See [Driver Security Testing Summary](https://docs.google.com/document/d/1y2K_RY4GZVXpQvv4JH_35mSzFRTawNJ3mibpvSBU8H0/edit?usp=sharing). Available upon request for approved partners (contact Rishabh Bisht \<rishabh.bisht@mongodb.com\>).
+
+## Security Assessment Report
+
+- Available upon request for approved partners (contact Rishabh Bisht \<rishabh.bisht@mongodb.com\>).
+
+## Signature Information
+
+- The source tarball for each release is accompanied by a detached GPG digital signature which may be verified against the `cpp-driver` public key available at https://pgp.mongodb.com/.
+
+## Known Vulnerabilities
+
+- Any vulnerabilities that may be shown in the links referenced above have been reviewed and accepted by the appropriate approvers. For detailed information, [C++ Driver - SSDLC Reports](https://drive.google.com/drive/folders/1q9RI55trFzHlh8McALSIAbT6ugyn8zlO) for release-specific reports.

--- a/etc/ssdlc_compliance_report.md
+++ b/etc/ssdlc_compliance_report.md
@@ -10,7 +10,7 @@
 
 ## Tool used to track third party vulnerabilities
 
-- See [Silk](https://us1.app.silk.security/inventory/asset-group/mongodb____DedupedAssetGroup____60640b8853771efe3af5f78ea37af5d1cdd190df).
+- See [Silk](https://us1.app.silk.security/inventory/asset-group/mongodb____DedupedAssetGroup____60640b8853771efe3af5f78ea37af5d1cdd190df) (internal).
 - See [C++ Driver - SSDLC Reports](https://drive.google.com/drive/folders/1q9RI55trFzHlh8McALSIAbT6ugyn8zlO) for release-specific reports.
 
 ## Third-Party Dependency Information
@@ -25,7 +25,7 @@
 
 ## Security Testing Report
 
-- See [Driver Security Testing Summary](https://docs.google.com/document/d/1y2K_RY4GZVXpQvv4JH_35mSzFRTawNJ3mibpvSBU8H0/edit?usp=sharing). Available upon request for approved partners (contact Rishabh Bisht \<rishabh.bisht@mongodb.com\>).
+- See [Driver Security Testing Summary](https://docs.google.com/document/d/1y2K_RY4GZVXpQvv4JH_35mSzFRTawNJ3mibpvSBU8H0/edit?usp=sharing) (internal). Available as needed from the MongoDB C++ Driver team.
 
 ## Security Assessment Report
 
@@ -37,4 +37,4 @@
 
 ## Known Vulnerabilities
 
-- Any vulnerabilities that may be shown in the links referenced above have been reviewed and accepted by the appropriate approvers. For detailed information, [C++ Driver - SSDLC Reports](https://drive.google.com/drive/folders/1q9RI55trFzHlh8McALSIAbT6ugyn8zlO) for release-specific reports.
+- Any vulnerabilities that may be shown in the links referenced above have been reviewed and accepted by the appropriate approvers. For detailed information, see [C++ Driver - SSDLC Reports](https://drive.google.com/drive/folders/1q9RI55trFzHlh8McALSIAbT6ugyn8zlO) for release-specific reports.

--- a/etc/ssdlc_compliance_report.md
+++ b/etc/ssdlc_compliance_report.md
@@ -1,4 +1,4 @@
-# Mongo C++ Driver SSDLC Compliance Report
+# MongoDB C++ Driver SSDLC Compliance Report
 
 ## Release Creator
 

--- a/etc/ssdlc_compliance_report.md
+++ b/etc/ssdlc_compliance_report.md
@@ -6,7 +6,7 @@
 
 ## Process Document
 
-- See [go/how-we-develop-software-doc](http://go/how-we-develop-software-doc).
+- Not available. <!-- CXX-3007: replace with link to public-facing document once available. -->
 
 ## Tool used to track third party vulnerabilities
 
@@ -29,7 +29,7 @@
 
 ## Security Assessment Report
 
-- Available upon request for approved partners (contact Rishabh Bisht \<rishabh.bisht@mongodb.com\>).
+- Not applicable to the MongoDB C++ Driver.
 
 ## Signature Information
 


### PR DESCRIPTION
Resolves CXX-3013, CXX-3024, and CXX-3039.

This PR adapts the [Markdown template](https://gist.github.com/rtimmons/8253d1dfcc5f233bdb2d9c73b8e5c129#file-minimal-md) for the SSDLC Compliance Report to be included with each release.

Contents are deliberately written in such a way to avoid requiring per-release modifications. Instead, the individually linked documents, release artifacts, and reports are expected to be updated per release (and throughout ongoing development) as described by the updated release instructions.

Note: we will likely want to adopt Papertrail (CXX-3011) to satisfy the Authorized Publication reporting requirements (CXX-3024). A link to an appropriate Papertrail webpage will then replace the currently-proposed link to the C/C++ Release Info spreadsheet.