### PR TITLE
CXX-2742 relocate `is_empty` to impl class

### DIFF
--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write.hpp
@@ -111,8 +111,6 @@ class bulk_write {
 
     bool _created_from_collection;
     std::unique_ptr<impl> _impl;
-
-    bool is_empty = true;
 };
 
 }  // namespace v_noabi

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/bulk_write.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/bulk_write.cpp
@@ -41,7 +41,7 @@ bulk_write& bulk_write::operator=(bulk_write&&) noexcept = default;
 bulk_write::~bulk_write() = default;
 
 bool bulk_write::empty() const noexcept {
-    return is_empty;
+    return _impl->is_empty;
 }
 
 bulk_write& bulk_write::append(const model::write& operation) {
@@ -176,7 +176,7 @@ bulk_write& bulk_write::append(const model::write& operation) {
         }
     }
 
-    is_empty = false;
+    _impl->is_empty = false;
 
     return *this;
 }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/bulk_write.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/bulk_write.hh
@@ -37,6 +37,7 @@ class bulk_write::impl {
     impl& operator=(const impl&) = delete;
 
     mongoc_bulk_operation_t* operation_t;
+    bool is_empty = true;
 };
 
 }  // namespace v_noabi


### PR DESCRIPTION
# Summary

Relocate field `_is_empty` to impl class.

# Background & Motivation

The [abi-compliance-check](https://spruce.mongodb.com/task/mongo_cxx_driver_abi_stability_polyfill_abi_compliance_check_9223cfcf72bb3ced16c20275e460ba8d6b76a3e2_24_07_01_19_26_58/files?execution=0) task identified an ABI change from https://github.com/mongodb/mongo-cxx-driver/pull/1150 (under "Problems with Data Types" in the attached [HTML report](https://mciuploads.s3.amazonaws.com/mongo-cxx-driver/master/9223cfcf72bb3ced16c20275e460ba8d6b76a3e2/mongo_cxx_driver_9223cfcf72bb3ced16c20275e460ba8d6b76a3e2/mongo_cxx_driver_abi_stability_polyfill_9223cfcf72bb3ced16c20275e460ba8d6b76a3e2_24_07_01_19_26_58/0/abi-compliance-check/noabi/compat_report.html)). Adding `_is_empty` to `mongocxx::v_noabi::bulk_write` changed the size of the type.

Many C++ driver classes use the [PImpl pattern](https://en.cppreference.com/w/cpp/language/pimpl) to hide implementation details. Adding fields to the private `mongocxx::v_noabi::bulk_write::impl` class does not impact the size or layout of public `mongocxx::v_noabi::bulk_write` class.

Though symbols in `mongocxx::v_noabi` do not guarantee ABI stability, I expect avoiding unnecessary ABI changes may help ongoing efforts to migrate interfaces to a stable ABI (CXX-1569).

The [ABI compatibility report](https://mciuploads.s3.amazonaws.com/mongo-cxx-driver/master/9223cfcf72bb3ced16c20275e460ba8d6b76a3e2/6687e587bc2c44000762e76e/mongo_cxx_driver_abi_stability_polyfill_patch_9223cfcf72bb3ced16c20275e460ba8d6b76a3e2_6687e587bc2c44000762e76e_24_07_05_12_22_32/0/abi-compliance-check/noabi/compat_report.html) for this PR no longer reports the size change.