### PR TITLE
CXX-2742 Consider addition of empty() to mongocxx::bulk_write

### DIFF
--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write.hpp
@@ -58,6 +58,8 @@ class bulk_write {
     ///
     ~bulk_write();
 
+    bool empty();
+
     ///
     /// Appends a single write to the bulk write operation. The write operation's contents are
     /// copied into the bulk operation completely, so there is no dependency between the life of an
@@ -104,6 +106,8 @@ class bulk_write {
 
     bool _created_from_collection;
     std::unique_ptr<impl> _impl;
+
+    bool is_empty = true;
 };
 
 }  // namespace v_noabi

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write.hpp
@@ -61,9 +61,9 @@ class bulk_write {
     ///
     /// Checks if a bulk write operation is empty.
     ///
-    /// @return A boolean that returns true if the bulk write operation is empty.
+    /// @return A boolean indicating if the bulk write operation is empty.
     ///
-    bool empty();
+    bool empty() const noexcept;
 
     ///
     /// Appends a single write to the bulk write operation. The write operation's contents are

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write.hpp
@@ -58,6 +58,11 @@ class bulk_write {
     ///
     ~bulk_write();
 
+    ///
+    /// Checks if a bulk write operation is empty.
+    ///
+    /// @return A boolean that returns true if the bulk write operation is empty.
+    ///
     bool empty();
 
     ///

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/bulk_write.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/bulk_write.cpp
@@ -40,6 +40,10 @@ bulk_write& bulk_write::operator=(bulk_write&&) noexcept = default;
 
 bulk_write::~bulk_write() = default;
 
+bool bulk_write::empty() {
+    return is_empty;
+}
+
 bulk_write& bulk_write::append(const model::write& operation) {
     switch (operation.type()) {
         case write_type::k_insert_one: {
@@ -171,6 +175,8 @@ bulk_write& bulk_write::append(const model::write& operation) {
             break;
         }
     }
+
+    is_empty = false;
 
     return *this;
 }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/bulk_write.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/bulk_write.cpp
@@ -40,7 +40,7 @@ bulk_write& bulk_write::operator=(bulk_write&&) noexcept = default;
 
 bulk_write::~bulk_write() = default;
 
-bool bulk_write::empty() {
+bool bulk_write::empty() const noexcept {
     return is_empty;
 }
 

--- a/src/mongocxx/test/bulk_write.cpp
+++ b/src/mongocxx/test/bulk_write.cpp
@@ -358,7 +358,7 @@ TEST_CASE("calling empty on a bulk write before and after appending", "[bulk_wri
     auto bw = client["db"]["coll"].create_bulk_write();
 
     REQUIRE(bw.empty());
-    bw.append(model::insert_one(make_document(kvp("id", 1))));
+    bw.append(model::insert_one(make_document(kvp("_id", 1))));
     bw.execute();
     REQUIRE_FALSE(bw.empty());
 }

--- a/src/mongocxx/test/bulk_write.cpp
+++ b/src/mongocxx/test/bulk_write.cpp
@@ -351,4 +351,15 @@ TEST_CASE("passing write operations to append calls corresponding C function", "
         REQUIRE(called);
     }
 }
+
+TEST_CASE("calling empty on a bulk write before and after appending", "[bulk_write]") {
+    instance::current();
+    mongocxx::client client{mongocxx::uri{}};
+    auto bw = client["db"]["coll"].create_bulk_write();
+
+    REQUIRE(bw.empty());
+    bw.append(model::insert_one(make_document(kvp("id",1))));
+    bw.execute();
+    REQUIRE_FALSE(bw.empty());
+}
 }  // namespace

--- a/src/mongocxx/test/bulk_write.cpp
+++ b/src/mongocxx/test/bulk_write.cpp
@@ -19,8 +19,8 @@
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/private/libmongoc.hh>
-#include <mongocxx/write_concern.hpp>
 #include <mongocxx/test/client_helpers.hh>
+#include <mongocxx/write_concern.hpp>
 
 namespace {
 using namespace mongocxx;

--- a/src/mongocxx/test/bulk_write.cpp
+++ b/src/mongocxx/test/bulk_write.cpp
@@ -20,6 +20,7 @@
 #include <mongocxx/instance.hpp>
 #include <mongocxx/private/libmongoc.hh>
 #include <mongocxx/write_concern.hpp>
+#include <mongocxx/test/client_helpers.hh>
 
 namespace {
 using namespace mongocxx;
@@ -354,7 +355,7 @@ TEST_CASE("passing write operations to append calls corresponding C function", "
 
 TEST_CASE("calling empty on a bulk write before and after appending", "[bulk_write]") {
     instance::current();
-    mongocxx::client client{mongocxx::uri{}};
+    mongocxx::client client{mongocxx::uri{}, test_util::add_test_server_api()};
     auto bw = client["db"]["coll"].create_bulk_write();
 
     REQUIRE(bw.empty());

--- a/src/mongocxx/test/bulk_write.cpp
+++ b/src/mongocxx/test/bulk_write.cpp
@@ -360,6 +360,7 @@ TEST_CASE("calling empty on a bulk write before and after appending", "[bulk_wri
 
     REQUIRE(bw.empty());
     bw.append(model::insert_one(make_document(kvp("_id", 1))));
+    REQUIRE_FALSE(bw.empty());
     bw.execute();
     REQUIRE_FALSE(bw.empty());
 }

--- a/src/mongocxx/test/bulk_write.cpp
+++ b/src/mongocxx/test/bulk_write.cpp
@@ -358,7 +358,7 @@ TEST_CASE("calling empty on a bulk write before and after appending", "[bulk_wri
     auto bw = client["db"]["coll"].create_bulk_write();
 
     REQUIRE(bw.empty());
-    bw.append(model::insert_one(make_document(kvp("id",1))));
+    bw.append(model::insert_one(make_document(kvp("id", 1))));
     bw.execute();
     REQUIRE_FALSE(bw.empty());
 }


### PR DESCRIPTION
[CXX-2742](https://jira.mongodb.org/browse/CXX-2742)
Consider addition of empty() to mongocxx::bulk_write 

[evergreen](https://spruce.mongodb.com/version/6671b7c166038200070e2eef/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

Added empty() to mongocxx::bulk_write and added a test for this call.