### PR TITLE
CXX-3064 Fix use of Doxygen @relates, @relatesalso, and groups

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,6 +5,7 @@ BasedOnStyle: Google
 BinPackArguments: false
 BinPackParameters: false
 ColumnLimit: 100
+CommentPragmas: '^\s*@(addtogroup|copydoc|defgroup|fn|ref)'
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 IncludeBlocks: Regroup

--- a/Doxyfile
+++ b/Doxyfile
@@ -2213,11 +2213,11 @@ INCLUDE_FILE_PATTERNS  =
 PREDEFINED             = BSONCXX_API= \
                          BSONCXX_CALL= \
                          BSONCXX_DEPRECATED \
-                         BSONCXX_INLINE= \
+                         BSONCXX_INLINE=inline \
                          MONGOCXX_API= \
                          MONGOCXX_CALL= \
-                         MONGOCXX_DEPRECATED \
-                         MONGOCXX_INLINE=
+                         MONGOCXX_DEPRECATED= \
+                         MONGOCXX_INLINE=inline
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/Doxyfile
+++ b/Doxyfile
@@ -2214,10 +2214,12 @@ PREDEFINED             = BSONCXX_API= \
                          BSONCXX_CALL= \
                          BSONCXX_DEPRECATED \
                          BSONCXX_INLINE=inline \
+                         BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR= \
                          MONGOCXX_API= \
                          MONGOCXX_CALL= \
                          MONGOCXX_DEPRECATED= \
-                         MONGOCXX_INLINE=inline
+                         MONGOCXX_INLINE=inline \
+                         MONGOCXX_PRIVATE_DOXYGEN_PREPROCESSOR=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/Doxyfile
+++ b/Doxyfile
@@ -639,7 +639,7 @@ SORT_MEMBER_DOCS       = YES
 # this will also influence the order of the classes in the class list.
 # The default value is: NO.
 
-SORT_BRIEF_DOCS        = NO
+SORT_BRIEF_DOCS        = YES
 
 # If the SORT_MEMBERS_CTORS_1ST tag is set to YES then doxygen will sort the
 # (brief and detailed) documentation of class members so that constructors and
@@ -651,14 +651,14 @@ SORT_BRIEF_DOCS        = NO
 # detailed member documentation.
 # The default value is: NO.
 
-SORT_MEMBERS_CTORS_1ST = NO
+SORT_MEMBERS_CTORS_1ST = YES
 
 # If the SORT_GROUP_NAMES tag is set to YES then doxygen will sort the hierarchy
 # of group names into alphabetical order. If set to NO the group names will
 # appear in their defined order.
 # The default value is: NO.
 
-SORT_GROUP_NAMES       = NO
+SORT_GROUP_NAMES       = YES
 
 # If the SORT_BY_SCOPE_NAME tag is set to YES, the class list will be sorted by
 # fully-qualified names, including namespaces. If set to NO, the class list will
@@ -668,7 +668,7 @@ SORT_GROUP_NAMES       = NO
 # list.
 # The default value is: NO.
 
-SORT_BY_SCOPE_NAME     = NO
+SORT_BY_SCOPE_NAME     = YES
 
 # If the STRICT_PROTO_MATCHING option is enabled and doxygen fails to do proper
 # type resolution of all parameters of a function it will reject a match between

--- a/Doxyfile
+++ b/Doxyfile
@@ -160,7 +160,8 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        =
+STRIP_FROM_PATH        = src/bsoncxx/include \
+                         src/mongocxx/include
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which

--- a/src/bsoncxx/include/bsoncxx/fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/fwd.hpp
@@ -1,0 +1,17 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// THIS FILE IS NOT INTENDED TO BE INCLUDABLE.
+#include <bsoncxx/v_noabi/bsoncxx/fwd.hpp>
+// THIS FILE IS NOT INTENDED TO BE INCLUDABLE.

--- a/src/bsoncxx/include/bsoncxx/fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/fwd.hpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// THIS FILE IS NOT INTENDED TO BE INCLUDABLE.
-#include <bsoncxx/v_noabi/bsoncxx/fwd.hpp>
-// THIS FILE IS NOT INTENDED TO BE INCLUDABLE.
+#if !defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+#error "This file is for documentation purposes only. It should not be included."
+#endif  // !defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
 
 ///
 /// @namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/fwd.hpp
@@ -15,3 +15,8 @@
 // THIS FILE IS NOT INTENDED TO BE INCLUDABLE.
 #include <bsoncxx/v_noabi/bsoncxx/fwd.hpp>
 // THIS FILE IS NOT INTENDED TO BE INCLUDABLE.
+
+///
+/// @namespace bsoncxx
+/// The top-level namespace for bsoncxx library entities.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
@@ -89,32 +89,24 @@ class element : private document::element {
 };
 
 ///
-/// @{
-///
 /// Convenience methods to compare for equality against a bson_value.
 ///
-/// Returns true if this element contains a bson_value that matches.
+/// Compares equal if this element contains a matching bson_value. Otherwise, compares unequal.
 ///
-/// @relates element
-///
-BSONCXX_API bool BSONCXX_CALL operator==(const element& elem, const types::bson_value::view& v);
-BSONCXX_API bool BSONCXX_CALL operator==(const types::bson_value::view& v, const element& elem);
-///
-/// @}
-///
+/// @{
 
-///
-/// @{
-///
-/// Convenience methods to compare for equality against a bson_value.
-///
-/// Returns false if this element contains a bson_value that matches.
-///
-/// @relates element
-///
+/// @relatesalso bsoncxx::v_noabi::array::element
+BSONCXX_API bool BSONCXX_CALL operator==(const element& elem, const types::bson_value::view& v);
+
+/// @relatesalso bsoncxx::v_noabi::array::element
+BSONCXX_API bool BSONCXX_CALL operator==(const types::bson_value::view& v, const element& elem);
+
+/// @relatesalso bsoncxx::v_noabi::array::element
 BSONCXX_API bool BSONCXX_CALL operator!=(const element& elem, const types::bson_value::view& v);
+
+/// @relatesalso bsoncxx::v_noabi::array::element
 BSONCXX_API bool BSONCXX_CALL operator!=(const types::bson_value::view& v, const element& elem);
-///
+
 /// @}
 ///
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view.hpp
@@ -130,15 +130,13 @@ class view {
     operator document::view() const;
 
     ///
-    /// @{
+    /// @relates bsoncx::v_noabi::document::view
     ///
     /// Compare two views for (in)-equality
     ///
-    /// @relates view
-    ///
+    /// @{
     friend BSONCXX_API bool BSONCXX_CALL operator==(view, view);
     friend BSONCXX_API bool BSONCXX_CALL operator!=(view, view);
-    ///
     /// @}
     ///
 
@@ -173,15 +171,13 @@ class view::const_iterator {
     const_iterator operator++(int);
 
     ///
+    /// @relates bsoncxx::v_noabi::array::view::const_iterator
+    ///
+    /// Compare two const_iterators for (in)-equality.
+    ///
     /// @{
-    ///
-    /// Compare two const_iterators for (in)-equality
-    ///
-    /// @relates view::const_iterator
-    ///
     friend BSONCXX_API bool BSONCXX_CALL operator==(const const_iterator&, const const_iterator&);
     friend BSONCXX_API bool BSONCXX_CALL operator!=(const const_iterator&, const const_iterator&);
-    ///
     /// @}
     ///
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view_or_value.hpp
@@ -25,7 +25,10 @@ namespace bsoncxx {
 namespace v_noabi {
 namespace array {
 
-using view_or_value = ::bsoncxx::v_noabi::view_or_value<view, value>;
+///
+/// Equivalent to `v_noabi::view_or_value<v_noabi::array::view, v_noabi::array::value>`.
+///
+using view_or_value = v_noabi::view_or_value<view, value>;
 
 }  // namespace array
 }  // namespace v_noabi

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
@@ -82,32 +82,30 @@ struct concatenate_array {
 };
 
 ///
-/// Helper method to concatenate a document. Use this with the document stream
-/// builder to merge an existing document's fields with a new document's.
+/// Helper method to concatenate a document.
 ///
-/// @param doc A document to be concatenated.
+/// Use this with the document stream builder to merge an existing document's fields with a new
+/// document's.
+///
+/// @param doc The document to concatenate.
 ///
 /// @return concatenate_doc A concatenating struct.
 ///
-/// @relatesalso concatenate_doc
+/// @see bsoncxx::v_noabi::builder::concatenate_doc
+///
+/// @note An overload accepting @ref v_noabi::array::view_or_value and returning a @ref
+/// concatenate_array is also declared in this scope.
 ///
 BSONCXX_INLINE concatenate_doc concatenate(document::view_or_value doc) {
     return {std::move(doc)};
 }
 
-///
-/// Method to concatenate an array with a new array. Use this with the array stream
-/// builder to merge an existing array's fields with a new array.
-///
-/// @param array An array to be concatenated.
-///
-/// @return concatenate_array A concatenating struct.
-///
-/// @relatesalso concatenate_array
-///
+// Why is Doxygen unable to parse this overload correctly???
+// @cond DOXYGEN_DISABLE "warning: no matching file member found for ..."
 BSONCXX_INLINE concatenate_array concatenate(array::view_or_value array) {
     return {std::move(array)};
 }
+// @endcond
 
 }  // namespace builder
 }  // namespace v_noabi

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
@@ -32,12 +32,12 @@ namespace builder {
 namespace stream {
 
 ///
-/// A streaming interface for constructing
-/// a BSON array.
+/// A streaming interface for constructing a BSON array.
 ///
-/// @note Use of the stream builder is discouraged. See
-/// https://www.mongodb.com/docs/languages/cpp/drivers/current/working-with-bson/#basic-builder for
-/// more details.
+/// @warning Use of the stream builder is discouraged. See
+/// [Working with
+/// BSON](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/working-with-bson/#basic-builder)
+/// for more details.
 ///
 class array : public array_context<> {
    public:

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
@@ -167,7 +167,7 @@ class array_context {
     ///
     /// Conversion operator for single_context.
     ///
-    /// @relatesalso single_context
+    /// @see bsoncxx::v_noabi::builder::stream::single_context
     ///
     BSONCXX_INLINE operator single_context();
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
@@ -30,12 +30,12 @@ namespace builder {
 namespace stream {
 
 ///
-/// A streaming interface for constructing
-/// a BSON document.
+/// A streaming interface for constructing a BSON document.
 ///
-/// @note Use of the stream builder is discouraged. See
-/// https://www.mongodb.com/docs/languages/cpp/drivers/current/working-with-bson/#basic-builder for
-/// more details.
+/// @warning Use of the stream builder is discouraged. See
+/// [Working with
+/// BSON](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/working-with-bson/#basic-builder)
+/// for more details.
 ///
 class document : public key_context<> {
    public:

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context.hpp
@@ -108,7 +108,7 @@ class value_context {
     ///
     /// Conversion operator for single_context.
     ///
-    /// @relatesalso single_context
+    /// @see bsoncxx::v_noabi::builder::stream::single_context
     ///
     operator single_context();
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/prelude.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/prelude.hpp
@@ -120,21 +120,3 @@
 // CXX-2769: out-of-place, but remains for backward compatibility.
 #pragma push_macro("BSONCXX_ENUM")
 #undef BSONCXX_ENUM
-
-// Doxygen does not account for generated header files.
-// Document globally applicable macros and namespaces here.
-
-///
-/// @namespace bsoncxx
-/// The top-level namespace for bsoncxx library entities.
-///
-
-///
-/// @namespace bsoncxx::v_noabi
-/// Entities declared in this namespace do not have a stable ABI.
-///
-
-///
-/// @namespace bsoncxx::v_noabi::stdx
-/// Declares polyfills for C++17 forward compatibility.
-///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/util.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/util.hpp
@@ -7,6 +7,7 @@
 #define BSONCXX_STRINGIFY_IMPL(...) #__VA_ARGS__
 
 /**
+ * @internal
  * @brief Token-paste two macro arguments, after macro expansion
  */
 #define BSONCXX_CONCAT(A, ...) BSONCXX_CONCAT_IMPL(A, __VA_ARGS__)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
@@ -65,15 +65,13 @@ class decimal128 {
     std::string to_string() const;
 
     ///
-    /// @{
+    /// @relates bsoncxx::v_noabi::decimal128
     ///
     /// Relational operators for decimal128
     ///
-    /// @relates decimal128
-    ///
+    /// @{
     friend BSONCXX_API bool BSONCXX_CALL operator==(const decimal128& lhs, const decimal128& rhs);
     friend BSONCXX_API bool BSONCXX_CALL operator!=(const decimal128& lhs, const decimal128& rhs);
-    ///
     /// @}
     ///
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
@@ -40,7 +40,7 @@ namespace document {
 /// interrogated by calling type(), the key can be extracted by calling key() and
 /// a specific value can be extracted through get_X() accessors.
 ///
-/// @relatesalso array::element
+/// @see bsoncxx::v_noabi::array::element
 ///
 class element {
    public:
@@ -387,22 +387,24 @@ class element {
 };
 
 ///
-/// @relates bsoncxx::v_noabi::document::element
-///
-/// @{
-///
 /// Convenience methods to compare for equality against a bson_value.
 ///
-/// Returns true if this element contains a bson_value that matches.
+/// Compares equal if the element contains a matching bson_value. Otherwise, compares unequal.
 ///
+/// @{
 
+/// @relatesalso bsoncxx::v_noabi::document::element
 BSONCXX_API bool BSONCXX_CALL operator==(const element& elem, const types::bson_value::view& v);
+
+/// @relatesalso bsoncxx::v_noabi::document::element
 BSONCXX_API bool BSONCXX_CALL operator==(const types::bson_value::view& v, const element& elem);
 
+/// @relatesalso bsoncxx::v_noabi::document::element
 BSONCXX_API bool BSONCXX_CALL operator!=(const element& elem, const types::bson_value::view& v);
+
+/// @relatesalso bsoncxx::v_noabi::document::element
 BSONCXX_API bool BSONCXX_CALL operator!=(const types::bson_value::view& v, const element& elem);
 
-///
 /// @}
 ///
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
@@ -387,31 +387,21 @@ class element {
 };
 
 ///
+/// @relates bsoncxx::v_noabi::document::element
+///
 /// @{
 ///
 /// Convenience methods to compare for equality against a bson_value.
 ///
 /// Returns true if this element contains a bson_value that matches.
 ///
-/// @relates element
-///
+
 BSONCXX_API bool BSONCXX_CALL operator==(const element& elem, const types::bson_value::view& v);
 BSONCXX_API bool BSONCXX_CALL operator==(const types::bson_value::view& v, const element& elem);
-///
-/// @}
-///
 
-///
-/// @{
-///
-/// Convenience methods to compare for equality against a bson_value.
-///
-/// Returns false if this element contains a bson_value that matches.
-///
-/// @relates element
-///
 BSONCXX_API bool BSONCXX_CALL operator!=(const element& elem, const types::bson_value::view& v);
 BSONCXX_API bool BSONCXX_CALL operator!=(const types::bson_value::view& v, const element& elem);
+
 ///
 /// @}
 ///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
@@ -250,21 +250,20 @@ BSONCXX_INLINE value::operator document::view() const noexcept {
 }
 
 ///
-/// @{
-///
 /// Compares two document values for (in)-equality.
 ///
-/// @relates document::value
-///
+/// @{
+
+/// @relatesalso bsoncxx::v_noabi::document::value
 BSONCXX_INLINE bool operator==(const value& lhs, const value& rhs) {
     return (lhs.view() == rhs.view());
 }
 
+/// @relatesalso bsoncxx::v_noabi::document::value
 BSONCXX_INLINE bool operator!=(const value& lhs, const value& rhs) {
     return !(lhs == rhs);
 }
 
-///
 /// @}
 ///
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view.hpp
@@ -129,15 +129,13 @@ class view {
     bool empty() const;
 
     ///
+    /// @relates bsoncxx::v_noabi::document::view
+    ///
+    /// Compare two document views for (in)-equality.
+    ///
     /// @{
-    ///
-    /// Compare two document views for (in)-equality
-    ///
-    /// @relates view
-    ///
     friend BSONCXX_API bool BSONCXX_CALL operator==(view, view);
     friend BSONCXX_API bool BSONCXX_CALL operator!=(view, view);
-    ///
     /// @}
     ///
 
@@ -173,15 +171,13 @@ class view::const_iterator {
     const_iterator operator++(int);
 
     ///
+    /// @relates bsoncxx::v_noabi::document::view::const_iterator
+    ///
+    /// Compares two const_iterators for (in)-equality.
+    ///
     /// @{
-    ///
-    /// Compares two const_iterators for (in)-equality
-    ///
-    /// @relates view::const_iterator
-    ///
     friend BSONCXX_API bool BSONCXX_CALL operator==(const const_iterator&, const const_iterator&);
     friend BSONCXX_API bool BSONCXX_CALL operator!=(const const_iterator&, const const_iterator&);
-    ///
     /// @}
     ///
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view_or_value.hpp
@@ -24,7 +24,10 @@ namespace bsoncxx {
 namespace v_noabi {
 namespace document {
 
-using view_or_value = bsoncxx::v_noabi::view_or_value<view, value>;
+///
+/// Equivalent to `v_noabi::view_or_value<v_noabi::document::view, v_noabi::document::value>`.
+///
+using view_or_value = v_noabi::view_or_value<v_noabi::document::view, v_noabi::document::value>;
 
 }  // namespace document
 }  // namespace v_noabi

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/fwd.hpp
@@ -46,3 +46,13 @@
 #include <bsoncxx/types/bson_value/view-fwd.hpp>
 #include <bsoncxx/validate-fwd.hpp>
 #include <bsoncxx/view_or_value-fwd.hpp>
+
+///
+/// @namespace bsoncxx::v_noabi
+/// Entities declared in this namespace do not have a stable ABI.
+///
+
+///
+/// @namespace bsoncxx::v_noabi::stdx
+/// Declares polyfills for C++17 forward compatibility.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
@@ -86,23 +86,22 @@ class oid {
     }
 
     ///
+    /// @relates bsoncxx::v_noabi::oid
+    ///
+    /// Relational operators for OIDs.
+    ///
     /// @{
-    ///
-    /// Relational operators for OIDs
-    ///
-    /// @relates oid
-    ///
     friend BSONCXX_API bool BSONCXX_CALL operator<(const oid& lhs, const oid& rhs);
     friend BSONCXX_API bool BSONCXX_CALL operator>(const oid& lhs, const oid& rhs);
     friend BSONCXX_API bool BSONCXX_CALL operator<=(const oid& lhs, const oid& rhs);
     friend BSONCXX_API bool BSONCXX_CALL operator>=(const oid& lhs, const oid& rhs);
     friend BSONCXX_API bool BSONCXX_CALL operator==(const oid& lhs, const oid& rhs);
     friend BSONCXX_API bool BSONCXX_CALL operator!=(const oid& lhs, const oid& rhs);
-    ///
     /// @}
     ///
 
     ///
+    /// @memberof bsoncxx::v_noabi::oid <!-- Fix leaky relates above. -->
     /// Extracts the timestamp portion of the underlying ObjectId.
     ///
     /// @return A std::time_t initialized to the timestamp.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
@@ -93,28 +93,30 @@ class view_or_value : public bsoncxx::v_noabi::view_or_value<stdx::string_view, 
 };
 
 ///
+/// Comparison operators for comparing string::view_or_value directly with `const char*`.
+///
 /// @{
-///
-/// Comparison operators for comparing string::view_or_value directly with const char *.
-///
-/// @relates view_or_value
-///
+
+/// @relatesalso bsoncxx::v_noabi::string::view_or_value
 BSONCXX_INLINE bool operator==(const view_or_value& lhs, const char* rhs) {
     return lhs.view() == stdx::string_view(rhs);
 }
 
+/// @relatesalso bsoncxx::v_noabi::string::view_or_value
 BSONCXX_INLINE bool operator!=(const view_or_value& lhs, const char* rhs) {
     return !(lhs == rhs);
 }
 
+/// @relatesalso bsoncxx::v_noabi::string::view_or_value
 BSONCXX_INLINE bool operator==(const char* lhs, const view_or_value& rhs) {
     return rhs == lhs;
 }
 
+/// @relatesalso bsoncxx::v_noabi::string::view_or_value
 BSONCXX_INLINE bool operator!=(const char* lhs, const view_or_value& rhs) {
     return !(rhs == lhs);
 }
-///
+
 /// @}
 ///
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types.hpp
@@ -663,165 +663,194 @@ BSONCXX_INLINE bool operator==(const b_maxkey&, const b_maxkey&) {
     return true;
 }
 
-#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
-
 ///
 /// @relatesalso bsoncxx::v_noabi::types::b_double
 ///
 /// free function comparator for b_double
 ///
-bool operator!=(const b_double& lhs, const b_double& rhs);
+inline bool operator!=(const b_double& lhs, const b_double& rhs) {
+    return !(lhs == rhs);
+}
 
 ///
 /// @relatesalso bsoncxx::v_noabi::types::b_string
 ///
 /// free function comparator for b_string
 ///
-bool operator!=(const b_string& lhs, const b_string& rhs);
+inline bool operator!=(const b_string& lhs, const b_string& rhs) {
+    return !(lhs == rhs);
+}
 
 ///
 /// @relatesalso bsoncxx::v_noabi::types::b_document
 ///
 /// free function comparator for b_document
 ///
-bool operator!=(const b_document& lhs, const b_document& rhs);
+inline bool operator!=(const b_document& lhs, const b_document& rhs) {
+    return !(lhs == rhs);
+}
 
 ///
 /// @relatesalso bsoncxx::v_noabi::types::b_array
 ///
 /// free function comparator for b_array
 ///
-bool operator!=(const b_array& lhs, const b_array& rhs);
+inline bool operator!=(const b_array& lhs, const b_array& rhs) {
+    return !(lhs == rhs);
+}
 
 ///
 /// @relatesalso bsoncxx::v_noabi::types::b_binary
 ///
 /// free function comparator for b_binary
 ///
-bool operator!=(const b_binary& lhs, const b_binary& rhs);
+inline bool operator!=(const b_binary& lhs, const b_binary& rhs) {
+    return !(lhs == rhs);
+}
 
 ///
 /// @relatesalso bsoncxx::v_noabi::types::b_undefined
 ///
 /// free function comparator for b_undefined
 ///
-bool operator!=(const b_undefined&, const b_undefined&);
+inline bool operator!=(const b_undefined& lhs, const b_undefined& rhs) {
+    return !(lhs == rhs);
+}
 
 ///
 /// @relatesalso bsoncxx::v_noabi::types::b_oid
 ///
 /// free function comparator for b_oid
 ///
-bool operator!=(const b_oid& lhs, const b_oid& rhs);
+inline bool operator!=(const b_oid& lhs, const b_oid& rhs) {
+    return !(lhs == rhs);
+}
 
 ///
 /// @relatesalso bsoncxx::v_noabi::types::b_bool
 ///
 /// free function comparator for b_bool
 ///
-bool operator!=(const b_bool& lhs, const b_bool& rhs);
+inline bool operator!=(const b_bool& lhs, const b_bool& rhs) {
+    return !(lhs == rhs);
+}
 
 ///
 /// @relatesalso bsoncxx::v_noabi::types::b_date
 ///
 /// free function comparator for b_date
 ///
-bool operator!=(const b_date& lhs, const b_date& rhs);
+inline bool operator!=(const b_date& lhs, const b_date& rhs) {
+    return !(lhs == rhs);
+}
 
 ///
 /// @relatesalso bsoncxx::v_noabi::types::b_null
 ///
 /// free function comparator for b_null
 ///
-bool operator!=(const b_null&, const b_null&);
+inline bool operator!=(const b_null& lhs, const b_null& rhs) {
+    return !(lhs == rhs);
+}
 
 ///
 /// @relatesalso bsoncxx::v_noabi::types::b_regex
 ///
 /// free function comparator for b_regex
 ///
-bool operator!=(const b_regex& lhs, const b_regex& rhs);
+inline bool operator!=(const b_regex& lhs, const b_regex& rhs) {
+    return !(lhs == rhs);
+}
 
 ///
 /// @relatesalso bsoncxx::v_noabi::types::b_dbpointer
 ///
 /// free function comparator for b_dbpointer
 ///
-bool operator!=(const b_dbpointer& lhs, const b_dbpointer& rhs);
+inline bool operator!=(const b_dbpointer& lhs, const b_dbpointer& rhs) {
+    return !(lhs == rhs);
+}
 
 ///
 /// @relatesalso bsoncxx::v_noabi::types::b_code
 ///
 /// free function comparator for b_code
 ///
-bool operator!=(const b_code& lhs, const b_code& rhs);
+inline bool operator!=(const b_code& lhs, const b_code& rhs) {
+    return !(lhs == rhs);
+}
 
 ///
 /// @relatesalso bsoncxx::v_noabi::types::b_symbol
 ///
 /// free function comparator for b_symbol
 ///
-bool operator!=(const b_symbol& lhs, const b_symbol& rhs);
+inline bool operator!=(const b_symbol& lhs, const b_symbol& rhs) {
+    return !(lhs == rhs);
+}
 
 ///
 /// @relatesalso bsoncxx::v_noabi::types::b_codewscope
 ///
 /// free function comparator for b_codewscope
 ///
-bool operator!=(const b_codewscope& lhs, const b_codewscope& rhs);
+inline bool operator!=(const b_codewscope& lhs, const b_codewscope& rhs) {
+    return !(lhs == rhs);
+}
 
 ///
 /// @relatesalso bsoncxx::v_noabi::types::b_int32
 ///
 /// free function comparator for b_int32
 ///
-bool operator!=(const b_int32& lhs, const b_int32& rhs);
+inline bool operator!=(const b_int32& lhs, const b_int32& rhs) {
+    return !(lhs == rhs);
+}
 
 ///
 /// @relatesalso bsoncxx::v_noabi::types::b_timestamp
 ///
 /// free function comparator for b_timestamp
 ///
-bool operator!=(const b_timestamp& lhs, const b_timestamp& rhs);
+inline bool operator!=(const b_timestamp& lhs, const b_timestamp& rhs) {
+    return !(lhs == rhs);
+}
 
 ///
 /// @relatesalso bsoncxx::v_noabi::types::b_int64
 ///
 /// free function comparator for b_int64
 ///
-bool operator!=(const b_int64& lhs, const b_int64& rhs);
+inline bool operator!=(const b_int64& lhs, const b_int64& rhs) {
+    return !(lhs == rhs);
+}
 
 ///
 /// @relatesalso bsoncxx::v_noabi::types::b_decimal128
 ///
 /// free function comparator for b_decimal128
 ///
-bool operator!=(const b_decimal128& lhs, const b_decimal128& rhs);
+inline bool operator!=(const b_decimal128& lhs, const b_decimal128& rhs) {
+    return !(lhs == rhs);
+}
 
 ///
 /// @relatesalso bsoncxx::v_noabi::types::b_minkey
 ///
 /// free function comparator for b_minkey
 ///
-bool operator!=(const b_minkey&, const b_minkey&);
+inline bool operator!=(const b_minkey& lhs, const b_minkey& rhs) {
+    return !(lhs == rhs);
+}
 
 ///
 /// @relatesalso bsoncxx::v_noabi::types::b_maxkey
 ///
 /// free function comparator for b_maxkey
 ///
-bool operator!=(const b_maxkey&, const b_maxkey&);
-
-#else
-
-#define BSONCXX_ENUM(name, val)                                                \
-    BSONCXX_INLINE bool operator!=(const b_##name& lhs, const b_##name& rhs) { \
-        return !(lhs == rhs);                                                  \
-    }
-#include <bsoncxx/enums/type.hpp>
-#undef BSONCXX_ENUM
-
-#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+inline bool operator!=(const b_maxkey& lhs, const b_maxkey& rhs) {
+    return !(lhs == rhs);
+}
 
 }  // namespace types
 }  // namespace v_noabi

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types.hpp
@@ -112,7 +112,7 @@ struct b_double {
 ///
 /// free function comparator for b_double
 ///
-/// @relatesalso b_double
+/// @relatesalso bsoncxx::v_noabi::types::b_double
 ///
 BSONCXX_INLINE bool operator==(const b_double& lhs, const b_double& rhs) {
     return lhs.value == rhs.value;
@@ -146,7 +146,7 @@ struct b_string {
 ///
 /// free function comparator for b_string
 ///
-/// @relatesalso b_string
+/// @relatesalso bsoncxx::v_noabi::types::b_string
 ///
 BSONCXX_INLINE bool operator==(const b_string& lhs, const b_string& rhs) {
     return lhs.value == rhs.value;
@@ -185,7 +185,7 @@ struct b_document {
 ///
 /// free function comparator for b_document
 ///
-/// @relatesalso b_document
+/// @relatesalso bsoncxx::v_noabi::types::b_document
 ///
 BSONCXX_INLINE bool operator==(const b_document& lhs, const b_document& rhs) {
     return lhs.value == rhs.value;
@@ -210,7 +210,7 @@ struct b_array {
 ///
 /// free function comparator for b_array
 ///
-/// @relatesalso b_array
+/// @relatesalso bsoncxx::v_noabi::types::b_array
 ///
 BSONCXX_INLINE bool operator==(const b_array& lhs, const b_array& rhs) {
     return lhs.value == rhs.value;
@@ -230,7 +230,7 @@ struct b_binary {
 ///
 /// free function comparator for b_binary
 ///
-/// @relatesalso b_binary
+/// @relatesalso bsoncxx::v_noabi::types::b_binary
 ///
 BSONCXX_INLINE bool operator==(const b_binary& lhs, const b_binary& rhs) {
     return lhs.sub_type == rhs.sub_type && lhs.size == rhs.size &&
@@ -250,7 +250,7 @@ struct b_undefined {
 ///
 /// free function comparator for b_undefined
 ///
-/// @relatesalso b_undefined
+/// @relatesalso bsoncxx::v_noabi::types::b_undefined
 ///
 BSONCXX_INLINE bool operator==(const b_undefined&, const b_undefined&) {
     return true;
@@ -268,7 +268,7 @@ struct b_oid {
 ///
 /// free function comparator for b_oid
 ///
-/// @relatesalso b_oid
+/// @relatesalso bsoncxx::v_noabi::types::b_oid
 ///
 BSONCXX_INLINE bool operator==(const b_oid& lhs, const b_oid& rhs) {
     return lhs.value == rhs.value;
@@ -293,7 +293,7 @@ struct b_bool {
 ///
 /// free function comparator for b_bool
 ///
-/// @relatesalso b_bool
+/// @relatesalso bsoncxx::v_noabi::types::b_bool
 ///
 BSONCXX_INLINE bool operator==(const b_bool& lhs, const b_bool& rhs) {
     return lhs.value == rhs.value;
@@ -352,7 +352,7 @@ struct b_date {
 ///
 /// free function comparator for b_date
 ///
-/// @relatesalso b_date
+/// @relatesalso bsoncxx::v_noabi::types::b_date
 ///
 BSONCXX_INLINE bool operator==(const b_date& lhs, const b_date& rhs) {
     return lhs.value == rhs.value;
@@ -368,7 +368,7 @@ struct b_null {
 ///
 /// free function comparator for b_null
 ///
-/// @relatesalso b_null
+/// @relatesalso bsoncxx::v_noabi::types::b_null
 ///
 BSONCXX_INLINE bool operator==(const b_null&, const b_null&) {
     return true;
@@ -402,7 +402,7 @@ struct b_regex {
 ///
 /// free function comparator for b_regex
 ///
-/// @relatesalso b_regex
+/// @relatesalso bsoncxx::v_noabi::types::b_regex
 ///
 BSONCXX_INLINE bool operator==(const b_regex& lhs, const b_regex& rhs) {
     return lhs.regex == rhs.regex && lhs.options == rhs.options;
@@ -424,7 +424,7 @@ struct b_dbpointer {
 ///
 /// free function comparator for b_dbpointer
 ///
-/// @relatesalso b_dbpointer
+/// @relatesalso bsoncxx::v_noabi::types::b_dbpointer
 ///
 BSONCXX_INLINE bool operator==(const b_dbpointer& lhs, const b_dbpointer& rhs) {
     return lhs.collection == rhs.collection && lhs.value == rhs.value;
@@ -458,7 +458,7 @@ struct b_code {
 ///
 /// free function comparator for b_code
 ///
-/// @relatesalso b_code
+/// @relatesalso bsoncxx::v_noabi::types::b_code
 ///
 BSONCXX_INLINE bool operator==(const b_code& lhs, const b_code& rhs) {
     return lhs.code == rhs.code;
@@ -495,7 +495,7 @@ struct b_symbol {
 ///
 /// free function comparator for b_symbol
 ///
-/// @relatesalso b_symbol
+/// @relatesalso bsoncxx::v_noabi::types::b_symbol
 ///
 BSONCXX_INLINE bool operator==(const b_symbol& lhs, const b_symbol& rhs) {
     return lhs.symbol == rhs.symbol;
@@ -529,7 +529,7 @@ struct b_codewscope {
 ///
 /// free function comparator for b_codewscope
 ///
-/// @relatesalso b_codewscope
+/// @relatesalso bsoncxx::v_noabi::types::b_codewscope
 ///
 BSONCXX_INLINE bool operator==(const b_codewscope& lhs, const b_codewscope& rhs) {
     return lhs.code == rhs.code && lhs.scope == rhs.scope;
@@ -554,7 +554,7 @@ struct b_int32 {
 ///
 /// free function comparator for b_int32
 ///
-/// @relatesalso b_int32
+/// @relatesalso bsoncxx::v_noabi::types::b_int32
 ///
 BSONCXX_INLINE bool operator==(const b_int32& lhs, const b_int32& rhs) {
     return lhs.value == rhs.value;
@@ -573,7 +573,7 @@ struct b_timestamp {
 ///
 /// free function comparator for b_timestamp
 ///
-/// @relatesalso b_timestamp
+/// @relatesalso bsoncxx::v_noabi::types::b_timestamp
 ///
 BSONCXX_INLINE bool operator==(const b_timestamp& lhs, const b_timestamp& rhs) {
     return lhs.increment == rhs.increment && lhs.timestamp == rhs.timestamp;
@@ -598,7 +598,7 @@ struct b_int64 {
 ///
 /// free function comparator for b_int64
 ///
-/// @relatesalso b_int64
+/// @relatesalso bsoncxx::v_noabi::types::b_int64
 ///
 BSONCXX_INLINE bool operator==(const b_int64& lhs, const b_int64& rhs) {
     return lhs.value == rhs.value;
@@ -625,7 +625,7 @@ struct b_decimal128 {
 ///
 /// free function comparator for b_decimal128
 ///
-/// @relatesalso b_decimal128
+/// @relatesalso bsoncxx::v_noabi::types::b_decimal128
 ///
 BSONCXX_INLINE bool operator==(const b_decimal128& lhs, const b_decimal128& rhs) {
     return lhs.value == rhs.value;
@@ -641,7 +641,7 @@ struct b_minkey {
 ///
 /// free function comparator for b_minkey
 ///
-/// @relatesalso b_minkey
+/// @relatesalso bsoncxx::v_noabi::types::b_minkey
 ///
 BSONCXX_INLINE bool operator==(const b_minkey&, const b_minkey&) {
     return true;
@@ -657,11 +657,162 @@ struct b_maxkey {
 ///
 /// free function comparator for b_maxkey
 ///
-/// @relatesalso b_maxkey
+/// @relatesalso bsoncxx::v_noabi::types::b_maxkey
 ///
 BSONCXX_INLINE bool operator==(const b_maxkey&, const b_maxkey&) {
     return true;
 }
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+///
+/// @relatesalso bsoncxx::v_noabi::types::b_double
+///
+/// free function comparator for b_double
+///
+bool operator!=(const b_double& lhs, const b_double& rhs);
+
+///
+/// @relatesalso bsoncxx::v_noabi::types::b_string
+///
+/// free function comparator for b_string
+///
+bool operator!=(const b_string& lhs, const b_string& rhs);
+
+///
+/// @relatesalso bsoncxx::v_noabi::types::b_document
+///
+/// free function comparator for b_document
+///
+bool operator!=(const b_document& lhs, const b_document& rhs);
+
+///
+/// @relatesalso bsoncxx::v_noabi::types::b_array
+///
+/// free function comparator for b_array
+///
+bool operator!=(const b_array& lhs, const b_array& rhs);
+
+///
+/// @relatesalso bsoncxx::v_noabi::types::b_binary
+///
+/// free function comparator for b_binary
+///
+bool operator!=(const b_binary& lhs, const b_binary& rhs);
+
+///
+/// @relatesalso bsoncxx::v_noabi::types::b_undefined
+///
+/// free function comparator for b_undefined
+///
+bool operator!=(const b_undefined&, const b_undefined&);
+
+///
+/// @relatesalso bsoncxx::v_noabi::types::b_oid
+///
+/// free function comparator for b_oid
+///
+bool operator!=(const b_oid& lhs, const b_oid& rhs);
+
+///
+/// @relatesalso bsoncxx::v_noabi::types::b_bool
+///
+/// free function comparator for b_bool
+///
+bool operator!=(const b_bool& lhs, const b_bool& rhs);
+
+///
+/// @relatesalso bsoncxx::v_noabi::types::b_date
+///
+/// free function comparator for b_date
+///
+bool operator!=(const b_date& lhs, const b_date& rhs);
+
+///
+/// @relatesalso bsoncxx::v_noabi::types::b_null
+///
+/// free function comparator for b_null
+///
+bool operator!=(const b_null&, const b_null&);
+
+///
+/// @relatesalso bsoncxx::v_noabi::types::b_regex
+///
+/// free function comparator for b_regex
+///
+bool operator!=(const b_regex& lhs, const b_regex& rhs);
+
+///
+/// @relatesalso bsoncxx::v_noabi::types::b_dbpointer
+///
+/// free function comparator for b_dbpointer
+///
+bool operator!=(const b_dbpointer& lhs, const b_dbpointer& rhs);
+
+///
+/// @relatesalso bsoncxx::v_noabi::types::b_code
+///
+/// free function comparator for b_code
+///
+bool operator!=(const b_code& lhs, const b_code& rhs);
+
+///
+/// @relatesalso bsoncxx::v_noabi::types::b_symbol
+///
+/// free function comparator for b_symbol
+///
+bool operator!=(const b_symbol& lhs, const b_symbol& rhs);
+
+///
+/// @relatesalso bsoncxx::v_noabi::types::b_codewscope
+///
+/// free function comparator for b_codewscope
+///
+bool operator!=(const b_codewscope& lhs, const b_codewscope& rhs);
+
+///
+/// @relatesalso bsoncxx::v_noabi::types::b_int32
+///
+/// free function comparator for b_int32
+///
+bool operator!=(const b_int32& lhs, const b_int32& rhs);
+
+///
+/// @relatesalso bsoncxx::v_noabi::types::b_timestamp
+///
+/// free function comparator for b_timestamp
+///
+bool operator!=(const b_timestamp& lhs, const b_timestamp& rhs);
+
+///
+/// @relatesalso bsoncxx::v_noabi::types::b_int64
+///
+/// free function comparator for b_int64
+///
+bool operator!=(const b_int64& lhs, const b_int64& rhs);
+
+///
+/// @relatesalso bsoncxx::v_noabi::types::b_decimal128
+///
+/// free function comparator for b_decimal128
+///
+bool operator!=(const b_decimal128& lhs, const b_decimal128& rhs);
+
+///
+/// @relatesalso bsoncxx::v_noabi::types::b_minkey
+///
+/// free function comparator for b_minkey
+///
+bool operator!=(const b_minkey&, const b_minkey&);
+
+///
+/// @relatesalso bsoncxx::v_noabi::types::b_maxkey
+///
+/// free function comparator for b_maxkey
+///
+bool operator!=(const b_maxkey&, const b_maxkey&);
+
+#else
 
 #define BSONCXX_ENUM(name, val)                                                \
     BSONCXX_INLINE bool operator!=(const b_##name& lhs, const b_##name& rhs) { \
@@ -669,6 +820,8 @@ BSONCXX_INLINE bool operator==(const b_maxkey&, const b_maxkey&) {
     }
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
 
 }  // namespace types
 }  // namespace v_noabi

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
@@ -41,7 +41,7 @@ namespace bson_value {
 /// For accessors into this type and to extract the various BSON types out,
 /// please use bson_value::view.
 ///
-/// @relatesalso bson_value::view
+/// @see bsoncxx::v_noabi::bson_value::view
 ///
 class value {
    public:
@@ -276,48 +276,48 @@ class value {
 };
 
 ///
-/// @{
-///
 /// Compares values for (in)-equality.
 ///
-/// @relates bson_value::value
-///
+/// @{
+
+/// @relatesalso bsoncxx::v_noabi::types::bson_value::value
 BSONCXX_INLINE bool operator==(const value& lhs, const value& rhs) {
     return (lhs.view() == rhs.view());
 }
 
+/// @relatesalso bsoncxx::v_noabi::types::bson_value::value
 BSONCXX_INLINE bool operator!=(const value& lhs, const value& rhs) {
     return !(lhs == rhs);
 }
 
-///
 /// @}
 ///
 
 ///
-/// @{
-///
 /// Compares a value with a view for (in)-equality.
 ///
-/// @relates bson_value::value
-///
+/// @{
+
+/// @relatesalso bsoncxx::v_noabi::types::bson_value::value
 BSONCXX_INLINE bool operator==(const value& lhs, const view& rhs) {
     return (lhs.view() == rhs);
 }
 
+/// @relatesalso bsoncxx::v_noabi::types::bson_value::value
 BSONCXX_INLINE bool operator==(const view& lhs, const value& rhs) {
     return (rhs == lhs);
 }
 
+/// @relatesalso bsoncxx::v_noabi::types::bson_value::value
 BSONCXX_INLINE bool operator!=(const value& lhs, const view& rhs) {
     return !(lhs == rhs);
 }
 
+/// @relatesalso bsoncxx::v_noabi::types::bson_value::value
 BSONCXX_INLINE bool operator!=(const view& lhs, const value& rhs) {
     return !(lhs == rhs);
 }
 
-///
 /// @}
 ///
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
@@ -70,17 +70,15 @@ class view {
     ~view();
 
     ///
-    /// @{
+    /// @relates bsoncxx::v_noabi::types::bson_value::view
     ///
     /// Compare two bson_value::views for equality
     ///
-    /// @relates bson_value::view
-    ///
+    /// @{
     friend BSONCXX_API bool BSONCXX_CALL operator==(const bson_value::view&,
                                                     const bson_value::view&);
     friend BSONCXX_API bool BSONCXX_CALL operator!=(const bson_value::view&,
                                                     const bson_value::view&);
-    ///
     /// @}
     ///
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value.hpp
@@ -145,74 +145,80 @@ class view_or_value {
 };
 
 ///
+/// Compare view_or_value objects for (in)-equality.
+///
 /// @{
-///
-/// Compare view_or_value objects for (in)-equality
-///
-/// @relates: view_or_value
-///
+
+/// @relatesalso bsoncxx::v_noabi::view_or_value
 template <typename View, typename Value>
 BSONCXX_INLINE bool operator==(const view_or_value<View, Value>& lhs,
                                const view_or_value<View, Value>& rhs) {
     return lhs.view() == rhs.view();
 }
 
+/// @relatesalso bsoncxx::v_noabi::view_or_value
 template <typename View, typename Value>
 BSONCXX_INLINE bool operator!=(const view_or_value<View, Value>& lhs,
                                const view_or_value<View, Value>& rhs) {
     return !(lhs == rhs);
 }
-///
+
 /// @}
 ///
 
 ///
-/// @{
-///
 /// Mixed (in)-equality operators for view_or_value against View or Value types
 ///
-/// @relates view_or_value
-///
+/// @{
+
+/// @relatesalso bsoncxx::v_noabi::view_or_value
 template <typename View, typename Value>
 BSONCXX_INLINE bool operator==(const view_or_value<View, Value>& lhs, View rhs) {
     return lhs.view() == rhs;
 }
 
+/// @relatesalso bsoncxx::v_noabi::view_or_value
 template <typename View, typename Value>
 BSONCXX_INLINE bool operator==(View lhs, const view_or_value<View, Value>& rhs) {
     return rhs == lhs;
 }
 
+/// @relatesalso bsoncxx::v_noabi::view_or_value
 template <typename View, typename Value>
 BSONCXX_INLINE bool operator!=(const view_or_value<View, Value>& lhs, View rhs) {
     return !(lhs == rhs);
 }
 
+/// @relatesalso bsoncxx::v_noabi::view_or_value
 template <typename View, typename Value>
 BSONCXX_INLINE bool operator!=(View lhs, const view_or_value<View, Value>& rhs) {
     return !(rhs == lhs);
 }
 
+/// @relatesalso bsoncxx::v_noabi::view_or_value
 template <typename View, typename Value>
 BSONCXX_INLINE bool operator==(const view_or_value<View, Value>& lhs, const Value& rhs) {
     return lhs.view() == View(rhs);
 }
 
+/// @relatesalso bsoncxx::v_noabi::view_or_value
 template <typename View, typename Value>
 BSONCXX_INLINE bool operator==(const Value& lhs, const view_or_value<View, Value>& rhs) {
     return rhs == lhs;
 }
 
+/// @relatesalso bsoncxx::v_noabi::view_or_value
 template <typename View, typename Value>
 BSONCXX_INLINE bool operator!=(const view_or_value<View, Value>& lhs, const Value& rhs) {
     return !(lhs == rhs);
 }
 
+/// @relatesalso bsoncxx::v_noabi::view_or_value
 template <typename View, typename Value>
 BSONCXX_INLINE bool operator!=(const Value& lhs, const view_or_value<View, Value>& rhs) {
     return !(rhs == lhs);
 }
-///
+
 /// @}
 ///
 

--- a/src/bsoncxx/lib/CMakeLists.txt
+++ b/src/bsoncxx/lib/CMakeLists.txt
@@ -71,6 +71,7 @@ endif()
 set_dist_list(src_bsoncxx_lib_DIST
     CMakeLists.txt
     ${bsoncxx_sources_v_noabi}
+    bsoncxx/fwd.cpp
     bsoncxx/v_noabi/bsoncxx/config/config.hpp.in
     bsoncxx/v_noabi/bsoncxx/config/private/config.hh.in
     bsoncxx/v_noabi/bsoncxx/config/private/postlude.hh

--- a/src/bsoncxx/lib/CMakeLists.txt
+++ b/src/bsoncxx/lib/CMakeLists.txt
@@ -22,6 +22,7 @@ set(bsoncxx_sources_v_noabi
     bsoncxx/v_noabi/bsoncxx/document/value.cpp
     bsoncxx/v_noabi/bsoncxx/document/view.cpp
     bsoncxx/v_noabi/bsoncxx/exception/error_code.cpp
+    bsoncxx/v_noabi/bsoncxx/fwd.cpp
     bsoncxx/v_noabi/bsoncxx/json.cpp
     bsoncxx/v_noabi/bsoncxx/oid.cpp
     bsoncxx/v_noabi/bsoncxx/private/itoa.cpp
@@ -34,6 +35,7 @@ set(bsoncxx_sources_v_noabi
 
 list(APPEND bsoncxx_sources
     ${bsoncxx_sources_v_noabi}
+    bsoncxx/fwd.cpp
 )
 list(TRANSFORM bsoncxx_sources PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
 set(bsoncxx_sources "${bsoncxx_sources}" PARENT_SCOPE)

--- a/src/bsoncxx/lib/bsoncxx/fwd.cpp
+++ b/src/bsoncxx/lib/bsoncxx/fwd.cpp
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/fwd.hpp>  // <bsoncxx/v_noabi/bsoncxx/fwd.hpp>
+// Validate that <bsoncxx/v_noabi/bsoncxx/fwd.hpp> is included, not <bsoncxx/fwd.hpp>.
+#include <bsoncxx/fwd.hpp>

--- a/src/bsoncxx/lib/bsoncxx/fwd.cpp
+++ b/src/bsoncxx/lib/bsoncxx/fwd.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/fwd.hpp>  // <bsoncxx/v_noabi/bsoncxx/fwd.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/fwd.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/fwd.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v_noabi/bsoncxx/fwd.hpp>

--- a/src/mongocxx/include/mongocxx/fwd.hpp
+++ b/src/mongocxx/include/mongocxx/fwd.hpp
@@ -1,0 +1,17 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// THIS FILE IS NOT INTENDED TO BE INCLUDABLE.
+#include <mongocxx/v_noabi/mongocxx/fwd.hpp>
+// THIS FILE IS NOT INTENDED TO BE INCLUDABLE.

--- a/src/mongocxx/include/mongocxx/fwd.hpp
+++ b/src/mongocxx/include/mongocxx/fwd.hpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// THIS FILE IS NOT INTENDED TO BE INCLUDABLE.
-#include <mongocxx/v_noabi/mongocxx/fwd.hpp>
-// THIS FILE IS NOT INTENDED TO BE INCLUDABLE.
+#if !defined(MONGOCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+#error "This file is for documentation purposes only. It should not be included."
+#endif  // !defined(MONGOCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
 
 ///
 /// @namespace mongocxx

--- a/src/mongocxx/include/mongocxx/fwd.hpp
+++ b/src/mongocxx/include/mongocxx/fwd.hpp
@@ -15,3 +15,8 @@
 // THIS FILE IS NOT INTENDED TO BE INCLUDABLE.
 #include <mongocxx/v_noabi/mongocxx/fwd.hpp>
 // THIS FILE IS NOT INTENDED TO BE INCLUDABLE.
+
+///
+/// @namespace mongocxx
+/// The top-level namespace for mongocxx library entities.
+///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream.hpp
@@ -194,19 +194,19 @@ class change_stream::iterator {
     MONGOCXX_PRIVATE explicit iterator(iter_type type, const change_stream* change_stream);
 
     ///
+    /// @relates bsoncxx::v_noabi::change_stream::iterator
+    ///
+    /// Compare two iterators for (in)-equality.
+    ///
+    /// Iterators compare equal if they point to the same underlying change_stream or if both are
+    /// exhausted.
+    ///
     /// @{
-    ///
-    /// Compare two iterators for (in)-equality.  Iterators compare equal if
-    /// they point to the same underlying change_stream or if both are exhausted.
-    ///
-    /// @relates iterator
-    ///
     friend MONGOCXX_API bool MONGOCXX_CALL operator==(const change_stream::iterator&,
                                                       const change_stream::iterator&) noexcept;
 
     friend MONGOCXX_API bool MONGOCXX_CALL operator!=(const change_stream::iterator&,
                                                       const change_stream::iterator&) noexcept;
-    ///
     /// @}
     ///
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
@@ -218,9 +218,8 @@ class client {
         bsoncxx::v_noabi::string::view_or_value name) const&;
     MONGOCXX_INLINE mongocxx::v_noabi::database operator[](
         bsoncxx::v_noabi::string::view_or_value name) const&& = delete;
-
     ///
-    /// @brief Enumerates the databases in the client.
+    /// Enumerates the databases in the client.
     ///
     /// @return A mongocxx::v_noabi::cursor containing a BSON document for each
     ///   database. Each document contains a name field with the database
@@ -233,22 +232,48 @@ class client {
     ///
     /// @see https://www.mongodb.com/docs/manual/reference/command/listDatabases
     ///
-    /// @{
-
     cursor list_databases() const;
 
     ///
+    /// Enumerates the databases in the client.
+    ///
     /// @param session
     ///   The mongocxx::v_noabi::client_session with which to perform the aggregation.
+    ///
+    /// @return A mongocxx::v_noabi::cursor containing a BSON document for each
+    ///   database. Each document contains a name field with the database
+    ///   name, a sizeOnDisk field with the total size of the database file on
+    ///   disk in bytes, and an empty field specifying whether the database
+    ///   has any data.
+    ///
+    /// @throws mongocxx::v_noabi::operation_exception if the underlying 'listDatabases' command
+    /// fails.
+    ///
+    /// @see https://www.mongodb.com/docs/manual/reference/command/listDatabases
     ///
     cursor list_databases(const client_session& session) const;
 
     ///
+    /// Enumerates the databases in the client.
+    ///
     /// @param opts
     ///   Options passed directly to the 'listDatabases' command.
     ///
+    /// @return A mongocxx::v_noabi::cursor containing a BSON document for each
+    ///   database. Each document contains a name field with the database
+    ///   name, a sizeOnDisk field with the total size of the database file on
+    ///   disk in bytes, and an empty field specifying whether the database
+    ///   has any data.
+    ///
+    /// @throws mongocxx::v_noabi::operation_exception if the underlying 'listDatabases' command
+    /// fails.
+    ///
+    /// @see https://www.mongodb.com/docs/manual/reference/command/listDatabases
+    ///
     cursor list_databases(const bsoncxx::v_noabi::document::view_or_value opts) const;
 
+    ///
+    /// Enumerates the databases in the client.
     ///
     /// @param session
     ///   The mongocxx::v_noabi::client_session with which to perform the aggregation.
@@ -256,14 +281,55 @@ class client {
     /// @param opts
     ///   Options passed directly to the 'listDatabases' command.
     ///
+    /// @return A mongocxx::v_noabi::cursor containing a BSON document for each
+    ///   database. Each document contains a name field with the database
+    ///   name, a sizeOnDisk field with the total size of the database file on
+    ///   disk in bytes, and an empty field specifying whether the database
+    ///   has any data.
+    ///
+    /// @throws mongocxx::v_noabi::operation_exception if the underlying 'listDatabases' command
+    /// fails.
+    ///
+    /// @see https://www.mongodb.com/docs/manual/reference/command/listDatabases
+    ///
     cursor list_databases(const client_session& session,
                           const bsoncxx::v_noabi::document::view_or_value opts) const;
 
-    /// @}
     ///
+    /// Queries the MongoDB server for a list of known databases.
+    ///
+    /// @param filter
+    ///   An optional query expression to filter the returned database names.
+    ///
+    /// @return std::vector<std::string> containing the database names.
+    ///
+    /// @throws mongocxx::v_noabi::operation_exception if the underlying 'listDatabases'
+    /// command fails.
+    ///
+    /// @see https://www.mongodb.com/docs/manual/reference/command/listDatabases
+    ///
+    std::vector<std::string> list_database_names(
+        const bsoncxx::v_noabi::document::view_or_value filter = {}) const;
 
     ///
-    /// @{
+    /// Queries the MongoDB server for a list of known databases.
+    ///
+    /// @param session
+    ///   The mongocxx::v_noabi::client_session with which to perform the aggregation.
+    ///
+    /// @param filter
+    ///   An optional query expression to filter the returned database names.
+    ///
+    /// @return std::vector<std::string> containing the database names.
+    ///
+    /// @throws mongocxx::v_noabi::operation_exception if the underlying 'listDatabases'
+    /// command fails.
+    ///
+    /// @see https://www.mongodb.com/docs/manual/reference/command/listDatabases
+    ///
+    std::vector<std::string> list_database_names(
+        const client_session& session,
+        const bsoncxx::v_noabi::document::view_or_value filter = {}) const;
 
     ///
     /// Queries the MongoDB server for a list of known databases.
@@ -301,9 +367,6 @@ class client {
         const client_session& session,
         const bsoncxx::v_noabi::document::view_or_value filter = {}) const;
 
-    /// @}
-    ///
-
     ///
     /// Create a client session for a sequence of operations.
     ///
@@ -315,9 +378,6 @@ class client {
     /// server does not support.
     ///
     client_session start_session(const options::client_session& options = {});
-
-    ///
-    /// @{
 
     ///
     /// Get a change stream on this client with an empty pipeline.
@@ -390,9 +450,6 @@ class client {
     change_stream watch(const client_session& session,
                         const pipeline& pipe,
                         const options::change_stream& options = {});
-
-    /// @}
-    ///
 
     ///
     /// Prevents resource cleanup in the child process from interfering

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
@@ -332,42 +332,6 @@ class client {
         const bsoncxx::v_noabi::document::view_or_value filter = {}) const;
 
     ///
-    /// Queries the MongoDB server for a list of known databases.
-    ///
-    /// @param filter
-    ///   An optional query expression to filter the returned database names.
-    ///
-    /// @return std::vector<std::string> containing the database names.
-    ///
-    /// @throws mongocxx::v_noabi::operation_exception if the underlying 'listDatabases'
-    /// command fails.
-    ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/listDatabases
-    ///
-
-    std::vector<std::string> list_database_names(
-        const bsoncxx::v_noabi::document::view_or_value filter = {}) const;
-
-    ///
-    /// Queries the MongoDB server for a list of known databases.
-    ///
-    /// @param session
-    ///   The mongocxx::v_noabi::client_session with which to perform the aggregation.
-    /// @param filter
-    ///   An optional query expression to filter the returned database names.
-    ///
-    /// @return std::vector<std::string> containing the database names.
-    ///
-    /// @throws mongocxx::v_noabi::operation_exception if the underlying 'listDatabases'
-    /// command fails.
-    ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/listDatabases
-    ///
-    std::vector<std::string> list_database_names(
-        const client_session& session,
-        const bsoncxx::v_noabi::document::view_or_value filter = {}) const;
-
-    ///
     /// Create a client session for a sequence of operations.
     ///
     /// @return A client_session object. See `mongocxx::v_noabi::client_session` for more

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
@@ -220,9 +220,7 @@ class client {
         bsoncxx::v_noabi::string::view_or_value name) const&& = delete;
 
     ///
-    /// @{
-    ///
-    /// Enumerates the databases in the client.
+    /// @brief Enumerates the databases in the client.
     ///
     /// @return A mongocxx::v_noabi::cursor containing a BSON document for each
     ///   database. Each document contains a name field with the database
@@ -235,48 +233,22 @@ class client {
     ///
     /// @see https://www.mongodb.com/docs/manual/reference/command/listDatabases
     ///
+    /// @{
+
     cursor list_databases() const;
 
     ///
-    /// Enumerates the databases in the client.
-    ///
     /// @param session
     ///   The mongocxx::v_noabi::client_session with which to perform the aggregation.
-    ///
-    /// @return A mongocxx::v_noabi::cursor containing a BSON document for each
-    ///   database. Each document contains a name field with the database
-    ///   name, a sizeOnDisk field with the total size of the database file on
-    ///   disk in bytes, and an empty field specifying whether the database
-    ///   has any data.
-    ///
-    /// @throws mongocxx::v_noabi::operation_exception if the underlying 'listDatabases' command
-    /// fails.
-    ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/listDatabases
     ///
     cursor list_databases(const client_session& session) const;
 
     ///
-    /// Enumerates the databases in the client.
-    ///
     /// @param opts
     ///   Options passed directly to the 'listDatabases' command.
     ///
-    /// @return A mongocxx::v_noabi::cursor containing a BSON document for each
-    ///   database. Each document contains a name field with the database
-    ///   name, a sizeOnDisk field with the total size of the database file on
-    ///   disk in bytes, and an empty field specifying whether the database
-    ///   has any data.
-    ///
-    /// @throws mongocxx::v_noabi::operation_exception if the underlying 'listDatabases' command
-    /// fails.
-    ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/listDatabases
-    ///
     cursor list_databases(const bsoncxx::v_noabi::document::view_or_value opts) const;
 
-    ///
-    /// Enumerates the databases in the client.
     ///
     /// @param session
     ///   The mongocxx::v_noabi::client_session with which to perform the aggregation.
@@ -284,19 +256,14 @@ class client {
     /// @param opts
     ///   Options passed directly to the 'listDatabases' command.
     ///
-    /// @return A mongocxx::v_noabi::cursor containing a BSON document for each
-    ///   database. Each document contains a name field with the database
-    ///   name, a sizeOnDisk field with the total size of the database file on
-    ///   disk in bytes, and an empty field specifying whether the database
-    ///   has any data.
-    ///
-    /// @throws mongocxx::v_noabi::operation_exception if the underlying 'listDatabases' command
-    /// fails.
-    ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/listDatabases
-    ///
     cursor list_databases(const client_session& session,
                           const bsoncxx::v_noabi::document::view_or_value opts) const;
+
+    /// @}
+    ///
+
+    ///
+    /// @{
 
     ///
     /// Queries the MongoDB server for a list of known databases.
@@ -311,6 +278,7 @@ class client {
     ///
     /// @see https://www.mongodb.com/docs/manual/reference/command/listDatabases
     ///
+
     std::vector<std::string> list_database_names(
         const bsoncxx::v_noabi::document::view_or_value filter = {}) const;
 
@@ -319,7 +287,6 @@ class client {
     ///
     /// @param session
     ///   The mongocxx::v_noabi::client_session with which to perform the aggregation.
-    ///
     /// @param filter
     ///   An optional query expression to filter the returned database names.
     ///
@@ -334,7 +301,6 @@ class client {
         const client_session& session,
         const bsoncxx::v_noabi::document::view_or_value filter = {}) const;
 
-    ///
     /// @}
     ///
 
@@ -352,8 +318,10 @@ class client {
 
     ///
     /// @{
+
     ///
-    /// Gets a change stream on this client with an empty pipeline.
+    /// Get a change stream on this client with an empty pipeline.
+    ///
     /// Change streams are only supported with a "majority" read concern or no read concern.
     ///
     /// @param options
@@ -366,6 +334,10 @@ class client {
     ///
     change_stream watch(const options::change_stream& options = {});
 
+    ///
+    /// Get a change stream on this client with an empty pipeline.
+    ///
+    /// Change streams are only supported with a "majority" read concern or no read concern.
     ///
     /// @param session
     ///   The mongocxx::v_noabi::client_session with which to perform the watch operation.
@@ -380,7 +352,8 @@ class client {
     change_stream watch(const client_session& session, const options::change_stream& options = {});
 
     ///
-    /// Gets a change stream on this client.
+    /// Get a change stream on this client.
+    ///
     /// Change streams are only supported with a "majority" read concern or no read concern.
     ///
     /// @param pipe
@@ -398,7 +371,9 @@ class client {
     change_stream watch(const pipeline& pipe, const options::change_stream& options = {});
 
     ///
-    /// Gets a change stream on this client.
+    /// Get a change stream on this client.
+    ///
+    /// Change streams are only supported with a "majority" read concern or no read concern.
     ///
     /// @param session
     ///   The mongocxx::v_noabi::client_session with which to perform the watch operation.
@@ -416,7 +391,6 @@ class client {
                         const pipeline& pipe,
                         const options::change_stream& options = {});
 
-    ///
     /// @}
     ///
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
@@ -141,8 +141,6 @@ class collection {
     explicit operator bool() const noexcept;
 
     ///
-    /// @{
-    ///
     /// Runs an aggregation framework pipeline against this collection.
     ///
     /// @param pipeline
@@ -188,12 +186,7 @@ class collection {
     cursor aggregate(const client_session& session,
                      const pipeline& pipeline,
                      const options::aggregate& options = options::aggregate());
-    ///
-    /// @}
-    ///
 
-    ///
-    /// @{
     ///
     /// Creates a new bulk operation to be executed against this collection.
     /// The lifetime of the bulk_write is independent of the collection.
@@ -220,12 +213,7 @@ class collection {
     ///
     mongocxx::v_noabi::bulk_write create_bulk_write(const client_session& session,
                                                     const options::bulk_write& options = {});
-    ///
-    /// @}
-    ///
 
-    ///
-    /// @{
     ///
     /// Sends a write to the server as a bulk write operation.
     ///
@@ -275,12 +263,7 @@ class collection {
         const client_session& session,
         const model::write& write,
         const options::bulk_write& options = options::bulk_write());
-    ///
-    /// @}
-    ///
 
-    ///
-    /// @{
     ///
     /// Sends a container of writes to the server as a bulk write operation.
     ///
@@ -334,12 +317,7 @@ class collection {
         const client_session& session,
         const container_type& writes,
         const options::bulk_write& options = options::bulk_write());
-    ///
-    /// @}
-    ///
 
-    ///
-    /// @{
     ///
     /// Sends writes starting at @c begin and ending at @c end to the server as a bulk write
     /// operation.
@@ -398,12 +376,7 @@ class collection {
         write_model_iterator_type begin,
         write_model_iterator_type end,
         const options::bulk_write& options = options::bulk_write());
-    ///
-    /// @}
-    ///
 
-    ///
-    /// @{
     ///
     /// Counts the number of documents matching the provided filter.
     ///
@@ -453,12 +426,7 @@ class collection {
     std::int64_t count_documents(const client_session& session,
                                  bsoncxx::v_noabi::document::view_or_value filter,
                                  const options::count& options = options::count());
-    ///
-    /// @}
-    ///
 
-    ///
-    /// @{
     ///
     /// Returns an estimate of the number of documents in the collection.
     ///
@@ -476,12 +444,7 @@ class collection {
     ///
     std::int64_t estimated_document_count(
         const options::estimated_document_count& options = options::estimated_document_count());
-    ///
-    /// @}
-    ///
 
-    ///
-    /// @{
     ///
     /// Creates an index over the collection for the provided keys with the provided options.
     ///
@@ -534,12 +497,6 @@ class collection {
         options::index_view operation_options = options::index_view{});
 
     ///
-    /// @}
-    ///
-
-    ///
-    /// @{
-    ///
     /// Deletes all matching documents from the collection.
     ///
     /// @param filter
@@ -583,12 +540,6 @@ class collection {
         const options::delete_options& options = options::delete_options());
 
     ///
-    /// @}
-    ///
-
-    ///
-    /// @{
-    ///
     /// Deletes a single matching document from the collection.
     ///
     /// @param filter
@@ -631,12 +582,6 @@ class collection {
         bsoncxx::v_noabi::document::view_or_value filter,
         const options::delete_options& options = options::delete_options());
 
-    ///
-    /// @}
-    ///
-
-    ///
-    /// @{
     ///
     /// Finds the distinct values for a specified field across the collection.
     ///
@@ -646,11 +591,11 @@ class collection {
     ///   Document view representing the documents for which the distinct operation will apply.
     /// @param options
     ///   Optional arguments, see options::distinct.
-
+    ///
     /// @return mongocxx::v_noabi::cursor having the distinct values for the specified
     /// field.  If the operation fails, the cursor throws
     /// mongocxx::v_noabi::query_exception when the returned cursor is iterated.
-
+    ///
     /// @see https://www.mongodb.com/docs/manual/reference/command/distinct/
     ///
     cursor distinct(bsoncxx::v_noabi::string::view_or_value name,
@@ -668,11 +613,11 @@ class collection {
     ///   Document view representing the documents for which the distinct operation will apply.
     /// @param options
     ///   Optional arguments, see options::distinct.
-
+    ///
     /// @return mongocxx::v_noabi::cursor having the distinct values for the specified
     /// field.  If the operation fails, the cursor throws
     /// mongocxx::v_noabi::query_exception when the returned cursor is iterated.
-
+    ///
     /// @see https://www.mongodb.com/docs/manual/reference/command/distinct/
     ///
     cursor distinct(const client_session& session,
@@ -680,12 +625,6 @@ class collection {
                     bsoncxx::v_noabi::document::view_or_value filter,
                     const options::distinct& options = options::distinct());
 
-    ///
-    /// @}
-    ///
-
-    ///
-    /// @{
     ///
     /// Drops this collection and all its contained documents from the database.
     ///
@@ -735,12 +674,6 @@ class collection {
               bsoncxx::v_noabi::document::view_or_value collection_options = {});
 
     ///
-    /// @}
-    ///
-
-    ///
-    /// @{
-    ///
     /// Finds the documents in this collection which match the provided filter.
     ///
     /// @param filter
@@ -784,8 +717,6 @@ class collection {
                 const options::find& options = options::find());
 
     ///
-    /// @{
-    ///
     /// Finds a single document in this collection that match the provided filter.
     ///
     /// @param filter
@@ -825,12 +756,6 @@ class collection {
         const options::find& options = options::find());
 
     ///
-    /// @}
-    ///
-
-    ///
-    /// @{
-    ///
     /// Finds a single document matching the filter, deletes it, and returns the original.
     ///
     /// @param filter
@@ -875,12 +800,6 @@ class collection {
         bsoncxx::v_noabi::document::view_or_value filter,
         const options::find_one_and_delete& options = options::find_one_and_delete());
 
-    ///
-    /// @}
-    ///
-
-    ///
-    /// @{
     ///
     /// Finds a single document matching the filter, replaces it, and returns either the original
     /// or the replacement document.
@@ -934,12 +853,6 @@ class collection {
         bsoncxx::v_noabi::document::view_or_value replacement,
         const options::find_one_and_replace& options = options::find_one_and_replace());
 
-    ///
-    /// @}
-    ///
-
-    ///
-    /// @{
     ///
     /// Finds a single document matching the filter, updates it, and returns either the original
     /// or the newly-updated document.
@@ -1099,12 +1012,6 @@ class collection {
         std::initializer_list<_empty_doc_tag> update,
         const options::find_one_and_update& options = options::find_one_and_update());
 
-    ///
-    /// @}
-    ///
-
-    ///
-    /// @{
     ///
     /// Inserts a single document into the collection. If the document is missing an identifier
     /// (@c _id field) one will be generated for it.
@@ -1119,8 +1026,11 @@ class collection {
     /// disengaged.
     ///
     /// @throws mongocxx::v_noabi::bulk_write_exception if the operation fails.
+    ///
     stdx::optional<result::insert_one> insert_one(
         bsoncxx::v_noabi::document::view_or_value document, const options::insert& options = {});
+
+    ///
     ///
     /// Inserts a single document into the collection. If the document is missing an identifier
     /// (@c _id field) one will be generated for it.
@@ -1137,16 +1047,12 @@ class collection {
     /// disengaged.
     ///
     /// @throws mongocxx::v_noabi::bulk_write_exception if the operation fails.
+    ///
     stdx::optional<result::insert_one> insert_one(
         const client_session& session,
         bsoncxx::v_noabi::document::view_or_value document,
         const options::insert& options = {});
-    ///
-    /// @}
-    ///
 
-    ///
-    /// @{
     ///
     /// Inserts multiple documents into the collection. If any of the documents are missing
     /// identifiers the driver will generate them.
@@ -1202,8 +1108,6 @@ class collection {
         const options::insert& options = options::insert());
 
     ///
-    /// @{
-    ///
     /// Inserts multiple documents into the collection. If any of the documents are missing
     /// identifiers the driver will generate them.
     ///
@@ -1259,12 +1163,8 @@ class collection {
         document_view_iterator_type begin,
         document_view_iterator_type end,
         const options::insert& options = options::insert());
-    ///
-    /// @}
-    ///
 
     ///
-    /// @{
     ///
     /// Returns a list of the indexes currently on this collection.
     ///
@@ -1289,10 +1189,6 @@ class collection {
     /// @see https://www.mongodb.com/docs/manual/reference/command/listIndexes/
     ///
     cursor list_indexes(const client_session& session) const;
-
-    ///
-    /// @}
-    ///
 
     ///
     /// Returns the name of this collection.
@@ -1352,10 +1248,6 @@ class collection {
                 const bsoncxx::v_noabi::stdx::optional<write_concern>& write_concern = {});
 
     ///
-    /// @}
-    ///
-
-    ///
     /// Sets the read_concern for this collection. Changes will not have any effect on existing
     /// cursors or other read operations which use the previously-set read concern.
     ///
@@ -1396,8 +1288,6 @@ class collection {
     ///
     mongocxx::v_noabi::read_preference read_preference() const;
 
-    ///
-    /// @{
     ///
     /// Replaces a single document matching the provided filter in this collection.
     ///
@@ -1452,8 +1342,6 @@ class collection {
         const options::replace& options = options::replace{});
 
     ///
-    /// @{
-    ///
     /// Updates multiple documents matching the provided filter in this collection.
     ///
     /// @param filter
@@ -1607,12 +1495,6 @@ class collection {
                                                const options::update& options = options::update());
 
     ///
-    /// @}
-    ///
-
-    ///
-    /// @{
-    ///
     /// Updates a single document matching the provided filter in this collection.
     ///
     /// @param filter
@@ -1764,10 +1646,6 @@ class collection {
                                               bsoncxx::v_noabi::document::view_or_value filter,
                                               std::initializer_list<_empty_doc_tag> update,
                                               const options::update& options = options::update());
-
-    ///
-    /// @}
-    ///
 
     ///
     /// Sets the write_concern for this collection. Changes will not have any effect on existing
@@ -1787,10 +1665,10 @@ class collection {
 
     ///
     /// Gets an index_view to the collection.
+    ///
     index_view indexes();
 
     ///
-    /// @{
     ///
     /// Gets a change stream on this collection with an empty pipeline.
     /// Change streams are only supported with a "majority" read concern or no read concern.
@@ -1856,11 +1734,8 @@ class collection {
                         const options::change_stream& options = {});
 
     ///
-    /// @}
-    ///
-
-    ///
     /// Gets a search_index_view to the collection.
+    ///
     search_index_view search_indexes();
 
    private:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/config/prelude.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/config/prelude.hpp
@@ -63,16 +63,3 @@
 #pragma push_macro("MONGOCXX_UNREACHABLE")
 #undef MONGOCXX_UNREACHABLE
 #define MONGOCXX_UNREACHABLE std::abort()
-
-// Doxygen does not account for generated header files.
-// Document globally applicable macros and namespaces here.
-
-///
-/// @namespace mongocxx
-/// The top-level namespace for mongocxx library entities.
-///
-
-///
-/// @namespace mongocxx::v_noabi
-/// Entities declared in this namespace do not have a stable ABI.
-///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
@@ -162,16 +162,14 @@ class cursor::iterator {
     friend ::mongocxx::v_noabi::cursor;
 
     ///
-    /// @{
+    /// @relates mongocxx::v_noabi::mongocxx::cursor::iterator
     ///
-    /// Compare two iterators for (in)-equality.  Iterators compare equal if
+    /// Compare two iterators for (in)-equality. Iterators compare equal if
     /// they point to the same underlying cursor or if both are exhausted.
     ///
-    /// @relates iterator
-    ///
+    /// @{
     friend MONGOCXX_API bool MONGOCXX_CALL operator==(const iterator&, const iterator&);
     friend MONGOCXX_API bool MONGOCXX_CALL operator!=(const iterator&, const iterator&);
-    ///
     /// @}
     ///
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
@@ -84,8 +84,6 @@ class database {
     explicit operator bool() const noexcept;
 
     ///
-    /// @{
-    ///
     /// Runs an aggregation framework pipeline against this database for
     /// pipeline stages that do not require an underlying collection,
     /// such as $currentOp and $listLocalSessions.
@@ -135,12 +133,7 @@ class database {
     cursor aggregate(const client_session& session,
                      const pipeline& pipeline,
                      const options::aggregate& options = options::aggregate());
-    ///
-    /// @}
-    ///
 
-    ///
-    /// @{
     ///
     /// Runs a command against this database.
     ///
@@ -181,12 +174,7 @@ class database {
     ///
     bsoncxx::v_noabi::document::value run_command(bsoncxx::v_noabi::document::view_or_value command,
                                                   uint32_t server_id);
-    ///
-    /// @}
-    ///
 
-    ///
-    /// @{
     ///
     /// Explicitly creates a collection in this database with the specified options.
     ///
@@ -334,12 +322,6 @@ class database {
         const stdx::optional<write_concern>& write_concern = {});
 
     ///
-    /// @}
-    ///
-
-    ///
-    /// @{
-    ///
     /// Drops the database and all its collections.
     ///
     /// @param write_concern (optional)
@@ -373,9 +355,6 @@ class database {
     void drop(const client_session& session,
               const bsoncxx::v_noabi::stdx::optional<mongocxx::v_noabi::write_concern>&
                   write_concern = {});
-    ///
-    /// @}
-    ///
 
     ///
     /// Checks whether this database contains a collection having the given name.
@@ -389,8 +368,6 @@ class database {
     ///
     bool has_collection(bsoncxx::v_noabi::string::view_or_value name) const;
 
-    ///
-    /// @{
     ///
     /// Enumerates the collections in this database.
     ///
@@ -451,10 +428,6 @@ class database {
     ///
     std::vector<std::string> list_collection_names(
         const client_session& session, bsoncxx::v_noabi::document::view_or_value filter = {});
-
-    ///
-    /// @}
-    ///
 
     ///
     /// Get the name of this database.
@@ -563,8 +536,6 @@ class database {
         const options::gridfs::bucket& options = options::gridfs::bucket()) const;
 
     ///
-    /// @{
-    ///
     /// Gets a change stream on this database with an empty pipeline.
     /// Change streams are only supported with a "majority" read concern or no read concern.
     ///
@@ -627,10 +598,6 @@ class database {
     change_stream watch(const client_session& session,
                         const pipeline& pipe,
                         const options::change_stream& options = {});
-
-    ///
-    /// @}
-    ///
 
    private:
     friend ::mongocxx::v_noabi::client_encryption;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description.hpp
@@ -73,26 +73,20 @@ class topology_description {
         using const_iterator = container::const_iterator;
 
         ///
-        /// @{
-        ///
         /// Returns an iterator to the beginning.
         ///
+        /// @{
         iterator begin() noexcept;
         const_iterator begin() const noexcept;
-
-        ///
         /// @}
         ///
 
         ///
-        /// @{
-        ///
         /// Returns an iterator to the end.
         ///
+        /// @{
         iterator end() noexcept;
         const_iterator end() const noexcept;
-
-        ///
         /// @}
         ///
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception.hpp
@@ -51,15 +51,13 @@ class operation_exception : public exception {
                         std::string what_arg = "");
 
     ///
-    /// @{
-    ///
     /// The optional raw bson error document from the server.
     ///
     /// @returns The raw server error, if it is available.
     ///
+    /// @{
     const stdx::optional<bsoncxx::v_noabi::document::value>& raw_server_error() const;
     stdx::optional<bsoncxx::v_noabi::document::value>& raw_server_error();
-    ///
     /// @}
     ///
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/fwd.hpp
@@ -111,3 +111,8 @@
 #include <mongocxx/validation_criteria-fwd.hpp>
 #include <mongocxx/write_concern-fwd.hpp>
 #include <mongocxx/write_type-fwd.hpp>
+
+///
+/// @namespace mongocxx::v_noabi
+/// Entities declared in this namespace do not have a stable ABI.
+///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
@@ -511,8 +511,7 @@ class bucket {
                             std::ostream* destination);
 
     ///
-    /// @copydoc download_to_stream(bsoncxx::v_noabi::types::bson_value::view id, std::ostream*
-    /// destination)
+    /// @copydoc download_to_stream(bsoncxx::v_noabi::types::bson_value::view id, std::ostream* destination)
     ///
     /// @param start The byte offset to the beginning of content to download.
     /// @param end The byte offset to the end of content to download.
@@ -549,14 +548,12 @@ class bucket {
                             bsoncxx::v_noabi::types::bson_value::view id,
                             std::ostream* destination);
 
-    // clang-format off
     ///
     /// @copydoc download_to_stream(const client_session& session, bsoncxx::v_noabi::types::bson_value::view id, std::ostream* destination)
     ///
     /// @param start The byte offset to the beginning of content to download.
     /// @param end The byte offset to the end of content to download.
     ///
-    // clang-format on
     void download_to_stream(const client_session& session,
                             bsoncxx::v_noabi::types::bson_value::view id,
                             std::ostream* destination,

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
@@ -100,8 +100,6 @@ class bucket {
     explicit operator bool() const noexcept;
 
     ///
-    /// @{
-    ///
     /// Opens a gridfs::uploader to create a new GridFS file. The id of the file will be
     /// automatically generated as an ObjectId.
     ///
@@ -163,12 +161,7 @@ class bucket {
     uploader open_upload_stream(const client_session& session,
                                 stdx::string_view filename,
                                 const options::gridfs::upload& options = {});
-    ///
-    /// @}
-    ///
 
-    ///
-    /// @{
     ///
     /// Opens a gridfs::uploader to create a new GridFS file.
     ///
@@ -237,12 +230,7 @@ class bucket {
                                         bsoncxx::v_noabi::types::bson_value::view id,
                                         stdx::string_view filename,
                                         const options::gridfs::upload& options = {});
-    ///
-    /// @}
-    ///
 
-    ///
-    /// @{
     ///
     /// Creates a new GridFS file by uploading bytes from an input stream. The id of the file will
     /// be automatically generated as an ObjectId.
@@ -336,12 +324,7 @@ class bucket {
                                               stdx::string_view filename,
                                               std::istream* source,
                                               const options::gridfs::upload& options = {});
-    ///
-    /// @}
-    ///
 
-    ///
-    /// @{
     ///
     /// Creates a new GridFS file with a user-supplied unique id by uploading bytes from an input
     /// stream.
@@ -437,12 +420,7 @@ class bucket {
                                     stdx::string_view filename,
                                     std::istream* source,
                                     const options::gridfs::upload& options = {});
-    ///
-    /// @}
-    ///
 
-    ///
-    /// @{
     ///
     /// Opens a gridfs::downloader to read a GridFS file.
     ///
@@ -481,12 +459,7 @@ class bucket {
     ///
     downloader open_download_stream(const client_session& session,
                                     bsoncxx::v_noabi::types::bson_value::view id);
-    ///
-    /// @}
-    ///
 
-    ///
-    /// @{
     ///
     /// Downloads the contents of a stored GridFS file from the bucket and writes it to a stream.
     ///
@@ -559,12 +532,7 @@ class bucket {
                             std::ostream* destination,
                             std::size_t start,
                             std::size_t end);
-    ///
-    /// @}
-    ///
 
-    ///
-    /// @{
     ///
     /// Deletes a GridFS file from the bucket.
     ///
@@ -593,12 +561,7 @@ class bucket {
     ///   if an error occurs when removing file data or chunk data from the database.
     ///
     void delete_file(const client_session& session, bsoncxx::v_noabi::types::bson_value::view id);
-    ///
-    /// @}
-    ///
 
-    ///
-    /// @{
     ///
     /// Finds the documents in the files collection of the bucket which match the provided filter.
     ///
@@ -645,9 +608,6 @@ class bucket {
     cursor find(const client_session& session,
                 bsoncxx::v_noabi::document::view_or_value filter,
                 const options::find& options = {});
-    ///
-    /// @}
-    ///
 
     ///
     /// Gets the name of the GridFS bucket.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/hint.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/hint.hpp
@@ -53,19 +53,23 @@ class hint {
     explicit hint(bsoncxx::v_noabi::string::view_or_value index);
 
     ///
-    /// @{
+    /// @relates mongocxx::v_noabi::hint
     ///
-    /// Compare this hint to a string for (in)-equality
+    /// Convenience methods to compare for equality against an index name.
     ///
-    /// @relates hint
+    /// Compares equal if the hint contains a matching index name. Otherwise, compares unequal.
     ///
     friend MONGOCXX_API bool MONGOCXX_CALL operator==(const hint& index_hint, std::string index);
 
+    ///
+    /// @relates mongocxx::v_noabi::hint
+    ///
+    /// Convenience methods to compare for equality against an index document.
+    ///
+    /// Compares equal if the hint contains a matching index document. Otherwise, compares unequal.
+    ///
     friend MONGOCXX_API bool MONGOCXX_CALL operator==(const hint& index_hint,
                                                       bsoncxx::v_noabi::document::view index);
-    ///
-    /// @}
-    ///
 
     ///
     /// Returns a types::bson_value::view representing this hint.
@@ -91,54 +95,41 @@ class hint {
 };
 
 ///
-/// Convenience methods to compare for equality against an index name.
+/// Convenience methods to compare against an index name.
 ///
-/// Return true if this hint contains an index name that matches.
-///
-/// @relates hint
-///
-MONGOCXX_API bool MONGOCXX_CALL operator==(std::string index, const hint& index_hint);
-
+/// Compares equal if the hint contains a matching index name. Otherwise, compares unequal.
 ///
 /// @{
-///
-/// Convenience methods to compare for inequality against an index name.
-///
-/// Return true if this hint contains an index name that matches.
-///
-/// @relates hint
-///
+
+/// @relatesalso mongocxx::v_noabi::hint
+MONGOCXX_API bool MONGOCXX_CALL operator==(std::string index, const hint& index_hint);
+
+/// @relatesalso mongocxx::v_noabi::hint
 MONGOCXX_API bool MONGOCXX_CALL operator!=(const hint& index_hint, std::string index);
+
+/// @relatesalso mongocxx::v_noabi::hint
 MONGOCXX_API bool MONGOCXX_CALL operator!=(std::string index, const hint& index_index);
-///
+
 /// @}
 ///
 
 ///
 /// Convenience methods to compare for equality against an index document.
 ///
-/// Return true if this hint contains an index document that matches.
-///
-/// @relates hint
-///
-MONGOCXX_API bool MONGOCXX_CALL operator==(bsoncxx::v_noabi::document::view index,
-                                           const hint& index_hint);
-
+/// Compares equal if the hint contains a matching index document. Otherwise, compares unequal.
 ///
 /// @{
-///
-/// Convenience methods to compare for equality against an index document.
-///
-/// Return true if this hint contains an index document that matches.
-///
-///
-/// @relates hint
-///
+
+/// @relatesalso mongocxx::v_noabi::hint
+MONGOCXX_API bool MONGOCXX_CALL operator==(bsoncxx::v_noabi::document::view index,
+                                           const hint& index_hint);
+/// @relatesalso mongocxx::v_noabi::hint
 MONGOCXX_API bool MONGOCXX_CALL operator!=(const hint& index_hint,
                                            bsoncxx::v_noabi::document::view index);
+/// @relatesalso mongocxx::v_noabi::hint
 MONGOCXX_API bool MONGOCXX_CALL operator!=(bsoncxx::v_noabi::document::view index,
                                            const hint& index_hint);
-///
+
 /// @}
 ///
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view.hpp
@@ -46,8 +46,6 @@ class index_view {
     index_view& operator=(const index_view&) = delete;
 
     ///
-    /// @{
-    ///
     /// Returns a cursor over all the indexes.
     ///
     cursor list();
@@ -60,12 +58,6 @@ class index_view {
     ///
     cursor list(const client_session& session);
 
-    ///
-    /// @}
-    ///
-
-    ///
-    /// @{
     ///
     /// Creates an index. A convenience method that calls create_many.
     ///
@@ -121,12 +113,6 @@ class index_view {
         const bsoncxx::v_noabi::document::view_or_value& index_options = {},
         const options::index_view& options = options::index_view{});
 
-    ///
-    /// @}
-    ///
-
-    ///
-    /// @{
     ///
     /// Creates an index. A convenience method that calls create_many.
     ///
@@ -174,12 +160,6 @@ class index_view {
         const options::index_view& options = options::index_view{});
 
     ///
-    /// @}
-    ///
-
-    ///
-    /// @{
-    ///
     /// Adds a container of indexes to the collection.
     ///
     /// @param indexes
@@ -227,12 +207,6 @@ class index_view {
         const options::index_view& options = options::index_view{});
 
     ///
-    /// @}
-    ///
-
-    ///
-    /// @{
-    ///
     /// Drops a single index by name.
     ///
     /// @param name
@@ -273,12 +247,6 @@ class index_view {
                   stdx::string_view name,
                   const options::index_view& options = options::index_view{});
 
-    ///
-    /// @}
-    ///
-
-    ///
-    /// @{
     ///
     /// Attempts to drop a single index from the collection given the keys and options.
     ///
@@ -337,12 +305,6 @@ class index_view {
                   const options::index_view& options = options::index_view{});
 
     ///
-    /// @}
-    ///
-
-    ///
-    /// @{
-    ///
     /// Attempts to drop a single index from the collection given an index model.
     ///
     /// @param index
@@ -390,12 +352,6 @@ class index_view {
                   const options::index_view& options = options::index_view{});
 
     ///
-    /// @}
-    ///
-
-    ///
-    /// @{
-    ///
     /// Drops all indexes in the collection.
     ///
     /// @param options
@@ -425,10 +381,6 @@ class index_view {
     ///
     void drop_all(const client_session& session,
                   const options::index_view& options = options::index_view{});
-
-    ///
-    /// @}
-    ///
 
    private:
     friend ::mongocxx::v_noabi::collection;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_many.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_many.hpp
@@ -51,8 +51,6 @@ class update_many {
 
    public:
     ///
-    /// @{
-    ///
     /// Constructs an update operation that will modify all documents matching the filter.
     ///
     /// @param filter
@@ -83,10 +81,6 @@ class update_many {
     ///
     update_many(bsoncxx::v_noabi::document::view_or_value filter,
                 std::initializer_list<_empty_doc_tag> update);
-
-    ///
-    /// @}
-    ///
 
     ///
     /// Gets the filter.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_one.hpp
@@ -51,8 +51,6 @@ class update_one {
 
    public:
     ///
-    /// @{
-    ///
     /// Constructs an update operation that will modify a single document matching the filter.
     ///
     /// @param filter
@@ -83,10 +81,6 @@ class update_one {
     ///
     update_one(bsoncxx::v_noabi::document::view_or_value filter,
                std::initializer_list<_empty_doc_tag> update);
-
-    ///
-    /// @}
-    ///
 
     ///
     /// Gets the filter

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/write.hpp
@@ -87,8 +87,7 @@ class write {
     ~write();
 
     ///
-    /// Returns the current type of this write. You must call this
-    /// method before calling any of the get methods below.
+    /// Returns the current type of this write.
     ///
     write_type type() const;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
@@ -163,15 +163,13 @@ class read_concern {
     friend ::mongocxx::v_noabi::uri;
 
     ///
-    /// @{
+    /// @relates mongocxx::v_noabi::read_concern
     ///
     /// Compares two read_concern objects for (in)-equality.
     ///
-    /// @relates: read_concern
-    ///
+    /// @{
     friend MONGOCXX_API bool MONGOCXX_CALL operator==(const read_concern&, const read_concern&);
     friend MONGOCXX_API bool MONGOCXX_CALL operator!=(const read_concern&, const read_concern&);
-    ///
     /// @}
     ///
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
@@ -291,17 +291,15 @@ class read_preference {
     friend ::mongocxx::v_noabi::uri;
 
     ///
-    /// @{
+    /// @relates mongocxx::v_noabi::read_preference
     ///
     /// Compares two read_preference objects for (in)-equality.
     ///
-    /// @relates: read_preference
-    ///
+    /// @{
     friend MONGOCXX_API bool MONGOCXX_CALL operator==(const read_preference&,
                                                       const read_preference&);
     friend MONGOCXX_API bool MONGOCXX_CALL operator!=(const read_preference&,
                                                       const read_preference&);
-    ///
     /// @}
     ///
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_view.hpp
@@ -31,8 +31,6 @@ class search_index_view {
     ~search_index_view();
 
     ///
-    /// @{
-    ///
     /// Returns a cursor over all the search indexes.
     ///
     /// @param options
@@ -84,12 +82,6 @@ class search_index_view {
                 bsoncxx::v_noabi::string::view_or_value name,
                 const options::aggregate& options = options::aggregate());
 
-    ///
-    /// @}
-    ///
-
-    ///
-    /// @{
     ///
     /// This is a convenience method for creating a single search index with a default name.
     ///
@@ -165,12 +157,6 @@ class search_index_view {
     std::string create_one(const client_session& session, const search_index_model& model);
 
     ///
-    /// @}
-    ///
-
-    ///
-    /// @{
-    ///
     /// Creates multiple search indexes in the collection.
     ///
     /// @param models
@@ -194,12 +180,6 @@ class search_index_view {
                                          const std::vector<search_index_model>& models);
 
     ///
-    /// @}
-    ///
-
-    ///
-    /// @{
-    ///
     /// Drops a single search index from the collection by the index name.
     ///
     /// @param name
@@ -217,12 +197,6 @@ class search_index_view {
     ///
     void drop_one(const client_session& session, bsoncxx::v_noabi::string::view_or_value name);
 
-    ///
-    /// @}
-    ///
-
-    ///
-    /// @{
     ///
     /// Updates a single search index from the collection by the search index name.
     ///
@@ -247,10 +221,6 @@ class search_index_view {
     void update_one(const client_session& session,
                     bsoncxx::v_noabi::string::view_or_value name,
                     bsoncxx::v_noabi::document::view_or_value definition);
-
-    ///
-    /// @}
-    ///
 
    private:
     friend ::mongocxx::v_noabi::collection;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
@@ -253,15 +253,13 @@ class write_concern {
     friend ::mongocxx::v_noabi::uri;
 
     ///
-    /// @{
+    /// @relates mongocxx::v_noabi::write_concern
     ///
     /// Compares two write_concern objects for (in)-equality.
     ///
-    /// @relates: write_concern
-    ///
+    /// @{
     friend MONGOCXX_API bool MONGOCXX_CALL operator==(const write_concern&, const write_concern&);
     friend MONGOCXX_API bool MONGOCXX_CALL operator!=(const write_concern&, const write_concern&);
-    ///
     /// @}
     ///
 

--- a/src/mongocxx/lib/CMakeLists.txt
+++ b/src/mongocxx/lib/CMakeLists.txt
@@ -159,6 +159,7 @@ endif()
 set_dist_list(src_mongocxx_lib_DIST
     CMakeLists.txt
     ${mongocxx_sources_v_noabi}
+    mongocxx/fwd.cpp
     mongocxx/v_noabi/mongocxx/config/config.hpp.in
     mongocxx/v_noabi/mongocxx/config/private/config.hh.in
     mongocxx/v_noabi/mongocxx/config/private/postlude.hh

--- a/src/mongocxx/lib/CMakeLists.txt
+++ b/src/mongocxx/lib/CMakeLists.txt
@@ -38,6 +38,7 @@ set(mongocxx_sources_v_noabi
     mongocxx/v_noabi/mongocxx/exception/error_code.cpp
     mongocxx/v_noabi/mongocxx/exception/operation_exception.cpp
     mongocxx/v_noabi/mongocxx/exception/server_error_code.cpp
+    mongocxx/v_noabi/mongocxx/fwd.cpp
     mongocxx/v_noabi/mongocxx/gridfs/bucket.cpp
     mongocxx/v_noabi/mongocxx/gridfs/downloader.cpp
     mongocxx/v_noabi/mongocxx/gridfs/uploader.cpp
@@ -110,6 +111,7 @@ set(mongocxx_sources_v_noabi
 
 list(APPEND mongocxx_sources
     ${mongocxx_sources_v_noabi}
+    mongocxx/fwd.cpp
 )
 list(TRANSFORM mongocxx_sources PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
 set(mongocxx_sources "${mongocxx_sources}" PARENT_SCOPE)

--- a/src/mongocxx/lib/mongocxx/fwd.cpp
+++ b/src/mongocxx/lib/mongocxx/fwd.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/fwd.hpp>  // <mongocxx/v_noabi/mongocxx/fwd.hpp>

--- a/src/mongocxx/lib/mongocxx/fwd.cpp
+++ b/src/mongocxx/lib/mongocxx/fwd.cpp
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/fwd.hpp>  // <mongocxx/v_noabi/mongocxx/fwd.hpp>
+// Validate that <mongocxx/v_noabi/mongocxx/fwd.hpp> is included, not <mongocxx/fwd.hpp>.
+#include <mongocxx/fwd.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/fwd.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/fwd.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/v_noabi/mongocxx/fwd.hpp>


### PR DESCRIPTION
## Summary

Resolves CXX-3064. Related to CXX-2827.

This PR is a parallel companion to https://github.com/mongodb/mongo-cxx-driver/pull/1169. Whereas https://github.com/mongodb/mongo-cxx-driver/pull/1169 focuses on the deployment process and tooling, this PR focuses on various fixes and improvements to the contents of the current API docs itself.

## The "Incompleteness" Problem

The Doxyfile sets `EXTRACT_ALL = NO`. This enables warnings for undocumented entities. However, this _also_ means directories and namespaces MUST be explicitly documented in order to properly generate their corresponding pages. This is the reason behind so many pages for directories and namespaces being completely devoid of useful information or missing a navigatable page entirely.

For example, this is the page for the `bsoncxx/v_noabi/bsoncxx` directory (note: subdirectory information is completely absent despite having pages):

![image](https://github.com/user-attachments/assets/2eb9795a-67c5-4100-91d8-bbc69dfcd863)

Undocumented headers do not generate a page at all (hence their absence in directory pages as above):

![image](https://github.com/user-attachments/assets/993dbfb1-6ca2-48e6-b9b9-7c8b1d94dc42)

Undocumented namespaces similarly do not generate a page at all:

![image](https://github.com/user-attachments/assets/7768f032-669c-492c-aa2a-4af223be5a01)

This means the "array" in "bsoncxx > v_noabi > array > element" is not navigatable/interactable (among many similar cases of "dead" links):

![image](https://github.com/user-attachments/assets/57c925b7-7a19-44f4-ab56-6be2f4ca2ce1)

These factors all contribute to a feeling of "incompleteness" in the quality of the API docs.

This PR lays the foundations to address all of the issues described above. However, the addition of documentation of directories, namespaces, and files are deferred to a followup PR due to the volume of changes required.

A preview of upcoming changes:

![image](https://github.com/user-attachments/assets/984e757d-114e-48f8-9c92-5d3bfae02a5b)

## Root Level Forward Headers

This PR adds a `bsoncxx/fwd.hpp` and `mongocxx/fwd.hpp` at the library root level, _not_ to be confused with `bsoncxx/v_noabi/bsoncxx/fwd.hpp` and `mongocxx/v_noabi/mongocxx/fwd.hpp` added by https://github.com/mongodb/mongo-cxx-driver/pull/1061. These headers are _NOT_ expected to be included or even includeable (`<bsoncxx/v_noabi/bsoncxx>` is prioritized before `<bsoncxx>` by include directory search paths, so these new `fwd.hpp` headers will never be found). Nevertheless, just in case, they are defined to behave equivalently to their `v_noabi` counterparts should they be included anyways.

These headers may be renamed to something else if `fwd.hpp` is confusing for their purpose.

The purpose of these headers is to provide a definitive location to add Doxygen documentation for root-level _directories_ and _namespaces_.

```
src/bsoncxx/include/ # Similarly for mongocxx.
└── bsoncxx/
    ├── fwd.hpp      # Documents bsoncxx/ and bsoncxx::.
    ├── v_noabi/bsoncxx/
    │   ├── fwd.hpp  # Documents bsoncxx/v_noabi and bsoncxx::v_noabi.
    │   └── ...
    └── v1/          # CXX-2745
        ├── fwd.hpp  # Documents bsoncxx/v1 and bsoncxx::v1.
        └── ...
```

https://github.com/mongodb/mongo-cxx-driver/pull/1039#issuecomment-1773264817 added some of these docs to the `prelude.hpp` headers, as forward headers were not yet implemented at the time. These are relocated to their corresponding forward headers.

The addition of documentation of directories, namespaces, and files are deferred to a followup PR due to the volume of changes required.

## Sorted Documentation

This PR proposes setting various `SORT_*` options to `YES`. This is primarily to automate the (alphabetical) grouping of related functions without requiring use of Doxygen groups. This will secondarily discourage writing documentation sensitive to in-source-declaration-order (e.g. "see above/below") allowing for greater freedom of in-source ordering without impacting API documentation results.

## `@relates`, `@relatesalso`, and Groups

After much pain and debugging, some rules were derived:

1. `@relatesalso` is _not_ equivalent to `@see`.
1. `@relatesalso` is not inherited by group members (`@relates` is).
2. Member group comments should not be their own doc comment block.
3. Documentation distributed to group members generally comes _before_ the `@{`, not after, except when `DISTRIBUTE_GROUP_DOC` applies instead (reuse doc of first group member for the rest).

This PR addresses all known violations of these rules by applying the following patterns (and generally avoiding use of groups when able):

```cpp
class example {
public:
  ///
  /// @relates example <!-- Inherited by group members. -->
  ///
  /// Common documentation for group members.
  ///
  /// @{ <!-- Asymmetric block for group marker. -->

  friend void group_member(int i);
  friend void group_member(double d);

  /// @} <!-- Asymmetric block for group marker. -->
  ///

  void unrelated(); // Asymmetry of the group marker comments avoid
                    // leaking the group documentation into the
                    // next entity when used in class definition scope.
};

///
/// Common documentation for group members.
///
/// @{

/// @relatesalso example <!-- Per group member. -->
inline void group_member(example e, int i);

/// @relatesalso example <!-- Per group member. -->
inline void group_member(example e, double d);

/// @} <!-- Asymmetric block for group marker. -->
///
```

It is important to use `@relatesalso` for non-member functions (especially operators) to ensure their declaration is included in the documentation of the enclosing namespace. Otherwise, they are only documented in the related class page. This is especially important for correctly documenting root namespace redeclarations in CXX-2745.

Use of per-member documentation should be avoided whenever possible to avoid the complexities of merging group-and-member documentations (`@param` commands in particular are a problem). Copying relevant documentation per member (e.g. `mongocxx::v_noabi::hint::operator==` overloads) is preferable to twisting contents to accomodate all group members.

## BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR

This (and its mongocxx counterpart) are added to facilitate workarounds for the very unfortunate Doxygen using-declaration problem described in https://github.com/mongodb/mongo-cxx-driver/pull/1066. These workarounds will come in a followup PR, but as a preview of their intended usage:

```cpp
namespace bsoncxx {
namespace array {

#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

/// @ref v_noabi::array::element
class element {};

#else

using v_noabi::array::element;

#endif // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

} // namespace array
} // namespace bsoncxx
```

A preview of the results:

![image](https://github.com/user-attachments/assets/eb7aa5ed-d619-478c-a991-d6ee452f8e4d)

This will be discussed in greater detail in the relevant followup PR.

## STRIP_FROM_PATH = ON

Old:

![image](https://github.com/user-attachments/assets/dab9385d-7485-4335-8421-9fce709785de)

New:

![image](https://github.com/user-attachments/assets/446767ae-f0c2-4a18-88ea-9e45faf5d997)

## Miscellaneous

- Set `BSONCXX_INLINE=inline` (+ mongocxx) to correctly communicate inline functions to Doxygen.
- Added ClangFormat `CommentPragmas` to avoid breaking long Doxygen commands by wrapping (e.g. `@copydoc`).
- Added a missing `@internal` in `util.hpp`.
- Fixed links to [Working with BSON](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/working-with-bson/#basic-builder).
