### PR TITLE
CXX-3067 test for existing examples target before add_custom_target

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -30,7 +30,10 @@ add_subdirectory(bsoncxx)
 add_subdirectory(mongocxx)
 add_subdirectory(projects)
 
-add_custom_target(examples DEPENDS ${MONGOCXX_EXAMPLE_EXECUTABLES} ${BSONCXX_EXAMPLE_EXECUTABLES})
+if (NOT TARGET examples)
+  add_custom_target(examples)
+endif ()
+add_dependencies(examples ${MONGOCXX_EXAMPLE_EXECUTABLES} ${BSONCXX_EXAMPLE_EXECUTABLES})
 
 add_custom_target(run-examples DEPENDS examples)
 


### PR DESCRIPTION
Resolves CXX-3067. Companion to https://github.com/mongodb/mongo-c-driver/pull/1675.

Avoid the C Driver imported via `add_subdirectory()`, which defines the `examples` target, from conflicting with CXX Driver's attempt to create an `examples` target. Otherwise the following error may be observed:
```
CMake Error at examples/CMakeLists.txt:33 (add_custom_target):
  add_custom_target cannot create target "examples" because another target
  with the same name already exists.  The existing target is a custom target
  created in source directory
  "_deps/mongo-c-driver-src/src/libbson".
  See documentation for policy CMP0002 for more details.
```

If a `tests` target is ever added to the CXX Driver, it will need the existence check as well.