### PR TITLE
CXX-3065 guard against use of REQUIRE within APM callbacks

### DIFF
--- a/cmake/BsoncxxUtil.cmake
+++ b/cmake/BsoncxxUtil.cmake
@@ -143,6 +143,7 @@ function(bsoncxx_add_library TARGET OUTPUT_NAME LINK_TYPE)
     if(BSONCXX_POLY_USE_MNMLSTC AND NOT BSONCXX_POLY_USE_SYSTEM_MNMLSTC)
         target_include_directories(
             ${TARGET}
+            SYSTEM
             PUBLIC
             $<BUILD_INTERFACE:${CORE_INCLUDE_DIR}>
             $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/bsoncxx/v_noabi/bsoncxx/third_party/mnmlstc>

--- a/src/bsoncxx/test/CMakeLists.txt
+++ b/src/bsoncxx/test/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(test_bson
     bson_util_itoa.cpp
     bson_validate.cpp
     bson_value.cpp
+    exception_guard.cpp
     json.cpp
     oid.cpp
     optional.test.cpp
@@ -141,6 +142,8 @@ set_dist_list(src_bsoncxx_test_DIST
     bson_validate.cpp
     bson_value.cpp
     catch.hh
+    exception_guard.cpp
+    exception_guard.hh
     json.cpp
     oid.cpp
     optional.test.cpp

--- a/src/bsoncxx/test/exception_guard.cpp
+++ b/src/bsoncxx/test/exception_guard.cpp
@@ -1,0 +1,225 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/test/exception_guard.hh>
+
+//
+
+#include <atomic>
+#include <chrono>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <bsoncxx/test/catch.hh>
+
+namespace {
+
+TEST_CASE("bsoncxx::test::exception_guard", "[test]") {
+    using EGuard = bsoncxx::test::exception_guard_state;
+
+    EGuard eguard;
+
+    SECTION("init") {
+        CHECK(eguard.ptr == nullptr);
+        CHECK(eguard.file == bsoncxx::stdx::string_view(""));
+        CHECK(eguard.line == 0u);
+        CHECK(eguard.func == bsoncxx::stdx::string_view(""));
+    }
+
+    SECTION("reset") {
+        // clang-format off
+        BSONCXX_TEST_EXCEPTION_GUARD_RESET(eguard); const auto line = __LINE__;
+        // clang-format on
+
+        CHECK(eguard.ptr == nullptr);
+        CHECK(eguard.file == bsoncxx::stdx::string_view(__FILE__));
+        CHECK(eguard.line == line);
+        CHECK(eguard.func == bsoncxx::stdx::string_view(__func__));
+    }
+
+    SECTION("simple") {
+        SECTION("no throw") {
+            BSONCXX_TEST_EXCEPTION_GUARD_BEGIN(eguard);
+            BSONCXX_TEST_EXCEPTION_GUARD_END(eguard);
+
+            CHECK(eguard.ptr == nullptr);
+            CHECK(eguard.file == bsoncxx::stdx::string_view(""));
+            CHECK(eguard.line == 0u);
+            CHECK(eguard.func == bsoncxx::stdx::string_view(""));
+
+            BSONCXX_TEST_EXCEPTION_GUARD_CHECK(eguard);
+            SUCCEED("no exception was thrown by the check");
+        }
+
+        SECTION("throw") {
+            struct EGuardException {};
+
+            EGuard expected;
+
+            // clang-format off
+            BSONCXX_TEST_EXCEPTION_GUARD_BEGIN(eguard);
+            throw EGuardException();
+            BSONCXX_TEST_EXCEPTION_GUARD_END(eguard); BSONCXX_TEST_EXCEPTION_GUARD_RESET(expected);
+            // clang-format on
+
+            CHECK(eguard.ptr != nullptr);
+            CHECK(eguard.file == expected.file);
+            CHECK(eguard.line == expected.line);
+            CHECK(eguard.func == expected.func);
+            CHECK(eguard.ignored.empty());
+
+            const auto check_expr = [&] { BSONCXX_TEST_EXCEPTION_GUARD_CHECK(eguard); };
+            REQUIRE_THROWS_AS(check_expr(), EGuardException);
+            REQUIRE_THROWS_AS(check_expr(), EGuardException);  // Rethrow is OK.
+
+            CHECK(eguard.ptr != nullptr);
+            CHECK(eguard.file == expected.file);
+            CHECK(eguard.line == expected.line);
+            CHECK(eguard.func == expected.func);
+            CHECK(eguard.ignored.empty());
+        }
+
+        SECTION("ignored") {
+            struct EGuardException : std::runtime_error {
+                using std::runtime_error::runtime_error;
+            };
+
+            // clang-format off
+            BSONCXX_TEST_EXCEPTION_GUARD_BEGIN(eguard);
+            throw EGuardException("one");
+            BSONCXX_TEST_EXCEPTION_GUARD_END(eguard);
+            // clang-format on
+
+            REQUIRE(eguard.ptr != nullptr);
+            REQUIRE(eguard.ignored.size() == 0u);
+
+            EGuard expected;
+
+            // clang-format off
+            BSONCXX_TEST_EXCEPTION_GUARD_BEGIN(eguard);
+            throw EGuardException("two");
+            BSONCXX_TEST_EXCEPTION_GUARD_END(eguard); BSONCXX_TEST_EXCEPTION_GUARD_RESET(expected);
+            // clang-format on
+
+            const auto npos = std::string::npos;
+
+            REQUIRE(eguard.ignored.size() == 1u);
+            {
+                const auto& log = eguard.ignored[0];
+                const auto log_view = bsoncxx::stdx::string_view(log);
+
+                CAPTURE(log);
+                CAPTURE(expected.file);
+                CAPTURE(expected.line);
+                CAPTURE(expected.func);
+
+                CHECK_THAT(log, Catch::Contains("two"));
+                CHECK(log_view.find(expected.file) != npos);
+                CHECK(log_view.find(std::to_string(expected.line)) != npos);
+                CHECK(log_view.find(expected.func) == npos);  // Func is not logged.
+            }
+
+            // clang-format off
+            BSONCXX_TEST_EXCEPTION_GUARD_BEGIN(eguard);
+            throw Catch::TestFailureException(); // As-if by `REQUIRE(false)`.
+            BSONCXX_TEST_EXCEPTION_GUARD_END(eguard); BSONCXX_TEST_EXCEPTION_GUARD_RESET(expected);
+            // clang-format on
+
+            REQUIRE(eguard.ignored.size() == 2u);
+            {
+                const auto& log = eguard.ignored[1];
+                const auto log_view = bsoncxx::stdx::string_view(log);
+
+                CAPTURE(log);
+                CAPTURE(expected.file);
+                CAPTURE(expected.line);
+                CAPTURE(expected.func);
+
+                CHECK_THAT(log, Catch::Contains("Catch::TestFailureException"));
+                CHECK(log_view.find(expected.file) != npos);
+                CHECK(log_view.find(std::to_string(expected.line)) != npos);
+                CHECK(log_view.find(expected.func) == npos);  // Func is not logged.
+            }
+
+            // The original exception.
+            const auto check_expr = [&] { BSONCXX_TEST_EXCEPTION_GUARD_CHECK(eguard); };
+            REQUIRE_THROWS_WITH(check_expr(), Catch::Contains("one"));
+        }
+    }
+
+    SECTION("concurrent") {
+        EGuard expected;
+
+        struct EGuardException : std::runtime_error {
+            int id;
+            EGuardException(int i) : std::runtime_error(std::to_string(i)), id(i) {}
+        };
+
+        {
+            std::atomic_int counter;
+            std::atomic_bool latch;
+
+            std::atomic_init(&counter, 0);
+            std::atomic_init(&latch, false);
+
+            auto fn = [&] {
+                // A simple latch to maximize parallelism.
+                while (!latch.load()) {
+                }
+
+                BSONCXX_TEST_EXCEPTION_GUARD_BEGIN(eguard);
+                throw EGuardException(++counter);
+                // clang-format off
+                BSONCXX_TEST_EXCEPTION_GUARD_END(eguard); BSONCXX_TEST_EXCEPTION_GUARD_RESET(expected);
+                // clang-format on
+            };
+
+            std::vector<std::thread> threads;
+
+            threads.emplace_back(fn);
+            threads.emplace_back(fn);
+            threads.emplace_back(fn);
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            latch.store(true);
+
+            for (auto& thread : threads) {
+                thread.join();
+            }
+
+            REQUIRE(counter.load() == 3);
+        }
+
+        REQUIRE(eguard.ptr != nullptr);
+        CHECK(eguard.file == expected.file);
+        CHECK(eguard.line == expected.line);
+        CHECK(eguard.func == expected.func);
+
+        auto test = [&] {
+            try {
+                BSONCXX_TEST_EXCEPTION_GUARD_CHECK(eguard);
+                FAIL("should have thrown an EGuardException");
+            } catch (const EGuardException& e) {
+                CAPTURE(e.id);
+                CHECK(e.id > 0);
+            }
+        };
+
+        REQUIRE_NOTHROW(test());
+    }
+}
+
+}  // namespace

--- a/src/bsoncxx/test/exception_guard.hh
+++ b/src/bsoncxx/test/exception_guard.hh
@@ -1,0 +1,104 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <exception>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <bsoncxx/stdx/string_view.hpp>
+#include <bsoncxx/test/catch.hh>
+
+#include <bsoncxx/config/private/prelude.hh>
+
+namespace bsoncxx {
+namespace test {
+
+struct exception_guard_state {
+    std::mutex m = {};
+    std::exception_ptr ptr = {};
+    stdx::string_view file = {};
+    std::size_t line = {};
+    stdx::string_view func = {};
+    std::vector<std::string> ignored;  // Cannot use INFO() in guarded regions.
+};
+
+#define BSONCXX_TEST_EXCEPTION_GUARD_RESET(e)          \
+    if (1) {                                           \
+        ((void)e);                                     \
+        std::lock_guard<std::mutex> _eguard_lock{e.m}; \
+        e.ptr = {};                                    \
+        e.file = __FILE__;                             \
+        e.line = __LINE__;                             \
+        e.func = __func__;                             \
+    } else                                             \
+        ((void)0)
+
+// Marks the beginning of a guarded region wherein any exceptions thrown are stored by exception
+// guard state. Only the FIRST exception is stored; any others are caught and ignored.
+#define BSONCXX_TEST_EXCEPTION_GUARD_BEGIN(e) \
+    try {                                     \
+        (void)e;                              \
+    ((void)0)
+
+// Marks the end of a guarded region.
+#define BSONCXX_TEST_EXCEPTION_GUARD_END(e)                                      \
+    (void)e;                                                                     \
+    }                                                                            \
+    catch (...) {                                                                \
+        std::lock_guard<std::mutex> _eguard_lock{e.m};                           \
+        if (!e.ptr) {                                                            \
+            e.ptr = std::current_exception();                                    \
+            e.file = __FILE__;                                                   \
+            e.line = __LINE__;                                                   \
+            e.func = __func__;                                                   \
+        } else {                                                                 \
+            std::ostringstream oss;                                              \
+            oss << __FILE__ << ":" << __LINE__ << ": exception guard ignored: "; \
+            try {                                                                \
+                throw;                                                           \
+            } catch (const std::exception& exc) {                                \
+                oss << exc.what();                                               \
+            } catch (const Catch::TestFailureException&) {                       \
+                oss << "Catch::TestFailureException";                            \
+            } catch (...) {                                                      \
+                oss << "unknown exception";                                      \
+            }                                                                    \
+            e.ignored.push_back(oss.str());                                      \
+        }                                                                        \
+    }                                                                            \
+    ((void)0)
+
+// Rethrow the stored exception if present.
+#define BSONCXX_TEST_EXCEPTION_GUARD_CHECK(e)          \
+    if (1) {                                           \
+        (void)e;                                       \
+        std::lock_guard<std::mutex> _eguard_lock{e.m}; \
+        for (auto const& log : e.ignored) {            \
+            UNSCOPED_INFO(log);                        \
+        }                                              \
+        if (e.ptr) {                                   \
+            std::rethrow_exception(e.ptr);             \
+        }                                              \
+    } else                                             \
+        ((void)0)
+
+}  // namespace test
+}  // namespace bsoncxx
+
+#include <bsoncxx/config/private/postlude.hh>

--- a/src/bsoncxx/test/string_view.test.cpp
+++ b/src/bsoncxx/test/string_view.test.cpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/stdx/operators.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/stdx/type_traits.hpp>
-#include <third_party/catch/include/catch.hpp>
+#include <bsoncxx/test/catch.hh>
 
 #include <bsoncxx/config/prelude.hpp>
 

--- a/src/bsoncxx/test/type_traits.test.cpp
+++ b/src/bsoncxx/test/type_traits.test.cpp
@@ -2,7 +2,7 @@
 #include <type_traits>
 
 #include <bsoncxx/stdx/type_traits.hpp>
-#include <third_party/catch/include/catch.hpp>
+#include <bsoncxx/test/catch.hh>
 
 #include <bsoncxx/config/prelude.hpp>
 

--- a/src/mongocxx/test/client_helpers.cpp
+++ b/src/mongocxx/test/client_helpers.cpp
@@ -28,6 +28,7 @@
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/string/to_string.hpp>
+#include <bsoncxx/test/catch.hh>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
 #include <mongocxx/client.hpp>
@@ -36,7 +37,6 @@
 #include <mongocxx/exception/operation_exception.hpp>
 #include <mongocxx/private/libmongoc.hh>
 #include <mongocxx/test/client_helpers.hh>
-#include <third_party/catch/include/catch.hpp>
 
 #include <mongocxx/config/private/prelude.hh>
 

--- a/src/mongocxx/test/client_helpers.hh
+++ b/src/mongocxx/test/client_helpers.hh
@@ -25,13 +25,13 @@
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
+#include <bsoncxx/test/catch.hh>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/options/client.hpp>
 #include <mongocxx/stdx.hpp>
-#include <third_party/catch/include/catch.hpp>
 
 #include <mongocxx/config/private/prelude.hh>
 

--- a/src/mongocxx/test/sdam-monitoring.cpp
+++ b/src/mongocxx/test/sdam-monitoring.cpp
@@ -17,6 +17,7 @@
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/to_string.hpp>
 #include <bsoncxx/test/catch.hh>
+#include <bsoncxx/test/exception_guard.hh>
 #include <mongocxx/client.hpp>
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/instance.hpp>
@@ -52,6 +53,7 @@ TEST_CASE("SDAM Monitoring", "[sdam_monitoring]") {
         test_uri = uri{"mongodb://localhost/?replicaSet=" + rs_name};
     }
 
+    bsoncxx::test::exception_guard_state eguard;
     options::apm apm_opts;
     stdx::optional<oid> topology_id;
 
@@ -68,7 +70,7 @@ TEST_CASE("SDAM Monitoring", "[sdam_monitoring]") {
             server_opening_events++;
             if (topology_id) {
                 // A previous server was opened first.
-                REQUIRE(topology_id.value() == event.topology_id());
+                CHECK(topology_id.value() == event.topology_id());
             }
 
             topology_id = event.topology_id();
@@ -76,6 +78,8 @@ TEST_CASE("SDAM Monitoring", "[sdam_monitoring]") {
 
         // ServerDescriptionChanged
         apm_opts.on_server_changed([&](const events::server_changed_event& event) {
+            BSONCXX_TEST_EXCEPTION_GUARD_BEGIN(eguard);
+
             server_changed_events++;
             // A server_opening_event should have set topology_id.
             REQUIRE(topology_id);
@@ -106,6 +110,8 @@ TEST_CASE("SDAM Monitoring", "[sdam_monitoring]") {
             }
 
             REQUIRE(old_sd.id() == new_sd.id());
+
+            BSONCXX_TEST_EXCEPTION_GUARD_END(eguard);
         });
 
         // We don't expect a ServerClosedEvent unless a replica set member is removed.
@@ -115,6 +121,7 @@ TEST_CASE("SDAM Monitoring", "[sdam_monitoring]") {
         ///////////////////////////////////////////////////////////////////////
 
         open_and_close_client(test_uri, apm_opts);
+        BSONCXX_TEST_EXCEPTION_GUARD_CHECK(eguard);
         REQUIRE(server_opening_events > 0);
         REQUIRE(server_changed_events > 0);
     }
@@ -134,7 +141,7 @@ TEST_CASE("SDAM Monitoring", "[sdam_monitoring]") {
             topology_opening_events++;
             if (topology_id) {
                 // A previous server was opened first.
-                REQUIRE(topology_id.value() == event.topology_id());
+                CHECK(topology_id.value() == event.topology_id());
             }
 
             topology_id = event.topology_id();
@@ -142,6 +149,8 @@ TEST_CASE("SDAM Monitoring", "[sdam_monitoring]") {
 
         // TopologyDescriptionChanged
         apm_opts.on_topology_changed([&](const events::topology_changed_event& event) {
+            BSONCXX_TEST_EXCEPTION_GUARD_BEGIN(eguard);
+
             topology_changed_events++;
             // A topology_opening_event should have set topology_id.
             REQUIRE(topology_id);
@@ -186,12 +195,14 @@ TEST_CASE("SDAM Monitoring", "[sdam_monitoring]") {
                     REQUIRE(new_sd_type == "Mongos");
                 }
             }
+
+            BSONCXX_TEST_EXCEPTION_GUARD_END(eguard);
         });
 
         // TopologyClosedEvent
         apm_opts.on_topology_closed([&](const events::topology_closed_event& event) {
             topology_closed_events++;
-            REQUIRE(topology_id.value() == event.topology_id());
+            CHECK(topology_id.value() == event.topology_id());
         });
 
         ///////////////////////////////////////////////////////////////////////
@@ -199,6 +210,7 @@ TEST_CASE("SDAM Monitoring", "[sdam_monitoring]") {
         ///////////////////////////////////////////////////////////////////////
 
         open_and_close_client(test_uri, apm_opts);
+        BSONCXX_TEST_EXCEPTION_GUARD_CHECK(eguard);
         REQUIRE(topology_opening_events > 0);
         REQUIRE(topology_changed_events > 0);
         REQUIRE(topology_closed_events > 0);
@@ -229,20 +241,20 @@ TEST_CASE("SDAM Monitoring", "[sdam_monitoring]") {
         // ServerHeartbeatStartedEvent
         apm_opts.on_heartbeat_started([&](const events::heartbeat_started_event& event) {
             heartbeat_started_events++;
-            REQUIRE_FALSE(event.host().empty());
-            REQUIRE(event.port() != 0);
+            CHECK_FALSE(event.host().empty());
+            CHECK(event.port() != 0);
             // Client is single-threaded, and will never perform an awaitable hello.
-            REQUIRE(!event.awaited());
+            CHECK(!event.awaited());
         });
 
         // ServerHeartbeatSucceededEvent
         apm_opts.on_heartbeat_succeeded([&](const events::heartbeat_succeeded_event& event) {
             heartbeat_succeeded_events++;
-            REQUIRE_FALSE(event.host().empty());
-            REQUIRE(event.port() != 0);
-            REQUIRE_FALSE(event.reply().empty());
+            CHECK_FALSE(event.host().empty());
+            CHECK(event.port() != 0);
+            CHECK_FALSE(event.reply().empty());
             // Client is single-threaded, and will never perform an awaitable hello.
-            REQUIRE(!event.awaited());
+            CHECK(!event.awaited());
         });
 
         // Don't expect a ServerHeartbeatFailedEvent here, see the test below.
@@ -252,6 +264,7 @@ TEST_CASE("SDAM Monitoring", "[sdam_monitoring]") {
         ///////////////////////////////////////////////////////////////////////
 
         open_and_close_client(test_uri, apm_opts);
+        BSONCXX_TEST_EXCEPTION_GUARD_CHECK(eguard);
         REQUIRE(heartbeat_started_events > 0);
         REQUIRE(heartbeat_succeeded_events > 0);
         REQUIRE(started_awaited_called);
@@ -273,10 +286,10 @@ TEST_CASE("Heartbeat failed event", "[sdam_monitoring]") {
     // ServerHeartbeatFailedEvent
     apm_opts.on_heartbeat_failed([&](const events::heartbeat_failed_event& event) {
         heartbeat_failed_events++;
-        REQUIRE_FALSE(event.host().empty());
-        REQUIRE_FALSE(event.message().empty());
-        REQUIRE(event.port() != 0);
-        REQUIRE(!event.awaited());
+        CHECK_FALSE(event.host().empty());
+        CHECK_FALSE(event.message().empty());
+        CHECK(event.port() != 0);
+        CHECK(!event.awaited());
     });
 
     REQUIRE_THROWS_AS(

--- a/src/mongocxx/test/spec/monitoring.cpp
+++ b/src/mongocxx/test/spec/monitoring.cpp
@@ -17,12 +17,12 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/json.hpp>
+#include <bsoncxx/test/catch.hh>
 #include <bsoncxx/test/to_string.hh>
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/test/client_helpers.hh>
 #include <mongocxx/test/spec/monitoring.hh>
 #include <mongocxx/test/spec/unified_tests/assert.hh>
-#include <third_party/catch/include/catch.hpp>
 
 #include <mongocxx/config/private/prelude.hh>
 

--- a/src/mongocxx/test/spec/unified_tests/assert.cpp
+++ b/src/mongocxx/test/spec/unified_tests/assert.cpp
@@ -21,11 +21,11 @@
 
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/string/to_string.hpp>
+#include <bsoncxx/test/catch.hh>
 #include <bsoncxx/test/to_string.hh>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/value.hpp>
 #include <mongocxx/test/client_helpers.hh>
-#include <third_party/catch/include/catch.hpp>
 
 using namespace bsoncxx;
 using namespace mongocxx;

--- a/src/mongocxx/test/spec/unified_tests/operations.cpp
+++ b/src/mongocxx/test/spec/unified_tests/operations.cpp
@@ -20,11 +20,11 @@
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/string/to_string.hpp>
+#include <bsoncxx/test/catch.hh>
 #include <bsoncxx/types/bson_value/value.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/test/spec/monitoring.hh>
-#include <third_party/catch/include/catch.hpp>
 
 #include <mongocxx/config/prelude.hpp>
 


### PR DESCRIPTION
## Summary

Resolves CXX-3065. Verified by [this patch](https://spruce.mongodb.com/version/6699827a7979a60007a98203).

Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1015:

> Any user code that currently violates the nothrow requirement will now terminate via `noexcept` rather than be allowed to continue with potentially unbounded libmongoc runtime errors. [...] (consider: [our own test cases](https://github.com/mongodb/mongo-cxx-driver/blob/eae761bb770b7a25101a5fd8a44471471cc8e222/src/mongocxx/test/sdam-monitoring.cpp#L71) violate this requirement in failure conditions, as Catch2 uses exceptions to report test assertion failures))

This PR implements a workaround for such assertions in our test suite.

## Exceptions in APM Callbacks

The "[sdam_monitoring]" test cases (two total) can be used to demonstrate the problem by deliberately inverting one of the assertion conditions to trigger assertion failure:

```diff
--- a/src/mongocxx/test/sdam-monitoring.cpp
+++ b/src/mongocxx/test/sdam-monitoring.cpp
@@ ... @@ TEST_CASE("Heartbeat failed event", "[sdam_monitoring]") {
     // ServerHeartbeatFailedEvent
     apm_opts.on_heartbeat_failed([&](const events::heartbeat_failed_event& event) {
         heartbeat_failed_events++;
-        REQUIRE_FALSE(event.host().empty());
+        REQUIRE(event.host().empty()); // Deliberate assertion failure.
         REQUIRE_FALSE(event.message().empty());
         REQUIRE(event.port() != 0);
         REQUIRE(!event.awaited());
```

Executing `test_driver -r compact --order rand --rng-seed 0 "[sdam_monitoring]"` produces the following output (slightly edited for brevity):

```
sdam-monitoring.cpp: failed: event.host().empty() for: false
fatal error: APM callback heartbeat_failed exited via an exception
terminate called after throwing an instance of 'Catch::TestFailureException'
sdam-monitoring.cpp: failed: fatal error condition with message: 'SIGABRT - Abort (abnormal termination) signal'; expression was: {Unknown expression after the reported line}
Failed 1 test case, failed both 2 assertions.
```

The test suite prematurely terminates after running only the "Heartbeat failed event" test case due to the [QoI check](https://github.com/mongodb/mongo-cxx-driver/blob/edc22ae9072106cce7b1b1fd2cd1ae275c2a5d98/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/private/apm.hh#L38) added in https://github.com/mongodb/mongo-cxx-driver/pull/1015. The "SDAM Monitoring" test case is not executed.

## Exception Guards

A new `bsoncxx/test/exception_guard.hh` component is added (for testing only!) providing a mechanism to store-and-rethrow exceptions thrown within an "exception guard region" to allow for graceful return from APM callback functions while still propagating the thrown exception.

This feature is achieved using `std::exception_ptr`:

```cpp
mongocxx::options::apm apm_opts;

// Exception Guard State
std::exception_ptr eptr = nullptr;

apm_opts.on_command_started([&](auto event) {
  // Exception Guard Region: Begin
  try {

    REQUIRE(false); // Throw a Catch::TestAssertFailure.

  } catch (...) {
    if (!eptr) {
      eptr = std::current_exception(); // Catch and store the exception.
    }
  }
  // Exception Guard Region: End
});

// ...

// Exception Guard Check
if (eptr) {
  std::rethrow_exception(eptr); // Rethrow the exception.
}
```

This pattern is abstracted by exception guard macros:

```cpp
mongocxx::options::apm apm_opts;

bsoncxx::test::exception_guard_state eguard;

apm_opts.on_command_started([&](auto event) {
  BSONCXX_TEST_EXCEPTION_GUARD_BEGIN(eguard);

  REQUIRE(false); // Throw a Catch::TestAssertFailure.

  BSONCXX_TEST_EXCEPTION_GUARD_END(eguard); // Catch and store the exception.
});

// ...

BSONCXX_TEST_EXCEPTION_GUARD_CHECK(eguard); // Rethrow the exception.
```

An additional `BSONCXX_TEST_EXCEPTION_GUARD_RESET()` macro is provided to reset the exception guard state for testing and reuse (this is not expected to be used often).

The utility includes some additional features such as basic thread-safety and logging of ignored exceptions (only the first exception is caught and checked). See the new test code for a demonstration of its features.

Supporting the storage of multiple exceptions was considered overkill considering the purpose this utility is meant to fulfill (a workaround specifically for exceptions expected to be thrown from APM callbacks). It is not expected to be used for other purposes.

> [!NOTE]
> Catch2 is _not_ thread-safe. This utility does _not_ add support thread-safe assertions.

`BSONCXX_TEST_EXCEPTION_GUARD_CHECK()` is not _strictly_ necessary (since Catch tracks test case failure internally regardless of how the exception is handled), but helps avoid the unnecessary and noisy execution of further assertions for an already-failed test case. The check also provides an opportunity to log any additionally-thrown exceptions which were ignored by the exception guard.

Applying this pattern to the "[sdam_monitoring]" case described above produces the following output:

```
../src/mongocxx/test/sdam-monitoring.cpp:291: failed: event.host().empty() for: false
Failed 1 test case, failed 1 assertion.
```

Importantly, there is no premature termination, and although it is not apparent from this compact output, the other "SDAM Monitoring" test case is executed with success. The QoI check is no longer triggered.

## CHECK vs. REQUIRE

In most cases, this new utility is not used. As noted in https://github.com/mongodb/mongo-cxx-driver/pull/1015#pullrequestreview-1603684257, `CHECK` is a non-throwing alternative to `REQUIRE` which still marks the test case as failed. This PR favors changing `REQUIRE*` -> `CHECK*` when able over using the new exception guard utility, as this is arguably the more "correct" use of APM callbacks (which, again, shouldn't be throwing exceptions).

However, in the interest of avoiding significant refactors, this is only done in obvious cases where the assertion does not appear to be guarding code (e.g. a null check prior to dereference). This PR does not attempt to eliminate `REQUIRE` entirely from APM callbacks.

## Miscellaneous

- All test code should be including `<bsoncxx/test/catch.hh>` (which defines `StringMaker` specializations for our types) instead of directly including the Catch2 header.
- Added `SYSTEM` to the `target_include_directories()` command importing mnmlstc/core headers to avoid [irrelevant warnings-as-errors](https://parsley.mongodb.com/evergreen/mongo_cxx_driver_ubuntu2004_debug_asan_latest_compile_and_test_with_shared_libs_patch_9223cfcf72bb3ced16c20275e460ba8d6b76a3e2_6699748d1bfd320007cd4762_24_07_18_20_01_18/0/task?bookmarks=0,1335&selectedLineRange=L1299).