### PR TITLE
CXX-1843: Provide a cleaner API for working with pool entries

### DIFF
--- a/examples/mongocxx/pool.cpp
+++ b/examples/mongocxx/pool.cpp
@@ -45,14 +45,14 @@ int main() {
         auto run = [&](std::int64_t j) {
             // Each client and collection can only be used in a single thread.
             auto client = pool.acquire();
-            auto coll = (*client)["test"][collection_names[static_cast<std::size_t>(j)]];
+            auto coll = client["test"][collection_names[static_cast<std::size_t>(j)]];
             coll.delete_many({});
 
             bsoncxx::types::b_int64 index = {j};
             coll.insert_one(bsoncxx::builder::basic::make_document(kvp("x", index)));
 
             if (auto doc =
-                    (*client)["test"][collection_names[static_cast<std::size_t>(j)]].find_one({})) {
+                    client["test"][collection_names[static_cast<std::size_t>(j)]].find_one({})) {
                 // In order to ensure that the newline is printed immediately after the document,
                 // they need to be streamed to std::cout as a single string.
                 std::stringstream ss;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
@@ -17,11 +17,12 @@
 #include <functional>
 #include <memory>
 
-#include <mongocxx/client-fwd.hpp>
 #include <mongocxx/options/auto_encryption-fwd.hpp>
 #include <mongocxx/pool-fwd.hpp>
 
 #include <bsoncxx/stdx/optional.hpp>
+#include <mongocxx/client.hpp>
+#include <mongocxx/database.hpp>
 #include <mongocxx/options/pool.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/uri.hpp>
@@ -96,8 +97,10 @@ class pool {
         /// Return true if this entry has a client acquired from the pool.
         explicit operator bool() const noexcept;
 
-        // Allows the pool_entry["db_name"] syntax to be used to access a database within the entry's underlying client.
-        mongocxx::v_noabi::database operator[](bsoncxx::v_noabi::string::view_or_value name) const&;
+        // Allows the pool_entry["db_name"] syntax to be used to access a database within the
+        // entry's underlying client.
+        MONGOCXX_INLINE mongocxx::v_noabi::database operator[](
+            bsoncxx::v_noabi::string::view_or_value name) const&;
         mongocxx::v_noabi::database operator[](bsoncxx::v_noabi::string::view_or_value name) && =
             delete;
 
@@ -131,6 +134,11 @@ class pool {
     class MONGOCXX_PRIVATE impl;
     const std::unique_ptr<impl> _impl;
 };
+
+MONGOCXX_INLINE mongocxx::v_noabi::database pool::entry::operator[](
+    bsoncxx::v_noabi::string::view_or_value name) const& {
+    return (**this)[name];
+}
 
 }  // namespace v_noabi
 }  // namespace mongocxx

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
@@ -98,8 +98,9 @@ class pool {
 
         // Obtains database with speified name in the entry's underlying client.
         // A database cannot be obtained from a temporary client object
-        mongocxx::v_noabi::database operator[] (bsoncxx::v_noabi::string::view_or_value name) const&;
-        mongocxx::v_noabi::database operator[] (bsoncxx::v_noabi::string::view_or_value name) && = delete;
+        mongocxx::v_noabi::database operator[](bsoncxx::v_noabi::string::view_or_value name) const&;
+        mongocxx::v_noabi::database operator[](bsoncxx::v_noabi::string::view_or_value name) && =
+            delete;
 
        private:
         friend ::mongocxx::v_noabi::pool;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
@@ -96,6 +96,11 @@ class pool {
         /// Return true if this entry has a client acquired from the pool.
         explicit operator bool() const noexcept;
 
+        // Obtains database with speified name in the entry's underlying client.
+        // A database cannot be obtained from a temporary client object
+        mongocxx::v_noabi::database operator[] (bsoncxx::v_noabi::string::view_or_value name) const&;
+        mongocxx::v_noabi::database operator[] (bsoncxx::v_noabi::string::view_or_value name) && = delete;
+
        private:
         friend ::mongocxx::v_noabi::pool;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
@@ -96,8 +96,7 @@ class pool {
         /// Return true if this entry has a client acquired from the pool.
         explicit operator bool() const noexcept;
 
-        // Obtains database with speified name in the entry's underlying client.
-        // A database cannot be obtained from a temporary client object
+        // Allows the pool_entry["db_name"] syntax to be used to access a database within the entry's underlying client.
         mongocxx::v_noabi::database operator[](bsoncxx::v_noabi::string::view_or_value name) const&;
         mongocxx::v_noabi::database operator[](bsoncxx::v_noabi::string::view_or_value name) && =
             delete;

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
@@ -127,11 +127,6 @@ pool::entry::operator bool() const noexcept {
     return static_cast<bool>(_client);
 }
 
-mongocxx::v_noabi::database pool::entry::operator[](
-    bsoncxx::v_noabi::string::view_or_value name) const& {
-    return (**this)[name];
-}
-
 // construct a pool entry from a pointer to a client
 pool::entry::entry(pool::entry::unique_client p) : _client(std::move(p)) {}
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
@@ -127,6 +127,11 @@ pool::entry::operator bool() const noexcept {
     return static_cast<bool>(_client);
 }
 
+mongocxx::v_noabi::database pool::entry::operator[] (bsoncxx::v_noabi::string::view_or_value name) const&
+{
+    return (**this)[name];
+}
+
 // construct a pool entry from a pointer to a client
 pool::entry::entry(pool::entry::unique_client p) : _client(std::move(p)) {}
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
@@ -127,8 +127,8 @@ pool::entry::operator bool() const noexcept {
     return static_cast<bool>(_client);
 }
 
-mongocxx::v_noabi::database pool::entry::operator[] (bsoncxx::v_noabi::string::view_or_value name) const&
-{
+mongocxx::v_noabi::database pool::entry::operator[](
+    bsoncxx::v_noabi::string::view_or_value name) const& {
     return (**this)[name];
 }
 

--- a/src/mongocxx/test/pool.cpp
+++ b/src/mongocxx/test/pool.cpp
@@ -143,7 +143,14 @@ TEST_CASE("calling acquire on a pool returns an entry that manages its client", 
         client = nullptr;
         REQUIRE(push_called);
     }
-}
+
+    SECTION("[ ] overload can be used to directly access a database from underlying client") {
+        pool p{};
+        auto client = p.acquire();
+        database db = client["mydb"];
+        REQUIRE(db.name() == stdx::string_view{"mydb"});
+    }
+} 
 
 TEST_CASE("try_acquire returns an engaged stdx::optional<entry>", "[pool]") {
     instance::current();

--- a/src/mongocxx/test/pool.cpp
+++ b/src/mongocxx/test/pool.cpp
@@ -150,7 +150,7 @@ TEST_CASE("calling acquire on a pool returns an entry that manages its client", 
         database db = client["mydb"];
         REQUIRE(db.name() == stdx::string_view{"mydb"});
     }
-} 
+}
 
 TEST_CASE("try_acquire returns an engaged stdx::optional<entry>", "[pool]") {
     instance::current();


### PR DESCRIPTION
Overload operator[] for obtaining the underlying database of a pool entry.