### PR TITLE
CXX-3008 replace invalid multiple Bash herestrings with output files

### DIFF
--- a/.evergreen/check-augmented-sbom.sh
+++ b/.evergreen/check-augmented-sbom.sh
@@ -46,16 +46,6 @@ echo "Comparing Augmented SBOM..."
 jq -S '.' ./etc/augmented.sbom.json >|old.json
 jq -S '.' ./etc/augmented.sbom.json.new >|new.json
 
-[[ -f old.json ]] || {
-  echo "missing old.json" 1>&2
-  exit 1
-}
-
-[[ -f new.json ]] || {
-  echo "missing new.json" 1>&2
-  exit 1
-}
-
 # Allow task to upload the augmented SBOM despite failed diff.
 if ! diff -sty --left-column -W 200 old.json new.json >|diff.txt; then
   declare status

--- a/.evergreen/check-augmented-sbom.sh
+++ b/.evergreen/check-augmented-sbom.sh
@@ -43,11 +43,21 @@ podman run \
 
 echo "Comparing Augmented SBOM..."
 
-old_json="$(jq -S '.' ./etc/augmented.sbom.json)"
-new_json="$(jq -S '.' ./etc/augmented.sbom.json.new)"
+jq -S '.' ./etc/augmented.sbom.json >|old.json
+jq -S '.' ./etc/augmented.sbom.json.new >|new.json
+
+[[ -f old.json ]] || {
+  echo "missing old.json" 1>&2
+  exit 1
+}
+
+[[ -f new.json ]] || {
+  echo "missing new.json" 1>&2
+  exit 1
+}
 
 # Allow task to upload the augmented SBOM despite failed diff.
-if ! diff -sty --left-column -W 200 <<<"${old_json:?}" <<<"${new_json:?}" >|diff.txt; then
+if ! diff -sty --left-column -W 200 old.json new.json >|diff.txt; then
   declare status
   status='{"status":"failed", "type":"test", "should_continue":true, "desc":"detected significant changes in Augmented SBOM"}'
   curl -sS -d "${status:?}" -H "Content-Type: application/json" -X POST localhost:2285/task_status || true


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1154. Sorry, I fell for the multiple herestring trap again (which is not supported by Bash). 🤦

This PR falls back to the old tried-and-true output file method instead of using procsubs and herestrings. Verified (properly) by [this patch](https://spruce.mongodb.com/task/mongo_cxx_driver_silk_silk_check_augmented_sbom_patch_7ddaa1b1405fefa85305fef6f1fb45e35913d6d0_6679999cb23a430007957549_24_06_24_16_06_53/logs?execution=0).