### PR TITLE
CXX-3008 fix jq command and update SilkBomb before download

### DIFF
--- a/etc/augmented.sbom.json
+++ b/etc/augmented.sbom.json
@@ -62,7 +62,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2024-06-06T18:10:31.789025+00:00",
+    "timestamp": "2024-06-05T21:16:58.419485+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -109,5 +109,6 @@
   "version": 1,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
-  "specVersion": "1.5"
+  "specVersion": "1.5",
+  "vulnerabilities": []
 }


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1143. An unrelated error in the r3.10 project on EVG revealed failing jq commands were not correctly exiting the script.

Fixing the script revealed a significant change in the Augmented SBOM (empty vulnerabilities field).