### PR TITLE
CXX-2771 consistent copyright date and license notice

### DIFF
--- a/.evergreen/build_snapshot_rpm.sh
+++ b/.evergreen/build_snapshot_rpm.sh
@@ -7,7 +7,7 @@ set -o errexit
 #
 
 #
-# Copyright 2020 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -156,4 +156,3 @@ fi
 
 sudo mock -r ${config} --use-bootstrap-image --isolation=simple --clean
 (cd "${mock_result}" ; tar zcvf ../rpm.tar.gz *.rpm)
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB Inc.
+# Copyright 2016 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ General structure:
 Example:
 
 ```{.cpp}
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ General structure:
 Example:
 
 ```{.cpp}
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB Inc.
+# Copyright 2016 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/benchmark/benchmark_runner.cpp
+++ b/benchmark/benchmark_runner.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/benchmark_runner.cpp
+++ b/benchmark/benchmark_runner.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/benchmark_runner.hpp
+++ b/benchmark/benchmark_runner.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/benchmark_runner.hpp
+++ b/benchmark/benchmark_runner.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/bson/bson_decoding.hpp
+++ b/benchmark/bson/bson_decoding.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/bson/bson_decoding.hpp
+++ b/benchmark/bson/bson_decoding.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/bson/bson_encoding.hpp
+++ b/benchmark/bson/bson_encoding.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/bson/bson_encoding.hpp
+++ b/benchmark/bson/bson_encoding.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/microbench.cpp
+++ b/benchmark/microbench.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/microbench.cpp
+++ b/benchmark/microbench.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/microbench.hpp
+++ b/benchmark/microbench.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/microbench.hpp
+++ b/benchmark/microbench.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/multi_doc/bulk_insert.hpp
+++ b/benchmark/multi_doc/bulk_insert.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/multi_doc/bulk_insert.hpp
+++ b/benchmark/multi_doc/bulk_insert.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/multi_doc/find_many.hpp
+++ b/benchmark/multi_doc/find_many.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/multi_doc/find_many.hpp
+++ b/benchmark/multi_doc/find_many.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/multi_doc/gridfs_download.hpp
+++ b/benchmark/multi_doc/gridfs_download.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/multi_doc/gridfs_download.hpp
+++ b/benchmark/multi_doc/gridfs_download.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/multi_doc/gridfs_upload.hpp
+++ b/benchmark/multi_doc/gridfs_upload.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/multi_doc/gridfs_upload.hpp
+++ b/benchmark/multi_doc/gridfs_upload.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/parallel/gridfs_multi_export.hpp
+++ b/benchmark/parallel/gridfs_multi_export.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/parallel/gridfs_multi_export.hpp
+++ b/benchmark/parallel/gridfs_multi_export.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/parallel/gridfs_multi_import.hpp
+++ b/benchmark/parallel/gridfs_multi_import.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/parallel/gridfs_multi_import.hpp
+++ b/benchmark/parallel/gridfs_multi_import.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/parallel/json_multi_export.hpp
+++ b/benchmark/parallel/json_multi_export.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/parallel/json_multi_export.hpp
+++ b/benchmark/parallel/json_multi_export.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/parallel/json_multi_import.hpp
+++ b/benchmark/parallel/json_multi_import.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/parallel/json_multi_import.hpp
+++ b/benchmark/parallel/json_multi_import.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/score_recorder.cpp
+++ b/benchmark/score_recorder.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/score_recorder.cpp
+++ b/benchmark/score_recorder.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/score_recorder.hpp
+++ b/benchmark/score_recorder.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/score_recorder.hpp
+++ b/benchmark/score_recorder.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/single_doc/find_one_by_id.hpp
+++ b/benchmark/single_doc/find_one_by_id.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/single_doc/find_one_by_id.hpp
+++ b/benchmark/single_doc/find_one_by_id.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/single_doc/insert_one.hpp
+++ b/benchmark/single_doc/insert_one.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/single_doc/insert_one.hpp
+++ b/benchmark/single_doc/insert_one.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/single_doc/run_command.hpp
+++ b/benchmark/single_doc/run_command.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/benchmark/single_doc/run_command.hpp
+++ b/benchmark/single_doc/run_command.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018-present MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018-present MongoDB Inc.
+# Copyright 2018-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmake/make_dist/CMakeLists.txt
+++ b/cmake/make_dist/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018-present MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmake/make_dist/CMakeLists.txt
+++ b/cmake/make_dist/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018-present MongoDB Inc.
+# Copyright 2018-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018-present MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018-present MongoDB Inc.
+# Copyright 2018-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018-present MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018-present MongoDB Inc.
+# Copyright 2018-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/themes/CMakeLists.txt
+++ b/docs/themes/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018-present MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/themes/CMakeLists.txt
+++ b/docs/themes/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018-present MongoDB Inc.
+# Copyright 2018-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/themes/mongodb/CMakeLists.txt
+++ b/docs/themes/mongodb/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018-present MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/themes/mongodb/CMakeLists.txt
+++ b/docs/themes/mongodb/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018-present MongoDB Inc.
+# Copyright 2018-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/etc/CMakeLists.txt
+++ b/etc/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018-present MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/etc/CMakeLists.txt
+++ b/etc/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018-present MongoDB Inc.
+# Copyright 2018-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/etc/calc_release_version.py
+++ b/etc/calc_release_version.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright 2018-present MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/etc/generate-uninstall.cmd
+++ b/etc/generate-uninstall.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-REM Copyright 2018-present MongoDB, Inc.
+REM Copyright 2009-present MongoDB, Inc.
 REM
 REM Licensed under the Apache License, Version 2.0 (the "License");
 REM you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ echo.@echo off
 echo.
 echo.REM MongoDB C++ Driver uninstall program, generated with CMake
 echo.
-echo.REM Copyright 2018-present MongoDB, Inc.
+echo.REM Copyright 2009-present MongoDB, Inc.
 echo.REM
 echo.REM Licensed under the Apache License, Version 2.0 (the "License");
 echo.REM you may not use this file except in compliance with the License.

--- a/etc/generate-uninstall.sh
+++ b/etc/generate-uninstall.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright 2018-present MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ fi
 printf "#!/bin/sh\n"
 printf "# MongoDB C++ Driver uninstall program, generated with CMake"
 printf "\n"
-printf "# Copyright 2018-present MongoDB, Inc.\n"
+printf "# Copyright 2009-present MongoDB, Inc.\n"
 printf "#\n"
 printf "# Licensed under the Apache License, Version 2.0 (the \"License\");\n"
 printf "# you may not use this file except in compliance with the License.\n"

--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright 2020 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB Inc.
+# Copyright 2016 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/add_subdirectory/CMakeLists.txt
+++ b/examples/add_subdirectory/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/add_subdirectory/CMakeLists.txt
+++ b/examples/add_subdirectory/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020 MongoDB Inc.
+# Copyright 2020 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/add_subdirectory/hello_mongocxx.cpp
+++ b/examples/add_subdirectory/hello_mongocxx.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/add_subdirectory/hello_mongocxx.cpp
+++ b/examples/add_subdirectory/hello_mongocxx.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/bsoncxx/CMakeLists.txt
+++ b/examples/bsoncxx/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/bsoncxx/CMakeLists.txt
+++ b/examples/bsoncxx/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB Inc.
+# Copyright 2016 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/bsoncxx/builder_basic.cpp
+++ b/examples/bsoncxx/builder_basic.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/bsoncxx/builder_basic.cpp
+++ b/examples/bsoncxx/builder_basic.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/bsoncxx/builder_core.cpp
+++ b/examples/bsoncxx/builder_core.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/bsoncxx/builder_core.cpp
+++ b/examples/bsoncxx/builder_core.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/bsoncxx/builder_list.cpp
+++ b/examples/bsoncxx/builder_list.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/bsoncxx/builder_list.cpp
+++ b/examples/bsoncxx/builder_list.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/bsoncxx/builder_stream.cpp
+++ b/examples/bsoncxx/builder_stream.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/bsoncxx/builder_stream.cpp
+++ b/examples/bsoncxx/builder_stream.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/bsoncxx/builder_stream_customization.cpp
+++ b/examples/bsoncxx/builder_stream_customization.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/bsoncxx/builder_stream_customization.cpp
+++ b/examples/bsoncxx/builder_stream_customization.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/bsoncxx/decimal128.cpp
+++ b/examples/bsoncxx/decimal128.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/bsoncxx/decimal128.cpp
+++ b/examples/bsoncxx/decimal128.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/bsoncxx/getting_values.cpp
+++ b/examples/bsoncxx/getting_values.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/bsoncxx/getting_values.cpp
+++ b/examples/bsoncxx/getting_values.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/bsoncxx/view_and_value.cpp
+++ b/examples/bsoncxx/view_and_value.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/bsoncxx/view_and_value.cpp
+++ b/examples/bsoncxx/view_and_value.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/CMakeLists.txt
+++ b/examples/mongocxx/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/mongocxx/CMakeLists.txt
+++ b/examples/mongocxx/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB Inc.
+# Copyright 2016 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/mongocxx/aggregate.cpp
+++ b/examples/mongocxx/aggregate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/aggregate.cpp
+++ b/examples/mongocxx/aggregate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/automatic_client_side_field_level_encryption.cpp
+++ b/examples/mongocxx/automatic_client_side_field_level_encryption.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-present MongoDB Inc.
+// Copyright 2020-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/automatic_client_side_field_level_encryption.cpp
+++ b/examples/mongocxx/automatic_client_side_field_level_encryption.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/bulk_write.cpp
+++ b/examples/mongocxx/bulk_write.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/bulk_write.cpp
+++ b/examples/mongocxx/bulk_write.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/causal_consistency.cpp
+++ b/examples/mongocxx/causal_consistency.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-present MongoDB Inc.
+// Copyright 2020-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/causal_consistency.cpp
+++ b/examples/mongocxx/causal_consistency.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/change_streams.cpp
+++ b/examples/mongocxx/change_streams.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/change_streams.cpp
+++ b/examples/mongocxx/change_streams.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/client_session.cpp
+++ b/examples/mongocxx/client_session.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/client_session.cpp
+++ b/examples/mongocxx/client_session.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/connect.cpp
+++ b/examples/mongocxx/connect.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/connect.cpp
+++ b/examples/mongocxx/connect.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/create.cpp
+++ b/examples/mongocxx/create.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/create.cpp
+++ b/examples/mongocxx/create.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/document_validation.cpp
+++ b/examples/mongocxx/document_validation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/document_validation.cpp
+++ b/examples/mongocxx/document_validation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/exception.cpp
+++ b/examples/mongocxx/exception.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/exception.cpp
+++ b/examples/mongocxx/exception.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/explicit_encryption.cpp
+++ b/examples/mongocxx/explicit_encryption.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-present MongoDB Inc.
+// Copyright 2020-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/explicit_encryption.cpp
+++ b/examples/mongocxx/explicit_encryption.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/explicit_encryption_auto_decryption.cpp
+++ b/examples/mongocxx/explicit_encryption_auto_decryption.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-present MongoDB Inc.
+// Copyright 2020-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/explicit_encryption_auto_decryption.cpp
+++ b/examples/mongocxx/explicit_encryption_auto_decryption.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/get_values_from_documents.cpp
+++ b/examples/mongocxx/get_values_from_documents.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/get_values_from_documents.cpp
+++ b/examples/mongocxx/get_values_from_documents.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/gridfs.cpp
+++ b/examples/mongocxx/gridfs.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/gridfs.cpp
+++ b/examples/mongocxx/gridfs.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/index.cpp
+++ b/examples/mongocxx/index.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/index.cpp
+++ b/examples/mongocxx/index.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/inserted_id.cpp
+++ b/examples/mongocxx/inserted_id.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/inserted_id.cpp
+++ b/examples/mongocxx/inserted_id.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/instance_management.cpp
+++ b/examples/mongocxx/instance_management.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/instance_management.cpp
+++ b/examples/mongocxx/instance_management.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/mongodb.com/aggregation_examples.cpp
+++ b/examples/mongocxx/mongodb.com/aggregation_examples.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/mongodb.com/aggregation_examples.cpp
+++ b/examples/mongocxx/mongodb.com/aggregation_examples.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/mongodb.com/documentation_examples.cpp
+++ b/examples/mongocxx/mongodb.com/documentation_examples.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/mongodb.com/documentation_examples.cpp
+++ b/examples/mongocxx/mongodb.com/documentation_examples.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/mongodb.com/index_examples.cpp
+++ b/examples/mongocxx/mongodb.com/index_examples.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/mongodb.com/index_examples.cpp
+++ b/examples/mongocxx/mongodb.com/index_examples.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/mongodb.com/runcommand_examples.cpp
+++ b/examples/mongocxx/mongodb.com/runcommand_examples.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/mongodb.com/runcommand_examples.cpp
+++ b/examples/mongocxx/mongodb.com/runcommand_examples.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/mongodb.com/usage_overview.cpp
+++ b/examples/mongocxx/mongodb.com/usage_overview.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/mongodb.com/usage_overview.cpp
+++ b/examples/mongocxx/mongodb.com/usage_overview.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/pool.cpp
+++ b/examples/mongocxx/pool.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/pool.cpp
+++ b/examples/mongocxx/pool.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/query.cpp
+++ b/examples/mongocxx/query.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/query.cpp
+++ b/examples/mongocxx/query.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/query_projection.cpp
+++ b/examples/mongocxx/query_projection.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/query_projection.cpp
+++ b/examples/mongocxx/query_projection.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/remove.cpp
+++ b/examples/mongocxx/remove.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/remove.cpp
+++ b/examples/mongocxx/remove.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/server_side_field_level_encryption_enforcement.cpp
+++ b/examples/mongocxx/server_side_field_level_encryption_enforcement.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-present MongoDB Inc.
+// Copyright 2020-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/server_side_field_level_encryption_enforcement.cpp
+++ b/examples/mongocxx/server_side_field_level_encryption_enforcement.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/tailable_cursor.cpp
+++ b/examples/mongocxx/tailable_cursor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/tailable_cursor.cpp
+++ b/examples/mongocxx/tailable_cursor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/update.cpp
+++ b/examples/mongocxx/update.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/update.cpp
+++ b/examples/mongocxx/update.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/view_or_value_variant.cpp
+++ b/examples/mongocxx/view_or_value_variant.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/view_or_value_variant.cpp
+++ b/examples/mongocxx/view_or_value_variant.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/with_transaction.cpp
+++ b/examples/mongocxx/with_transaction.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-present MongoDB Inc.
+// Copyright 2020-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/mongocxx/with_transaction.cpp
+++ b/examples/mongocxx/with_transaction.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/projects/CMakeLists.txt
+++ b/examples/projects/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018-present MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/projects/CMakeLists.txt
+++ b/examples/projects/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018-present MongoDB Inc.
+# Copyright 2018-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/projects/bsoncxx/cmake/shared/CMakeLists.txt
+++ b/examples/projects/bsoncxx/cmake/shared/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2017 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/projects/bsoncxx/cmake/shared/CMakeLists.txt
+++ b/examples/projects/bsoncxx/cmake/shared/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2017 MongoDB Inc.
+# Copyright 2017 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/projects/bsoncxx/cmake/static/CMakeLists.txt
+++ b/examples/projects/bsoncxx/cmake/static/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2017 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/projects/bsoncxx/cmake/static/CMakeLists.txt
+++ b/examples/projects/bsoncxx/cmake/static/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2017 MongoDB Inc.
+# Copyright 2017 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/projects/bsoncxx/hello_bsoncxx.cpp
+++ b/examples/projects/bsoncxx/hello_bsoncxx.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/projects/bsoncxx/hello_bsoncxx.cpp
+++ b/examples/projects/bsoncxx/hello_bsoncxx.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/projects/mongocxx/cmake/shared/CMakeLists.txt
+++ b/examples/projects/mongocxx/cmake/shared/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2017 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/projects/mongocxx/cmake/shared/CMakeLists.txt
+++ b/examples/projects/mongocxx/cmake/shared/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2017 MongoDB Inc.
+# Copyright 2017 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/projects/mongocxx/cmake/static/CMakeLists.txt
+++ b/examples/projects/mongocxx/cmake/static/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2017 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/projects/mongocxx/cmake/static/CMakeLists.txt
+++ b/examples/projects/mongocxx/cmake/static/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2017 MongoDB Inc.
+# Copyright 2017 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/projects/mongocxx/hello_mongocxx.cpp
+++ b/examples/projects/mongocxx/hello_mongocxx.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/projects/mongocxx/hello_mongocxx.cpp
+++ b/examples/projects/mongocxx/hello_mongocxx.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/extras/docker/README.md
+++ b/extras/docker/README.md
@@ -3,7 +3,7 @@
 [MongoDB](https://hub.docker.com/r/mongodb/mongodb-community-server) is a
 cross-platform document-oriented NoSQL database. MongoDB uses JSON-like
 documents with optional schemas. MongoDB is developed by
-[MongoDB Inc](https://www.mongodb.com/).
+[MongoDB, Inc.](https://www.mongodb.com/).
 
 This image provides both a C++ driver as well as a C driver which are used to
 connect to MongoDB. The C++ driver is also known as

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB Inc.
+# Copyright 2016 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/bsoncxx/CMakeLists.txt
+++ b/src/bsoncxx/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/bsoncxx/CMakeLists.txt
+++ b/src/bsoncxx/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB Inc.
+# Copyright 2016 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/bsoncxx/bsoncxx.rc.in
+++ b/src/bsoncxx/bsoncxx.rc.in
@@ -33,7 +33,7 @@ BEGIN
             VALUE "OriginalFilename", BSONCXX_OUTPUT_BASENAME ".dll"
             VALUE "ProductName", "MongoDB C++ Driver"
             VALUE "ProductVersion", BSONCXX_VERSION
-            VALUE "LegalCopyright", "Copyright (C) 2014-present MongoDB, Inc."
+            VALUE "LegalCopyright", "Copyright 2009-present MongoDB, Inc."
         END
     END
     BLOCK "VarFileInfo"
@@ -42,4 +42,3 @@ BEGIN
         VALUE "Translation", 0x409, 1200
     END
 END
-

--- a/src/bsoncxx/cmake/CMakeLists.txt
+++ b/src/bsoncxx/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/bsoncxx/cmake/CMakeLists.txt
+++ b/src/bsoncxx/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 MongoDB Inc.
+# Copyright 2023 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/bsoncxx/cmake/libbsoncxx.pc.in
+++ b/src/bsoncxx/cmake/libbsoncxx.pc.in
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/bsoncxx/cmake/libbsoncxx.pc.in
+++ b/src/bsoncxx/cmake/libbsoncxx.pc.in
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB Inc.
+# Copyright 2016 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/CMakeLists.txt
+++ b/src/bsoncxx/include/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/CMakeLists.txt
+++ b/src/bsoncxx/include/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 MongoDB Inc.
+# Copyright 2023 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view_or_value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view_or_value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/helpers.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/helpers.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/helpers.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/helpers.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/impl.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/impl.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/impl.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/impl.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/kvp.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/kvp.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/kvp.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/kvp.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context.hpp
@@ -1,5 +1,5 @@
 
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context.hpp
@@ -1,5 +1,5 @@
 
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/compiler.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/compiler.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/compiler.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/compiler.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/postlude.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/postlude.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/postlude.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/postlude.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/prelude.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/prelude.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/prelude.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/prelude.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view_or_value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view_or_value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/enums/binary_sub_type.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/enums/binary_sub_type.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/enums/binary_sub_type.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/enums/binary_sub_type.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/enums/type.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/enums/type.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/enums/type.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/enums/type.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/operators.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/operators.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/operators.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/operators.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/optional.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/optional.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/optional.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/optional.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/string_view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/string_view.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/string_view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/string_view.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/type_traits.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/type_traits.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/type_traits.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/type_traits.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/to_string.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/to_string.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/to_string.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/to_string.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/make_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/make_value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/make_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/make_value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view_or_value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view_or_value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/util/functor.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/util/functor.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/util/functor.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/util/functor.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/CMakeLists.txt
+++ b/src/bsoncxx/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/CMakeLists.txt
+++ b/src/bsoncxx/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 MongoDB Inc.
+# Copyright 2023 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/element.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/element.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/element.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/element.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/value.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/value.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/view.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/view.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/builder/core.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/builder/core.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/builder/core.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/builder/core.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/config/config.hpp.in
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/config/config.hpp.in
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/config/config.hpp.in
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/config/config.hpp.in
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/config/private/config.hh.in
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/config/private/config.hh.in
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/config/private/config.hh.in
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/config/private/config.hh.in
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/config/private/postlude.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/config/private/postlude.hh
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/config/private/postlude.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/config/private/postlude.hh
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/config/private/prelude.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/config/private/prelude.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/config/private/prelude.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/config/private/prelude.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/config/version.hpp.in
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/config/version.hpp.in
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/config/version.hpp.in
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/config/version.hpp.in
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/decimal128.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/decimal128.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/decimal128.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/decimal128.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/element.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/element.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/element.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/element.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/value.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/value.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/view.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/view.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/exception/error_code.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/exception/error_code.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/exception/error_code.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/exception/error_code.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/json.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/json.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/json.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/json.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/oid.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/oid.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/oid.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/oid.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/helpers.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/helpers.hh
@@ -1,4 +1,4 @@
-// Copyright 2015-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/helpers.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/helpers.hh
@@ -1,4 +1,4 @@
-// Copyright 2015-present MongoDB Inc.
+// Copyright 2015-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/itoa.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/itoa.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/itoa.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/itoa.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/itoa.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/itoa.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/itoa.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/itoa.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/libbson.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/libbson.hh
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/libbson.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/libbson.hh
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/stack.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/stack.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/stack.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/stack.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/suppress_deprecation_warnings.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/suppress_deprecation_warnings.hh
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/suppress_deprecation_warnings.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/private/suppress_deprecation_warnings.hh
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/string/view_or_value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/string/view_or_value.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/string/view_or_value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/string/view_or_value.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/test_util/export_for_testing.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/test_util/export_for_testing.hh
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/test_util/export_for_testing.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/test_util/export_for_testing.hh
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/private/value.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/private/value.hh
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/private/value.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/private/value.hh
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/private/convert.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/private/convert.hh
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/private/convert.hh
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/private/convert.hh
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/validate.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/validate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/validate.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/validate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/CMakeLists.txt
+++ b/src/bsoncxx/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/CMakeLists.txt
+++ b/src/bsoncxx/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB Inc.
+# Copyright 2016 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/array.cpp
+++ b/src/bsoncxx/test/array.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/array.cpp
+++ b/src/bsoncxx/test/array.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/bson_b_date.cpp
+++ b/src/bsoncxx/test/bson_b_date.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/bson_b_date.cpp
+++ b/src/bsoncxx/test/bson_b_date.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/bson_builder.cpp
+++ b/src/bsoncxx/test/bson_builder.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/bson_builder.cpp
+++ b/src/bsoncxx/test/bson_builder.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/bson_get_values.cpp
+++ b/src/bsoncxx/test/bson_get_values.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/bson_get_values.cpp
+++ b/src/bsoncxx/test/bson_get_values.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/bson_serialization.cpp
+++ b/src/bsoncxx/test/bson_serialization.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/bson_serialization.cpp
+++ b/src/bsoncxx/test/bson_serialization.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/bson_types.cpp
+++ b/src/bsoncxx/test/bson_types.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/bson_types.cpp
+++ b/src/bsoncxx/test/bson_types.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/bson_util_itoa.cpp
+++ b/src/bsoncxx/test/bson_util_itoa.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/bson_util_itoa.cpp
+++ b/src/bsoncxx/test/bson_util_itoa.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/bson_validate.cpp
+++ b/src/bsoncxx/test/bson_validate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/bson_validate.cpp
+++ b/src/bsoncxx/test/bson_validate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/bson_value.cpp
+++ b/src/bsoncxx/test/bson_value.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/catch.hh
+++ b/src/bsoncxx/test/catch.hh
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/catch.hh
+++ b/src/bsoncxx/test/catch.hh
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/json.cpp
+++ b/src/bsoncxx/test/json.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/json.cpp
+++ b/src/bsoncxx/test/json.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/oid.cpp
+++ b/src/bsoncxx/test/oid.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/oid.cpp
+++ b/src/bsoncxx/test/oid.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/to_string.hh
+++ b/src/bsoncxx/test/to_string.hh
@@ -1,4 +1,4 @@
-// Copyright 2022 MongoDB Inc.
+// Copyright 2022 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/to_string.hh
+++ b/src/bsoncxx/test/to_string.hh
@@ -1,4 +1,4 @@
-// Copyright 2022 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/view_or_value.cpp
+++ b/src/bsoncxx/test/view_or_value.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/test/view_or_value.cpp
+++ b/src/bsoncxx/test/view_or_value.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bsoncxx/third_party/CMakeLists.txt
+++ b/src/bsoncxx/third_party/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/bsoncxx/third_party/CMakeLists.txt
+++ b/src/bsoncxx/third_party/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB Inc.
+# Copyright 2016 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB Inc.
+# Copyright 2016 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/mongocxx/cmake/CMakeLists.txt
+++ b/src/mongocxx/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/mongocxx/cmake/CMakeLists.txt
+++ b/src/mongocxx/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 MongoDB Inc.
+# Copyright 2023 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/mongocxx/cmake/libmongocxx.pc.in
+++ b/src/mongocxx/cmake/libmongocxx.pc.in
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/mongocxx/cmake/libmongocxx.pc.in
+++ b/src/mongocxx/cmake/libmongocxx.pc.in
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB Inc.
+# Copyright 2016 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/CMakeLists.txt
+++ b/src/mongocxx/include/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 MongoDB Inc.
+# Copyright 2023 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014-present MongoDB Inc.
+// Copyright 2014-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014-present MongoDB Inc.
+// Copyright 2014-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017-present MongoDB Inc.
+// Copyright 2017-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014-present MongoDB Inc.
+// Copyright 2014-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/config/compiler.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/config/compiler.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/config/compiler.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/config/compiler.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/config/postlude.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/config/postlude.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/config/postlude.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/config/postlude.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/config/prelude.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/config/prelude.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/config/prelude.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/config/prelude.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_failed_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_failed_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_failed_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_failed_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_failed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_failed_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_failed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_failed_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_started_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_started_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_started_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_started_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_started_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_started_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_started_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_started_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_succeeded_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_succeeded_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_succeeded_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_succeeded_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_succeeded_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_succeeded_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_succeeded_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_succeeded_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_changed_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_changed_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_changed_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_changed_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_changed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_changed_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_changed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_changed_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_closed_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_closed_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_closed_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_closed_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_closed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_closed_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_closed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_closed_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_description-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_description-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_description-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_description-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_description.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_description.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_description.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_description.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_opening_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_opening_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_opening_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_opening_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_opening_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_opening_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_opening_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_opening_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_changed_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_changed_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_changed_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_changed_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_changed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_changed_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_changed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_changed_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_closed_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_closed_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_closed_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_closed_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_closed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_closed_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_closed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_closed_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_opening_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_opening_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_opening_event-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_opening_event-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_opening_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_opening_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_opening_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_opening_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/authentication_exception-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/authentication_exception-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/authentication_exception-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/authentication_exception-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/authentication_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/authentication_exception.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/authentication_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/authentication_exception.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/bulk_write_exception-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/bulk_write_exception-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/bulk_write_exception-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/bulk_write_exception-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/bulk_write_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/bulk_write_exception.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/bulk_write_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/bulk_write_exception.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/error_code-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/error_code-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/error_code-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/error_code-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/error_code.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/error_code.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/error_code.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/error_code.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015-present MongoDB Inc.
+// Copyright 2015-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/exception-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/exception-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/exception-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/exception-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/exception.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/exception.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/gridfs_exception-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/gridfs_exception-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/gridfs_exception-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/gridfs_exception-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/gridfs_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/gridfs_exception.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/gridfs_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/gridfs_exception.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/logic_error-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/logic_error-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/logic_error-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/logic_error-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/logic_error.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/logic_error.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/logic_error.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/logic_error.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/query_exception-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/query_exception-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/query_exception-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/query_exception-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/query_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/query_exception.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/query_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/query_exception.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/server_error_code-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/server_error_code-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/server_error_code-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/server_error_code-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/server_error_code.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/server_error_code.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/server_error_code.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/server_error_code.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/write_exception-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/write_exception-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/write_exception-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/write_exception-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/write_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/write_exception.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/write_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/write_exception.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/downloader-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/downloader-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/downloader-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/downloader-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/downloader.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/downloader.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/downloader.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/downloader.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/uploader-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/uploader-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/uploader-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/uploader-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/uploader.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/uploader.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/uploader.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/uploader.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/hint-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/hint-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/hint-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/hint-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/hint.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/hint.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/hint.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/hint.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_model-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_model-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_model-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_model-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_model.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_model.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_model.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_model.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/instance-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/instance-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/instance-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/instance-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/instance.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/instance.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/instance.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/instance.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_many-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_many-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_many-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_many-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_many.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_many.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_many.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_many.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_one-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_one-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_one-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_one-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_one.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_one.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/insert_one-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/insert_one-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/insert_one-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/insert_one-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/insert_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/insert_one.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/insert_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/insert_one.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/replace_one-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/replace_one-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/replace_one-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/replace_one-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/replace_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/replace_one.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/replace_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/replace_one.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_many-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_many-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_many-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_many-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_many.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_many.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_many.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_many.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_one-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_one-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_one-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_one-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_one.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_one.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/write-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/write-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/write-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/write-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/write.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/write.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/apm-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/apm-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/apm-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/apm-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/apm.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/apm.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/apm.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/apm.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/bulk_write-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/bulk_write-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/bulk_write-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/bulk_write-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/bulk_write.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/bulk_write.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_session-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_session-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_session-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_session-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_session.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017-present MongoDB Inc.
+// Copyright 2017-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_session.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/create_collection.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/create_collection.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/create_collection.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/create_collection.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/delete-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/delete-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/delete-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/delete-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/delete.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/delete.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/delete.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/delete.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/estimated_document_count-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/estimated_document_count-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/estimated_document_count-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/estimated_document_count-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/estimated_document_count.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/estimated_document_count.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/estimated_document_count.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/estimated_document_count.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_common_options-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_common_options-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_common_options-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_common_options-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_common_options.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_common_options.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_common_options.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_common_options.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/bucket-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/bucket-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/bucket-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/bucket-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/bucket.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/bucket.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/bucket.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/bucket.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/upload-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/upload-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/upload-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/upload-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/upload.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/upload.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/upload.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/upload.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/pool-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/pool-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/pool-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/pool-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/pool.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/pool.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/pool.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/pool.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/range-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/range-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/range-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/range-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/range.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/range.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/range.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/range.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/server_api-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/server_api-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/server_api-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/server_api-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/server_api.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/server_api.hpp
@@ -1,4 +1,4 @@
-// Copyright 2021 MongoDB Inc.
+// Copyright 2021 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/server_api.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/server_api.hpp
@@ -1,4 +1,4 @@
-// Copyright 2021 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/ssl.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/ssl.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/ssl.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/ssl.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/tls-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/tls-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/tls-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/tls-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/tls.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/tls.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/tls.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/tls.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019 MongoDB Inc.
+// Copyright 2019 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/update-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/update-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/update-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/update-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/update.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/update.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/update.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/update.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/bulk_write-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/bulk_write-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/bulk_write-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/bulk_write-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/bulk_write.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/bulk_write.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/delete-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/delete-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/delete-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/delete-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/delete.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/delete.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/delete.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/delete.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/gridfs/upload-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/gridfs/upload-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/gridfs/upload-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/gridfs/upload-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/gridfs/upload.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/gridfs/upload.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/gridfs/upload.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/gridfs/upload.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_many-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_many-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_many-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_many-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_many.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_many.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_many.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_many.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_one-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_one-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_one-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_one-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_one.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_one.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/replace_one-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/replace_one-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/replace_one-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/replace_one-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/replace_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/replace_one.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/replace_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/replace_one.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/update-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/update-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/update-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/update-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/update.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/update.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/update.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/update.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_model-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_model-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_model-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_model-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_view-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_view-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_view-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_view-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stdx.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stdx.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stdx.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stdx.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/validation_criteria-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/validation_criteria-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/validation_criteria-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/validation_criteria-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/validation_criteria.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/validation_criteria.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/validation_criteria.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/validation_criteria.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_type-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_type-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_type-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_type-fwd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_type.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_type.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_type.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_type.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/CMakeLists.txt
+++ b/src/mongocxx/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/CMakeLists.txt
+++ b/src/mongocxx/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 MongoDB Inc.
+# Copyright 2023 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/bulk_write.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/bulk_write.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-present MongoDB Inc.
+// Copyright 2014-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/bulk_write.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/bulk_write.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/change_stream.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/change_stream.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/change_stream.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/change_stream.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client_encryption.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client_encryption.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client_encryption.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client_encryption.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client_session.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client_session.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-present MongoDB Inc.
+// Copyright 2017-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client_session.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client_session.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-present MongoDB Inc.
+// Copyright 2014-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/config/config.hpp.in
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/config/config.hpp.in
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/config/config.hpp.in
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/config/config.hpp.in
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/config/private/config.hh.in
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/config/private/config.hh.in
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/config/private/config.hh.in
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/config/private/config.hh.in
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/config/private/postlude.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/config/private/postlude.hh
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/config/private/postlude.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/config/private/postlude.hh
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/config/private/prelude.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/config/private/prelude.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/config/private/prelude.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/config/private/prelude.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/config/version.hpp.in
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/config/version.hpp.in
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/config/version.hpp.in
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/config/version.hpp.in
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/cursor.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/cursor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/cursor.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/cursor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/database.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/database.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/database.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/database.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_failed_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_failed_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_failed_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_failed_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_started_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_started_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_started_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_started_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_succeeded_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_succeeded_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_succeeded_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_succeeded_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/server_changed_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/server_changed_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/server_changed_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/server_changed_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/server_closed_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/server_closed_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/server_closed_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/server_closed_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/server_description.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/server_description.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/server_description.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/server_description.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/server_opening_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/server_opening_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/server_opening_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/server_opening_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/topology_changed_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/topology_changed_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/topology_changed_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/topology_changed_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/topology_closed_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/topology_closed_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/topology_closed_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/topology_closed_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/topology_description.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/topology_description.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/topology_description.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/topology_description.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/topology_opening_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/topology_opening_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/topology_opening_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/topology_opening_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/error_code.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/error_code.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/error_code.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/error_code.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-present MongoDB Inc.
+// Copyright 2015-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/operation_exception.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/operation_exception.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/operation_exception.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/operation_exception.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/private/mongoc_error.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/private/mongoc_error.hh
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/private/mongoc_error.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/private/mongoc_error.hh
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/server_error_code.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/server_error_code.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/server_error_code.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/server_error_code.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/bucket.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/bucket.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/bucket.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/bucket.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/downloader.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/downloader.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/downloader.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/downloader.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/private/bucket.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/private/bucket.hh
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/private/bucket.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/private/bucket.hh
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/private/downloader.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/private/downloader.hh
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/private/downloader.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/private/downloader.hh
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/private/uploader.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/private/uploader.hh
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/private/uploader.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/private/uploader.hh
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/uploader.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/uploader.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/uploader.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/uploader.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/hint.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/hint.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/hint.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/hint.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/index_model.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/index_model.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/index_model.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/index_model.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/index_view.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/index_view.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/index_view.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/index_view.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/instance.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/instance.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/instance.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/instance.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/logger.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/logger.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/logger.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/logger.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/delete_many.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/delete_many.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/delete_many.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/delete_many.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/delete_one.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/delete_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/delete_one.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/delete_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/insert_one.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/insert_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/insert_one.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/insert_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/replace_one.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/replace_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/replace_one.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/replace_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/update_many.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/update_many.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/update_many.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/update_many.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/update_one.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/update_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/update_one.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/update_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/write.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/write.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/write.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/write.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/aggregate.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/aggregate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/aggregate.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/aggregate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/apm.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/apm.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/apm.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/apm.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/auto_encryption.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/auto_encryption.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/auto_encryption.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/auto_encryption.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/bulk_write.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/bulk_write.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/bulk_write.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/bulk_write.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/change_stream.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/change_stream.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/change_stream.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/change_stream.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/client.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/client.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/client.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/client.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/client_encryption.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/client_encryption.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/client_encryption.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/client_encryption.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/client_session.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/client_session.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-present MongoDB Inc.
+// Copyright 2017-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/client_session.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/client_session.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/count.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/count.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/count.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/count.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/create_collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/create_collection.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/create_collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/create_collection.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/data_key.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/data_key.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/data_key.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/data_key.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/delete.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/delete.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/delete.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/delete.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/distinct.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/distinct.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/distinct.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/distinct.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/encrypt.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/encrypt.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/encrypt.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/encrypt.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/estimated_document_count.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/estimated_document_count.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/estimated_document_count.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/estimated_document_count.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find_one_and_update.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find_one_and_update.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find_one_and_update.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find_one_and_update.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/gridfs/bucket.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/gridfs/bucket.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/gridfs/bucket.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/gridfs/bucket.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/gridfs/upload.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/gridfs/upload.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/gridfs/upload.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/gridfs/upload.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/index.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/index.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/index.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/index.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/index_view.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/index_view.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/index_view.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/index_view.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/insert.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/insert.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/insert.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/insert.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/pool.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/pool.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/pool.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/pool.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/private/apm.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/private/apm.hh
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/private/apm.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/private/apm.hh
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/private/server_api.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/private/server_api.hh
@@ -1,4 +1,4 @@
-// Copyright 2021 MongoDB Inc.
+// Copyright 2021 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/private/server_api.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/private/server_api.hh
@@ -1,4 +1,4 @@
-// Copyright 2021 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/private/ssl.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/private/ssl.hh
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/private/ssl.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/private/ssl.hh
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/private/transaction.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/private/transaction.hh
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/private/transaction.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/private/transaction.hh
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/range.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/range.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/range.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/range.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/replace.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/replace.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/replace.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/replace.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/server_api.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/server_api.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 MongoDB Inc.
+// Copyright 2021 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/server_api.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/server_api.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/tls.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/tls.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/tls.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/tls.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/transaction.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/transaction.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/transaction.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/transaction.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/update.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/update.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/update.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/update.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pipeline.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pipeline.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pipeline.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pipeline.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/bulk_write.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/bulk_write.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/bulk_write.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/bulk_write.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/change_stream.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/change_stream.hh
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/change_stream.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/change_stream.hh
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client_encryption.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client_encryption.hh
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client_encryption.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client_encryption.hh
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client_session.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client_session.hh
@@ -1,4 +1,4 @@
-// Copyright 2017-present MongoDB Inc.
+// Copyright 2017-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client_session.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client_session.hh
@@ -1,4 +1,4 @@
-// Copyright 2017-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/collection.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/collection.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/collection.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/collection.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/conversions.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/conversions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/conversions.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/conversions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/conversions.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/conversions.hh
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/conversions.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/conversions.hh
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/cursor.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/cursor.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/cursor.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/cursor.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/database.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/database.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/database.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/database.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/index_view.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/index_view.hh
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/index_view.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/index_view.hh
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libbson.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libbson.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libbson.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libbson.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libbson.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libbson.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libbson.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libbson.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libmongoc.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libmongoc.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libmongoc.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libmongoc.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libmongoc.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libmongoc.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libmongoc.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libmongoc.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libmongoc_symbols.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libmongoc_symbols.hh
@@ -1,4 +1,4 @@
-// Copyright 2014-present MongoDB Inc.
+// Copyright 2014-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libmongoc_symbols.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libmongoc_symbols.hh
@@ -1,4 +1,4 @@
-// Copyright 2014-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/numeric_casting.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/numeric_casting.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/numeric_casting.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/numeric_casting.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-present MongoDB Inc.
+// Copyright 2022-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/numeric_casting.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/numeric_casting.hh
@@ -1,4 +1,4 @@
-// Copyright 2022-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/numeric_casting.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/numeric_casting.hh
@@ -1,4 +1,4 @@
-// Copyright 2022-present MongoDB Inc.
+// Copyright 2022-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/pipeline.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/pipeline.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/pipeline.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/pipeline.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/pool.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/pool.hh
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/pool.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/pool.hh
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/read_concern.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/read_concern.hh
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/read_concern.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/read_concern.hh
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/read_preference.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/read_preference.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/read_preference.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/read_preference.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/uri.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/uri.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/uri.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/uri.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/write_concern.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/write_concern.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/write_concern.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/write_concern.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/read_concern.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/read_concern.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/read_concern.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/read_concern.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/read_preference.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/read_preference.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/read_preference.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/read_preference.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/bulk_write.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/bulk_write.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/bulk_write.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/bulk_write.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/delete.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/delete.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/delete.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/delete.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/gridfs/upload.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/gridfs/upload.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/gridfs/upload.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/gridfs/upload.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/insert_many.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/insert_many.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/insert_many.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/insert_many.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/insert_one.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/insert_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/insert_one.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/insert_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/replace_one.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/replace_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/replace_one.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/replace_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB Inc.
+// Copyright 2023 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/update.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/update.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/update.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/update.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/test_util/export_for_testing.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/test_util/export_for_testing.hh
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/test_util/export_for_testing.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/test_util/export_for_testing.hh
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/test_util/mock.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/test_util/mock.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/test_util/mock.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/test_util/mock.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/uri.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/uri.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/uri.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/uri.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/validation_criteria.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/validation_criteria.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/validation_criteria.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/validation_criteria.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/write_concern.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/write_concern.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/write_concern.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/write_concern.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/mongocxx.rc.in
+++ b/src/mongocxx/mongocxx.rc.in
@@ -33,7 +33,7 @@ BEGIN
             VALUE "OriginalFilename", MONGOCXX_OUTPUT_BASENAME ".dll"
             VALUE "ProductName", "MongoDB C++ Driver"
             VALUE "ProductVersion", MONGOCXX_VERSION
-            VALUE "LegalCopyright", "Copyright (C) 2014-present MongoDB, Inc."
+            VALUE "LegalCopyright", "Copyright 2009-present MongoDB, Inc."
         END
     END
     BLOCK "VarFileInfo"
@@ -42,4 +42,3 @@ BEGIN
         VALUE "Translation", 0x409, 1200
     END
 END
-

--- a/src/mongocxx/test/CMakeLists.txt
+++ b/src/mongocxx/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB, Inc.
+# Copyright 2009-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/CMakeLists.txt
+++ b/src/mongocxx/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 MongoDB Inc.
+# Copyright 2016 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/bulk_write.cpp
+++ b/src/mongocxx/test/bulk_write.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/bulk_write.cpp
+++ b/src/mongocxx/test/bulk_write.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/change_streams.cpp
+++ b/src/mongocxx/test/change_streams.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/change_streams.cpp
+++ b/src/mongocxx/test/change_streams.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/client.cpp
+++ b/src/mongocxx/test/client.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/client.cpp
+++ b/src/mongocxx/test/client.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/client_helpers.cpp
+++ b/src/mongocxx/test/client_helpers.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/client_helpers.cpp
+++ b/src/mongocxx/test/client_helpers.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/client_helpers.hh
+++ b/src/mongocxx/test/client_helpers.hh
@@ -1,4 +1,4 @@
-// Copyright 2016-present MongoDB Inc.
+// Copyright 2016-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/client_helpers.hh
+++ b/src/mongocxx/test/client_helpers.hh
@@ -1,4 +1,4 @@
-// Copyright 2016-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/client_session.cpp
+++ b/src/mongocxx/test/client_session.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/client_session.cpp
+++ b/src/mongocxx/test/client_session.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/client_side_encryption.cpp
+++ b/src/mongocxx/test/client_side_encryption.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/client_side_encryption.cpp
+++ b/src/mongocxx/test/client_side_encryption.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/collection_mocked.cpp
+++ b/src/mongocxx/test/collection_mocked.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/collection_mocked.cpp
+++ b/src/mongocxx/test/collection_mocked.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/conversions.cpp
+++ b/src/mongocxx/test/conversions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/conversions.cpp
+++ b/src/mongocxx/test/conversions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/database.cpp
+++ b/src/mongocxx/test/database.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-present MongoDB Inc.
+// Copyright 2014-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/database.cpp
+++ b/src/mongocxx/test/database.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/gridfs/bucket.cpp
+++ b/src/mongocxx/test/gridfs/bucket.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/gridfs/bucket.cpp
+++ b/src/mongocxx/test/gridfs/bucket.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/gridfs/downloader.cpp
+++ b/src/mongocxx/test/gridfs/downloader.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/gridfs/downloader.cpp
+++ b/src/mongocxx/test/gridfs/downloader.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/gridfs/uploader.cpp
+++ b/src/mongocxx/test/gridfs/uploader.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/gridfs/uploader.cpp
+++ b/src/mongocxx/test/gridfs/uploader.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/hint.cpp
+++ b/src/mongocxx/test/hint.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/hint.cpp
+++ b/src/mongocxx/test/hint.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/index_view.cpp
+++ b/src/mongocxx/test/index_view.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/index_view.cpp
+++ b/src/mongocxx/test/index_view.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/instance.cpp
+++ b/src/mongocxx/test/instance.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/instance.cpp
+++ b/src/mongocxx/test/instance.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/logging.cpp
+++ b/src/mongocxx/test/logging.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/logging.cpp
+++ b/src/mongocxx/test/logging.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/model/delete_many.cpp
+++ b/src/mongocxx/test/model/delete_many.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/model/delete_many.cpp
+++ b/src/mongocxx/test/model/delete_many.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/model/delete_one.cpp
+++ b/src/mongocxx/test/model/delete_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/model/delete_one.cpp
+++ b/src/mongocxx/test/model/delete_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/model/insert_one.cpp
+++ b/src/mongocxx/test/model/insert_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/model/insert_one.cpp
+++ b/src/mongocxx/test/model/insert_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/model/replace_one.cpp
+++ b/src/mongocxx/test/model/replace_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/model/replace_one.cpp
+++ b/src/mongocxx/test/model/replace_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/model/update_many.cpp
+++ b/src/mongocxx/test/model/update_many.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/model/update_many.cpp
+++ b/src/mongocxx/test/model/update_many.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/model/update_one.cpp
+++ b/src/mongocxx/test/model/update_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/model/update_one.cpp
+++ b/src/mongocxx/test/model/update_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/aggregate.cpp
+++ b/src/mongocxx/test/options/aggregate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/aggregate.cpp
+++ b/src/mongocxx/test/options/aggregate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/bulk_write.cpp
+++ b/src/mongocxx/test/options/bulk_write.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/bulk_write.cpp
+++ b/src/mongocxx/test/options/bulk_write.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/client_session.cpp
+++ b/src/mongocxx/test/options/client_session.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/client_session.cpp
+++ b/src/mongocxx/test/options/client_session.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/count.cpp
+++ b/src/mongocxx/test/options/count.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/count.cpp
+++ b/src/mongocxx/test/options/count.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/create_collection.cpp
+++ b/src/mongocxx/test/options/create_collection.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/create_collection.cpp
+++ b/src/mongocxx/test/options/create_collection.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/delete.cpp
+++ b/src/mongocxx/test/options/delete.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/delete.cpp
+++ b/src/mongocxx/test/options/delete.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/distinct.cpp
+++ b/src/mongocxx/test/options/distinct.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/distinct.cpp
+++ b/src/mongocxx/test/options/distinct.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/find.cpp
+++ b/src/mongocxx/test/options/find.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/find.cpp
+++ b/src/mongocxx/test/options/find.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/find_one_and_delete.cpp
+++ b/src/mongocxx/test/options/find_one_and_delete.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/find_one_and_delete.cpp
+++ b/src/mongocxx/test/options/find_one_and_delete.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/find_one_and_replace.cpp
+++ b/src/mongocxx/test/options/find_one_and_replace.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/find_one_and_replace.cpp
+++ b/src/mongocxx/test/options/find_one_and_replace.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/find_one_and_update.cpp
+++ b/src/mongocxx/test/options/find_one_and_update.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/find_one_and_update.cpp
+++ b/src/mongocxx/test/options/find_one_and_update.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/gridfs/bucket.cpp
+++ b/src/mongocxx/test/options/gridfs/bucket.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/gridfs/bucket.cpp
+++ b/src/mongocxx/test/options/gridfs/bucket.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/gridfs/upload.cpp
+++ b/src/mongocxx/test/options/gridfs/upload.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/gridfs/upload.cpp
+++ b/src/mongocxx/test/options/gridfs/upload.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/index.cpp
+++ b/src/mongocxx/test/options/index.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/index.cpp
+++ b/src/mongocxx/test/options/index.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/insert.cpp
+++ b/src/mongocxx/test/options/insert.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/insert.cpp
+++ b/src/mongocxx/test/options/insert.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/pool.cpp
+++ b/src/mongocxx/test/options/pool.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/pool.cpp
+++ b/src/mongocxx/test/options/pool.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/replace.cpp
+++ b/src/mongocxx/test/options/replace.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/replace.cpp
+++ b/src/mongocxx/test/options/replace.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/update.cpp
+++ b/src/mongocxx/test/options/update.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/options/update.cpp
+++ b/src/mongocxx/test/options/update.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/pool.cpp
+++ b/src/mongocxx/test/pool.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/pool.cpp
+++ b/src/mongocxx/test/pool.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/private/numeric_casting.cpp
+++ b/src/mongocxx/test/private/numeric_casting.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/private/numeric_casting.cpp
+++ b/src/mongocxx/test/private/numeric_casting.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-present MongoDB Inc.
+// Copyright 2022-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/private/scoped_bson_t.cpp
+++ b/src/mongocxx/test/private/scoped_bson_t.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/private/scoped_bson_t.cpp
+++ b/src/mongocxx/test/private/scoped_bson_t.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/private/write_concern.cpp
+++ b/src/mongocxx/test/private/write_concern.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/private/write_concern.cpp
+++ b/src/mongocxx/test/private/write_concern.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/read_concern.cpp
+++ b/src/mongocxx/test/read_concern.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/read_concern.cpp
+++ b/src/mongocxx/test/read_concern.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/read_preference.cpp
+++ b/src/mongocxx/test/read_preference.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/read_preference.cpp
+++ b/src/mongocxx/test/read_preference.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/result/bulk_write.cpp
+++ b/src/mongocxx/test/result/bulk_write.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/result/bulk_write.cpp
+++ b/src/mongocxx/test/result/bulk_write.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/result/delete.cpp
+++ b/src/mongocxx/test/result/delete.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/result/delete.cpp
+++ b/src/mongocxx/test/result/delete.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/result/gridfs/upload.cpp
+++ b/src/mongocxx/test/result/gridfs/upload.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/result/gridfs/upload.cpp
+++ b/src/mongocxx/test/result/gridfs/upload.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/result/insert_one.cpp
+++ b/src/mongocxx/test/result/insert_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/result/insert_one.cpp
+++ b/src/mongocxx/test/result/insert_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/result/replace_one.cpp
+++ b/src/mongocxx/test/result/replace_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/result/replace_one.cpp
+++ b/src/mongocxx/test/result/replace_one.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/result/update.cpp
+++ b/src/mongocxx/test/result/update.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/result/update.cpp
+++ b/src/mongocxx/test/result/update.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/sdam-monitoring.cpp
+++ b/src/mongocxx/test/sdam-monitoring.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/sdam-monitoring.cpp
+++ b/src/mongocxx/test/sdam-monitoring.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/client_side_encryption.cpp
+++ b/src/mongocxx/test/spec/client_side_encryption.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/client_side_encryption.cpp
+++ b/src/mongocxx/test/spec/client_side_encryption.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-present MongoDB Inc.
+// Copyright 2019-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/command_monitoring.cpp
+++ b/src/mongocxx/test/spec/command_monitoring.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/command_monitoring.cpp
+++ b/src/mongocxx/test/spec/command_monitoring.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/crud.cpp
+++ b/src/mongocxx/test/spec/crud.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/crud.cpp
+++ b/src/mongocxx/test/spec/crud.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/gridfs.cpp
+++ b/src/mongocxx/test/spec/gridfs.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/gridfs.cpp
+++ b/src/mongocxx/test/spec/gridfs.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 MongoDB Inc.
+// Copyright 2017 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/initial_dns_seedlist_discovery.cpp
+++ b/src/mongocxx/test/spec/initial_dns_seedlist_discovery.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/initial_dns_seedlist_discovery.cpp
+++ b/src/mongocxx/test/spec/initial_dns_seedlist_discovery.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/mongohouse.cpp
+++ b/src/mongocxx/test/spec/mongohouse.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/mongohouse.cpp
+++ b/src/mongocxx/test/spec/mongohouse.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/monitoring.cpp
+++ b/src/mongocxx/test/spec/monitoring.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/monitoring.cpp
+++ b/src/mongocxx/test/spec/monitoring.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/monitoring.hh
+++ b/src/mongocxx/test/spec/monitoring.hh
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/monitoring.hh
+++ b/src/mongocxx/test/spec/monitoring.hh
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/operation.cpp
+++ b/src/mongocxx/test/spec/operation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/operation.cpp
+++ b/src/mongocxx/test/spec/operation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/operation.hh
+++ b/src/mongocxx/test/spec/operation.hh
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/operation.hh
+++ b/src/mongocxx/test/spec/operation.hh
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/read_write_concern.cpp
+++ b/src/mongocxx/test/spec/read_write_concern.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/read_write_concern.cpp
+++ b/src/mongocxx/test/spec/read_write_concern.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/retryable-reads.cpp
+++ b/src/mongocxx/test/spec/retryable-reads.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/retryable-reads.cpp
+++ b/src/mongocxx/test/spec/retryable-reads.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/transactions.cpp
+++ b/src/mongocxx/test/spec/transactions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/transactions.cpp
+++ b/src/mongocxx/test/spec/transactions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/unified_tests/assert.cpp
+++ b/src/mongocxx/test/spec/unified_tests/assert.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-present MongoDB Inc.
+// Copyright 2020-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/unified_tests/assert.cpp
+++ b/src/mongocxx/test/spec/unified_tests/assert.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/unified_tests/assert.hh
+++ b/src/mongocxx/test/spec/unified_tests/assert.hh
@@ -1,4 +1,4 @@
-// Copyright 2020-present MongoDB Inc.
+// Copyright 2020-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/unified_tests/assert.hh
+++ b/src/mongocxx/test/spec/unified_tests/assert.hh
@@ -1,4 +1,4 @@
-// Copyright 2020-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/unified_tests/entity.cpp
+++ b/src/mongocxx/test/spec/unified_tests/entity.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/unified_tests/entity.cpp
+++ b/src/mongocxx/test/spec/unified_tests/entity.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/unified_tests/entity.hh
+++ b/src/mongocxx/test/spec/unified_tests/entity.hh
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/unified_tests/entity.hh
+++ b/src/mongocxx/test/spec/unified_tests/entity.hh
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/unified_tests/operations.cpp
+++ b/src/mongocxx/test/spec/unified_tests/operations.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/unified_tests/operations.cpp
+++ b/src/mongocxx/test/spec/unified_tests/operations.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/unified_tests/operations.hh
+++ b/src/mongocxx/test/spec/unified_tests/operations.hh
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/unified_tests/operations.hh
+++ b/src/mongocxx/test/spec/unified_tests/operations.hh
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc.
+// Copyright 2020 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/uri_options.cpp
+++ b/src/mongocxx/test/spec/uri_options.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/uri_options.cpp
+++ b/src/mongocxx/test/spec/uri_options.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/util.cpp
+++ b/src/mongocxx/test/spec/util.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/util.cpp
+++ b/src/mongocxx/test/spec/util.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/util.hh
+++ b/src/mongocxx/test/spec/util.hh
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/spec/util.hh
+++ b/src/mongocxx/test/spec/util.hh
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/transactions.cpp
+++ b/src/mongocxx/test/transactions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB Inc.
+// Copyright 2018-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/transactions.cpp
+++ b/src/mongocxx/test/transactions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/uri.cpp
+++ b/src/mongocxx/test/uri.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/uri.cpp
+++ b/src/mongocxx/test/uri.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/validation_criteria.cpp
+++ b/src/mongocxx/test/validation_criteria.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB Inc.
+// Copyright 2015 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/validation_criteria.cpp
+++ b/src/mongocxx/test/validation_criteria.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/versioned_api.cpp
+++ b/src/mongocxx/test/versioned_api.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 MongoDB Inc.
+// Copyright 2021 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/versioned_api.cpp
+++ b/src/mongocxx/test/versioned_api.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/write_concern.cpp
+++ b/src/mongocxx/test/write_concern.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/test/write_concern.cpp
+++ b/src/mongocxx/test/write_concern.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/third_party/catch/include/helpers.hpp
+++ b/src/third_party/catch/include/helpers.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/third_party/catch/include/helpers.hpp
+++ b/src/third_party/catch/include/helpers.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 MongoDB Inc.
+// Copyright 2014 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/third_party/catch/main.cpp
+++ b/src/third_party/catch/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB Inc.
+// Copyright 2016 MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/third_party/catch/main.cpp
+++ b/src/third_party/catch/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Resolves CXX-2771. Analogous to changes in https://github.com/mongodb/mongo-c-driver/pull/1655.