### PR TITLE
CXX-3069 document directories, namespaces, and generated headers

### DIFF
--- a/src/bsoncxx/include/bsoncxx/fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/fwd.hpp
@@ -17,6 +17,82 @@
 #endif  // !defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
 
 ///
+/// @file
+/// For documentation purposes only.
+///
+/// This header is not intended to be includable.
+///
+/// @note This header is shadowed by @ref bsoncxx/v_noabi/bsoncxx/fwd.hpp per include directory
+/// search ordering.
+///
+
+///
+/// @dir bsoncxx/include/bsoncxx
+/// Provides headers declaring entities in @ref bsoncxx
+///
+
+///
 /// @namespace bsoncxx
-/// The top-level namespace for bsoncxx library entities.
+/// The top-level namespace within which all bsoncxx library entities are declared.
+///
+/// In addition to declaring ABI namespaces (`v_noabi`, `v1`, etc.), this namespace also provides
+/// "redeclarations" of entities within ABI namespaces. These redeclarations are intended to be the
+/// preferred method for using bsoncxx library entities when ABI stability of the bsoncxx library is
+/// NOT a requirement by the user. See [Root Namespace
+/// Redeclarations](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/api-abi-versioning/abi-versioning/#std-label-cpp-abi-root-namespace-redec).
+///
+
+///
+/// @namespace bsoncxx::array
+/// Declares entities representing a BSON array.
+///
+
+///
+/// @namespace bsoncxx::builder
+/// Declares entities used to build BSON documents.
+///
+
+///
+/// @namespace bsoncxx::builder::basic
+/// Declares entities used with "basic" BSON builder syntax.
+///
+
+///
+/// @namespace bsoncxx::builder::stream
+/// Declares entities used with "streaming" BSON builder syntax.
+///
+
+///
+/// @namespace bsoncxx::document
+/// Declares entities representing a BSON document.
+///
+
+///
+/// @namespace bsoncxx::exception
+/// Declares entities related to bsoncxx exceptions and error codes.
+///
+
+///
+/// @namespace bsoncxx::stdx
+/// Declares C++17 standard library polyfills.
+///
+
+///
+/// @namespace bsoncxx::string
+/// Declares entities related to handling string types.
+///
+
+///
+/// @namespace bsoncxx::types
+/// Declares entities representing BSON value types.
+///
+
+///
+/// @namespace bsoncxx::types::bson_value
+/// Declares entities representing any BSON value type.
+///
+
+///
+/// @namespace std
+/// The top-level namespace reserved for the C++ standard library.
 ///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/compiler.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/compiler.hpp
@@ -44,3 +44,10 @@ BSONCXX_DISABLE_WARNING(MSVC(5275));
 
 #define BSONCXX_INLINE inline BSONCXX_PRIVATE
 #define BSONCXX_CALL BSONCXX_IF_MSVC(__cdecl)
+
+///
+/// @file
+/// Provides macros for internal use.
+///
+/// @warning For internal use only!
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/postlude.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/postlude.hpp
@@ -101,3 +101,15 @@ static_assert(false, "BSONCXX_ENUM must be undef'ed");
 #pragma pop_macro("BSONCXX_IF_GNU_LIKE")
 
 #pragma pop_macro("BSONCXX_FWD")
+
+///
+/// @file
+/// The bsoncxx macro guard postlude header.
+///
+/// @warning For internal use only!
+///
+/// This header uses macro pragmas to guard macros defined by the bsoncxx library for internal use
+/// by "popping" their prior definition onto the stack after use by bsoncxx headers.
+///
+/// @see bsoncxx/v_noabi/bsoncxx/config/prelude.hpp
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/prelude.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/prelude.hpp
@@ -120,3 +120,23 @@
 // CXX-2769: out-of-place, but remains for backward compatibility.
 #pragma push_macro("BSONCXX_ENUM")
 #undef BSONCXX_ENUM
+
+///
+/// @file
+/// The bsoncxx macro guard prelude header.
+///
+/// @warning For internal use only!
+///
+/// @par "Includes" @parblock
+/// @li @ref bsoncxx/v_noabi/bsoncxx/config/compiler.hpp
+/// @li @ref bsoncxx-v_noabi-bsoncxx-config-config-hpp
+/// @li @ref bsoncxx-v_noabi-bsoncxx-config-export-hpp
+/// @li @ref bsoncxx/v_noabi/bsoncxx/config/util.hpp
+/// @li @ref bsoncxx-v_noabi-bsoncxx-config-version-hpp
+/// @endparblock
+///
+/// This header uses macro pragmas to guard macros defined by the bsoncxx library for internal use
+/// by "pushing" their prior definition onto the stack before use by bsoncxx headers.
+///
+/// @see bsoncxx/v_noabi/bsoncxx/config/postlude.hpp
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/util.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/util.hpp
@@ -135,3 +135,9 @@
 
 #define BSONCXX_FWD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
 
+///
+/// @file
+/// Provides macros for internal use.
+///
+/// @warning For internal use only!
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/fwd.hpp
@@ -48,11 +48,371 @@
 #include <bsoncxx/view_or_value-fwd.hpp>
 
 ///
+/// @file
+/// Aggregate of all forward headers declaring entities in @ref bsoncxx::v_noabi.
+///
+/// @par "Includes" @parblock
+/// @li All header files under @ref src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx
+/// "bsoncxx/v_noabi/bsoncxx" whose filename ends with `-fwd.hpp`.
+/// @endparblock
+///
+
+///
+/// @dir bsoncxx/v_noabi
+/// The directory relative to which headers declaring entities in @ref bsoncxx::v_noabi are
+/// typically included.
+///
+/// For backward compatibility, unstable ABI headers may be included using the syntax
+/// `<bsoncxx/foo.hpp>`, which is equivalent to `<bsoncxx/v_noabi/bsoncxx/foo.hpp>`.
+///
+
+///
+/// @dir bsoncxx/v_noabi/bsoncxx
+/// Provides headers declaring entities in @ref bsoncxx::v_noabi.
+///
+
+///
+/// @dir bsoncxx/v_noabi/bsoncxx/array
+/// Provides headers declaring entities in @ref bsoncxx::v_noabi::array.
+///
+
+///
+/// @dir bsoncxx/v_noabi/bsoncxx/builder
+/// Provides headers declaring entities in @ref bsoncxx::v_noabi::builder.
+///
+
+///
+/// @dir bsoncxx/v_noabi/bsoncxx/builder/basic
+/// Provides headers declaring entities in @ref bsoncxx::v_noabi::builder::basic.
+///
+
+///
+/// @dir bsoncxx/v_noabi/bsoncxx/builder/stream
+/// Provides headers declaring entities in @ref bsoncxx::v_noabi::builder::stream.
+///
+
+///
+/// @dir bsoncxx/v_noabi/bsoncxx/config
+/// Provides headers related to bsoncxx library configuration.
+///
+/// @par "Generated Headers"
+///
+/// Generated headers are documented by the following pages:
+///
+/// @li @ref bsoncxx-v_noabi-bsoncxx-config-config-hpp
+/// @li @ref bsoncxx-v_noabi-bsoncxx-config-export-hpp
+/// @li @ref bsoncxx-v_noabi-bsoncxx-config-version-hpp
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+///
+/// @defgroup bsoncxx-v_noabi-bsoncxx-config-config-hpp bsoncxx/v_noabi/bsoncxx/config/config.hpp
+/// This page documents macros provided by the generated header
+/// `bsoncxx/v_noabi/bsoncxx/config/config.hpp`.
+///
+/// @name bsoncxx/v_noabi/bsoncxx/config/config.hpp
+///
+/// These macros are provided by @ref bsoncxx-v_noabi-bsoncxx-config-config-hpp "config.hpp",
+/// **NOT** by @ref bsoncxx/v_noabi/bsoncxx/fwd.hpp "fwd.hpp" (where this is documented in source)!
+///
+/// @{
+///
+
+///
+/// @ingroup bsoncxx-v_noabi-bsoncxx-config-config-hpp
+/// Defined when configured to use a bundled mnmlstc/core as the C++17 polyfill library.
+///
+/// @deprecated Support for external polyfill libraries is deprecated and will be removed in an
+/// upcoming major release. Set `ENABLE_BSONCXX_POLY_USE_IMPLS=ON` or `BSONCXX_POLY_USE_IMPLS=ON`
+/// when configuring the bsoncxx library.
+///
+#define BSONCXX_POLY_USE_MNMLSTC
+
+///
+/// @ingroup bsoncxx-v_noabi-bsoncxx-config-config-hpp
+/// Defined when configured to use an external mnmlstc/core as the C++17 polyfill library.
+///
+/// @deprecated Support for external polyfill libraries is deprecated and will be removed in an
+/// upcoming major release. Set `ENABLE_BSONCXX_POLY_USE_IMPLS=ON` or `BSONCXX_POLY_USE_IMPLS=ON`
+/// when configuring the bsoncxx library.
+///
+#define BSONCXX_POLY_USE_SYSTEM_MNMLSTC
+
+///
+/// @ingroup bsoncxx-v_noabi-bsoncxx-config-config-hpp
+/// Defined when configured to use Boost as the C++17 polyfill library.
+///
+/// @deprecated Support for external polyfill libraries is deprecated and will be removed in an
+/// upcoming major release. Set `ENABLE_BSONCXX_POLY_USE_IMPLS=ON` or `BSONCXX_POLY_USE_IMPLS=ON`
+/// when configuring the bsoncxx library.
+///
+#define BSONCXX_POLY_USE_BOOST
+
+///
+/// @ingroup bsoncxx-v_noabi-bsoncxx-config-config-hpp
+/// Defined when configured to use bsoncxx's own C++17 polyfill implementations.
+///
+#define BSONCXX_POLY_USE_IMPLS
+
+///
+/// @ingroup bsoncxx-v_noabi-bsoncxx-config-config-hpp
+/// Defined when configured to use the C++ standard library for C++17 features.
+///
+#define BSONCXX_POLY_USE_STD
+
+///
+/// @ingroup bsoncxx-v_noabi-bsoncxx-config-config-hpp
+/// For internal use only!
+///
+/// @deprecated To be removed in an upcoming major release.
+/// <!-- Explicitly documented due to long-standing availability. -->
+///
+#define BSONCXX_INLINE_NAMESPACE_BEGIN
+
+///
+/// @ingroup bsoncxx-v_noabi-bsoncxx-config-config-hpp
+/// For internal use only!
+///
+/// @deprecated To be removed in an upcoming major release.
+/// <!-- Explicitly documented due to long-standing availability. -->
+///
+#define BSONCXX_INLINE_NAMESPACE_END
+
+///
+/// @} <!-- bsoncxx/v_noabi/bsoncxx/config/config.hpp -->
+///
+
+///
+/// @defgroup bsoncxx-v_noabi-bsoncxx-config-export-hpp bsoncxx/v_noabi/bsoncxx/config/export.hpp
+/// This page documents macros provided by the generated header
+/// `bsoncxx/v_noabi/bsoncxx/config/export.hpp`.
+///
+/// @name bsoncxx/v_noabi/bsoncxx/config/export.hpp
+///
+/// These macros are provided by @ref bsoncxx-v_noabi-bsoncxx-config-export-hpp "export.hpp",
+/// **NOT** by @ref bsoncxx/v_noabi/bsoncxx/fwd.hpp "fwd.hpp" (where this is documented in source)!
+///
+/// @{
+///
+
+///
+/// @ingroup bsoncxx-v_noabi-bsoncxx-config-export-hpp
+/// Defined when the bsoncxx library is built as a static library.
+///
+/// @warning For internal use only!
+///
+/// This macro is not defined when the bsoncxx library is built as a shared library.
+///
+/// @note This macro is intended to be automatically defined by the CMake or pkg-config package
+/// configuration file used to import the bsoncxx library. Manually defining this macro is NOT
+/// recommended, but may be necessary depending on how the mongocxx library is being imported or
+/// packaged.
+///
+#define BSONCXX_STATIC
+
+///
+/// @ingroup bsoncxx-v_noabi-bsoncxx-config-export-hpp
+/// Declares the associated entity as part of the ABI.
+///
+/// @warning For internal use only!
+///
+/// @note This is a symbol visibility control macro, NOT a declaration of public API. Public API vs.
+/// private API is determined by the placement of the entity being declared (e.g. in a public
+/// header, as a public class member, etc.) or by documentation (e.g. absence of "For internal use
+/// only!" warnings). See [API and ABI
+/// Versioning](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/api-abi-versioning/).
+///
+#define BSONCXX_API
+
+///
+/// @ingroup bsoncxx-v_noabi-bsoncxx-config-export-hpp
+/// Excludes the associated entity from being part of the ABI.
+///
+/// @warning For internal use only!
+///
+/// @note This is a symbol visibility control macro, NOT a declaration of private API. Public API
+/// vs. private API is determined by the placement of the entity being declared (e.g. in a detail
+/// header, as a private class member, etc.) or by documentation (e.g. "For internal use only!",
+/// absence of documentation, etc.). See [API and ABI
+/// Versioning](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/api-abi-versioning/).
+///
+#define BSONCXX_PRIVATE
+
+///
+/// @ingroup bsoncxx-v_noabi-bsoncxx-config-export-hpp
+/// Declares the associated entity as deprecated.
+///
+/// @warning For internal use only!
+///
+#define BSONCXX_DEPRECATED
+
+///
+/// @ingroup bsoncxx-v_noabi-bsoncxx-config-export-hpp
+/// Equivalent to @ref BSONCXX_API and @ref BSONCXX_DEPRECATED.
+///
+/// @warning For internal use only!
+///
+#define BSONCXX_DEPRECATED_EXPORT
+
+///
+/// @ingroup bsoncxx-v_noabi-bsoncxx-config-export-hpp
+/// Equivalent to @ref BSONCXX_PRIVATE and @ref BSONCXX_DEPRECATED.
+///
+/// @warning For internal use only!
+///
+#define BSONCXX_DEPRECATED_NO_EXPORT
+
+///
+/// @} <!-- bsoncxx/v_noabi/bsoncxx/config/export.hpp -->
+///
+
+///
+/// @defgroup bsoncxx-v_noabi-bsoncxx-config-version-hpp bsoncxx/v_noabi/bsoncxx/config/version.hpp
+/// This page documents macros provided by the generated header
+/// `bsoncxx/v_noabi/bsoncxx/config/version.hpp`.
+///
+/// @name bsoncxx/v_noabi/bsoncxx/config/version.hpp
+///
+/// These macros are provided by @ref bsoncxx-v_noabi-bsoncxx-config-version-hpp "version.hpp",
+/// **NOT** by @ref bsoncxx/v_noabi/bsoncxx/fwd.hpp "fwd.hpp" (where this is documented in source)!
+///
+/// @{
+///
+
+///
+/// @ingroup bsoncxx-v_noabi-bsoncxx-config-version-hpp
+/// Defined as this bsoncxx library's API major version number.
+///
+/// This value is derived from the `BUILD_VERSION` variable during configuration.
+///
+#define BSONCXX_VERSION_MAJOR
+
+///
+/// @ingroup bsoncxx-v_noabi-bsoncxx-config-version-hpp
+/// Defined as this bsoncxx library's API minor version number.
+///
+/// This value is derived from the `BUILD_VERSION` variable during configuration.
+///
+#define BSONCXX_VERSION_MINOR
+
+///
+/// @ingroup bsoncxx-v_noabi-bsoncxx-config-version-hpp
+/// Defined as this bsoncxx library's API patch version number.
+///
+/// This value is derived from the `BUILD_VERSION` variable during configuration.
+///
+#define BSONCXX_VERSION_PATCH
+
+///
+/// @ingroup bsoncxx-v_noabi-bsoncxx-config-version-hpp
+/// Defined as this bsoncxx library's API version number suffix if any.
+///
+/// This value is derived from the `BUILD_VERSION` variable during configuration.
+///
+#define BSONCXX_VERSION_EXTRA
+
+///
+/// @} <!-- bsoncxx/v_noabi/bsoncxx/config/version.hpp -->
+///
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+///
+/// @dir bsoncxx/v_noabi/bsoncxx/document
+/// Provides headers declaring entities in @ref bsoncxx::v_noabi::document.
+///
+
+///
+/// @dir bsoncxx/v_noabi/bsoncxx/enums
+/// Provides X macro headers over BSON types and binary subtypes.
+///
+
+///
+/// @dir bsoncxx/v_noabi/bsoncxx/exception
+/// Provides headers declaring entities in @ref bsoncxx::v_noabi::exception.
+///
+
+///
+/// @dir bsoncxx/v_noabi/bsoncxx/stdx
+/// Provides headers declaring entities in @ref bsoncxx::v_noabi::stdx.
+///
+
+///
+/// @dir bsoncxx/v_noabi/bsoncxx/string
+/// Provides headers declaring entities in @ref bsoncxx::v_noabi::string.
+///
+
+///
+/// @dir bsoncxx/v_noabi/bsoncxx/types
+/// Provides headers declaring entities in @ref bsoncxx::v_noabi::types.
+///
+
+///
+/// @dir bsoncxx/v_noabi/bsoncxx/types/bson_value
+/// Provides headers declaring entities in @ref bsoncxx::v_noabi::types::bson_value.
+///
+
+///
+/// @dir bsoncxx/v_noabi/bsoncxx/util
+/// Headers provided by this directory are deprecated.
+///
+/// @deprecated To be removed in an upcoming major release.
+///
+
+///
 /// @namespace bsoncxx::v_noabi
-/// Entities declared in this namespace do not have a stable ABI.
+/// Declares entities whose ABI stability is NOT guaranteed.
+///
+
+///
+/// @namespace bsoncxx::v_noabi::array
+/// @copydoc bsoncxx::array
+///
+
+///
+/// @namespace bsoncxx::v_noabi::builder
+/// @copydoc bsoncxx::builder
+///
+
+///
+/// @namespace bsoncxx::v_noabi::builder::basic
+/// @copydoc bsoncxx::builder::basic
+///
+
+///
+/// @namespace bsoncxx::v_noabi::builder::stream
+/// @copydoc bsoncxx::builder::stream
+///
+
+///
+/// @namespace bsoncxx::v_noabi::document
+/// @copydoc bsoncxx::document
+///
+
+///
+/// @namespace bsoncxx::v_noabi::exception
+/// @copydoc bsoncxx::exception
 ///
 
 ///
 /// @namespace bsoncxx::v_noabi::stdx
-/// Declares polyfills for C++17 forward compatibility.
+/// @copydoc bsoncxx::stdx
+///
+
+///
+/// @namespace bsoncxx::v_noabi::string
+/// @copydoc bsoncxx::string
+///
+
+///
+/// @namespace bsoncxx::v_noabi::types
+/// @copydoc bsoncxx::types
+///
+/// @see bsoncxx::v_noabi::types::bson_value
+///
+
+///
+/// @namespace bsoncxx::v_noabi::types::bson_value
+/// Declares entities representing any BSON value type.
 ///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/fwd.hpp
@@ -198,21 +198,6 @@
 
 ///
 /// @ingroup bsoncxx-v_noabi-bsoncxx-config-export-hpp
-/// Defined when the bsoncxx library is built as a static library.
-///
-/// @warning For internal use only!
-///
-/// This macro is not defined when the bsoncxx library is built as a shared library.
-///
-/// @note This macro is intended to be automatically defined by the CMake or pkg-config package
-/// configuration file used to import the bsoncxx library. Manually defining this macro is NOT
-/// recommended, but may be necessary depending on how the mongocxx library is being imported or
-/// packaged.
-///
-#define BSONCXX_STATIC
-
-///
-/// @ingroup bsoncxx-v_noabi-bsoncxx-config-export-hpp
 /// Declares the associated entity as part of the ABI.
 ///
 /// @warning For internal use only!

--- a/src/mongocxx/include/mongocxx/fwd.hpp
+++ b/src/mongocxx/include/mongocxx/fwd.hpp
@@ -17,6 +17,62 @@
 #endif  // !defined(MONGOCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
 
 ///
+/// @file
+/// For documentation purposes only.
+///
+/// This header is not intended to be includable.
+///
+/// @note This header is shadowed by @ref mongocxx/v_noabi/mongocxx/fwd.hpp per include directory
+/// search ordering.
+///
+
+///
+/// @dir mongocxx/include/mongocxx
+/// Provides headers declaring entities in @ref mongocxx
+///
+
+///
 /// @namespace mongocxx
-/// The top-level namespace for mongocxx library entities.
+/// The top-level namespace within which all mongocxx library entities are declared.
+///
+/// In addition to declaring ABI namespaces (`v_noabi`, `v1`, etc.), this namespace also provides
+/// "redeclarations" of entities within ABI namespaces. These redeclarations are intended to be the
+/// preferred method for using bsoncxx library entities when ABI stability of the bsoncxx library is
+/// NOT a requirement by the user. See [Root Namespace
+/// Redeclarations](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/api-abi-versioning/abi-versioning/#std-label-cpp-abi-root-namespace-redec).
+///
+
+///
+/// @namespace mongocxx::events
+/// Declares entities describing APM events.
+///
+
+///
+/// @namespace mongocxx::gridfs
+/// Declares entities related to GridFS.
+///
+
+///
+/// @namespace mongocxx::model
+/// Declares entities representing bulk write operations.
+///
+
+///
+/// @namespace mongocxx::options
+/// Declares entities representing options to use with various commands.
+///
+
+///
+/// @namespace mongocxx::options::gridfs
+/// Declares entities representing options specific to GridFS.
+///
+
+///
+/// @namespace mongocxx::result
+/// Declares entities representing the result of various commands.
+///
+
+///
+/// @namespace mongocxx::result::gridfs
+/// Declares entities representing the result of GridFS commands.
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/fwd.hpp
@@ -113,6 +113,296 @@
 #include <mongocxx/write_type-fwd.hpp>
 
 ///
+/// @file
+/// Aggregate of all forward headers declaring entities in @ref mongocxx::v_noabi.
+///
+/// @par "Includes" @parblock
+/// @li All header files under @ref src/mongocxx/include/mongocxx/v_noabi/mongocxx
+/// "mongocxx/v_noabi/mongocxx" whose filename ends with `-fwd.hpp`.
+/// @endparblock
+///
+
+///
+/// @dir mongocxx/v_noabi
+/// The directory relative to which headers declaring entities in @ref mongocxx::v_noabi
+/// are typically included.
+///
+/// For backward compatibility, unstable ABI headers may be included using the syntax
+/// `<mongocxx/foo.hpp>`, which is equivalent to `<mongocxx/v_noabi/mongocxx/foo.hpp>`.
+///
+
+///
+/// @dir mongocxx/v_noabi/mongocxx
+/// Provides headers declaring entities in @ref mongocxx::v_noabi.
+///
+
+///
+/// @dir mongocxx/v_noabi/mongocxx/config
+/// Provides headers related to mongocxx library configuration.
+///
+
+#if defined(MONGOCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+///
+/// @defgroup mongocxx-v_noabi-mongocxx-config-config-hpp mongocxx/v_noabi/mongocxx/config/config.hpp
+/// This page documents macros provided by the generated header
+/// `mongocxx/v_noabi/mongocxx/config/config.hpp`.
+///
+/// @name mongocxx/v_noabi/mongocxx/config/config.hpp
+///
+/// These macros are provided by @ref mongocxx-v_noabi-mongocxx-config-config-hpp "config.hpp",
+/// **NOT** by @ref mongocxx/v_noabi/mongocxx/fwd.hpp "fwd.hpp" (where this is documented)!
+///
+/// @{
+///
+
+///
+/// @ingroup mongocxx-v_noabi-mongocxx-config-config-hpp
+/// For internal use only!
+///
+/// @deprecated To be removed in an upcoming major release.
+/// <!-- Explicitly documented due to long-standing availability. -->
+///
+#define MONGOCXX_INLINE_NAMESPACE_BEGIN
+
+///
+/// @ingroup mongocxx-v_noabi-mongocxx-config-config-hpp
+/// For internal use only!
+///
+/// @deprecated To be removed in an upcoming major release.
+/// <!-- Explicitly documented due to long-standing availability. -->
+///
+#define MONGOCXX_INLINE_NAMESPACE_END
+
+///
+/// @} <!-- mongocxx/v_noabi/mongocxx/config/config.hpp -->
+///
+
+///
+/// @defgroup mongocxx-v_noabi-mongocxx-config-export-hpp mongocxx/v_noabi/mongocxx/config/export.hpp
+/// This page documents macros provided by the generated header
+/// `mongocxx/v_noabi/mongocxx/config/export.hpp`.
+///
+/// @name mongocxx/v_noabi/mongocxx/config/export.hpp
+///
+/// These macros are provided by @ref mongocxx-v_noabi-mongocxx-config-export-hpp "export.hpp",
+/// **NOT** by @ref mongocxx/v_noabi/mongocxx/fwd.hpp "fwd.hpp" (where this is documented)!
+///
+/// @{
+///
+
+///
+/// @ingroup mongocxx-v_noabi-mongocxx-config-export-hpp
+/// Defined when the mongocxx library is built as a static library.
+///
+/// @warning For internal use only!
+///
+/// This macro is not defined when the mongocxx library is built as a shared library.
+///
+/// @note This macro is intended to be automatically defined by the CMake or pkg-config package
+/// configuration file used to import the mongocxx library. Manually defining this macro is NOT
+/// recommended, but may be necessary depending on how the mongocxx library is being imported or
+/// packaged.
+///
+#define MONGOCXX_STATIC
+
+///
+/// @ingroup mongocxx-v_noabi-mongocxx-config-export-hpp
+/// Declares the associated entity as part of the ABI.
+///
+/// @warning For internal use only!
+///
+/// @note This is a symbol visibility control macro, NOT a declaration of public API. Public API vs.
+/// private API is determined by the placement of the entity being declared (e.g. in a public
+/// header, as a public class member, etc.) or by documentation (e.g. absence of "For internal use
+/// only!" warnings). See [API and ABI
+/// Versioning](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/api-abi-versioning/).
+///
+#define MONGOCXX_API
+
+///
+/// @ingroup mongocxx-v_noabi-mongocxx-config-export-hpp
+/// Excludes the associated entity from being part of the ABI.
+///
+/// @warning For internal use only!
+///
+/// @note This is a symbol visibility control macro, NOT a declaration of private API. Public API
+/// vs. private API is determined by the placement of the entity being declared (e.g. in a detail
+/// header, as a private class member, etc.) or by documentation (e.g. "For internal use only!",
+/// absence of documentation, etc.). See [API and ABI
+/// Versioning](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/api-abi-versioning/).
+///
+#define MONGOCXX_PRIVATE
+
+///
+/// @ingroup mongocxx-v_noabi-mongocxx-config-export-hpp
+/// Declares the associated entity as deprecated.
+///
+/// @warning For internal use only!
+///
+#define MONGOCXX_DEPRECATED
+
+///
+/// @ingroup mongocxx-v_noabi-mongocxx-config-export-hpp
+/// Equivalent to @ref MONGOCXX_API and @ref MONGOCXX_DEPRECATED.
+///
+/// @warning For internal use only!
+///
+#define MONGOCXX_DEPRECATED_EXPORT
+
+///
+/// @ingroup mongocxx-v_noabi-mongocxx-config-export-hpp
+/// Equivalent to @ref MONGOCXX_PRIVATE and @ref MONGOCXX_DEPRECATED.
+///
+/// @warning For internal use only!
+///
+#define MONGOCXX_DEPRECATED_NO_EXPORT
+
+///
+/// @} <!-- mongocxx/v_noabi/mongocxx/config/export.hpp -->
+///
+
+///
+/// @defgroup mongocxx-v_noabi-mongocxx-config-version-hpp mongocxx/v_noabi/mongocxx/config/version.hpp
+/// This page documents macros provided by the generated header
+/// `mongocxx/v_noabi/mongocxx/config/version.hpp`.
+///
+/// @name mongocxx/v_noabi/mongocxx/config/version.hpp
+///
+/// These macros are provided by @ref mongocxx-v_noabi-mongocxx-config-version-hpp "version.hpp",
+/// **NOT** by @ref mongocxx/v_noabi/mongocxx/fwd.hpp "fwd.hpp" (where this is documented)!
+///
+/// @{
+///
+
+///
+/// @ingroup mongocxx-v_noabi-mongocxx-config-version-hpp
+/// Defined as a string literal encoding this mongocxx library's API version number.
+///
+/// This value includes the major version, minor version, patch version, and suffix if any.
+///
+/// Example: `"1.2.3-extra"`
+///
+/// This value is derived from the `BUILD_VERSION` variable during configuration.
+///
+#define MONGOCXX_VERSION_STRING
+
+///
+/// @ingroup mongocxx-v_noabi-mongocxx-config-version-hpp
+/// Defined as this mongocxx library's API major version number.
+///
+/// This value is derived from the `BUILD_VERSION` variable during configuration.
+///
+#define MONGOCXX_VERSION_MAJOR
+
+///
+/// @ingroup mongocxx-v_noabi-mongocxx-config-version-hpp
+/// Defined as this mongocxx library's API minor version number.
+///
+/// This value is derived from the `BUILD_VERSION` variable during configuration.
+///
+#define MONGOCXX_VERSION_MINOR
+
+///
+/// @ingroup mongocxx-v_noabi-mongocxx-config-version-hpp
+/// Defined as this mongocxx library's API patch version number.
+///
+/// This value is derived from the `BUILD_VERSION` variable during configuration.
+///
+#define MONGOCXX_VERSION_PATCH
+
+///
+/// @ingroup mongocxx-v_noabi-mongocxx-config-version-hpp
+/// Defined as this mongocxx library's API version number suffix if any.
+///
+/// This value is derived from the `BUILD_VERSION` variable during configuration.
+///
+#define MONGOCXX_VERSION_EXTRA
+
+///
+/// @} <!-- mongocxx/v_noabi/mongocxx/config/version.hpp -->
+///
+
+#endif  // defined(MONGOCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+///
+/// @dir mongocxx/v_noabi/mongocxx/events
+/// Provides headers declaring entities in @ref mongocxx::v_noabi::events.
+///
+
+///
+/// @dir mongocxx/v_noabi/mongocxx/exception
+/// Provides headers declaring entities in @ref mongocxx::v_noabi::exception.
+///
+
+///
+/// @dir mongocxx/v_noabi/mongocxx/gridfs
+/// Provides headers declaring entities in @ref mongocxx::v_noabi::gridfs.
+///
+
+///
+/// @dir mongocxx/v_noabi/mongocxx/model
+/// Provides headers declaring entities in @ref mongocxx::v_noabi::model.
+///
+
+///
+/// @dir mongocxx/v_noabi/mongocxx/options
+/// Provides headers declaring entities in @ref mongocxx::v_noabi::options.
+///
+
+///
+/// @dir mongocxx/v_noabi/mongocxx/options/gridfs
+/// Provides headers declaring entities in @ref mongocxx::v_noabi::options::gridfs.
+///
+
+///
+/// @dir mongocxx/v_noabi/mongocxx/result
+/// Provides headers declaring entities in @ref mongocxx::v_noabi::result.
+///
+
+///
+/// @dir mongocxx/v_noabi/mongocxx/result/gridfs
+/// Provides headers declaring entities in @ref mongocxx::v_noabi::result::gridfs.
+///
+
+///
 /// @namespace mongocxx::v_noabi
-/// Entities declared in this namespace do not have a stable ABI.
+/// Declares entities whose ABI stability is NOT guaranteed.
+///
+
+///
+/// @namespace mongocxx::v_noabi::events
+/// @copydoc mongocxx::events
+///
+
+///
+/// @namespace mongocxx::v_noabi::gridfs
+/// @copydoc mongocxx::gridfs
+///
+
+///
+/// @namespace mongocxx::v_noabi::model
+/// @copydoc mongocxx::model
+///
+/// @see mongocxx::v_noabi::bulk_write
+///
+
+///
+/// @namespace mongocxx::v_noabi::options
+/// @copydoc mongocxx::options
+///
+
+///
+/// @namespace mongocxx::v_noabi::options::gridfs
+/// @copydoc mongocxx::options::gridfs
+///
+
+///
+/// @namespace mongocxx::v_noabi::result
+/// @copydoc mongocxx::result
+///
+
+///
+/// @namespace mongocxx::v_noabi::result::gridfs
+/// @copydoc mongocxx::result::gridfs
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/fwd.hpp
@@ -193,21 +193,6 @@
 
 ///
 /// @ingroup mongocxx-v_noabi-mongocxx-config-export-hpp
-/// Defined when the mongocxx library is built as a static library.
-///
-/// @warning For internal use only!
-///
-/// This macro is not defined when the mongocxx library is built as a shared library.
-///
-/// @note This macro is intended to be automatically defined by the CMake or pkg-config package
-/// configuration file used to import the mongocxx library. Manually defining this macro is NOT
-/// recommended, but may be necessary depending on how the mongocxx library is being imported or
-/// packaged.
-///
-#define MONGOCXX_STATIC
-
-///
-/// @ingroup mongocxx-v_noabi-mongocxx-config-export-hpp
 /// Declares the associated entity as part of the ABI.
 ///
 /// @warning For internal use only!


### PR DESCRIPTION
## Summary

Partially resolves CXX-3069. Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1170.

Adds Doxygen documentation for directories, namespaces, and generated headers. Docs for files and root namespace redeclarations are deferred to a followup PR.

This PR proposes organizing Doxygen documentation at the _bottom_ of header files in the following order:

```cpp
// License notice.

#pragma once

#include <headers> // Include directives and etc.

namespace bsoncxx { ... } // Declarations and definitions.

///
/// @file
/// Documentation for this file.
///

///
/// @dir path/to/dir
/// Documentation for relevant subdirectories.
///

///
/// @namespace ns::qualifier
/// Documentation for relevant namespaces.
///
```

This is to avoid their interference with general development workflows, as these particular sets of documentation is not expected to be changed often.

## Directories

This PR adds documentation of directories, which partially enables navigation via intermediate directories and the "File List" page.

![image](https://github.com/user-attachments/assets/4d1b2c2f-e082-4227-8086-22d685efa90b)

More importantly, it triggers population of directory pages with subdirectory and file information (file docs are deferred to a followup PR).

![image](https://github.com/user-attachments/assets/9da89194-581e-4018-94e2-7354b67afb31)

Directories defer documentation to namespaces whenever able to avoid redundancy by referencing the namespace in its brief, since the directory structure mirrors the namespace structure.

To avoid ambiguity regarding which header within subdirectory to place directory documentation, all directory docs are collectively placed in the ABI directory's `fwd.hpp` file (with the exception of the library root directory itself).

Note: sometimes paths must be fully qualified relative to the project root directory or the library root directory for proper disambiguation by Doxygen, but this usually isn't necessary.

## Namespaces

This PR adds documentation of namespaces (including root namespaces; redeclaration docs are deferred to a followup PR), which enables navigation via intermediate namespaces.

![image](https://github.com/user-attachments/assets/6211c97f-24fe-474e-91c9-ae62c8617696)

This triggers population of namespace pages with nested namespaces.

![image](https://github.com/user-attachments/assets/60a1043b-28a2-4bc1-8670-63d9e4731e41)

Similar to namespaces, all namespace docs are collectively placed in the ABI directory's `fwd.hpp` file to avoid placement ambiguity.

Currently, due to having a 1-to-1 relationship, v_noabi namespace docs reuse root namespace docs via `@copydoc`. This may no longer be possible if namespace restructuring occurs in the future, but this is expected to be a far-future concern.

## Config Headers

This PR also adds documentation for generated headers under `config/` (i.e. `config.hpp`) in the form of Doxygen modules (aka "named groups"). This PR also documents headers already visible under the `config/` directory (i.e. `prelude.hpp`) for completeness.

![image](https://github.com/user-attachments/assets/2ee61c1c-7696-41c7-a3d8-8865dd4b608b)

![image](https://github.com/user-attachments/assets/2531f236-bae0-4b8e-881d-ba64f63502b5)

This means macros such as `BSONCXX_POLY_USE_*` and `BSONCXX_VERSION_*` are _finally_ documented proper by the API doc pages! 🎉 

Headers which are not intended for use by consumers of the library are labeled with a `@warning For internal use only!`. Docs for such files are intentionally kept brief and sparse in detail to avoid encouraging users to use the provided entities despite the warning.

Due to generated headers "not existing" according to Doxygen due to docs being generated from files under `include/` only, their docs are defined in the ABI directory's `fwd.hpp` file alongside directory and namespace docs within a `#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)` block defining stubs for entities (primarily macros) provided by the relevant header files.

This has the effect of listing the generated header docs both in the `fwd.hpp` file page (where it is document) as well as the dedicated Module page (corresponding to the generated header). Some care and emphasis was required to make clear what file actually provides the documented entities.

## Transitive Includes

The `prelude.hpp` and `fwd.hpp` headers demonstrates how _supported_ transitive includes are intended to be explicitly documented following `SHOW_INCLUDE_FILES = NO` in https://github.com/mongodb/mongo-cxx-driver/pull/1166.

![image](https://github.com/user-attachments/assets/8286b7eb-9b17-4a82-b6cf-daf275d49d92)

![image](https://github.com/user-attachments/assets/23d96d3b-cf0b-4434-a588-70ac370e9b78)

This is implemented using a `@par` command with a paragraph title and a `@li` list. The `@parblock` is not strictly necessary but is included regardless to clearly denote the expected scope of the page element (e.g. such that it does not unintentionally apply to subsequent paragraphs).

![image](https://github.com/user-attachments/assets/ee07ed9e-3535-462e-8ac9-53f2f6fb3c64)

This pattern is expected to be used sparingly and only for header files where the transitive includes are clearly expected and deliberately supported (e.g. `view_or_value.hpp` transitively includes the corresponding `view.hpp` and `value.hpp` headers).

