### PR TITLE
Refine and update release instructions post 3.10.2 release

### DIFF
--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -1,40 +1,122 @@
 # Releasing the mongocxx driver
 
-If doing a release on a version prior to 3.5.0, follow the old instructions from
-the shared Google drive. Go to File -> Version History -> See Version History
-and select the version "Pre CXX-584".
+The release steps for a patch release differ slightly from release steps for a minor or major release.
+Ensure steps specific to patch releases are correctly applied or skipped depending on the type of release.
 
-## Ensure tests are passing
+`X.Y.Z` is used to refer to a release version with major version `X`, minor version `Y`, and patch version `Z`. For sake of examples, `1.2.3` is used as the new patch release version and `1.3.0` is used as the non-patch release version (implying the current stable release version is `1.2.2`).
 
-Ensure the latest commit has run tests on the Evergreen waterfall.
+> [!WARNING]
+> Do NOT accidentally use example version numbers when executing release commands and scripts!
 
-For a minor release this should be the
-[waterfall](https://spruce.mongodb.com/commits/mongo-cxx-driver) tracking the
-master branch (requires auth).
-For a patch release this is the waterfall tracking the latest release. E.g. if you are
-releasing 1.2.3, then refer to the the waterfall tracking
-[releases/v1.2](https://spruce.mongodb.com/commits/mongo-cxx-driver-latest-release)
-(requires auth).
+## Remote Repositories
 
-If there are test failures, ensure they are at least expected or not introduced
-by changes in the new release.
+In some steps, the main remote repository must be distinguished from a personal fork remote repository.
 
-## Check Coverity
+The main repository is referred to as `upstream`.
+
+The fork repository is referred to as `origin`.
+
+The main repository may be explicitly named during initial clone via `--origin <name>`:
+
+```bash
+git clone -o upstream git@github.com:mongodb/mongo-cxx-driver.git
+```
+
+The fork repository may be subsequently added via `git remote add`:
+
+```bash
+git remote add origin git@github.com:<username>/mongo-cxx-driver.git
+```
+
+An existing remote may be renamed using `git remote rename <old> <new>`.
+
+## Secrets and Credentials
+
+> [!WARNING]
+> Avoid directly typing secret values as command-line arguments. Save the secret values to the relevant file using an editor. Use `source path/to/secret.txt && program --argument "${SECRET:?}"` instead of `program --argument "<secret>"`.
+
+Some release steps require one or more of the following secrets.
+
+- A GitHub Personal Access Token (Classic).
+  - Location: `~/.secrets/github-token.txt`
+  - Format:
+    ```
+    <github_token>
+    ```
+  - Instructions: go to the GitHub settings page
+  [Personal Access Tokens](https://github.com/settings/tokens) and create a
+  (classic) token with the "repo" scope selected.
+
+    Configure SSO to authorize this token for the `mongodb` organization. (Do not forget this step!)
+- Jira OAuth credentials.
+  - Location: `~/.secrets/jira-creds.txt`
+  - Format:
+    ```
+    Username: evergreen.jirareleases@mongodb.com
+
+    access_token : <access_token>
+    access_token_secret : <access_token_secret>
+    consumer_key : <consumer_key>
+    key_cert: -----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----
+    ```
+    Note the `"\n"` strings must be preserved as-is in the key_cert value.
+- Artifactory credentials.
+  - Location: `~/.secrets/artifactory-creds.txt`:
+  - Format:
+    ```bash
+    ARTIFACTORY_USER=<username>
+    ARTIFACTORY_PASSWORD=<password>
+    ```
+- Garasign credentials
+  - Location: `~/.secrets/garasign-creds.txt`
+  - Format:
+    ```bash
+    GRS_CONFIG_USER1_USERNAME=<username>
+    GRS_CONFIG_USER1_PASSWORD=<password>
+    ```
+- Silk credentials.
+  - Location: `~/.secrets/silk-creds.txt`
+  - Format:
+    ```bash
+    SILK_CLIENT_ID=<client_id>
+    SILK_CLIENT_SECRET=<client_secret>
+    ```
+- Snyk credentials.
+  - Location: `~/.secrets/snyk-creds.txt`
+  - Format:
+    ```bash
+    SNYK_API_TOKEN=<token>
+    ```
+
+## Pre-Release Steps
+
+> [!TIP]
+> Pre-release steps should preferably be done regularly and PRIOR to the scheduled release date.
+
+### Evergreen
+
+Ensure Evergreen has run mainline tasks on the latest commit.
+
+For non-patch releases, check the [mongo-cxx-driver](https://spruce.mongodb.com/commits/mongo-cxx-driver) project mainline.
+
+For patch releases, check the [mongo-cxx-driver-latest-release](https://spruce.mongodb.com/commits/mongo-cxx-driver-latest-release) project
+
+Ensure there are no new or unexpected task failures.
+
+### Coverity
 
 Ensure there are no new or unexpected issues with High severity or greater.
 
 Update the [SSDLC Report spreadsheet](https://docs.google.com/spreadsheets/d/1sp0bLjj29xO9T8BwDIxUk5IPJ493QkBVCJKIgptxEPc/edit?usp=sharing) with any updates to new or known issues.
 
-## Check and Update the SBOM Lite
-
-**Note: this should preferably be done regularly and PRIOR to the scheduled release date.**
+### SBOM Lite
 
 Ensure the list of bundled dependencies in `etc/purls.txt` is up-to-date. If not, update `etc/purls.txt`.
 
 If `etc/purls.txt` was updated, update the SBOM Lite document using the following command(s):
 
 ```bash
-# Artifactory and Silk credentials. Ask for these from a team member.
+# Artifactory and Silk credentials.
 . $HOME/.secrets/artifactory-creds.txt
 . $HOME/.secrets/silk-creds.txt
 
@@ -54,16 +136,14 @@ podman run \
 
 Commit the latest version of the SBOM Lite document into the repo as `etc/cyclonedx.sbom.json`. (This may just be a modification of the timestamp.)
 
-## Check and Update the Augmented SBOM
-
-**Note: this should preferably be done regularly and PRIOR to the scheduled release date.**
+### Augmented SBOM
 
 Ensure the `silk-check-augmented-sbom` task is passing on Evergreen for the relevant release branch. If it is passing, nothing needs to be done.
 
  If the `silk-check-augmented-sbom` task was failing, update the Augmented SBOM document using the following command(s):
 
 ```bash
-# Artifactory and Silk credentials. Ask for these from a team member.
+# Artifactory and Silk credentials.
 . $HOME/.secrets/artifactory-creds.txt
 . $HOME/.secrets/silk-creds.txt
 
@@ -85,237 +165,274 @@ Review the contents of the new Augmented SBOM and ensure any new or known vulner
 
 Update the [SSDLC Report spreadsheet](https://docs.google.com/spreadsheets/d/1sp0bLjj29xO9T8BwDIxUk5IPJ493QkBVCJKIgptxEPc/edit?usp=sharing) with any updates to new or known vulnerabilities.
 
-Update `etc/third_party_vulnerabilities.md` with any updates to new or known vulnerabilities for third party dependencies that must be reported.
+Update `etc/third_party_vulnerabilities.md` with any updates to new or known vulnerabilities for third party dependencies that have not yet been fixed by the upcoming release.
 
 Commit the latest version of the Augmented SBOM document into the repo as `etc/augmented.sbom.json`. The Augmented SBOM document does not need to be updated if the `silk-check-augmented-sbom` was not failing (in which case the only changes present would a version bump or timestamp update).
 
-## Check and Update Snyk
+### Check Snyk
 
-**Note: this should preferably be done regularly and PRIOR to the scheduled release date.**
-
-Inspect the list of projects in the latest report for the mongodb/mongo-cxx-driver target in [Snyk](https://app.snyk.io/).
+Inspect the list of projects in the latest report for the `mongodb/mongo-cxx-driver` target in [Snyk](https://app.snyk.io/org/dev-prod/).
 
 Deactivate any projects that will not be relevant in the upcoming release. Remove any projects that are not relevant to the current release.
 
-## Check fixVersions in Jira
+### Check Jira
 
-Ensure that all tickets under the
-[version to be released](https://jira.mongodb.com/projects/CXX?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page&status=unreleased)
-are in `Closed` status on the C++ Driver releases page. If not, bulk change open
-tickets that will NOT be in the release to a new version (create it if
-necessary).
+Inspect the list of tickets assigned to the version to be released on [Jira](https://jira.mongodb.com/projects/CXX?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page&status=unreleased).
 
-For a patch release, check that all tickets for the version to be released have
-changes cherry-picked onto the release branch. This is indicated by a comment on
-the ticket. Here is an
-[example comment](https://jira.mongodb.com/browse/CXX-2650?focusedCommentId=5271981&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-5271981).
+Ensure all related ticket statuses are `Closed` (with the exception of the ticket tracking the release itself).
 
-## Audit Jira ticket titles and types
+For tickets that are will not be part of this release, update their fix version accordingly.
 
-Update Jira ticket types and titles as appropriate.
-User-facing issues should generally be either "Bug" or "New Feature".
-Non-user facing issues should generally be "Task" tickets.
+> [!IMPORTANT]
+> For a patch release, ensure the commits for all related tickets have been cherry-picked onto the release branch.
 
-## Update CHANGELOG.md pre-release ...
+> [!TIP]
+> This is a good time to also update entries in `CHANGELOG.md` corresponding to the tickets whose fix versions are being updated.
 
-### ... for a minor release (e.g. `1.2.0`)
+Update the contents of related Jira tickets as appropriate (improve the title, clarify the description, link related tickets, etc.).
 
-Create a new branch to contain changelog updates from the master branch: `git checkout -b pre-release-changes master`. This branch will be used to create a PR.
+> [!NOTE]
+> A ticket whose changes may impact users should either be a "Bug" or "New Feature".
+> Otherwise, the ticket should typically be a "Task".
 
-Check Jira for tickets closed in this fix version. Update CHANGELOG.md with notable changes not already mentioned. Remove `[Unreleased]` from the version being released.
+## Release Steps
 
-Check if there is an `[Unreleased]` section for a patch version (e.g. `1.1.4 [Unreleased]`). Normally, the C++ Driver does not release patches for old minor versions. If an unreleased patch release section is no longer applicable, move its entries into the minor release section (as needed) and remove the patch release section. If you are unsure whether the patch release is planned, ask in the #dbx-c-cxx channel.
+### Update CHANGELOG...
 
-Example (if `1.2.0` is being released):
+This step depends on the release type.
+
+#### ... for a Patch Release
+
+Checkout the current release branch `releases/vX.Y` (e.g. for a patch release `1.2.3`, the current release branch is `releases/v1.2`).
+
+```bash
+git fetch upstream
+git checkout releases/vX.Y
+```
+
+Update `CHANGELOG.md` with a summary of important changes in this release. Consult the list of related Jira tickets (updated ealier) as well as the list of commits since the last release.
+
+Remove the `[Unreleased]` tag from the relevant patch release section, e.g. for release `1.2.3`:
+
 ```md
-## 1.2.0 [Unreleased]
+## 1.2.3
 
-### Fixed
+...
 
-- Fixes A <!-- Unreleased fix on master branch -->
+## 1.2.2
 
-## 1.1.4 [Unreleased]
+...
 
-### Fixed
-
-- Fixes B <!-- Unreleased fix on `releases/v1.1` branch. B is implicity fixed on 1.2.0. Change was cherry-picked from master. -->
 ```
 
-Becomes:
+Commit and push the updates to `CHANGELOG.md` to `releases/vX.Y` (a PR is not required):
+
+```bash
+git commit -m 'Update CHANGELOG for X.Y.Z'
+git push upstream releases/vX.Y
+```
+
+#### ... for a Non-Patch Release
+
+Create a new branch named `pre-release-changes` on `master`. This branch will be used to later create a PR prior to release.
+
+```bash
+git fetch upstream
+git checkout -b pre-release-changes upstream/master
+```
+
+Update `CHANGELOG.md` with a summary of important changes in this release. Consult the list of related Jira tickets (updated earlier) as well as the list of commits since the last release.
+
+Remove the `[Unreleased]` tag from the relevant non-patch release section, e.g. for release `1.3.0`:
+
 ```md
-## 1.2.0
+## 1.3.0
 
-### Fixed
+...
 
-- Fixes A
-- Fixes B <!-- 1.1.4 is no longer planned. Document B in 1.2.0 -->
-```
+## 1.2.2
 
-Commit with a message like `Update CHANGELOG for <version>`. Create a PR for the `pre-release-changes` branch which contains the commits made up to this point. Once the PR is merged, proceed with the rest of the release. The `pre-release-changes` branch may be deleted.
-
-### ... for a patch release (e.g. `1.2.3`)
-
-Check out the existing release branch (e.g. `releases/v1.2`).
-
-Check Jira for tickets closed in this fix version. Update CHANGELOG.md with notable changes not already mentioned. Remove `[Unreleased]` from the version being released.
-
-Commit with a message like `Update CHANGELOG for <version>`. Push the change.
-
-
-## Clone and set up environment
-
-Do a fresh clone, to avoid local git branches or IDE files from interfering.
+...
 
 ```
-git clone git@github.com:mongodb/mongo-cxx-driver.git mongo-cxx-driver-release
+
+> [!IMPORTANT]
+> If there are entries under an unreleased patch release section with the old minor release number, move the entries into a new patch release section and remove the old patch release section. For example, for a `1.3.0` minor release, move entries from `1.2.3 [Unreleased]` to `1.3.1 [Unreleased]` and remove `1.2.3 [Unreleased]`. (This is analogous to updating the fix version of Jira tickets, as done earlier.)
+
+Commit the updates to `CHANGELOG.md`.
+
+```bash
+git commit -m 'Update CHANGELOG for X.Y.Z'
+```
+
+Push the `pre-release-changes` branch to a fork repository and create a PR to merge `pre-release-changes` onto `master`:
+
+```bash
+git remote add origin git@github.com:<username>/mongo-cxx-driver.git
+git push -u origin pre-release-changes
+```
+
+Once the PR is merged, delete the `pre-release-changes` branch.
+
+### Fresh Clone
+
+To avoid potential complications during the release process, clone the updated repository in a new directory:
+
+```bash
+git clone -o upstream git@github.com:mongodb/mongo-cxx-driver.git mongo-cxx-driver-release
 cd mongo-cxx-driver-release
 ```
 
-Start a Python 3 virtual environment and install required packages with pip.
+Create and activate a fresh Python 3 virtual environment with required packages installed:
 
-```
-python3 -m venv ~/virtualenv
-. ~/virtualenv/bin/activate
+```bash
+
+python3 -m venv ~/mongo-cxx-driver-release-venv # Outside the mongo-cxx-driver-release directory!
+source ~/mongo-cxx-driver-release-venv/bin/activate
 pip install -r etc/requirements.txt
 ```
 
-## Tag the release
+### Create a Release Tag...
 
-If doing a minor release (e.g. releasing r1.2.0, with a zero patch component),
-stay on the master branch. You will create a new `releases/vX.Y` branch later in
-the instructions. If doing a patch release (e.g. releasing rX.Y.Z with non-zero
-`Z`), check out the corresponding release branch, which should be an existing
-`releases/vX.Y` branch.
+> [!IMPORTANT]
+> Do NOT push the release tag immediately after its creation!
 
-Create a tag for the commit to serve as the release (or release candidate):
+#### ... for a Patch Release
 
+Checkout the release branch (containing the changes from earlier steps) and create a tag for the release.
+
+```bash
+git checkout releases/vX.Y
+git tag rX.Y.Z
 ```
-git tag r1.2.3
+
+#### ... for a Non-Patch Release
+
+Checkout the `master` branch (containing the changes from earlier steps) and create a tag for the release:
+
+```bash
+git checkout master
+git tag rX.Y.0
 ```
 
-## Run make_release.py
+> [!NOTE]
+> A new release branch `releases/vX.Y` will be created later as part of post-release steps.
 
-`make_release.py` creates the distribution tarball
-(e.g. mongo-cxx-driver-r1.2.3.tar.gz) and corresponding signature file (e.g.
-mongo-cxx-driver-r1.2.3.tar.gz.asc), interacts with Jira, and drafts the release
-on GitHub.
+### Run etc/make_release.py
 
-To see all available options, run with `--help`
+This script performs the following steps:
+
+- create the distribution tarball (e.g. `mongo-cxx-driver-r1.2.3.tar.gz`),
+- creates a signature file for the distribution tarball (e.g. `mongo-cxx-driver-r1.2.3.tar.gz.asc`),
+- query Jira for release and ticket statuses, and
+- creates a release draft on GitHub.
+
+To see all available options, run with `--help`.
 
 ```
 python ./etc/make_release.py --help
 ```
 
-The following credentials are required. Ask for these from a team member if necessary. (Note: avoid typing secrets as command-line arguments).
+The following secrets are required by this script:
 
-- A GitHub token. Go to the GitHub settings page
-  [Personal Access Tokens](https://github.com/settings/tokens) and create a
-  token.  Save the token secret to `~/.secrets/github_token.txt`.
-- Jira OAuth credentials. Save it to `~/.secrets/jira_creds.txt`.
-- Artifactory credentials. Save these to `~/.secrets/artifactory-creds.txt`:
-  ```bash
-  ARTIFACTORY_USER=<username>
-  ARTIFACTORY_PASSWORD=<password>
-  ```
-- Garasign credentials. Save these to `~/.secrets/garasign-creds.txt`:
-  ```bash
-  GRS_CONFIG_USER1_USERNAME=<username>
-  GRS_CONFIG_USER1_PASSWORD=<password>
-  ```
-- Silk credentials. Save these to `~/.secrets/silk-creds.txt`:
-  ```bash
-  SILK_CLIENT_ID=<client_id>
-  SILK_CLIENT_SECRET=<client_secret>
-  ```
-- Snyk credentials. Save these to `~/.secrets/snyk-creds.txt`:
-  ```bash
-  SNYK_API_TOKEN=<token>
-  ```
+- GitHub Personal Access Token.
+- Jira OAuth credentials.
+- Artifactory credentials.
+- Garasign credentials.
 
 Run the release script with the git tag created above as an argument and
 `--dry-run` to test for unexpected errors.
 
-```
-python ./etc/make_release.py \
-    --dry-run \
-    --jira-creds-file ~/.secrets/jira_creds.txt \
-    --github-token-file ~/.secrets/github_token.txt \
-    r1.2.3
+```bash
+make_release_args=(
+    --jira-creds-file ~/.secrets/jira-creds.txt
+    --github-token-file ~/.secrets/github-token.txt
+)
+python ./etc/make_release.py "${make_release_args[@]:?}" --dry-run rX.Y.Z
 ```
 
-If all goes well, run the command again without `--dry-run`, which should build
-and test the tarball and draft the GitHub release.
-
-### Troubleshooting make_release.py
+> [!TIP]
+> Export environment variables (e.g.`CMAKE_BUILD_PARALLEL_LEVEL`) to improve the speed of this command.
 
 If an error occurs, inspect logs the script produces, and troubleshoot as
 follows:
 
 - Use `--dry-run` to prevent unrecoverable effects.
 - If building the C driver fails, use an existing C driver build (ensure it is
-  the right version) with `--with-c-driver /path/to/cdriver/install`.
+  the right version) with `--with-c-driver /path/to/c-driver/install`.
 - Use `--skip-distcheck` to bypass time consuming checks when building the
   distribution tarball.
 - If the script succeeded at creating the distribution tarball, pass it directly
-  with `--dist-file ./build/mongo-cxx-driver-r1.2.3.tar.gz`.
+  with `--dist-file ./build/mongo-cxx-driver-rX.Y.Z.tar.gz`.
 
-## Push the tag
+If all goes well, run the command again without `--dry-run`. This should update Jira and create a draft release on GitHub.
 
-Review the build output and, assuming the distcheck target is successful, push
-the tag into the main remote:
+> [!TIP]
+> To avoid the Jira ticket tracking the release itself from preventing the script from completing successfully, pass `--allow-open-issues`. Carefully inspect the list of open tickets before using this flag!
 
-```
-git push git@github.com:mongodb/mongo-cxx-driver.git refs/tags/r1.2.3
-```
+Verify the successful creation of the release draft on GitHub.
 
-### Release the Version in GitHub
+### Push the Release Tag
 
-Review the generated release draft on GitHub, then publish the release:
+Push the release tag (created earlier) to the remote repository:
 
-```
-Edit -> Publish Release
+```bash
+git push origin rX.Y.Z
 ```
 
-## Release the Version in Jira
+### Release on GitHub
+
+Verify the pushed release tag is detected by the release draft (refresh the page if necessary).
+
+Review the contents of the release draft, then publish the release.
+
+### Release on Jira
 
 Navigate to the
 [fixVersions page on Jira](https://jira.mongodb.com/plugins/servlet/project-config/CXX/versions?status=unreleased).
-Click the "..." next to the version you are about to release and select
-"Release".
 
-## Update releases/stable branch if needed
+Click the "..." next to the relevant version and select "Release".
+
+### Update releases/stable
 
 The `releases/stable` branch tracks the most recent "stable" release for users
 who install from the git repository.
 
-After any stable release (i.e. not an alpha, beta, RC, etc. release), check out
-the `releases/stable` branch, reset it to the new release tag, and force push it
-to the repo:
+> [!WARNING]
+> This step does NOT apply to alpha, beta, release candidate (RC), or similar types of "unstable" release versions which may contain a suffix in its release tag.
 
-```
+Check out the `releases/stable` branch, hard-reset it to the new release tag, then force-push it
+to the remote repository:
+
+```bash
 git checkout releases/stable
-git reset --hard r1.2.3
-git push -f origin releases/stable
+git reset --hard rX.Y.Z
+git push -f upstream releases/stable
 ```
 
-## Branch if necessary
+## Post-Release Steps
 
-If doing a new minor release `X.Y.0` (e.g. a `1.2.0` release), create branch
-`releases/vX.Y` (e.g `releases/v1.2`): `git checkout -b releases/v1.2 master`
+### Create a New Release Branch
 
-Push the new branch:
+> [!IMPORTANT]
+> The creation of a new release branch only applies to non-patch releases! Patch releases should continue to use the existing release branch.
+
+For a new non-patch release `X.Y.0`, create a new branch `releases/vX.Y`:
+
+```bash
+git fetch upstream
+git checkout -b releases/vX.Y upstream/master
+```
+
+Push the new branch to the remote repository:
 
 ```
-git push --set-upstream origin releases/v1.2
+git push origin releases/vX.Y
 ```
 
 The new branch should be continuously tested on Evergreen. Update the "Display Name" and "Branch Name" of the [mongo-cxx-driver-latest-release Evergreen project](https://spruce.mongodb.com/project/mongo-cxx-driver-latest-release/settings/general) to refer to the new release branch.
 
-## Update Silk and Snyk with new branch if necessary
-
-After creating the new minor release branch in the prior step, update Silk and Snyk to trach the new release branch.
-
-For Silk, use the [create-silk-asset-group.py script](https://github.com/mongodb/mongo-c-driver/blob/master/tools/create-silk-asset-group.py) in the C Driver to create a new Silk asset group:
+The new branch should be tracked by Silk. Use the [create-silk-asset-group.py script](https://github.com/mongodb/mongo-c-driver/blob/master/tools/create-silk-asset-group.py) in the C Driver to create a new Silk asset group:
 
 ```bash
 # Snyk credentials. Ask for these from a team member.
@@ -337,14 +454,21 @@ create_args=(
 python path/to/tools/create-silk-asset-group.py "${create_args[@]:?}"
 ```
 
-For Snyk, configure and build the CXX Driver with `BSONCXX_POLY_USE_MNMLSTC=ON` (force download of mnmlstc/core sources) and no `CMAKE_PREFIX_PATH` entry to a C Driver installation (force download of C Driver sources), then run:
+### Update Snyk
+
+> [!IMPORTANT]
+> Run the Snyk commands in a fresh clone of the post-release repository to avoid existing build and release artifacts from affecting Snyk.
+
+Checkout the new release tag.
+
+Configure and build the CXX Driver with `BSONCXX_POLY_USE_MNMLSTC=ON` (force download of mnmlstc/core sources) and no `CMAKE_PREFIX_PATH` entry to an existing C Driver installation (force download of C Driver sources), then run:
 
 ```bash
 # Snyk credentials. Ask for these from a team member.
 . ~/.secrets/snyk-creds.txt
 
-# Name of the new minor release branch. Ensure this is correct!
-branch="releases/vX.Y"
+# The new release tag. Ensure this is correct!
+release_tag="rX.Y.Z"
 
 # Authenticate with Snyk dev-prod organization.
 snyk auth "${SNYK_API_TOKEN:?}"
@@ -354,7 +478,7 @@ snyk auth "${SNYK_API_TOKEN:?}"
 snyk_args=(
   --org=dev-prod
   --remote-repo-url=https://github.com/mongodb/mongo-cxx-driver/
-  --target-reference="${branch:?}"
+  --target-reference="${release_tag:?}"
   --unmanaged
   --all-projects
   --detection-depth=10 # build/src/bsoncxx/third_party/_deps/core-install/include/core
@@ -362,153 +486,227 @@ snyk_args=(
 )
 snyk test "${snyk_args[@]:?}" --print-deps
 
-# Create a new Snyk target reference for the new release branch.
+# Create a new Snyk target reference for the new release tag.
 snyk monitor "${snyk_args[@]:?}"
 ```
 
-## Create Documentation Tickets
+### Create Documentation Tickets
 
-Documentation generation must be run after the release tag has been made and
-pushed.
+Create and checkout a new branch `post-release-changes` relative to `master` to contain documentation updates following the new release:
 
-- Create and checkout a new branch to contain documentation updates from master:
-  `git checkout -b post-release-changes master`. This branch will be used to
-  create a PR later.
-- Edit `etc/apidocmenu.md` and add the released version in the `mongocxx` column
-  following the established pattern. If this is a minor release (X.Y.0), revise
-  the entire document as needed.
-- Edit the `README.md` to match.
-- If the release was not a release candidate, ensure a [DOCSP JIRA
-  ticket](https://jira.mongodb.org/projects/DOCSP/issues/) is created to request
-  updating:
+```bash
+git fetch upstream
+git checkout -b post-release-changes upstream/master
+```
 
-  - the `Installing the MongoDB C driver` section of the [Advanced Installation
-    documentation](https://github.com/mongodb/docs-cpp/blob/master/source/installation/advanced.txt)
-    to reflect libmongoc requirements
-  - the `Driver Status by Family and Version` section of the [home
-    page](https://github.com/mongodb/docs-cpp/blob/master/source/installation/linux.txt)
-  - the [C++ driver
-    version](https://github.com/mongodb/docs-cpp/blob/e13d787967172220ae19e5d78df61e2071735f0f/snooty.toml#L20-L21).
-- Edit `etc/generate-all-apidocs.pl` and add the new release version to the
-  `@DOC_TAGS` array, following the established pattern.
-- Commit these changes:
-  `git commit -am "Prepare to generate r1.2.3 release documentation"`
-- Ensure you have `doxygen` and `hugo` installed and up to date.
-- Run `git clean -dxf` to clear out all extraneous files.
-- Configure with `cmake` in the `build` directory as you usually would.
-- Build docs locally to test.
-  - To test Hugo documentation, run the `docs` build target with
-    `cmake --build ./build --target docs`.
-  - To test generation of all API docs for all tags, build the  `doxygen-all`
-    target with `cmake --build ./build --target doxygen-all` and be prepared to
-    wait a while.
-- To generate and deploy documentation to GitHub Pages, build both the
-  `hugo-deploy` and `doxygen-deploy` targets. The doxygen build will take a long
-  time.
-  - `cmake --build ./build --target hugo-deploy`
-  - `cmake --build ./build --target doxygen-deploy`
-- If the release was not a release candidate, update symlinks
-  - Check out the `gh-pages` branch and git pull the deployed docs.
-  - Update the `api/mongocxx-v3` symlink to point to the newly released version.
-    If a minor version bump has occurred, revise the symlink structure as
-    needed. Make sure `current` always points to a symlink tracking the latest
-    stable release branch.
-  - Commit and push the symlink change:
-    `git commit -am "Update symlink for r1.2.3"`
-   - Switch back to the branch with documentation updates: `git checkout post-release-changes`.
-- Wait a few minutes and verify mongocxx.org has updated.
+This branch will be used to create a PR later.
 
-## Merge the release branch back into `master` if necessary
+> [!IMPORTANT]
+> Make sure the `post-release-changes` branch is created on `master`, not `rX.Y.Z` or `releases/vX.Y`!
 
-If this is a patch release on a minor release branch, create a pull request on GitHub to merge the latest state of the `releases/rX.Y` branch containing the new release tag `rX.Y.Z` into the `master` branch. Use the "Create a merge commit" option when merging this pull request.
+Add the new release to the tables in `etc/apidocmenu.md`.
 
-> [IMPORTANT]
-> Use the "Create a merge commit" option when merging this pull request!
+Edit `README.md` to match the updated `etc/apidocmenu.md`.
 
-Do **NOT** delete the release branch after merge.
+(Stable Releases Only) Close the Jira ticket tracking this release with "Documentation Changes" set to "Needed". Fill the "Documentation Changes Summary" field with information requesting updates to:
 
-Verify correct repo state by running `git describe --tags --abbrev=0` on the post-merge `master` branch, which should return the patch release tag `rX.Y.Z`. Adding the `--first-parent` flag should return the last minor release tag `rX.Y.0`.
+  - the "Installing the MongoDB C Driver" section of the [Advanced Configuration and Installation Options](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/installation/advanced/#installing-the-mongodb-c-driver) page
+    with any new libmongoc version requirements,
+  - the "Driver Status by Family and Version" section of the [home
+    page](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/#driver-status-by-family-and-version), and
+  - the [full version](https://github.com/mongodb/docs-cpp/blob/master/snooty.toml) for the C++ Driver documentation pages.
 
-## Update CHANGELOG.md post-release ...
+This will generate a DOCSP ticket with instructions to update the C++ Driver docs.
 
-CHANGELOG.md on the `master` branch contains sections for every release. This is intended to ease searching for changes among all releases.
-CHANGELOG.md on a release branch (e.g. `releases/v1.2`) contains entries for patch releases of the minor version number tracked by the release branch (e.g. for 1.2.1, 1.2.2, 1.2.3, etc.), as well as all entries prior to the initial minor release (e.g. before 1.2.0).
+Example (using Jira syntax formatting):
 
-### ... on the release branch
+```
+* The [Advanced Installation|https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/installation/advanced/#installing-the-mongodb-c-driver] page must be updated with a new requirement: "For mongocxx-X.Y.x, libmongoc A.B.C or later is required.
+* The [MongoDB C++ Driver|https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/#driver-status-by-family-and-version] page must be updated: {{{}mongocxx X.Y.x{}}} is now a previous stable release and no longer under active development; {{{}mongocxx X.Y+1.x{}}} is the new current stable release eligible for bug fixes.
+* the [full version|https://github.com/mongodb/docs-cpp/blob/master/snooty.toml] for C++ Driver documentation must be updated to {{{}X.Y.Z{}}}.
+```
 
-Check out the release branch (e.g. `releases/v1.2`).
+### Publish Updated Documentation
 
-Update CHANGELOG.md to add an `[Unreleased]` section for the next patch release. Example (if `1.2.3` was just released):
+> [!NOTE]
+> Some of these commands may take a while to complete.
+
+Add the new release to the `@DOC_TAGS` array in `etc/generate-all-apidocs.pl`.
+
+Commit these changes to the `post-release-changes` branch:
+
+```bash
+git commit -am "Prepare to generate rX.Y.Z release documentation"
+```
+
+Ensure `doxygen` and `hugo` are locally installed and up-to-date.
+
+```bash
+command -V doxygen hugo
+```
+
+Run `git clean -dfx` to restore the repository to a clean state.
+
+Configure CMake using `build` as the binary directory. Leave all other configuration variables as their default.
+
+```bash
+cmake -S . -B build
+```
+
+Test generating Hugo docs locally by building the `docs` target:
+
+```bash
+cmake --build build --target docs
+```
+
+Test generating Doxygen docs by building the `doxygen-all` target:
+
+```bash
+cmake --build build --target doxygen-all
+```
+
+Verify that the `build/docs/api/mongocxx-X.Y.Z` directory is present and populated.
+
+Generate and deploy the updated documentation to GitHub pages by building the `hugo-deploy` and `doxygen-deploy` targets:
+
+```bash
+cmake --build build --target hugo-deploy
+cmake --build build --target doxygen-deploy
+```
+
+These commands will update the `gh-pages` branch and push the changes to the remote repository.
+
+> [!WARNING]
+> Build and release artifacts may still be present in the repository after this step. Do not accidentally commit these files into the repository in the following steps!
+
+### Update Symlinks
+
+> [!IMPORTANT]
+> Symlink updates only apply to stable releases! Release candidates and other unstable releases do not require updating symlinks.
+
+Checkout the updated `gh-pages` branch:
+
+```bash
+git checkout gh-pages
+git pull
+```
+
+Update the `api/mongocxx-v3` symlink to refer to the new release version:
+
+```bash
+cd api
+rm mongocxx-v3
+ln -s mongocxx-X.Y.Z mongocxx-v3
+```
+
+Double-check that the `current` symlink is pointing to the symlink tracking the latest stable release:
+
+```
+current     -> mongocxx-v3
+mongocxx-v3 -> mongocxx-X.Y.Z
+```
+
+Commit and push this change to the `gh-pages` branch:
+
+```bash
+git commit -m "Update symlink for rX.Y.Z"
+```
+
+Verify the https://mongocxx.org/api/current/ page has been updated with the new release.
+
+### Update CHANGELOG...
+
+#### ... for a Patch Release
+
+Checkout the updated `releases/vX.Y` branch.
+
+```bash
+git checkout releases/vX.Y
+git pull
+```
+
+Add a section for the next patch release, e.g. following a `1.2.3` release:
 
 ```md
 ## 1.2.4 [Unreleased]
 
-<!-- Will contain entries for the next patch release -->
+<!-- Will contain entries for the next patch release. -->
 
-## 1.2.3
+## 1.2.3 <!-- Just released. -->
 
-<!-- Contains published release notes -->
+## 1.2.2 <!-- Prior release. -->
 ```
 
-Commit and push this change to the release branch (no PR necessary for release branch).
+Commit the changes to the `releases/vX.Y` branch and push the branch to the remote repository (a PR is not required for this step).
 
-### ... on the `master` branch
+#### ... for a Non-Patch Release
 
-Check out the `post-release-changes` branch created before editing and generating documentation.
+Checkout the `post-release-changes` branch.
 
-Ensure `[Unreleased]` is removed from the recently released section. Ensure the contents of the recently released section match the published release notes.
-
-Ensure there are `[Unreleased]` sections for the next minor and patch releases. Example (if `1.2.3` was just released):
+Add a section for the next minor release, e.g. following a `1.3.0` release:
 
 ```md
-## 1.3.0 [Unreleased]
+## 1.4.0 [Unreleased]
 
-<!-- Will contain entries for the next minor release -->
+<!-- Will contain entries for the next minor release. -->
 
-## 1.2.4 [Unreleased]
+## 1.3.0 <!-- Just released. -->
 
-<!-- Will contain entries for the next patch release -->
-
-## 1.2.3
-
-<!-- Contains published release notes -->
+## 1.2.2 <!-- Prior release. -->
 ```
 
-Commit the change.
+Commit these changes to `post-release-changes`.
 
-Create a PR from the `post-release-changes` branch to merge to `master`.
+### Merge Post-Release Changes
 
-## Homebrew
+Push the `post-releases-changes` branch to your personal fork repository and create a PR to merge the post-release changes into `master`.
+
+```bash
+git remote add origin git@github.com:<username>/mongo-cxx-driver.git
+git push -u origin post-release-changes
+```
+
+### Announce on Community Forums
+
+Post an announcement to the [Developer Community Forum](https://www.mongodb.com/community/forums/tags/c/announcements/driver-releases/110/cxx) under "Product & Driver Announcements > Driver Releases" and include the "production" and "cxx" tags.
+
+Template:
+
+```md
+The MongoDB C++ Driver Team is pleased to announce the availability of [MongoDB C++ Driver X.Y.Z](https://github.com/mongodb/mongo-cxx-driver/releases/tag/rX.Y.Z).
+
+Please note that this version of mongocxx requires [MongoDB C Driver A.B.C](https://github.com/mongodb/mongo-c-driver/releases/tag/A.B.C) or higher.
+
+See the [MongoDB C++ Driver Manual](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/) and the [Driver Installation Instructions](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/installation/) for more details on downloading, installing, and using this driver.
+
+NOTE: The mongocxx 3.10.x series does not promise API or ABI stability across patch releases.
+
+Please feel free to post any questions on the MongoDB Community forum in the [Drivers](https://www.mongodb.com/community/forums/c/data/drivers/7) category tagged with [cxx](https://www.mongodb.com/community/forums/tag/cxx). Bug reports should be filed against the [CXX](https://jira.mongodb.org/projects/CXX) project in the MongoDB JIRA. Your feedback on the C++11 driver is greatly appreciated.
+
+Sincerely,
+
+The C++ Driver Team
+```
+
+## Packaging
+
+### Homebrew
+
 This requires a macOS machine.
 If this is a stable release, update the [mongo-cxx-driver](https://github.com/Homebrew/homebrew-core/blob/master/Formula/mongo-cxx-driver.rb) homebrew formula, using: `brew bump-formula-pr mongo-cxx-driver --url <tarball url>`
 
 Example:
 `brew bump-formula-pr mongo-cxx-driver --url https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.7.3/mongo-cxx-driver-r3.7.3.tar.gz`
 
-## vcpkg
-Submit a PR or create an issue to update the vc-pkg file for mongo-c-driver.
+### vcpkg
+
+Submit a PR or create an issue to update the vc-pkg file for mongo-cxx-driver.
 To submit an issue, follow: https://github.com/microsoft/vcpkg/issues/new/choose. Example: https://github.com/microsoft/vcpkg/issues/34984
 
-## Conan
-Submit a PR or create an issue to update the Conan recipe for mongo-c-driver.
+### Conan
+
+Submit a PR or create an issue to update the Conan recipe for mongo-cxx-driver.
 To submit an issue, follow: https://github.com/conan-io/conan-center-index/issues/new/choose/. Example: https://github.com/conan-io/conan-center-index/issues/21006
-
-## Comment on the generated DOCSP ticket
-
-Minor releases generate a DOCSP ticket. Add a comment to the generated DOCSP ticket describing if the
-[MongoDB Compatibility Table](https://www.mongodb.com/docs/drivers/cxx/#mongodb-compatibility)
-or [Language Compatibility Table](https://www.mongodb.com/docs/drivers/cxx/#language-compatibility)
-should be updated. Generally, only a minor release will require updates.
-(See [DOCSP-30876](https://jira.mongodb.com/browse/DOCSP-30876) for an example.)
-
-## Announce on Community Forums
-
-Announce Post to the [developer community forum](https://community.mongodb.com)
-under `Product & Driver Announcements` with the tag `cxx`.
-
-See this
-[example announcement](https://www.mongodb.com/community/forums/t/mongodb-c-11-driver-3-9-0-released/252724)
-of the stable release of 3.9.0.
 
 ## Docker Image Build and Publish
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -181,7 +181,7 @@ Inspect the list of tickets assigned to the version to be released on [Jira](htt
 
 Ensure all related ticket statuses are `Closed` (with the exception of the ticket tracking the release itself).
 
-For tickets that are will not be part of this release, update their fix version accordingly.
+For tickets that will not be part of this release, update their fix version accordingly.
 
 > [!IMPORTANT]
 > For a patch release, ensure the commits for all related tickets have been cherry-picked onto the release branch.
@@ -257,7 +257,7 @@ Remove the `[Unreleased]` tag from the relevant non-patch release section, e.g. 
 ```
 
 > [!IMPORTANT]
-> If there are entries under an unreleased patch release section with the old minor release number, move the entries into a new patch release section and remove the old patch release section. For example, for a `1.3.0` minor release, move entries from `1.2.3 [Unreleased]` to `1.3.1 [Unreleased]` and remove `1.2.3 [Unreleased]`. (This is analogous to updating the fix version of Jira tickets, as done earlier.)
+> If there are entries under an unreleased patch release section with the old minor release number, move the entries into this release's section and remove the unreleased patch release section. For example, for a `1.3.0` minor release, move entries from `1.2.3 [Unreleased]` to `1.3.0` and remove `1.2.3 [Unreleased]`. Due to cherry-picking, a non-patch release should always (already) contain the changes targeting a patch release with a prior minor version number. (This is analogous to updating the fix version of Jira tickets, as done earlier.)
 
 Commit the updates to `CHANGELOG.md`.
 
@@ -366,9 +366,6 @@ follows:
   with `--dist-file ./build/mongo-cxx-driver-rX.Y.Z.tar.gz`.
 
 If all goes well, run the command again without `--dry-run`. This should update Jira and create a draft release on GitHub.
-
-> [!TIP]
-> To avoid the Jira ticket tracking the release itself from preventing the script from completing successfully, pass `--allow-open-issues`. Carefully inspect the list of open tickets before using this flag!
 
 Verify the successful creation of the release draft on GitHub.
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -410,6 +410,29 @@ git reset --hard rX.Y.Z
 git push -f upstream releases/stable
 ```
 
+### Upload SSDLC Reports
+
+Navigate to the [C++ Driver SSDLC Reports](https://drive.google.com/drive/folders/1q9RI55trFzHlh8McALSIAbT6ugyn8zlO) folder and update the master spreadsheet.
+
+Once complete, make two copies of the spreadsheet.
+
+Rename one copy to: "SSDLC Report: mongo-cxx-driver X.Y.Z". Leave this copy in this folder.
+
+Rename the other copy to: "static_analysis_report-X.Y.Z". Move this copy into the [SSDLC Compliance Files](https://drive.google.com/drive/folders/1_qwTwYyqPL7VjrZOiuyiDYi1y2NYiClS) folder and name it.
+
+Upload a copy of the `etc/ssdlc_compliance_report.md` and `etc/third_party_vulnerabilities.md` files from the `rX.Y.Z` repository. Rename the files with the version number `-X.Y.Z` suffix as already done for other files in this folder.
+
+> [!WARNING]
+> Uploading a file into the SSDLC Compliance Files folder is an irreversible action! However, the files may still be renamed. If necessary, rename any accidentally uploaded files to "(Delete Me)" or similar.
+
+Three new files should be present in the [SSDLC Compliance Files](https://drive.google.com/drive/folders/1_qwTwYyqPL7VjrZOiuyiDYi1y2NYiClS) folder following a release `X.Y.Z`:
+
+```
+ssdlc_compliance_report-X.Y.Z.md
+third_party_vulnerabilities-X.Y.Z.md
+static_analysis-X.Y.Z
+```
+
 ## Post-Release Steps
 
 ### Create a New Release Branch

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -420,17 +420,18 @@ Rename one copy to: "SSDLC Report: mongo-cxx-driver X.Y.Z". Leave this copy in t
 
 Rename the other copy to: "static_analysis_report-X.Y.Z". Move this copy into the [SSDLC Compliance Files](https://drive.google.com/drive/folders/1_qwTwYyqPL7VjrZOiuyiDYi1y2NYiClS) folder and name it.
 
-Upload a copy of the `etc/ssdlc_compliance_report.md` and `etc/third_party_vulnerabilities.md` files from the `rX.Y.Z` repository. Rename the files with the version number `-X.Y.Z` suffix as already done for other files in this folder.
+Upload a copy of the `etc/ssdlc_compliance_report.md`, `etc/third_party_vulnerabilities.md`, and `etc/augmented.sbom.json` files. Rename the files with the version number `-X.Y.Z` suffix in their filenames as already done for other files in this folder.
 
 > [!WARNING]
 > Uploading a file into the SSDLC Compliance Files folder is an irreversible action! However, the files may still be renamed. If necessary, rename any accidentally uploaded files to "(Delete Me)" or similar.
 
-Three new files should be present in the [SSDLC Compliance Files](https://drive.google.com/drive/folders/1_qwTwYyqPL7VjrZOiuyiDYi1y2NYiClS) folder following a release `X.Y.Z`:
+Four new files should be present in the [SSDLC Compliance Files](https://drive.google.com/drive/folders/1_qwTwYyqPL7VjrZOiuyiDYi1y2NYiClS) folder following a release `X.Y.Z`:
 
 ```
 ssdlc_compliance_report-X.Y.Z.md
 third_party_vulnerabilities-X.Y.Z.md
 static_analysis-X.Y.Z
+augmented.sbom-X.Y.Z.json
 ```
 
 ## Post-Release Steps


### PR DESCRIPTION
This PR proposes updates to the release instructions after a thorough audit during the 3.10.2 release process.

Notable changes:

- List of required secrets and credentials is consolated and moved to the top of the file.
- More instructions are now accompanied by the corresponding commands to execute.
- More use of GitHub Alerts (tip, note, warning, etc.)
- Added instructions to update and upload SSDLC reports.
- Removed merge-back step from post-release instructions.

The merge-back of `releases/vX.Y` into `master` post-release introduced in https://github.com/mongodb/mongo-cxx-driver/pull/1148 was meant to ensure all release tags are accessible from `master` to facilitate use of `git describe --tags` and similar patterns. However, GitHub PR merge methods do not permit a "clean" means to resolve merge conflicts without forcing the introduction of irrelevant changes back into to the release branch. Ideally, the merge commit itself, created locally and pushed as part of the PR, would resolve conflicts without impacting the release branch state, but GitHub _still(?!?!)_ [does not support fast-forward merge](https://github.com/orgs/community/discussions/4618) as an option for PRs. We could temporarily unprotect the `master` branch during releases to support the push of such a merge commit and fast-forward merge, but this feels like a great inconvenience given updated repo administrative permission settings. The use of an intermediate conflict-resolving commit that does not belong to the release branch as a workaround does not seem ideal either. Therefore, this PR reverts to the status quo of unreachable-from-`master` patch release tags on release branches.