### PR TITLE
CXX-3069 document headers and root namespace redeclarations (bsoncxx)

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -901,8 +901,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/operators.hpp \
-                         src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/type_traits.hpp
+EXCLUDE                =
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/Doxyfile
+++ b/Doxyfile
@@ -938,7 +938,7 @@ EXCLUDE_SYMBOLS        = bsoncxx::detail \
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           = .
+EXAMPLE_PATH           = examples
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and

--- a/examples/bsoncxx/CMakeLists.txt
+++ b/examples/bsoncxx/CMakeLists.txt
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include_directories(
-    ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/bsoncxx/v_noabi
-)
-
 set(BSONCXX_EXAMPLES
     builder_core.cpp
     builder_list.cpp

--- a/examples/mongocxx/CMakeLists.txt
+++ b/examples/mongocxx/CMakeLists.txt
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include_directories(
-    ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/bsoncxx/v_noabi
-    ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/mongocxx/v_noabi
-)
-
 set(MONGOCXX_EXAMPLES
     aggregate.cpp
     automatic_client_side_field_level_encryption.cpp

--- a/examples/mongocxx/connect.cpp
+++ b/examples/mongocxx/connect.cpp
@@ -19,7 +19,6 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/json.hpp>
-#include <bsoncxx/stdx/make_unique.hpp>
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/logger.hpp>
@@ -44,6 +43,11 @@ class logger final : public mongocxx::logger {
     std::ostream* const _stream;
 };
 
+// Use `std::make_unique` with C++14 and newer.
+std::unique_ptr<logger> make_logger() {
+    return std::unique_ptr<logger>(new logger(&std::cout));
+}
+
 }  // namespace
 
 int main(int argc, char* argv[]) {
@@ -53,7 +57,7 @@ int main(int argc, char* argv[]) {
     // The mongocxx::instance constructor and destructor initialize and shut down the driver,
     // respectively. Therefore, a mongocxx::instance must be created before using the driver and
     // must remain alive for as long as the driver is in use.
-    mongocxx::instance inst{bsoncxx::stdx::make_unique<logger>(&std::cout)};
+    mongocxx::instance inst{make_logger()};
 
     try {
         const auto uri = mongocxx::uri{(argc >= 2) ? argv[1] : mongocxx::uri::k_default_uri};

--- a/examples/mongocxx/gridfs.cpp
+++ b/examples/mongocxx/gridfs.cpp
@@ -17,15 +17,12 @@
 #include <ostream>
 
 #include <bsoncxx/json.hpp>
-#include <bsoncxx/stdx/make_unique.hpp>
 #include <mongocxx/client.hpp>
 #include <mongocxx/gridfs/bucket.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>
 
 using namespace mongocxx;
-
-using bsoncxx::stdx::make_unique;
 
 int main() {
     // The mongocxx::instance constructor and destructor initialize and shut down the driver,
@@ -61,7 +58,9 @@ int main() {
     auto bytes_counter = 0;
 
     auto buffer_size = std::min(file_length, static_cast<std::int64_t>(downloader.chunk_size()));
-    auto buffer = make_unique<std::uint8_t[]>(static_cast<std::size_t>(buffer_size));
+
+    // Use `std::make_unique` with C++14 and newer.
+    auto buffer = std::unique_ptr<std::uint8_t[]>(new std::uint8_t[buffer_size]);
 
     while (auto length_read =
                downloader.read(buffer.get(), static_cast<std::size_t>(buffer_size))) {

--- a/examples/mongocxx/index.cpp
+++ b/examples/mongocxx/index.cpp
@@ -14,7 +14,6 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
-#include <bsoncxx/stdx/make_unique.hpp>
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>
@@ -58,8 +57,11 @@ int main(int, char**) {
     {
         db["restaurants"].drop();
         mongocxx::options::index index_options{};
-        std::unique_ptr<mongocxx::options::index::wiredtiger_storage_options> wt_options =
-            bsoncxx::stdx::make_unique<mongocxx::options::index::wiredtiger_storage_options>();
+
+        // Use `std::make_unique` with C++14 and newer.
+        std::unique_ptr<mongocxx::options::index::wiredtiger_storage_options> wt_options{
+            new mongocxx::options::index::wiredtiger_storage_options()};
+
         wt_options->config_string("block_allocation=first");
         index_options.storage_options(std::move(wt_options));
         db["restaurants"].create_index(make_document(kvp("cuisine", 1)), index_options);

--- a/examples/mongocxx/instance_management.cpp
+++ b/examples/mongocxx/instance_management.cpp
@@ -14,8 +14,8 @@
 
 #include <cstdlib>
 #include <memory>
+#include <type_traits>
 
-#include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 #include <mongocxx/instance.hpp>
@@ -80,11 +80,14 @@ void configure(mongocxx::uri uri) {
                                 bsoncxx::stdx::string_view) noexcept {}
     };
 
-    auto instance =
-        bsoncxx::stdx::make_unique<mongocxx::instance>(bsoncxx::stdx::make_unique<noop_logger>());
+    // Use `std::make_unique` with C++14 and newer.
+    auto instance = std::unique_ptr<mongocxx::instance>(
+        new mongocxx::instance(std::unique_ptr<noop_logger>(new noop_logger())));
 
-    mongo_access::instance().configure(std::move(instance),
-                                       bsoncxx::stdx::make_unique<mongocxx::pool>(std::move(uri)));
+    // Use `std::make_unique` with C++14 and newer.
+    auto pool = std::unique_ptr<mongocxx::pool>(new mongocxx::pool(std::move(uri)));
+
+    mongo_access::instance().configure(std::move(instance), std::move(pool));
 }
 
 bool do_work() {

--- a/examples/mongocxx/view_or_value_variant.cpp
+++ b/examples/mongocxx/view_or_value_variant.cpp
@@ -15,7 +15,6 @@
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
-#include <bsoncxx/stdx/make_unique.hpp>
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/stdx.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element-fwd.hpp
@@ -35,3 +35,21 @@ using ::bsoncxx::v_noabi::array::element;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::array::element.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace array {
+
+/// @ref bsoncxx::v_noabi::array::element
+class element {};
+
+}  // namespace array
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
@@ -124,3 +124,30 @@ using ::bsoncxx::v_noabi::array::operator!=;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Defines bsoncxx::v_noabi::array::element.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace array {
+
+/// @ref bsoncxx::v_noabi::array::operator==(const v_noabi::array::element& elem, const v_noabi::types::bson_value::view& v)
+bool operator==(const v_noabi::array::element& elem, const v_noabi::types::bson_value::view& v);
+
+/// @ref bsoncxx::v_noabi::array::operator==(const v_noabi::types::bson_value::view& v, const v_noabi::array::element& elem)
+bool operator==(const v_noabi::types::bson_value::view& v, const v_noabi::array::element& elem);
+
+/// @ref bsoncxx::v_noabi::array::operator!=(const v_noabi::array::element& elem, const v_noabi::types::bson_value::view& v)
+bool operator!=(const v_noabi::array::element& elem, const v_noabi::types::bson_value::view& v);
+
+/// @ref bsoncxx::v_noabi::array::operator!=(const v_noabi::types::bson_value::view& v, const v_noabi::array::element& elem)
+bool operator!=(const v_noabi::types::bson_value::view& v, const v_noabi::array::element& elem);
+
+}  // namespace array
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
@@ -127,7 +127,7 @@ using ::bsoncxx::v_noabi::array::operator!=;
 
 ///
 /// @file
-/// Defines bsoncxx::v_noabi::array::element.
+/// Provides @ref bsoncxx::v_noabi::array::element.
 ///
 
 #if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value-fwd.hpp
@@ -35,3 +35,21 @@ using ::bsoncxx::v_noabi::array::value;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::array::value.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace array {
+
+/// @ref bsoncxx::v_noabi::array::value
+class value {};
+
+}  // namespace array
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value.hpp
@@ -120,3 +120,8 @@ BSONCXX_INLINE value::operator array::view() const noexcept {
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::array::value.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view-fwd.hpp
@@ -35,3 +35,21 @@ using ::bsoncxx::v_noabi::array::view;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::array::view.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace array {
+
+/// @ref bsoncxx::v_noabi::array::view
+class view {};
+
+}  // namespace array
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view.hpp
@@ -190,3 +190,8 @@ class view::const_iterator {
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::array::view.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/view_or_value.hpp
@@ -43,3 +43,21 @@ using ::bsoncxx::v_noabi::array::view_or_value;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::array::view_or_value.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace array {
+
+/// @ref bsoncxx::v_noabi::array::view_or_value
+class view_or_value {};
+
+}  // namespace array
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array-fwd.hpp
@@ -35,3 +35,23 @@ using ::bsoncxx::v_noabi::builder::basic::array;
 }  // namespace basic
 }  // namespace builder
 }  // namespace bsoncxx
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::builder::basic::array.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace builder {
+namespace basic {
+
+/// @ref bsoncxx::v_noabi::builder::basic::array
+class array {};
+
+}  // namespace basic
+}  // namespace builder
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
@@ -139,7 +139,7 @@ using ::bsoncxx::v_noabi::builder::basic::make_array;
 
 ///
 /// @file
-/// Defines bsoncxx::v_noabi::builder::basic::array.
+/// Provides @ref bsoncxx::v_noabi::builder::basic::array.
 ///
 
 #if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/array.hpp
@@ -136,3 +136,24 @@ using ::bsoncxx::v_noabi::builder::basic::make_array;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Defines bsoncxx::v_noabi::builder::basic::array.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace builder {
+namespace basic {
+
+/// @ref bsoncxx::v_noabi::builder::basic::make_array
+template <typename... Args>
+v_noabi::array::value make_array(Args&&... args);
+
+}  // namespace basic
+}  // namespace builder
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document-fwd.hpp
@@ -35,3 +35,23 @@ using ::bsoncxx::v_noabi::builder::basic::document;
 }  // namespace basic
 }  // namespace builder
 }  // namespace bsoncxx
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::builder::basic::document.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace builder {
+namespace basic {
+
+/// @ref bsoncxx::v_noabi::builder::basic::document
+class document {};
+
+}  // namespace basic
+}  // namespace builder
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
@@ -135,3 +135,24 @@ using ::bsoncxx::v_noabi::builder::basic::make_document;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Defines bsoncxx::v_noabi::builder::basic::document.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace builder {
+namespace basic {
+
+/// @ref bsoncxx::v_noabi::builder::basic::make_document
+template <typename... Args>
+v_noabi::document::value make_document(Args&&... args);
+
+}  // namespace basic
+}  // namespace builder
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/document.hpp
@@ -138,7 +138,7 @@ using ::bsoncxx::v_noabi::builder::basic::make_document;
 
 ///
 /// @file
-/// Defines bsoncxx::v_noabi::builder::basic::document.
+/// Provides @ref bsoncxx::v_noabi::builder::basic::document.
 ///
 
 #if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/helpers.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/helpers.hpp
@@ -41,3 +41,26 @@ using ::bsoncxx::v_noabi::builder::basic::concatenate;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Redeclares @ref bsoncxx::v_noabi::builder::concatenate in the @ref
+/// bsoncxx::v_noabi::builder::basic namespace.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace builder {
+namespace basic {
+
+/// @ref bsoncxx::v_noabi::builder::concatenate(v_noabi::document::view_or_value doc)
+/// @note An overload accepting @ref v_noabi::array::view_or_value and returning a @ref
+/// v_noabi::builder::concatenate_array is also declared in this scope.
+v_noabi::concatenate_doc concatenate(v_noabi::document::view_or_value doc);
+
+}  // namespace basic
+}  // namespace builder
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/impl.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/impl.hpp
@@ -62,3 +62,8 @@ BSONCXX_INLINE void value_append(core* core, T&& t) {
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// For internal use only!
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/kvp.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/kvp.hpp
@@ -48,3 +48,24 @@ using ::bsoncxx::v_noabi::builder::basic::kvp;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::builder::basic::kvp.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace builder {
+namespace basic {
+
+/// @ref bsoncxx::v_noabi::builder::basic::kvp
+template <typename T, typename U>
+std::tuple<T&&, U&&> kvp(T&& t, U&& u);
+
+}  // namespace basic
+}  // namespace builder
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array-fwd.hpp
@@ -35,3 +35,23 @@ using ::bsoncxx::v_noabi::builder::basic::sub_array;
 }  // namespace basic
 }  // namespace builder
 }  // namespace bsoncxx
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::builder::basic::sub_array.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace builder {
+namespace basic {
+
+/// @ref bsoncxx::v_noabi::builder::basic::sub_array
+class sub_array {};
+
+}  // namespace basic
+}  // namespace builder
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array.hpp
@@ -86,3 +86,8 @@ class sub_array {
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Defines bsoncxx::v_noabi::builder::basic::sub_array.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array.hpp
@@ -89,5 +89,5 @@ class sub_array {
 
 ///
 /// @file
-/// Defines bsoncxx::v_noabi::builder::basic::sub_array.
+/// Provides @ref bsoncxx::v_noabi::builder::basic::sub_array.
 ///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document-fwd.hpp
@@ -35,3 +35,23 @@ using ::bsoncxx::v_noabi::builder::basic::sub_document;
 }  // namespace basic
 }  // namespace builder
 }  // namespace bsoncxx
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::builder::basic::sub_document.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace builder {
+namespace basic {
+
+/// @ref bsoncxx::v_noabi::builder::basic::sub_document
+class sub_document {};
+
+}  // namespace basic
+}  // namespace builder
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document.hpp
@@ -109,5 +109,5 @@ class sub_document {
 
 ///
 /// @file
-/// Defines bsoncxx::v_noabi::builder::basic::sub_document.
+/// Provides @ref bsoncxx::v_noabi::builder::basic::sub_document.
 ///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document.hpp
@@ -106,3 +106,8 @@ class sub_document {
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Defines bsoncxx::v_noabi::builder::basic::sub_document.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate-fwd.hpp
@@ -33,3 +33,24 @@ using ::bsoncxx::v_noabi::builder::concatenate_doc;
 
 }  // namespace builder
 }  // namespace bsoncxx
+
+///
+/// @file
+/// Provides concatenators for use with "streaming" BSON builder syntax.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace builder {
+
+/// @ref bsoncxx::v_noabi::builder::concatenate_doc
+struct concatenate_doc {};
+
+/// @ref bsoncxx::v_noabi::builder::concatenate_array
+struct concatenate_array {};
+
+}  // namespace builder
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
@@ -123,7 +123,7 @@ using ::bsoncxx::v_noabi::builder::concatenate;
 
 ///
 /// @file
-/// Defines concatenators for use with "streaming" BSON builder syntax.
+/// Provides concatenators for use with "streaming" BSON builder syntax.
 ///
 
 #if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
@@ -94,7 +94,7 @@ struct concatenate_array {
 /// @see bsoncxx::v_noabi::builder::concatenate_doc
 ///
 /// @note An overload accepting @ref v_noabi::array::view_or_value and returning a @ref
-/// concatenate_array is also declared in this scope.
+/// v_noabi::builder::concatenate_array is also declared in this scope.
 ///
 BSONCXX_INLINE concatenate_doc concatenate(document::view_or_value doc) {
     return {std::move(doc)};
@@ -120,3 +120,23 @@ using ::bsoncxx::v_noabi::builder::concatenate;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Defines concatenators for use with "streaming" BSON builder syntax.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace builder {
+
+/// @ref bsoncxx::v_noabi::builder::concatenate
+/// @note An overload accepting @ref v_noabi::array::view_or_value and returning a @ref
+/// v_noabi::builder::concatenate_array is also declared in this scope.
+v_noabi::builder::concatenate_doc concatenate(v_noabi::document::view_or_value doc);
+
+}  // namespace builder
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core-fwd.hpp
@@ -35,3 +35,21 @@ using ::bsoncxx::v_noabi::builder::core;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::builder::core.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace builder {
+
+/// @ref bsoncxx::v_noabi::builder::core
+class core {};
+
+}  // namespace builder
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
@@ -702,3 +702,8 @@ class core {
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::builder::core.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list-fwd.hpp
@@ -35,3 +35,27 @@ using ::bsoncxx::v_noabi::builder::list;
 
 }  // namespace builder
 }  // namespace bsoncxx
+
+///
+/// @file
+/// Provides entities for use with "list" BSON builder syntax.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace builder {
+
+/// @ref bsoncxx::v_noabi::builder::array
+class array {};
+
+/// @ref bsoncxx::v_noabi::builder::document
+class document {};
+
+/// @ref bsoncxx::v_noabi::builder::list
+class list {};
+
+}  // namespace builder
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
@@ -30,7 +30,7 @@ namespace bsoncxx {
 namespace v_noabi {
 namespace builder {
 
-using namespace ::bsoncxx::v_noabi::types;  // Deprecated.
+using namespace ::bsoncxx::v_noabi::types;  // Deprecated. Deliberately undocumented.
 
 }  // namespace builder
 }  // namespace v_noabi
@@ -204,7 +204,7 @@ class array : public list {
 namespace bsoncxx {
 namespace builder {
 
-using namespace ::bsoncxx::v_noabi::types;  // Deprecated.
+using namespace ::bsoncxx::v_noabi::types;  // Deprecated. Deliberately undocumented.
 
 }  // namespace builder
 }  // namespace bsoncxx
@@ -213,3 +213,8 @@ using namespace ::bsoncxx::v_noabi::types;  // Deprecated.
 #if defined(BSONCXX_TEST_MACRO_GUARDS_FIX_MISSING_POSTLUDE)
 #include <bsoncxx/config/postlude.hpp>
 #endif
+
+///
+/// @file
+/// Defines entities for use with "list" BSON builder syntax.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
@@ -216,5 +216,5 @@ using namespace ::bsoncxx::v_noabi::types;  // Deprecated. Deliberately undocume
 
 ///
 /// @file
-/// Defines entities for use with "list" BSON builder syntax.
+/// Provides entities for use with "list" BSON builder syntax.
 ///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array-fwd.hpp
@@ -35,3 +35,23 @@ using ::bsoncxx::v_noabi::builder::stream::array;
 }  // namespace stream
 }  // namespace builder
 }  // namespace bsoncxx
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::builder::stream::array.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace builder {
+namespace stream {
+
+/// @ref bsoncxx::v_noabi::builder::stream::array
+class array {};
+
+}  // namespace stream
+}  // namespace builder
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array.hpp
@@ -90,3 +90,8 @@ class array : public array_context<> {
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::builder::stream::array.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context-fwd.hpp
@@ -38,3 +38,23 @@ using ::bsoncxx::v_noabi::builder::stream::array_context;
 }  // namespace stream
 }  // namespace builder
 }  // namespace bsoncxx
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::builder::stream::array_context.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace builder {
+namespace stream {
+
+/// @ref bsoncxx::v_noabi::builder::stream::array_context
+class array_context {};
+
+}  // namespace stream
+}  // namespace builder
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
@@ -193,3 +193,8 @@ class array_context {
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::builder::stream::array_context.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context-fwd.hpp
@@ -35,3 +35,23 @@ using ::bsoncxx::v_noabi::builder::stream::closed_context;
 }  // namespace stream
 }  // namespace builder
 }  // namespace bsoncxx
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::builder::stream::closed_context.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace builder {
+namespace stream {
+
+/// @ref bsoncxx::v_noabi::builder::stream::closed_context
+class closed_context {};
+
+}  // namespace stream
+}  // namespace builder
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context.hpp
@@ -41,3 +41,8 @@ struct closed_context {
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::builder::stream::closed_context.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document-fwd.hpp
@@ -35,3 +35,23 @@ using ::bsoncxx::v_noabi::builder::stream::document;
 }  // namespace stream
 }  // namespace builder
 }  // namespace bsoncxx
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::builder::stream::document.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace builder {
+namespace stream {
+
+/// @ref bsoncxx::v_noabi::builder::stream::document
+class document {};
+
+}  // namespace stream
+}  // namespace builder
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/document.hpp
@@ -88,3 +88,8 @@ class document : public key_context<> {
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::builder::stream::document.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers-fwd.hpp
@@ -33,3 +33,9 @@ struct BSONCXX_API finalize_type;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides types used to define stream manipulators in @ref
+/// bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp
@@ -24,7 +24,7 @@ namespace v_noabi {
 namespace builder {
 namespace stream {
 
-using ::bsoncxx::v_noabi::builder::concatenate;  // Deprecated.
+using ::bsoncxx::v_noabi::builder::concatenate;  // Deprecated. Deliberately undocumented.
 
 ///
 /// The type of a stream manipulator to open a subdocument.
@@ -100,7 +100,7 @@ namespace bsoncxx {
 namespace builder {
 namespace stream {
 
-using ::bsoncxx::v_noabi::builder::stream::concatenate;  // Deprecated.
+using ::bsoncxx::v_noabi::builder::stream::concatenate;  // Deprecated. Deliberately undocumented.
 
 using ::bsoncxx::v_noabi::builder::stream::close_array;
 using ::bsoncxx::v_noabi::builder::stream::close_document;
@@ -113,3 +113,35 @@ using ::bsoncxx::v_noabi::builder::stream::open_document;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides stream manipulators for use with "streaming" BSON builder syntax.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace builder {
+namespace stream {
+
+/// @ref bsoncxx::v_noabi::builder::stream::close_array
+constexpr close_array_type close_array;
+
+/// @ref bsoncxx::v_noabi::builder::stream::close_document
+constexpr close_document_type close_document;
+
+/// @ref bsoncxx::v_noabi::builder::stream::finalize
+constexpr finalize_type finalize;
+
+/// @ref bsoncxx::v_noabi::builder::stream::open_array
+constexpr open_array_type open_array;
+
+/// @ref bsoncxx::v_noabi::builder::stream::open_document
+constexpr open_document_type open_document;
+
+}  // namespace stream
+}  // namespace builder
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context-fwd.hpp
@@ -38,3 +38,23 @@ using ::bsoncxx::v_noabi::builder::stream::key_context;
 }  // namespace stream
 }  // namespace builder
 }  // namespace bsoncxx
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::builder::stream::key_context.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace builder {
+namespace stream {
+
+/// @ref bsoncxx::v_noabi::builder::stream::key_context
+class key_context {};
+
+}  // namespace stream
+}  // namespace builder
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context.hpp
@@ -183,3 +183,8 @@ class key_context {
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::builder::stream::key_context.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context-fwd.hpp
@@ -49,7 +49,7 @@ namespace bsoncxx {
 namespace builder {
 namespace stream {
 
-/// @ref bsoncxx::v_noabi::builder::stream::array_context
+/// @ref bsoncxx::v_noabi::builder::stream::single_context
 class single_context {};
 
 }  // namespace stream

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context-fwd.hpp
@@ -37,3 +37,23 @@ using ::bsoncxx::v_noabi::builder::stream::single_context;
 }  // namespace stream
 }  // namespace builder
 }  // namespace bsoncxx
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::builder::stream::single_context.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace builder {
+namespace stream {
+
+/// @ref bsoncxx::v_noabi::builder::stream::array_context
+class single_context {};
+
+}  // namespace stream
+}  // namespace builder
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/single_context.hpp
@@ -113,3 +113,8 @@ BSONCXX_INLINE value_context<T>::operator single_context() {
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::builder::stream::single_context.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context-fwd.hpp
@@ -40,3 +40,23 @@ using ::bsoncxx::v_noabi::builder::stream::value_context;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::builder::stream::value_context.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace builder {
+namespace stream {
+
+/// @ref bsoncxx::v_noabi::builder::stream::value_context
+class value_context {};
+
+}  // namespace stream
+}  // namespace builder
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context.hpp
@@ -141,3 +141,8 @@ class value_context {
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::builder::stream::value_context.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/util.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/util.hpp
@@ -1,34 +1,24 @@
-// clang-format off
-/**
- * @internal
- * @brief Convert the given macro argument to a string literal, after macro expansion
- */
+// Convert the given macro argument to a string literal, after macro expansion.
 #define BSONCXX_STRINGIFY(...) BSONCXX_STRINGIFY_IMPL(__VA_ARGS__)
 #define BSONCXX_STRINGIFY_IMPL(...) #__VA_ARGS__
 
-/**
- * @internal
- * @brief Token-paste two macro arguments, after macro expansion
- */
+// Token-paste two macro arguments, after macro expansion
 #define BSONCXX_CONCAT(A, ...) BSONCXX_CONCAT_IMPL(A, __VA_ARGS__)
 #define BSONCXX_CONCAT_IMPL(A, ...) A##__VA_ARGS__
 
-/**
- * @internal
- * @brief Expands to a _Pragma() preprocessor directive, after macro expansion
- *
- * The arguments an arbitrary "token soup", and should not be quoted like a regular
- * _Pragma. This macro will stringify-them itself.
- *
- * Example:
- *
- *      BSONCXX_PRAGMA(GCC diagnostic ignore "-Wconversion")
- *
- * will become:
- *
- *      _Pragma("GCC diagnostic ignore \"-Wconversion\"")
- *
- */
+// Expands to a _Pragma() preprocessor directive, after macro expansion
+//
+// The arguments an arbitrary "token soup", and should not be quoted like a regular
+// _Pragma. This macro will stringify-them itself.
+//
+// Example:
+//
+//      BSONCXX_PRAGMA(GCC diagnostic ignore "-Wconversion")
+//
+// will become:
+//
+//      _Pragma("GCC diagnostic ignore \"-Wconversion\"")
+//
 #define BSONCXX_PRAGMA(...) _bsoncxxPragma(__VA_ARGS__)
 #ifdef _MSC_VER
 // Old MSVC doesn't recognize C++11 _Pragma(), but it always recognized __pragma
@@ -37,87 +27,69 @@
 #define _bsoncxxPragma(...) _Pragma(BSONCXX_STRINGIFY(__VA_ARGS__))
 #endif
 
-/**
- * @internal
- * @brief Use in a declaration position to force the appearence of a semicolon
- * as the next token. Use this for statement-like or declaration-like macros to
- * enforce that their call sites are followed by a semicolon
- */
+// Use in a declaration position to force the appearence of a semicolon
+// as the next token. Use this for statement-like or declaration-like macros to
+// enforce that their call sites are followed by a semicolon
 #define BSONCXX_FORCE_SEMICOLON static_assert(true, "")
 
-/**
- * @internal
- * @brief Add a trailing noexcept, decltype-return, and return-body to a
- * function definition. (Not compatible with lambda expressions.)
- *
- * Example:
- *
- *      template <typename T>
- *      auto foo(T x, T y) BSONCXX_RETURNS(x + y);
- *
- * Becomes:
- *
- *      template <typename T>
- *      auto foo(T x, T y) noexcept(noexcept(x + y))
- *          -> decltype(x + y)
- *      { return x + y };
- *
- */
+// Add a trailing noexcept, decltype-return, and return-body to a
+// function definition. (Not compatible with lambda expressions.)
+//
+// Example:
+//
+//      template <typename T>
+//      auto foo(T x, T y) BSONCXX_RETURNS(x + y);
+//
+// Becomes:
+//
+//      template <typename T>
+//      auto foo(T x, T y) noexcept(noexcept(x + y))
+//          -> decltype(x + y)
+//      { return x + y };
+//
 #define BSONCXX_RETURNS(...)                                 \
     noexcept(noexcept(__VA_ARGS__))->decltype(__VA_ARGS__) { \
         return __VA_ARGS__;                                  \
     }                                                        \
     BSONCXX_FORCE_SEMICOLON
 
-/**
- * @internal
- * @macro mongocxx_cxx14_constexpr
- * @brief Expands to `constexpr` if compiling as c++14 or greater, otherwise
- * expands to `inline`.
- *
- * Use this on functions that can only be constexpr in C++14 or newer, including
- * non-const member functions.
- */
+// @macro mongocxx_cxx14_constexpr
+// Expands to `constexpr` if compiling as c++14 or greater, otherwise
+// expands to `inline`.
+//
+// Use this on functions that can only be constexpr in C++14 or newer, including
+// non-const member functions.
 #if __cplusplus >= 201402L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201402L && _MSC_VER > 1910)
 #define bsoncxx_cxx14_constexpr constexpr
 #else
 #define bsoncxx_cxx14_constexpr inline
 #endif
 
-/**
- * @internal
- * @brief Disable a warning for a particular compiler.
- *
- * The argument should be of the form:
- *
- * - Clang(<flag-string-literal>)
- * - GCC(<flag-string-literal>)
- * - GNU(<flag-string-literal>)
- * - MSVC(<id-integer-literal>)
- *
- * The "GNU" form applies to both GCC and Clang
- */
-#define BSONCXX_DISABLE_WARNING(Spec) \
+// Disable a warning for a particular compiler.
+//
+// The argument should be of the form:
+//
+// - Clang(<flag-string-literal>)
+// - GCC(<flag-string-literal>)
+// - GNU(<flag-string-literal>)
+// - MSVC(<id-integer-literal>)
+//
+// The "GNU" form applies to both GCC and Clang
+#define BSONCXX_DISABLE_WARNING(Spec)                     \
     BSONCXX_CONCAT(_bsoncxxDisableWarningImpl_for_, Spec) \
     BSONCXX_FORCE_SEMICOLON
 
-/**
- * @internal
- * @brief Push the current compiler diagnostics settings state
- */
-#define BSONCXX_PUSH_WARNINGS() \
+// Push the current compiler diagnostics settings state
+#define BSONCXX_PUSH_WARNINGS()                              \
     BSONCXX_IF_GNU_LIKE(BSONCXX_PRAGMA(GCC diagnostic push)) \
-    BSONCXX_IF_MSVC(BSONCXX_PRAGMA(warning(push))) \
+    BSONCXX_IF_MSVC(BSONCXX_PRAGMA(warning(push)))           \
     BSONCXX_FORCE_SEMICOLON
 
-/**
- * @internal
- * @brief Restore prior compiler diagnostics settings from before the most
- * recent BSONCXX_PUSH_WARNINGS()
- */
-#define BSONCXX_POP_WARNINGS() \
+// Restore prior compiler diagnostics settings from before the most
+// recent BSONCXX_PUSH_WARNINGS()
+#define BSONCXX_POP_WARNINGS()                              \
     BSONCXX_IF_GNU_LIKE(BSONCXX_PRAGMA(GCC diagnostic pop)) \
-    BSONCXX_IF_MSVC(BSONCXX_PRAGMA(warning(pop))) \
+    BSONCXX_IF_MSVC(BSONCXX_PRAGMA(warning(pop)))           \
     BSONCXX_FORCE_SEMICOLON
 
 #define _bsoncxxDisableWarningImpl_for_GCC(...) \
@@ -126,9 +98,9 @@
 #define _bsoncxxDisableWarningImpl_for_Clang(...) \
     BSONCXX_IF_CLANG(BSONCXX_PRAGMA(GCC diagnostic ignored __VA_ARGS__))
 
-#define _bsoncxxDisableWarningImpl_for_GNU(...) \
+#define _bsoncxxDisableWarningImpl_for_GNU(...)     \
     _bsoncxxDisableWarningImpl_for_GCC(__VA_ARGS__) \
-    _bsoncxxDisableWarningImpl_for_Clang(__VA_ARGS__)
+        _bsoncxxDisableWarningImpl_for_Clang(__VA_ARGS__)
 
 #define _bsoncxxDisableWarningImpl_for_MSVC(...) \
     BSONCXX_IF_MSVC(BSONCXX_PRAGMA(warning(disable : __VA_ARGS__)))

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128-fwd.hpp
@@ -31,3 +31,19 @@ using ::bsoncxx::v_noabi::decimal128;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::decimal128.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+
+/// @ref bsoncxx::v_noabi::decimal128
+class decimal128 {};
+
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
@@ -98,3 +98,8 @@ class decimal128 {
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::decimal128.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element-fwd.hpp
@@ -35,3 +35,21 @@ using ::bsoncxx::v_noabi::document::element;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::document::element.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace document {
+
+/// @ref bsoncxx::v_noabi::document::element
+class element {};
+
+}  // namespace document
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
@@ -422,3 +422,30 @@ using ::bsoncxx::v_noabi::document::operator!=;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::document::element.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace document {
+
+/// @ref bsoncxx::v_noabi::document::operator==(const v_noabi::document::element& elem, const v_noabi::types::bson_value::view& v)
+bool operator==(const v_noabi::document::element& elem, const v_noabi::types::bson_value::view& v);
+
+/// @ref bsoncxx::v_noabi::document::operator==(const v_noabi::types::bson_value::view& v, const v_noabi::document::element& elem)
+bool operator==(const v_noabi::types::bson_value::view& v, const v_noabi::document::element& elem);
+
+/// @ref bsoncxx::v_noabi::document::operator!=(const v_noabi::document::element& elem, const v_noabi::types::bson_value::view& v)
+bool operator!=(const v_noabi::document::element& elem, const v_noabi::types::bson_value::view& v);
+
+/// @ref bsoncxx::v_noabi::document::operator!=(const v_noabi::types::bson_value::view& v, const v_noabi::document::element& elem)
+bool operator!=(const v_noabi::types::bson_value::view& v, const v_noabi::document::element& elem);
+
+}  // namespace document
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value-fwd.hpp
@@ -35,3 +35,21 @@ using ::bsoncxx::v_noabi::document::value;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::document::value.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace document {
+
+/// @ref bsoncxx::v_noabi::document::value
+class value {};
+
+}  // namespace document
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
@@ -281,3 +281,24 @@ using ::bsoncxx::v_noabi::document::operator!=;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::document::value.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace document {
+
+/// @ref bsoncxx::v_noabi::document::operator==(const v_noabi::document::value& lhs, const v_noabi::document::value& rhs)
+inline bool operator==(const v_noabi::document::value& lhs, const v_noabi::document::value& rhs);
+
+/// @ref bsoncxx::v_noabi::document::operator!=(const v_noabi::document::value& lhs, const v_noabi::document::value& rhs)
+inline bool operator!=(const v_noabi::document::value& lhs, const v_noabi::document::value& rhs);
+
+}  // namespace document
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view-fwd.hpp
@@ -47,7 +47,7 @@ namespace bsoncxx {
 namespace document {
 
 /// @ref bsoncxx::v_noabi::document::view
-class element {};
+class view {};
 
 }  // namespace document
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view-fwd.hpp
@@ -35,3 +35,21 @@ using ::bsoncxx::v_noabi::document::view;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::document::view.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace document {
+
+/// @ref bsoncxx::v_noabi::document::view
+class element {};
+
+}  // namespace document
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view.hpp
@@ -190,3 +190,8 @@ class view::const_iterator {
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::document::view.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/view_or_value.hpp
@@ -42,3 +42,21 @@ using ::bsoncxx::v_noabi::document::view_or_value;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::document::view_or_value.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace document {
+
+/// @ref bsoncxx::v_noabi::document::view_or_value
+class view_or_value {};
+
+}  // namespace document
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/enums/binary_sub_type.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/enums/binary_sub_type.hpp
@@ -26,3 +26,13 @@ BSONCXX_ENUM(encrypted, 0x06)
 BSONCXX_ENUM(column, 0x07)
 BSONCXX_ENUM(sensitive, 0x08)
 BSONCXX_ENUM(user, 0x80)
+
+///
+/// @file
+/// X macro header expanding the user-provided `BSONCXX_ENUM` macro over BSON binary subtypes.
+///
+/// @warning The `BSONCXX_ENUM` macro must be defined by the user prior to including this header!
+///
+/// The user-provided `BSONCXX_ENUM` macro must accept two arguments: the name of the binary subtype
+/// corresponding value. See the source code for the list of expanded types and values.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/enums/type.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/enums/type.hpp
@@ -37,3 +37,13 @@ BSONCXX_ENUM(int64, 0x12)
 BSONCXX_ENUM(decimal128, 0x13)
 BSONCXX_ENUM(maxkey, 0x7F)
 BSONCXX_ENUM(minkey, 0xFF)
+
+///
+/// @file
+/// X macro header expanding the user-provided `BSONCXX_ENUM` macro over BSON types.
+///
+/// @warning The `BSONCXX_ENUM` macro must be defined by the user prior to including this header!
+///
+/// The user-provided `BSONCXX_ENUM` macro must accept two arguments: the name of the type and the
+/// corresponding value. See the source code for the list of expanded types and values.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code-fwd.hpp
@@ -37,3 +37,19 @@ template <>
 struct is_error_code_enum<bsoncxx::v_noabi::error_code>;
 
 }  // namespace std
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::error_code.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+
+/// @ref bsoncxx::v_noabi::error_code
+class error_code {};
+
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code.hpp
@@ -42,9 +42,13 @@ enum class error_code : std::int32_t {
 
     /// A document operation was performed while building an array.
     k_cannot_perform_document_operation_on_array,
+
+    // @cond DOXYGEN_DISABLE
 #define BSONCXX_ENUM(name, value) k_need_element_type_k_##name,
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
+    // @endcond DOXYGEN_DISABLE
+
     /// No key was provided when one was needed.
     k_need_key,
 
@@ -54,7 +58,7 @@ enum class error_code : std::int32_t {
     /// A document was closed while no document was open.
     k_no_document_to_close,
 
-    // Attempted to view or extract a document when a key was still awaiting a matching value.
+    /// Attempted to view or extract a document when a key was still awaiting a matching value.
     k_unmatched_key_in_builder,
 
     /// An empty element was accessed.
@@ -66,7 +70,7 @@ enum class error_code : std::int32_t {
     /// An Object ID string failed to parse.
     k_invalid_oid,
 
-    // This type is unused and deprecated.
+    /// This type is unused and deprecated.
     k_failed_converting_bson_to_json,
 
     /// A Decimal128 string failed to parse.
@@ -93,12 +97,18 @@ enum class error_code : std::int32_t {
     /// Invalid type.
     k_invalid_bson_type_id,
 
-/// A value failed to append.
+    // @cond DOXYGEN_DISABLE
 #define BSONCXX_ENUM(name, value) k_cannot_append_##name,
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
+    // @endcond DOXYGEN_DISABLE
+
+    /// A value failed to append.
     k_cannot_append_utf8 = k_cannot_append_string,
+
+    /// @deprecated Use `k_need_element_type_k_string` instead.
     k_need_element_type_k_utf8 = k_need_element_type_k_string,
+
     // Add new constant string message to error_code.cpp as well!
 };
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code.hpp
@@ -43,7 +43,7 @@ enum class error_code : std::int32_t {
     /// A document operation was performed while building an array.
     k_cannot_perform_document_operation_on_array,
 
-    // @cond DOXYGEN_DISABLE
+// @cond DOXYGEN_DISABLE
 #define BSONCXX_ENUM(name, value) k_need_element_type_k_##name,
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
@@ -97,7 +97,7 @@ enum class error_code : std::int32_t {
     /// Invalid type.
     k_invalid_bson_type_id,
 
-    // @cond DOXYGEN_DISABLE
+// @cond DOXYGEN_DISABLE
 #define BSONCXX_ENUM(name, value) k_cannot_append_##name,
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM
@@ -143,8 +143,30 @@ using ::bsoncxx::v_noabi::make_error_code;
 
 namespace std {
 
-// Specialize is_error_code_enum so we get simpler std::error_code construction
+///
+/// Indicates @ref bsoncxx::v_noabi::error_code is eligible for `std::error_code` implicit
+/// conversions.
+///
 template <>
 struct is_error_code_enum<bsoncxx::v_noabi::error_code> : public true_type {};
 
 }  // namespace std
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::error_code.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+
+/// @ref bsoncxx::v_noabi::error_category()
+const std::error_category& error_category();
+
+/// @ref bsoncxx::v_noabi::make_error_code(v_noabi::error_code error)
+std::error_code make_error_code(v_noabi::error_code error);
+
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception-fwd.hpp
@@ -31,3 +31,19 @@ using ::bsoncxx::v_noabi::exception;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::exception.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+
+/// @ref bsoncxx::v_noabi::exception
+class exception {};
+
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception.hpp
@@ -35,3 +35,8 @@ class exception : public std::system_error {
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::exception.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json-fwd.hpp
@@ -29,3 +29,19 @@ namespace bsoncxx {
 using ::bsoncxx::v_noabi::ExtendedJsonMode;
 
 }  // namespace bsoncxx
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::ExtendedJsonMode.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+
+/// @ref bsoncxx::v_noabi::ExtendedJsonMode
+enum class ExtendedJsonMode {};
+
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
@@ -40,7 +40,7 @@ enum class ExtendedJsonMode : std::uint8_t {
 /// Converts a BSON document to a JSON string, in extended format.
 ///
 /// @param view
-///   A valid BSON document.
+///   A valid BSON document or array.
 /// @param mode
 ///   An optional JSON representation mode.
 ///
@@ -48,11 +48,16 @@ enum class ExtendedJsonMode : std::uint8_t {
 ///
 /// @returns An extended JSON string.
 ///
+/// @{
+
 BSONCXX_API std::string BSONCXX_CALL to_json(document::view view,
                                              ExtendedJsonMode mode = ExtendedJsonMode::k_legacy);
 
 BSONCXX_API std::string BSONCXX_CALL to_json(array::view view,
                                              ExtendedJsonMode mode = ExtendedJsonMode::k_legacy);
+
+/// @}
+///
 
 ///
 /// Constructs a new document::value from the provided JSON text.
@@ -92,3 +97,31 @@ using ::bsoncxx::v_noabi::operator""_bson;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides utilities to convert between BSON and JSON representations.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+
+/// @ref bsoncxx::v_noabi::to_json(v_noabi::document::view view, v_noabi::ExtendedJsonMode mode)
+std::string to_json(v_noabi::document::view view,
+                    v_noabi::ExtendedJsonMode mode = ExtendedJsonMode::k_legacy);
+
+/// @ref bsoncxx::v_noabi::to_json(v_noabi::array::view view, v_noabi::ExtendedJsonMode mode)
+std::string to_json(v_noabi::array::view view,
+                    v_noabi::ExtendedJsonMode mode = ExtendedJsonMode::k_legacy);
+
+/// @ref bsoncxx::v_noabi::from_json(v_noabi::stdx::string_view json)
+v_noabi::document::value from_json(v_noabi::stdx::string_view json);
+
+// Space is required between `operator` and `""` in @ref to avoid confusing Doxygen.
+/// @ref bsoncxx::v_noabi::operator ""_bson(const char* json, size_t len)
+v_noabi::document::value operator""_bson(const char* json, std::size_t len);
+
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid-fwd.hpp
@@ -31,3 +31,19 @@ using ::bsoncxx::v_noabi::oid;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::oid.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+
+/// @ref bsoncxx::v_noabi::oid
+class oid {};
+
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
@@ -125,3 +125,8 @@ class oid {
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::oid.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
@@ -180,3 +180,10 @@ using ::bsoncxx::v_noabi::stdx::make_unique_for_overwrite;
 
 }  // namespace stdx
 }  // namespace bsoncxx
+
+///
+/// @file
+/// Provides `std::make_unique`-related polyfills for internal use.
+///
+/// @warning For internal use only!
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
@@ -218,4 +218,18 @@ std::unique_ptr<T> make_unique(std::size_t count);
 }  // namespace v_noabi
 }  // namespace bsoncxx
 
+namespace bsoncxx {
+namespace stdx {
+
+/// @ref bsoncxx::v_noabi::stdx::make_unique(Args&&... args)
+template <typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args);
+
+/// @ref bsoncxx::v_noabi::stdx::make_unique(std::size_t count)
+template <typename T>
+std::unique_ptr<T> make_unique(std::size_t count);
+
+}  // namespace stdx
+}  // namespace bsoncxx
+
 #endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
@@ -112,7 +112,7 @@ namespace stdx {
 using ::std::make_unique;
 #else
 
-/// Equivalent to `std::make_unique<T>(args...)` where `T` is a non-array type.
+// Equivalent to `std::make_unique<T>(args...)` where `T` is a non-array type.
 template <typename T,
           typename... Args,
           typename Impl = detail::make_unique_impl<T>,
@@ -123,7 +123,7 @@ std::unique_ptr<T> make_unique(Args&&... args) {
     return Impl::make(std::true_type{}, std::forward<Args>(args)...);
 }
 
-/// Equivalent to `std::make_unique<T>(count)` where `T` is an array type.
+// Equivalent to `std::make_unique<T>(count)` where `T` is an array type.
 template <
     typename T,
     typename Impl = detail::make_unique_impl<T>,
@@ -142,7 +142,7 @@ std::unique_ptr<T> make_unique(std::size_t count) {
 using ::std::make_unique_for_overwrite;
 #else
 
-/// Equivalent to `std::make_unique_for_overwrite<T>()` where `T` is a non-array type.
+// Equivalent to `std::make_unique_for_overwrite<T>()` where `T` is a non-array type.
 template <typename T,
           typename Impl = detail::make_unique_impl<T>,
           typename std::enable_if<!std::is_array<T>::value,
@@ -151,7 +151,7 @@ std::unique_ptr<T> make_unique_for_overwrite() {
     return Impl::make(std::false_type{});
 }
 
-/// Equivalent to `std::make_unique_for_overwrite<T>(count)` where `T` is an array type.
+// Equivalent to `std::make_unique_for_overwrite<T>(count)` where `T` is an array type.
 template <
     typename T,
     typename Impl = detail::make_unique_impl<T>,

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/make_unique.hpp
@@ -113,6 +113,7 @@ using ::std::make_unique;
 #else
 
 // Equivalent to `std::make_unique<T>(args...)` where `T` is a non-array type.
+// @cond DOXYGEN_DISABLE
 template <typename T,
           typename... Args,
           typename Impl = detail::make_unique_impl<T>,
@@ -122,8 +123,10 @@ template <typename T,
 std::unique_ptr<T> make_unique(Args&&... args) {
     return Impl::make(std::true_type{}, std::forward<Args>(args)...);
 }
+// @endcond
 
 // Equivalent to `std::make_unique<T>(count)` where `T` is an array type.
+// @cond DOXYGEN_DISABLE
 template <
     typename T,
     typename Impl = detail::make_unique_impl<T>,
@@ -133,6 +136,7 @@ template <
 std::unique_ptr<T> make_unique(std::size_t count) {
     return Impl::make(std::true_type{}, count);
 }
+// @endcond DOXYGEN_DISABLE
 
 #endif
 
@@ -185,5 +189,33 @@ using ::bsoncxx::v_noabi::stdx::make_unique_for_overwrite;
 /// @file
 /// Provides `std::make_unique`-related polyfills for internal use.
 ///
-/// @warning For internal use only!
+/// @deprecated Primarily for internal use; will be removed in an upcoming major release.
 ///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace v_noabi {
+namespace stdx {
+
+///
+/// Equivalent to `std::make_unique` for non-array types.
+///
+/// @deprecated Primarily for internal use; will be removed in an upcoming major release.
+///
+template <typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args);
+
+///
+/// Equivalent to `std::make_unique` for array types.
+///
+/// @deprecated Primarily for internal use. Will be removed in an upcoming major release.
+///
+template <typename T>
+std::unique_ptr<T> make_unique(std::size_t count);
+
+}  // namespace stdx
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/operators.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/operators.hpp
@@ -28,27 +28,23 @@ namespace detail {
 template <typename L, typename R>
 auto is_equality_comparable_f(...) -> std::false_type;
 
+BSONCXX_PUSH_WARNINGS();
+BSONCXX_DISABLE_WARNING(GNU("-Wfloat-equal"));
 template <typename L, typename R>
-auto is_equality_comparable_f(int,
-                              bool b = false,
-                              const_reference_t<L> l = soft_declval<L&>(),
-                              const_reference_t<R> r = soft_declval<R&>())
-    -> true_t<decltype((l == r) ? 0 : 0,  //
-                       (r == l) ? 0 : 0,
-                       (l != r) ? 0 : 0,
-                       (r != l) ? 0 : 0)>;
+auto is_equality_comparable_f(int, bool b = false)
+    -> true_t<decltype((std::declval<const L&>() == std::declval<const R&>()) ? 0 : 0,  //
+                       (std::declval<const R&>() == std::declval<const L&>()) ? 0 : 0,
+                       (std::declval<const L&>() != std::declval<const R&>()) ? 0 : 0,
+                       (std::declval<const R&>() != std::declval<const L&>()) ? 0 : 0)>;
+BSONCXX_POP_WARNINGS();
 
-/**
- * @brief Detect whether two types are equality-comparable.
- *
- * Requires L == R, L != R, R == L, and R != L
- */
+// Detect whether two types are equality-comparable.
+//
+// Requires L == R, L != R, R == L, and R != L.
 template <typename L, typename R = L>
 struct is_equality_comparable : decltype(is_equality_comparable_f<L, R>(0)) {};
 
-/**
- * @brief Callable object and tag type for equality comparison
- */
+// Callable object and tag type for equality comparison.
 struct equal_to {
     template <typename L, typename R>
     constexpr requires_t<bool, is_equality_comparable<L, R>>  //
@@ -57,10 +53,8 @@ struct equal_to {
     }
 };
 
-/**
- * @brief Derive from this class to define ADL-only operator== and operator!= on the basis of
- * an ADL-only tag_invoke(equal_to, l, r)
- */
+// Derive from this class to define ADL-only operator== and operator!= on the basis of
+// an ADL-only tag_invoke(equal_to, l, r).
 class equality_operators {
     template <typename L, typename R>
     constexpr static auto impl(rank<1>, L& l, R& r) BSONCXX_RETURNS(tag_invoke(equal_to{}, l, r));
@@ -68,20 +62,22 @@ class equality_operators {
     template <typename L, typename R>
     constexpr static auto impl(rank<0>, L& l, R& r) BSONCXX_RETURNS(tag_invoke(equal_to{}, r, l));
 
+    // @cond DOXYGEN_DISABLE "Found ';' while parsing initializer list!"
     template <typename Left, typename Other>
     constexpr friend auto operator==(const Left& self, const Other& other)
         BSONCXX_RETURNS(equality_operators::impl(rank<1>{}, self, other));
+    // @endcond
 
+    // @cond DOXYGEN_DISABLE "Found ';' while parsing initializer list!"
     template <typename Left, typename Other>
     constexpr friend auto operator!=(const Left& self, const Other& other)
         BSONCXX_RETURNS(!equality_operators::impl(rank<1>{}, self, other));
+    // @endcond
 };
 
-/**
- * @brief Very basic impl of C++20 std::strong_ordering
- *
- * We don't need other weaker orderings yet, so this is all that we have
- */
+// Very basic impl of C++20 std::strong_ordering.
+//
+// We don't need other weaker orderings yet, so this is all that we have.
 class strong_ordering {
     signed char _c;
     struct _construct {};
@@ -136,12 +132,12 @@ INLINE_VAR const strong_ordering strong_ordering::equal =
 
 #pragma pop_macro("INLINE_VAR")
 
-/**
- * @brief Implements a three-way comparison between two objects. That is, in
- * a single operation, determine whether the left operand is less-than, greater-than,
- * or equal-to the right-hand operand.
- */
+// Implements a three-way comparison between two objects. That is, in
+// a single operation, determine whether the left operand is less-than, greater-than,
+// or equal-to the right-hand operand.
 struct compare_three_way {
+    BSONCXX_PUSH_WARNINGS();
+    BSONCXX_DISABLE_WARNING(GNU("-Wfloat-equal"));
     template <typename L,
               typename R,
               typename = decltype(std::declval<L>() < std::declval<R>()),
@@ -151,6 +147,7 @@ struct compare_three_way {
                        : (l == r ? strong_ordering::equal  //
                                  : strong_ordering::greater);
     }
+    BSONCXX_POP_WARNINGS();
 
     template <typename L,
               typename R,
@@ -165,10 +162,8 @@ struct compare_three_way {
         BSONCXX_RETURNS((impl)(l, r, rank<2>{}));
 };
 
-/**
- * @brief Inherit to define ADL-visible ordering operators based on an ADL-visible
- * implementation of tag_invoke(compare_three_way, l, r)
- */
+// Inherit to define ADL-visible ordering operators based on an ADL-visible
+// implementation of tag_invoke(compare_three_way, l, r).
 struct ordering_operators {
     template <typename L, typename R>
     constexpr static auto impl(const L& l, const R& r, rank<1>)
@@ -183,7 +178,7 @@ struct ordering_operators {
 #define DEFOP(Oper)                                             \
     template <typename L, typename R>                           \
     constexpr friend auto operator Oper(const L& l, const R& r) \
-        BSONCXX_RETURNS(ordering_operators::impl(l, r, rank<1>{}) Oper 0)
+        BSONCXX_RETURNS(ordering_operators::impl(l, r, rank<1>{}) Oper nullptr)
     DEFOP(<);
     DEFOP(>);
     DEFOP(<=);
@@ -191,21 +186,19 @@ struct ordering_operators {
 #pragma pop_macro("DEFOP")
 };
 
-template <typename T, typename U>
+template <typename L, typename R>
 std::false_type is_partially_ordered_with_f(rank<0>);
 
-template <typename T, typename U>
-auto is_partially_ordered_with_f(rank<1>,
-                                 const T& l = soft_declval<T>(),
-                                 const U& r = soft_declval<U>())  //
-    -> true_t<decltype(l > r),
-              decltype(l < r),
-              decltype(l >= r),
-              decltype(l <= r),
-              decltype(r < l),
-              decltype(r > l),
-              decltype(r <= l),
-              decltype(r >= l)>;
+template <typename L, typename R>
+auto is_partially_ordered_with_f(rank<1>)
+    -> true_t<decltype(std::declval<const L&>() > std::declval<const R&>()),
+              decltype(std::declval<const L&>() < std::declval<const R&>()),
+              decltype(std::declval<const L&>() >= std::declval<const R&>()),
+              decltype(std::declval<const L&>() <= std::declval<const R&>()),
+              decltype(std::declval<const R&>() < std::declval<const L&>()),
+              decltype(std::declval<const R&>() > std::declval<const L&>()),
+              decltype(std::declval<const R&>() <= std::declval<const L&>()),
+              decltype(std::declval<const R&>() >= std::declval<const L&>())>;
 
 template <typename T, typename U>
 struct is_partially_ordered_with : decltype(is_partially_ordered_with_f<T, U>(rank<1>{})) {};

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/operators.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/operators.hpp
@@ -217,3 +217,10 @@ struct is_totally_ordered_with : conjunction<is_totally_ordered<T>,
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides comparison-related utilities for internal use.
+///
+/// @warning For internal use only!
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/optional.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/optional.hpp
@@ -844,3 +844,37 @@ using ::bsoncxx::v_noabi::stdx::optional;
 
 }  // namespace stdx
 }  // namespace bsoncxx
+
+///
+/// @file
+/// Provides `std::optional`-related polyfills for library API usage.
+///
+/// @note The API and ABI compatibility of this polyfill is determined by polyfill build
+/// configuration variables and the `BSONCXX_POLY_USE_*` macros provided by @ref
+/// bsoncxx-v_noabi-bsoncxx-config-config-hpp.
+///
+/// @see [Choosing a C++17
+/// Polyfill](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/polyfill-selection/)
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace v_noabi {
+namespace stdx {
+
+///
+/// A polyfill for `std::optional<T>`.
+///
+/// @note The API and ABI compatibility of this polyfill is determined by polyfill build
+/// configuration variables and the `BSONCXX_POLY_USE_*` macros provided by @ref
+/// bsoncxx-v_noabi-bsoncxx-config-config-hpp.
+///
+template <typename T>
+class optional {};
+
+}  // namespace stdx
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/optional.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/optional.hpp
@@ -86,6 +86,7 @@ using ::std::optional;
 #include <exception>
 #include <initializer_list>
 #include <memory>
+#include <new>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
@@ -99,48 +100,47 @@ namespace v_noabi {
 
 namespace stdx {
 
-/**
- * @brief Implementation of an std::optional-like class template
- *
- * Presents mostly the same interface as std::optional from C++17.
- *
- * @tparam T The type being made "optional"
- */
 template <typename T>
 class optional;
 
-/**
- * @brief Exception type thrown upon attempted access to a value-less optional<T>
- * via a throwing accessor API.
- */
+BSONCXX_PUSH_WARNINGS();
+BSONCXX_DISABLE_WARNING(Clang("-Wweak-vtables"));
+// Exception type thrown upon attempted access to a value-less optional<T> via a throwing accessor
+// API.
 class bad_optional_access : public std::exception {
    public:
     const char* what() const noexcept override {
         return "bad_optional_access()";
     }
 };
-/// Tag type to represent an empty optional value
+BSONCXX_POP_WARNINGS();
+
+// Tag type to represent an empty optional value.
 struct nullopt_t {
     explicit constexpr nullopt_t(std::nullptr_t) noexcept {}
 };
-/// Tag constant to construct or compare with an empty optional value
+
+// Tag constant to construct or compare with an empty optional value.
 static constexpr nullopt_t nullopt{nullptr};
-/// Tag used to call the emplacement-constructor of optional<T>
+
+// Tag used to call the emplacement-constructor of optional<T>.
 static constexpr struct in_place_t {
 } in_place;
 
 namespace detail {
 
-// Terminates the program when an illegal use of optional<T> is attempted
+// Terminates the program when an illegal use of optional<T> is attempted.
 [[noreturn]] inline void terminate_disengaged_optional(const char* what) noexcept {
     (void)std::fprintf(stderr, "%s: Invalid attempted use of disengaged optional<T>\n", what);
     std::terminate();
 }
-// Throws bad_optional_access for throwing optional<T> member functions
+
+// Throws bad_optional_access for throwing optional<T> member functions.
 [[noreturn]] inline void throw_bad_optional() {
     throw bad_optional_access();
 }
-// Base class of std::optional. Implementation detail, defined later
+
+// Base class of std::optional. Implementation detail, defined later.
 template <typename T>
 struct optional_base_class;
 
@@ -152,7 +152,7 @@ std::true_type not_an_optional_f(const T&);
 template <typename T>
 std::false_type not_an_optional_f(const optional<T>&);
 
-// Utility trait to detect specializations of stdx::optional
+// Utility trait to detect specializations of stdx::optional.
 template <typename T>
 struct not_an_optional : decltype(not_an_optional_f(std::declval<T const&>())) {};
 
@@ -189,36 +189,34 @@ class optional : bsoncxx::detail::equality_operators,
                  bsoncxx::detail::ordering_operators,
                  public detail::optional_base_class<T>::type {
    public:
-    /// The type of value held within this optional
     using value_type = T;
-    /// An lvalue-reference-to-mutable T
     using reference = bsoncxx::detail::add_lvalue_reference_t<T>;
-    /// An lvalue-reference-to-const T
     using const_reference =
         bsoncxx::detail::add_lvalue_reference_t<bsoncxx::detail::add_const_t<T>>;
-    /// An rvalue-reference-to-mutable T
     using rvalue_reference = bsoncxx::detail::add_rvalue_reference_t<T>;
-    /// An rvalue-reference-to-const T
     using const_rvalue_reference =
         bsoncxx::detail::add_rvalue_reference_t<bsoncxx::detail::add_const_t<T>>;
-    /// A pointer-to-mutable T
     using pointer = bsoncxx::detail::add_pointer_t<T>;
-    /// A pointer-to-const T
     using const_pointer = bsoncxx::detail::add_pointer_t<const T>;
 
-    // Constructors [1]
+    // Constructors [1].
+
     optional() = default;
     constexpr optional(nullopt_t) noexcept {}
 
-    // Ctor [2] and [3] are provided by base classes
+    // Ctor [2] and [3] are provided by base classes.
+
     optional(const optional&) = default;
     optional(optional&&) = default;
+
     // Same with assignments
+
     optional& operator=(const optional&) = default;
     optional& operator=(optional&&) = default;
     ~optional() = default;
 
     // In-place constructors
+
     template <typename... Args>
     bsoncxx_cxx14_constexpr explicit optional(in_place_t, Args&&... args) noexcept(
         noexcept(T(BSONCXX_FWD(args)...))) {
@@ -306,7 +304,8 @@ class optional : bsoncxx::detail::equality_operators,
         return this->has_value();
     }
 
-    // Unchecked dereference operators
+    // Unchecked dereference operators.
+
     bsoncxx_cxx14_constexpr reference operator*() & noexcept {
         _assert_has_value("operator*() &");
         return this->_storage.value;
@@ -324,7 +323,8 @@ class optional : bsoncxx::detail::equality_operators,
         return static_cast<const_rvalue_reference>(**this);
     }
 
-    // (Unchecked) member-access operators
+    // (Unchecked) member-access operators.
+
     bsoncxx_cxx14_constexpr pointer operator->() noexcept {
         _assert_has_value("operator->()");
         return std::addressof(**this);
@@ -334,7 +334,8 @@ class optional : bsoncxx::detail::equality_operators,
         return std::addressof(**this);
     }
 
-    // Checked accessors
+    // Checked accessors.
+
     bsoncxx_cxx14_constexpr reference value() & {
         _throw_if_empty();
         return **this;
@@ -352,7 +353,8 @@ class optional : bsoncxx::detail::equality_operators,
         return static_cast<const_rvalue_reference>(**this);
     }
 
-    // Checked value-or-alternative
+    // Checked value-or-alternative.
+
     template <typename U>
     bsoncxx_cxx14_constexpr value_type value_or(U&& dflt) const& {
         if (has_value()) {
@@ -385,35 +387,27 @@ class optional : bsoncxx::detail::equality_operators,
     }
 };
 
-/**
- * @brief Construct an optional by decay-copying the given value into a new
- * optional<decay_t<T>>
- *
- * @param value The value being made into an optional
- */
+// Construct an optional by decay-copying the given value into a new optional<decay_t<T>>.
+//
+// @param value The value being made into an optional.
 template <typename T>
 bsoncxx_cxx14_constexpr optional<bsoncxx::detail::decay_t<T>> make_optional(T&& value) noexcept(
     std::is_nothrow_constructible<bsoncxx::detail::decay_t<T>, T&&>::value) {
     return optional<bsoncxx::detail::decay_t<T>>(BSONCXX_FWD(value));
 }
 
-/**
- * @brief Emplace-construct a new optional of the given type with the given
- * constructor arguments
- *
- * @tparam T The type to be constructed
- * @param args Constructor arguments
- */
+// Emplace-construct a new optional of the given type with the given constructor arguments.
+//
+// @tparam T The type to be constructed
+// @param args Constructor arguments
 template <typename T, typename... Args>
 bsoncxx_cxx14_constexpr optional<T> make_optional(Args&&... args) noexcept(
     std::is_nothrow_constructible<T, Args&&...>::value) {
     return optional<T>(in_place, BSONCXX_FWD(args)...);
 }
 
-/**
- * @brief Emplace-construct a new optional of the given type with the given
- * arguments (accepts an init-list as the first argument)
- */
+// Emplace-construct a new optional of the given type with the given arguments (accepts an init-list
+// as the first argument).
 template <typename T, typename U, typename... Args>
 bsoncxx_cxx14_constexpr optional<T>
 make_optional(std::initializer_list<U> il, Args&&... args) noexcept(
@@ -423,9 +417,7 @@ make_optional(std::initializer_list<U> il, Args&&... args) noexcept(
 
 namespace detail {
 
-/**
- * @brief Union template that defines the storage for an optional's data.
- */
+// Union template that defines the storage for an optional's data.
 template <typename T, bool = std::is_trivially_destructible<T>::value>
 union storage_for {
     // Placeholder member for disengaged optional
@@ -452,14 +444,14 @@ union storage_for<T, true /* Is trivially destructible */> {
     storage_for& operator=(const storage_for&) = delete;
 };
 
-// Whether a type is copyable, moveable, or immobile
+// Whether a type is copyable, moveable, or immobile.
 enum copymove_classification {
     copyable,
     movable,
     immobile,
 };
 
-/// Classify the constructibility of the given type
+// Classify the constructibility of the given type.
 template <typename T,
           bool CanCopy = std::is_copy_constructible<T>::value,
           bool CanMove = std::is_move_constructible<T>::value>
@@ -467,7 +459,7 @@ constexpr copymove_classification classify_construct() {
     return CanCopy ? copyable : CanMove ? movable : immobile;
 }
 
-/// Classify the assignability of the given type
+// Classify the assignability of the given type.
 template <typename T,
           bool CanCopy = std::is_copy_assignable<T>::value,
           bool CanMove = std::is_move_assignable<T>::value>
@@ -475,15 +467,17 @@ constexpr copymove_classification classify_assignment() {
     return CanCopy ? copyable : CanMove ? movable : immobile;
 }
 
-/// Common base class for optional storage implementation
+// Common base class for optional storage implementation
+//
+// @tparam T
 template <typename T>
 class optional_common_base;
 
-/// Define the special member constructors for optional<T>
+// Define the special member constructors for optional<T>.
 template <typename T, copymove_classification = classify_construct<T>()>
 struct optional_construct_base;
 
-/// Define the special member assignment operators for optional<T>
+// Define the special member assignment operators for optional<T>.
 template <typename T, copymove_classification = classify_assignment<T>()>
 struct optional_assign_base;
 
@@ -499,15 +493,19 @@ struct optional_assign_base<T, copyable> : optional_construct_base<T> {};
 
 template <typename T>
 struct optional_assign_base<T, movable> : optional_construct_base<T> {
-    // Constructors defer to base
+    // Constructors defer to base.
+
     optional_assign_base() = default;
     optional_assign_base(optional_assign_base const&) = default;
     optional_assign_base(optional_assign_base&&) = default;
     ~optional_assign_base() = default;
 
-    // No copy
+    // Disallow copies.
+
     bsoncxx_cxx14_constexpr optional_assign_base& operator=(const optional_assign_base&) = delete;
-    // Allow move-assign:
+
+    // Allow move-assignment.
+
     bsoncxx_cxx14_constexpr optional_assign_base& operator=(optional_assign_base&& other) = default;
 };
 
@@ -548,12 +546,14 @@ template <>
 struct optional_destruct_helper<false /* Non-trivial */> {
     template <typename T>
     struct base : optional_common_base<T> {
-        // Special members defer to base
+        // Special members defer to base.
+
         base() = default;
         base(base const&) = default;
         base(base&&) = default;
         base& operator=(const base&) = default;
         base& operator=(base&&) = default;
+
         ~base() {
             // Here we destroy the contained object during destruction.
             this->reset();
@@ -563,12 +563,13 @@ struct optional_destruct_helper<false /* Non-trivial */> {
 
 template <>
 struct optional_destruct_helper<true /* Trivial */> {
-    // Just fall-through to the common base, which has no special destructor
+    // Just fall-through to the common base, which has no special destructor.
+
     template <typename T>
     using base = optional_common_base<T>;
 };
 
-// Optional's ADL-only operators live here:
+// Optional's ADL-only operators are defined here.
 struct optional_operators_base {
     template <typename T, typename U>
     friend bsoncxx_cxx14_constexpr auto tag_invoke(bsoncxx::detail::equal_to,
@@ -578,7 +579,11 @@ struct optional_operators_base {
         if (left.has_value() != right.has_value()) {
             return false;
         }
+
+        BSONCXX_PUSH_WARNINGS();
+        BSONCXX_DISABLE_WARNING(GNU("-Wfloat-equal"));
         return !left.has_value() || *left == *right;
+        BSONCXX_POP_WARNINGS();
     }
 
     template <typename T, typename U>
@@ -586,7 +591,10 @@ struct optional_operators_base {
                                      optional<T> const& left,
                                      U const& right) noexcept -> bsoncxx::detail::
         requires_t<bool, not_an_optional<U>, bsoncxx::detail::is_equality_comparable<T, U>> {
+        BSONCXX_PUSH_WARNINGS();
+        BSONCXX_DISABLE_WARNING(GNU("-Wfloat-equal"));
         return left.has_value() && *left == right;
+        BSONCXX_POP_WARNINGS();
     }
 
     template <typename T>
@@ -606,15 +614,15 @@ struct optional_operators_base {
             if (right.has_value()) {
                 return compare(*left, *right);
             } else {
-                // non-null is greater than any null
+                // Non-null is greater than any null.
                 return bsoncxx::detail::strong_ordering::greater;
             }
         } else {
             if (right.has_value()) {
-                // Null is less than any non-null
+                // Null is less than any non-null.
                 return bsoncxx::detail::strong_ordering::less;
             } else {
-                // Both are null
+                // Both are null.
                 return bsoncxx::detail::strong_ordering::equal;
             }
         }
@@ -630,7 +638,7 @@ struct optional_operators_base {
         if (left.has_value()) {
             return compare(*left, right);
         }
-        // null optional is less-than any non-null value
+        // Null optional is less-than any non-null value.
         return bsoncxx::detail::strong_ordering::less;
     }
 
@@ -654,7 +662,7 @@ struct optional_swap_mixin<T, true> {
     }
 };
 
-// Common base class of all optionals
+// Common base class of all optionals.
 template <typename T>
 class optional_common_base : optional_operators_base, optional_swap_mixin<T> {
     using storage_type = detail::storage_for<bsoncxx::detail::remove_const_t<T>>;
@@ -689,10 +697,7 @@ class optional_common_base : optional_operators_base, optional_swap_mixin<T> {
         return *this;
     }
 
-    /**
-     * @internal
-     * @brief If the optional is holding a value, destroy that value and set ourselves null
-     */
+    // If the optional is holding a value, destroy that value and set ourselves null.
     void reset() noexcept {
         if (this->_has_value) {
             this->_storage.value.~T();
@@ -700,11 +705,8 @@ class optional_common_base : optional_operators_base, optional_swap_mixin<T> {
         this->_has_value = false;
     }
 
-    /**
-     * @internal
-     * @brief If the optional is holding a value, destroy that value. Construct
-     * a new value in-place using the given arguments.
-     */
+    // If the optional is holding a value, destroy that value. Construct a new value in-place using
+    // the given arguments.
     template <typename... Args>
     T& emplace(Args&&... args) {
         this->reset();
@@ -712,11 +714,8 @@ class optional_common_base : optional_operators_base, optional_swap_mixin<T> {
         return this->_storage.value;
     }
 
-    /**
-     * @internal
-     * @brief If the optional is holding a value, destroy that value. Construct
-     * a new value in-place using the given arguments.
-     */
+    // If the optional is holding a value, destroy that value. Construct a new value in-place using
+    // the given arguments.
     template <typename U, typename... Args>
     T& emplace(std::initializer_list<U> il, Args&&... args) {
         this->reset();
@@ -724,20 +723,17 @@ class optional_common_base : optional_operators_base, optional_swap_mixin<T> {
         return this->_storage.value;
     }
 
-    /**
-     * @internal
-     * @brief Special swap for optional values that removes need for a temporary
-     */
+    // Special swap for optional values that removes need for a temporary.
     bsoncxx_cxx14_constexpr void swap(optional_common_base& other) noexcept(
         std::is_nothrow_move_constructible<T>::value&&
             bsoncxx::detail::is_nothrow_swappable<T>::value) {
         if (other._has_value) {
             if (this->_has_value) {
                 using std::swap;
-                // Defer to the underlying swap
+                // Defer to the underlying swap.
                 swap(this->_storage.value, other._storage.value);
             } else {
-                // "steal" the other's value
+                // "steal" the other's value.
                 this->emplace(std::move(other._storage.value));
                 other.reset();
             }
@@ -745,7 +741,7 @@ class optional_common_base : optional_operators_base, optional_swap_mixin<T> {
             other.emplace(std::move(this->_storage.value));
             this->reset();
         } else {
-            // Neither optional has a value, so do nothing
+            // Neither optional has a value, so do nothing.
         }
     }
 
@@ -754,11 +750,8 @@ class optional_common_base : optional_operators_base, optional_swap_mixin<T> {
     storage_type _storage;
     bool _has_value = false;
 
-    /**
-     * @internal
-     * @brief In-place construct a new value from the given arguments. Assumes
-     * that the optional does not have a live value.
-     */
+    // In-place construct a new value from the given arguments. Assumes that the optional does not
+    // have a live value.
     template <typename... Args>
     void _emplace_construct_anew(Args&&... args) noexcept(
         std::is_nothrow_constructible<T, Args&&...>::value) {
@@ -766,14 +759,11 @@ class optional_common_base : optional_operators_base, optional_swap_mixin<T> {
         this->_has_value = true;
     }
 
-    /**
-     * @internal
-     * @brief Perform the semantics of the assignment operator.
-     */
+    // Perform the semantics of the assignment operator.
     template <typename U>
     void _assign(U&& other_storage) {
         if (other_storage._has_value) {
-            // We are receiving a value
+            // We are receiving a value.
             if (this->_has_value) {
                 // We already have a value. Invoke the underlying assignment.
                 this->_storage.value = BSONCXX_FWD(other_storage)._storage.value;
@@ -782,7 +772,7 @@ class optional_common_base : optional_operators_base, optional_swap_mixin<T> {
                 this->_emplace_construct_anew(BSONCXX_FWD(other_storage)._storage.value);
             }
         } else {
-            // We are receiving nullopt. Destroy our value, if present:
+            // We are receiving nullopt. Destroy our value, if present.
             this->reset();
         }
     }
@@ -799,7 +789,7 @@ template <typename T,
 struct optional_hash;
 
 // Hash is "disabled" if the underlying type is not hashable (disabled = cannot construct the hash
-// invocable)
+// invocable).
 template <typename T>
 struct optional_hash<T, false> {
     optional_hash() = delete;

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/string_view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/string_view.hpp
@@ -115,30 +115,22 @@ namespace bsoncxx {
 namespace v_noabi {
 namespace stdx {
 
-/**
- * @brief Implementation of std::string_view-like class template
- */
 template <typename Char, typename Traits = std::char_traits<Char>>
 class basic_string_view : bsoncxx::detail::equality_operators, bsoncxx::detail::ordering_operators {
    public:
-    // Pointer to (non-const) character type
     using pointer = Char*;
-    // Pointer to const-character type
     using const_pointer = const Char*;
-    // Type representing the size of a string
     using size_type = std::size_t;
-    // Type representing the offset within a string
     using difference_type = std::ptrdiff_t;
-    // The type of the string character
     using value_type = Char;
 
-    // Constant sentinel value to represent an impossible/invalid string position
+    // Constant sentinel value to represent an impossible/invalid string position.
     static constexpr size_type npos = static_cast<size_type>(-1);
 
    private:
-    // Pointer to the beginning of the string being viewed
+    // Pointer to the beginning of the string being viewed.
     const_pointer _begin = nullptr;
-    // The size of the array that is being viewed via `_begin`
+    // The size of the array that is being viewed via `_begin`.
     size_type _size = 0;
 
    public:
@@ -150,33 +142,15 @@ class basic_string_view : bsoncxx::detail::equality_operators, bsoncxx::detail::
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
     using reverse_iterator = const_reverse_iterator;
 
-    /**
-     * @brief Default constructor. Constructs to an empty/null string view
-     */
     constexpr basic_string_view() noexcept = default;
     constexpr basic_string_view(const basic_string_view&) noexcept = default;
     bsoncxx_cxx14_constexpr basic_string_view& operator=(const basic_string_view&) noexcept =
         default;
 
-    /**
-     * @brief Construct a new string view from a pointer-to-character and an
-     * array length.
-     */
     constexpr basic_string_view(const_pointer s, size_type count) : _begin(s), _size(count) {}
 
-    /**
-     * @brief Construct a new string view from a C-style null-terminated character array.
-     *
-     * The string size is inferred as-if by strlen()
-     */
     constexpr basic_string_view(const_pointer s) : _begin(s), _size(traits_type::length(s)) {}
 
-    /**
-     * @brief Implicit conversion from string-like ranges.
-     *
-     * Requires that `StringLike` is a non-array contiguous range with the same
-     * value type as this string view, and is a std::string-like value.
-     */
     template <typename Alloc>
     constexpr basic_string_view(
         const std::basic_string<value_type, traits_type, Alloc>& str) noexcept
@@ -187,7 +161,6 @@ class basic_string_view : bsoncxx::detail::equality_operators, bsoncxx::detail::
         : _begin(sv.data()), _size(sv.size()) {}
 #endif
 
-    // Construction from a null pointer is deleted
     basic_string_view(std::nullptr_t) = delete;
 
     constexpr const_iterator begin() const noexcept {
@@ -219,96 +192,59 @@ class basic_string_view : bsoncxx::detail::equality_operators, bsoncxx::detail::
         return const_reverse_iterator{crbegin()};
     }
 
-    /**
-     * @brief Access the Nth element of the referred-to string
-     *
-     * @param offset A zero-based offset within the string to access. Must be less
-     * than size()
-     */
     constexpr const_reference operator[](size_type offset) const {
         return _begin[offset];
     }
 
-    /**
-     * @brief Access the Nth element of the referred-to string.
-     *
-     * @param pos A zero-based offset within the string to access. If not less
-     * than size(), throws std::out_of_range
-     */
     bsoncxx_cxx14_constexpr const_reference at(size_type pos) const {
         if (pos >= size()) {
             throw std::out_of_range{"bsoncxx::stdx::basic_string_view::at()"};
         }
         return _begin[pos];
     }
-    /// Access the first character in the string
+
     constexpr const_reference front() const {
         return (*this)[0];
     }
-    /// Access the last character in the string
+
     constexpr const_reference back() const {
         return (*this)[size() - 1];
     }
 
-    /// Obtain a pointer to the beginning of the referred-to character array
     constexpr const_pointer data() const noexcept {
         return _begin;
     }
-    /// Obtain the length of the referred-to string, in number of characters
+
     constexpr size_type size() const noexcept {
         return _size;
     }
-    /// Obtain the length of the referred-to string, in number of characters
+
     constexpr size_type length() const noexcept {
         return size();
     }
-    /// Return `true` if size() == 0, otherwise `false`
+
     constexpr bool empty() const noexcept {
         return size() == 0;
     }
-    /// Return the maximum value that could be returned by size()
+
     constexpr size_type max_size() const noexcept {
         return static_cast<size_type>(std::numeric_limits<difference_type>::max());
     }
 
-    /**
-     * @brief In-place modify the string_view to view N fewer characters from the beginning
-     *
-     * @param n The number of characters to remove from the beginning. Must be less than size()
-     */
     bsoncxx_cxx14_constexpr void remove_prefix(size_type n) {
         _begin += n;
         _size -= n;
     }
 
-    /**
-     * @brief In-place modify the string_view to view N fewer characters from the end
-     *
-     * @param n The number of characters to remove from the end. Must be less than size()
-     */
     bsoncxx_cxx14_constexpr void remove_suffix(size_type n) {
         _size -= n;
     }
 
-    /**
-     * @brief Swap the reference with another string_view
-     */
     bsoncxx_cxx14_constexpr void swap(basic_string_view& other) {
         std::swap(_begin, other._begin);
         std::swap(_size, other._size);
     }
 
-    /**
-     * @brief Copy the contents of the viewed string into the given output destination.
-     *
-     * @param dest The destination at which to write characters
-     * @param count The maximum number of characters to copy.
-     * @param pos The offset within the viewed string to begin copying from.
-     * @returns The number of characters that were copied to `dest`. The number
-     * of copied characters is always the lesser of `size()-pos` and `count`
-     *
-     * @throws std::out_of_range if pos > size()
-     */
     size_type copy(pointer dest, size_type count, size_type pos = 0) const {
         if (pos > size()) {
             throw std::out_of_range{"bsoncxx::stdx::basic_string_view::substr()"};
@@ -318,15 +254,6 @@ class basic_string_view : bsoncxx::detail::equality_operators, bsoncxx::detail::
         return count;
     }
 
-    /**
-     * @brief Obtain a substring of this string
-     *
-     * @param pos The zero-based index at which to start the new string.
-     * @param count The number of characters to include following `pos` in the new string.
-     * Automatically clamped to the available size
-     *
-     * @throws std::out_of_range if `pos` is greater than this->size()
-     */
     bsoncxx_cxx14_constexpr basic_string_view substr(size_type pos = 0,
                                                      size_type count = npos) const {
         if (pos > size()) {
@@ -335,52 +262,24 @@ class basic_string_view : bsoncxx::detail::equality_operators, bsoncxx::detail::
         return basic_string_view(_begin + pos, (std::min)(count, size() - pos));
     }
 
-    /**
-     * @brief Compare two strings lexicographically
-     *
-     * @param other The "right hand" operand of the comparison
-     * @returns `0` If *this == other
-     * @returns `n : n < 0` if *this is "less than" other.
-     * @returns `n : n > 0` if *this is "greater than" other.
-     */
     constexpr int compare(basic_string_view other) const noexcept {
-        // Another level of indirection to support restricted C++11 constexpr
+        // Another level of indirection to support restricted C++11 constexpr.
         return _compare2(Traits::compare(data(), other.data(), (std::min)(size(), other.size())),
                          other);
     }
 
-    /**
-     * @brief Compare *this with the given C-string
-     *
-     * @returns compare(basic_string_view(cstr))
-     */
     constexpr int compare(const_pointer cstr) const {
         return compare(basic_string_view(cstr));
     }
 
-    /**
-     * @brief Compare a substring of *this with `other`
-     *
-     * @returns substr(po1, count1).compare(other)
-     */
     constexpr int compare(size_type pos1, size_type count1, basic_string_view other) const {
         return substr(pos1, count1).compare(other);
     }
 
-    /**
-     * @brief Compare a substring of *this with the given C-string
-     *
-     * @returns substr(pos1, count1, basic_string_view(cstr))
-     */
     constexpr int compare(size_type pos1, size_type count1, const_pointer cstr) const {
         return compare(pos1, count1, basic_string_view(cstr));
     }
 
-    /**
-     * @brief Compare a substring of *this with a substring of `other`
-     *
-     * @returns substr(pos1, count1).compare(other.substr(pos2, count2))
-     */
     constexpr int compare(size_type pos1,
                           size_type count1,
                           basic_string_view other,
@@ -389,11 +288,6 @@ class basic_string_view : bsoncxx::detail::equality_operators, bsoncxx::detail::
         return substr(pos1, count1).compare(other.substr(pos2, count2));
     }
 
-    /**
-     * @brief Compare a substring of *this with a string viewed through the given pointer+size
-     *
-     * @returns substr(pos1, count1).compare(basic_string_view(str, count2))
-     */
     constexpr int compare(size_type pos1,
                           size_type count1,
                           const_pointer str,
@@ -401,10 +295,6 @@ class basic_string_view : bsoncxx::detail::equality_operators, bsoncxx::detail::
         return substr(pos1, count1).compare(basic_string_view(str, count2));
     }
 
-    /**
-     * @brief Find the zero-based offset of the left-most occurrence of the given infix,
-     * starting with pos. If infix does not occur, returns npos.
-     */
     bsoncxx_cxx14_constexpr size_type find(basic_string_view infix, size_type pos = 0) const
         noexcept {
         if (pos > size()) {
@@ -412,7 +302,7 @@ class basic_string_view : bsoncxx::detail::equality_operators, bsoncxx::detail::
         }
         basic_string_view sub = this->substr(pos);
         if (infix.empty()) {
-            // The empty string is always "present" at the beginning of any string
+            // The empty string is always "present" at the beginning of any string.
             return pos;
         }
         const_iterator found = std::search(sub.begin(), sub.end(), infix.begin(), infix.end());
@@ -422,13 +312,9 @@ class basic_string_view : bsoncxx::detail::equality_operators, bsoncxx::detail::
         return static_cast<size_type>(found - begin());
     }
 
-    /**
-     * @brief Find the zero-based offset of the right-most occurrence of the given infix,
-     * starting with (and including) pos. If infix does not occur, returns npos.
-     */
     bsoncxx_cxx14_constexpr size_type rfind(basic_string_view infix, size_type pos = npos) const
         noexcept {
-        // Calc the endpos where searching should begin, which includes the infix size
+        // Calc the endpos where searching should begin, which includes the infix size.
         const size_type substr_size = pos != npos ? pos + infix.size() : pos;
         if (infix.empty()) {
             return (std::min)(pos, size());
@@ -441,34 +327,18 @@ class basic_string_view : bsoncxx::detail::equality_operators, bsoncxx::detail::
         return static_cast<size_type>(rend() - f) - infix.size();
     }
 
-    /**
-     * @brief Find the zero-based index of the left-most occurrence of any character of the given
-     * set, starting at pos
-     */
     constexpr size_type find_first_of(basic_string_view set, size_type pos = 0) const noexcept {
         return _find_if(pos, [&](value_type chr) { return set.find(chr) != npos; });
     }
 
-    /**
-     * @brief Find the zero-based index of the right-most occurrence of any character of the
-     * given set, starting at (and including) pos
-     */
     constexpr size_type find_last_of(basic_string_view set, size_type pos = npos) const noexcept {
         return _rfind_if(pos, [&](value_type chr) { return set.find(chr) != npos; });
     }
 
-    /**
-     * @brief Find the zero-based index of the left-most occurrence of any character that
-     * is NOT a member of the given set of characters
-     */
     constexpr size_type find_first_not_of(basic_string_view set, size_type pos = 0) const noexcept {
         return _find_if(pos, [&](value_type chr) { return set.find(chr) == npos; });
     }
 
-    /**
-     * @brief Find the zero-based index of the right-most occurrence of any character that
-     * is NOT a member of the given set of characters, starting at (and including) pos
-     */
     constexpr size_type find_last_not_of(basic_string_view set, size_type pos = npos) const
         noexcept {
         return _rfind_if(pos, [&](value_type chr) { return set.find(chr) == npos; });
@@ -487,6 +357,7 @@ class basic_string_view : bsoncxx::detail::equality_operators, bsoncxx::detail::
         return Name(basic_string_view(cstr), pos);                                        \
     }                                                                                     \
     BSONCXX_FORCE_SEMICOLON
+
     DECL_FINDERS(find, 0);
     DECL_FINDERS(rfind, npos);
     DECL_FINDERS(find_first_of, 0);
@@ -495,9 +366,7 @@ class basic_string_view : bsoncxx::detail::equality_operators, bsoncxx::detail::
     DECL_FINDERS(find_last_not_of, npos);
 #pragma pop_macro("DECL_FINDERS")
 
-    /**
-     * @brief Explicit-conversion to a std::basic_string
-     */
+    // Explicit-conversion to a std::basic_string.
     template <typename Allocator>
     explicit operator std::basic_string<Char, Traits, Allocator>() const {
         return std::basic_string<Char, Traits, Allocator>(data(), size());
@@ -510,20 +379,20 @@ class basic_string_view : bsoncxx::detail::equality_operators, bsoncxx::detail::
 #endif
 
    private:
-    // Additional level-of-indirection for constexpr compare()
+    // Additional level-of-indirection for constexpr compare().
     constexpr int _compare2(int diff, basic_string_view other) const noexcept {
         // "diff" is the diff according to Traits::cmp
         return diff ? diff : static_cast<int>(size() - other.size());
     }
 
-    // Implementation of equality comparison
+    // Implementation of equality comparison.
     constexpr friend bool tag_invoke(bsoncxx::detail::equal_to,
                                      basic_string_view left,
                                      basic_string_view right) noexcept {
         return left.size() == right.size() && left.compare(right) == 0;
     }
 
-    // Implementation of a three-way-comparison
+    // Implementation of a three-way-comparison.
     constexpr friend bsoncxx::detail::strong_ordering tag_invoke(
         bsoncxx::detail::compare_three_way cmp,
         basic_string_view left,
@@ -538,7 +407,7 @@ class basic_string_view : bsoncxx::detail::equality_operators, bsoncxx::detail::
     }
 
     // Find the first in-bounds index I in [pos, size()) where the given predicate
-    // returns true for substr(I). If no index exists, returns npos
+    // returns true for substr(I). If no index exists, returns npos.
     template <typename F>
     bsoncxx_cxx14_constexpr size_type _find_if(size_type pos, F pred) const noexcept {
         const auto sub = substr(pos);
@@ -566,7 +435,8 @@ class basic_string_view : bsoncxx::detail::equality_operators, bsoncxx::detail::
     }
 };
 
-// Required to define this here for C++≤14 compatibility. Can be removed in C++≥17
+// Required to define this here for compatibility with C++14 and older. Can be removed in C++17 or
+// newer.
 template <typename C, typename Tr>
 const std::size_t basic_string_view<C, Tr>::npos;
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/string_view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/string_view.hpp
@@ -474,3 +474,36 @@ using ::bsoncxx::v_noabi::stdx::string_view;
 
 }  // namespace stdx
 }  // namespace bsoncxx
+
+///
+/// @file
+/// Provides `std::string_view`-related polyfills for library API usage.
+///
+/// @note The API and ABI compatibility of this polyfill is determined by polyfill build
+/// configuration variables and the `BSONCXX_POLY_USE_*` macros provided by @ref
+/// bsoncxx-v_noabi-bsoncxx-config-config-hpp.
+///
+/// @see [Choosing a C++17
+/// Polyfill](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/polyfill-selection/)
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace v_noabi {
+namespace stdx {
+
+///
+/// A polyfill for `std::string_view`.
+///
+/// @note The API and ABI compatibility of this polyfill is determined by polyfill build
+/// configuration variables and the `BSONCXX_POLY_USE_*` macros provided by @ref
+/// bsoncxx-v_noabi-bsoncxx-config-config-hpp.
+///
+class string_view {};
+
+}  // namespace stdx
+}  // namespace v_noabi
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/type_traits.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/type_traits.hpp
@@ -471,3 +471,10 @@ struct is_nothrow_swappable : is_nothrow_swappable_with<T&, T&> {};
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides `<type_traits>`-related polyfills for internal use.
+///
+/// @warning For internal use only!
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/type_traits.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/type_traits.hpp
@@ -22,15 +22,11 @@
 namespace bsoncxx {
 namespace detail {
 
-#define bsoncxx_ttparam \
-    template <class...> \
-    class
-
-/// Obtain the nested ::type of the given type argument
+// Obtain the nested ::type of the given type argument
 template <typename T>
 using type_t = typename T::type;
 
-/// Obtain the value_type member type of the given argument
+// Obtain the value_type member type of the given argument
 template <typename T>
 using value_type_t = typename T::value_type;
 
@@ -38,6 +34,7 @@ template <bool B, typename T = void>
 using enable_if_t = typename std::enable_if<B, T>::type;
 
 #pragma push_macro("DECL_ALIAS")
+#undef DECL_ALIAS
 #define DECL_ALIAS(Name)  \
     template <typename T> \
     using Name##_t = type_t<std::Name<T>>
@@ -59,63 +56,51 @@ DECL_ALIAS(add_rvalue_reference);
 template <typename... Ts>
 using common_type_t = type_t<std::common_type<Ts...>>;
 
-/**
- * @brief Remove top-level const+volatile+reference qualifiers from the given type.
- */
+// Remove top-level const+volatile+reference qualifiers from the given type.
 template <typename T>
 using remove_cvref_t = remove_cv_t<remove_reference_t<T>>;
 
-/**
- * @brief Create a reference-to-const for the given type
- */
+// Create a reference-to-const for the given type
 template <typename T>
 using const_reference_t = add_lvalue_reference_t<const remove_cvref_t<T>>;
 
-// Workaround for CWG issue 1558
+// Workaround for CWG issue 1558.
 template <typename...>
-struct _just_void_ {
+struct just_void {
     using type = void;
 };
-/**
- * @brief A "do-nothing" alias template that always evaluates to void
- *
- * @tparam Ts Zero or more type arguments, all discarded
- */
+
+// A "do-nothing" alias template that always evaluates to void.
+//
+// @tparam Ts Zero or more type arguments, all discarded
 template <typename... Ts>
 using void_t =
 #if defined(_MSC_VER) && _MSC_VER < 1910
     // Old MSVC requires that the type parameters actually be "used" to trigger SFINAE at caller.
-    // This was resolved by CWG issue 1558
-    typename _just_void_<Ts...>::type;
+    // This was resolved by CWG issue 1558.
+    typename just_void<Ts...>::type;
 #else
     void;
 #endif
 
-/**
- * @brief Alias for integral_constant<bool, B>
- */
+// Alias for integral_constant<bool, B>.
 template <bool B>
 using bool_constant = std::integral_constant<bool, B>;
 
-/**
- * @brief Holds a list of types.
- *
- * This template is never defined, so cannot be used in contexts that require a complete type.
- */
+// Holds a list of types.
+//
+// This template is never defined, so cannot be used in contexts that require a complete type.
 template <typename...>
 struct mp_list;
 
-// Like std::declval, but does not generate a hard error if used.
-template <typename T>
-extern add_rvalue_reference_t<T> soft_declval() noexcept;
-
-/// ## Implementation of the C++11 detection idiom
+// Details for implementing the C++11 detection idiom.
 namespace impl_detection {
 
 // Implementation of detection idiom for is_detected: true case
 template <
     // A metafunction to try and apply
-    bsoncxx_ttparam Oper,
+    template <class...>
+    class Oper,
     // The arguments to be given. These are deduced from the mp_list argument
     typename... Args,
     // Apply the arguments to the metafunction. If this yields a type, this function
@@ -126,7 +111,7 @@ std::true_type is_detected_f(mp_list<Args...>*);
 
 // Failure case for is_detected. Because this function takes an elipsis, this is
 // less preferred than the above overload that accepts a pointer type directly.
-template <bsoncxx_ttparam Oper>
+template <template <class...> class Oper>
 std::false_type is_detected_f(...);
 
 // Provides the detected_or impl
@@ -137,61 +122,53 @@ struct detection;
 template <>
 struct detection<false> {
     // We just return the default, since the metafunction will not apply
-    template <typename Default, bsoncxx_ttparam, typename...>
+    template <typename Default, template <class...> class, typename...>
     using f = Default;
 };
 
 // Detected case:
 template <>
 struct detection<true> {
-    template <typename, bsoncxx_ttparam Oper, typename... Args>
+    template <typename, template <class...> class Oper, typename... Args>
     using f = Oper<Args...>;
 };
 
-/// Workaround: MSVC 14.0 forgets whether a type resulting from the evaluation
-/// of a template-template parameter to an alias template is a reference.
-template <typename Dflt, typename Void, bsoncxx_ttparam Oper, typename... Args>
+// Workaround: MSVC 14.0 forgets whether a type resulting from the evaluation
+// of a template-template parameter to an alias template is a reference.
+template <typename Dflt, typename Void, template <class...> class Oper, typename... Args>
 struct vc140_detection {
     using type = Dflt;
 };
 
-template <typename Dflt, bsoncxx_ttparam Oper, typename... Args>
+template <typename Dflt, template <class...> class Oper, typename... Args>
 struct vc140_detection<Dflt, void_t<Oper<Args...>>, Oper, Args...> {
     using type = Oper<Args...>;
 };
 
 }  // namespace impl_detection
 
-/**
- * @brief The type yielded by detected_t if the given type operator does not
- * yield a type.
- */
+// The type yielded by detected_t if the given type operator does not yield a type.
 struct nonesuch {
     ~nonesuch() = delete;
     nonesuch(nonesuch const&) = delete;
     void operator=(nonesuch const&) = delete;
 };
 
-/**
- * @brief Results in true_type if the given metafunction yields a valid type when applied to the
- * given arguments, otherwise yields false_type
- *
- * @tparam Oper A template that evaluates to a type
- * @tparam Args Some number of arguments to apply to Oper
- */
-template <bsoncxx_ttparam Oper, typename... Args>
+// Results in true_type if the given metafunction yields a valid type when applied to the given
+// arguments, otherwise yields false_type.
+//
+// @tparam Oper A template that evaluates to a type
+// @tparam Args Some number of arguments to apply to Oper
+template <template <class...> class Oper, typename... Args>
 struct is_detected
     : decltype(impl_detection::is_detected_f<Oper>(static_cast<mp_list<Args...>*>(nullptr))) {};
 
-/**
- * @brief If Oper<Args...> evaluates to a type, yields that type. Otherwise, yields
- * the Dflt type
- *
- * @tparam Dflt The default type to return if the metafunction does not apply
- * @tparam Oper A metafunction to speculatively apply
- * @tparam Args The arguments to give to the Oper metafunction
- */
-template <typename Dflt, bsoncxx_ttparam Oper, typename... Args>
+// If Oper<Args...> evaluates to a type, yields that type. Otherwise, yields the Dflt type.
+//
+// @tparam Dflt The default type to return if the metafunction does not apply
+// @tparam Oper A metafunction to speculatively apply
+// @tparam Args The arguments to give to the Oper metafunction
+template <typename Dflt, template <class...> class Oper, typename... Args>
 using detected_or =
 #if defined(_MSC_VER) && _MSC_VER < 1910
     typename impl_detection::vc140_detection<Dflt, void, Oper, Args...>::type
@@ -201,23 +178,18 @@ using detected_or =
 #endif
     ;
 
-/**
- * @brief If Oper<Args...> evaluates to a type, yields that type. Otherwise, yields
- * the sentinel type `nonesuch`
- *
- * @tparam Oper A metafunction to try to apply
- * @tparam Args The metafunction arguments to apply to Oper
- */
-template <bsoncxx_ttparam Oper, typename... Args>
+// If Oper<Args...> evaluates to a type, yields that type. Otherwise, yields the sentinel type
+// `nonesuch`.
+//
+// @tparam Oper A metafunction to try to apply.
+// @tparam Args The metafunction arguments to apply to Oper.
+template <template <class...> class Oper, typename... Args>
 using detected_t = detected_or<nonesuch, Oper, Args...>;
 
-/**
- * @brief Impl of conditional_t
- *
- * Separating the boolean from the type arguments results in significant speedup to compilation
- * due to type memoization
- */
-
+// Impl of conditional_t.
+//
+// Separating the boolean from the type arguments results in significant speedup to compilation due
+// to type memoization.
 template <bool B>
 struct conditional {
     template <typename IfTrue, typename>
@@ -230,17 +202,15 @@ struct conditional<false> {
     using f = IfFalse;
 };
 
-/**
- * @brief Pick one of two types based on a boolean
- *
- * @tparam B A boolean value
- * @tparam T If `B` is true, pick this type
- * @tparam F If `B` is false, pick this type
- */
+// Pick one of two types based on a boolean.
+//
+// @tparam B A boolean value
+// @tparam T If `B` is true, pick this type
+// @tparam F If `B` is false, pick this type
 template <bool B, typename T, typename F>
 using conditional_t = typename conditional<B>::template f<T, F>;
 
-// impl for conjunction+disjunction
+// Impl for conjunction+disjunction
 namespace impl_logic {
 
 template <typename FalseType, typename Opers>
@@ -275,42 +245,35 @@ struct disj<std::true_type, mp_list<>> : std::false_type {};
 
 }  // namespace impl_logic
 
-/**
- * @brief inherits unambiguously from the first of `Ts...` for which
- * `Ts::value` is a valid expression equal to `false`, or the last of `Ts...` otherwise.
- *
- * conjunction<> (given no arguments) inherits from std::true_type.
- *
- * If any of `Ts::value == false`, then no subsequent `Ts::value` will be instantiated.
- */
+// Inherits unambiguously from the first of `Ts...` for which `Ts::value` is a valid expression
+// equal to `false`, or the last of `Ts...` otherwise.
+//
+// conjunction<> (given no arguments) inherits from std::true_type.
+//
+// If any of `Ts::value == false`, then no subsequent `Ts::value` will be instantiated.
+//
 template <typename... Cond>
 struct conjunction : impl_logic::conj<std::false_type, mp_list<Cond...>> {};
 
-/**
- * @brief Inherits unambiguous from the first of `Ts...` where `Ts::value` is `true`,
- * or the last of `Ts...` otherwise.
- *
- * Given no arguments, inherits from std::false_type;
- *
- * If any of `Ts::value == true`, then no subsequent `Ts::value` will be instantiated.
- */
+// Inherits unambiguous from the first of `Ts...` where `Ts::value` is `true`, or the last of
+// `Ts...` otherwise.
+//
+// Given no arguments, inherits from std::false_type.
+//
+// If any of `Ts::value == true`, then no subsequent `Ts::value` will be instantiated.
 template <typename... Cond>
 struct disjunction : impl_logic::disj<std::true_type, mp_list<Cond...>> {};
 
-/**
- * @brief Given a boolean type trait, returns a type trait which is the logical negation thereof
- *
- * @tparam T A type trait with a static member ::value
- */
+// A type trait that produces the negation of the given boolean type trait.
+//
+// @tparam T A type trait with a static member ::value.
 template <typename T>
 struct negation : bool_constant<!T::value> {};
 
-/**
- * @brief Yields std::true_type, regardless of type arguments.
- *
- * Useful for wrapping potential decltype() substitution failures in positions
- * that expect a bool_constant type.
- */
+// Yields std::true_type, regardless of type arguments.
+//
+// Useful for wrapping potential decltype() substitution failures in positions
+// that expect a bool_constant type.
 template <typename...>
 using true_t = std::true_type;
 
@@ -360,15 +323,12 @@ struct requirement<Constraint, enable_if_t<Constraint::value>> {
 
 }  // namespace impl_requires
 
-/**
- * @brief If none of `Ts::value is 'false'`, yields the type `Type`, otherwise
- * this type is undefined.
- *
- * Use this to perform enable-if style template constraints.
- *
- * @tparam Type The type to return upon success
- * @tparam Traits A list of type traits with nested ::value members
- */
+// If none of `Ts::value is 'false'`, yields the type `Type`, otherwise this type is undefined.
+//
+// Use this to perform enable-if style template constraints.
+//
+// @tparam Type The type to return upon success
+// @tparam Traits A list of type traits with nested ::value members
 template <typename Type, typename... Traits>
 #if defined _MSC_VER && _MSC_VER < 1920
 // VS 2015 has trouble with expression SFINAE.
@@ -379,15 +339,12 @@ using requires_t =
     decltype(impl_requires::requirement<conjunction<Traits...>>::test::template explain<Type>(0));
 #endif
 
-/**
- * @brief If any of `Ts::value` is 'true', this type is undefined, otherwise
- * yields the type `Type`.
- *
- * Use this to perform enable-if template contraints.
- *
- * @tparam Type The type to return upon success
- * @tparam Traits A list of type traits with nested ::value members
- */
+// If any of `Ts::value` is 'true', this type is undefined, otherwise yields the type `Type`.
+//
+// Use this to perform enable-if template contraints.
+//
+// @tparam Type The type to return upon success
+// @tparam Traits A list of type traits with nested ::value members
 template <typename Type, typename... Traits>
 using requires_not_t = requires_t<Type, negation<disjunction<Traits...>>>;
 
@@ -418,35 +375,30 @@ struct invoker<true, false> {
 }  // namespace impl_invoke
 
 static constexpr struct invoke_fn {
-    /**
-     * @brief Invoke the given object with the given arguments.
-     *
-     * @param fn An invocable: A callable, member object pointer, or member function pointer.
-     * @param args The arguments to use for invocation.
-     */
-
+    // Invoke the given object with the given arguments.
+    //
+    // @param fn An invocable: A callable, member object pointer, or member function pointer.
+    // @param args The arguments to use for invocation.
+    // @cond DOXYGEN_DISABLE "Found ';' while parsing initializer list!"
     template <typename F, typename... Args, typename Fd = remove_cvref_t<F>>
     constexpr auto operator()(F&& fn, Args&&... args) const
         BSONCXX_RETURNS(impl_invoke::invoker<std::is_member_object_pointer<Fd>::value,
                                              std::is_member_function_pointer<Fd>::value>  //
                         ::apply(static_cast<F&&>(fn), static_cast<Args&&>(args)...));
+    // @endcond
 } invoke;
 
-/**
- * @brief Yields the type that would result from invoking F with the given arguments.
- *
- * @tparam F An invocable function pointer, object, or pointer-to-member.
- * @tparam Args The arguments to apply
- */
+// Yields the type that would result from invoking F with the given arguments.
+//
+// @tparam F A invocable: A function pointer or callable object, or a member pointer
+// @tparam Args The arguments to apply
 template <typename F, typename... Args>
 using invoke_result_t = decltype(invoke(std::declval<F>(), std::declval<Args>()...));
 
-/**
- * @brief Trait type to detect if the given object can be "invoked" using the given arguments.
- *
- * @tparam F An invocable function pointer, object, or pointer-to-member.
- * @tparam Args The arguments to match against
- */
+// Trait type to detect if the given object can be "invoked" using the given arguments.
+//
+// @tparam F A invocable: A function pointer or callable object, or a member pointer
+// @tparam Args The arguments to match against
 template <typename F, typename... Args>
 #if defined(_MSC_VER) && _MSC_VER < 1910
 using is_invocable = is_detected<invoke_result_t, F, Args...>;
@@ -455,21 +407,21 @@ struct is_invocable : is_detected<invoke_result_t, F, Args...> {
 };
 #endif
 
-/**
- * @brief Trait detects whether the given types are the same after the removal
- * of top-level CV-ref qualifiers
- */
+// Trait detects whether the given types are the same after the removal of top-level CV-ref
+// qualifiers
 template <typename T, typename U>
 struct is_alike : std::is_same<remove_cvref_t<T>, remove_cvref_t<U>> {};
 
-/**
- * @brief Tag type for creating ranked overloads to force disambiguation.
- *
- * @tparam N The ranking of the overload. A higher value is ranked greater than
- * lower values.
- */
+// Tag type for creating ranked overloads to force disambiguation.
+//
+// @tparam N The ranking of the overload. A higher value is ranked greater than
+// lower values.
 template <std::size_t N>
-struct rank : rank<N - 1> {};
+struct rank :
+    // @cond DOXYGEN_DISABLE " Detected potential recursive class relation ..."
+    rank<N - 1>
+// @endcond
+{};
 
 template <>
 struct rank<0> {};
@@ -478,8 +430,8 @@ namespace swap_detection {
 
 using std::swap;
 
-///! Declare an unusable variadic swap. If not present, MSVC 19.00 (VS2015) errors in
-///! this header and complains "'std::swap': function does not take 1 arguments" (???)
+// Declare an unusable variadic swap. If not present, MSVC 19.00 (VS2015) errors in
+// this header and complains "'std::swap': function does not take 1 arguments" (???).
 void swap(...) = delete;
 
 template <typename T, typename U>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/to_string.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/to_string.hpp
@@ -25,11 +25,29 @@ namespace bsoncxx {
 namespace v_noabi {
 namespace string {
 
+///
+/// Convert a `bsoncxx::v_noabi::stdx::string_view` to a `std::string`.
+///
+/// This function may be used in place of explicit conversion to `std::string`, which may not be
+/// supported across all polyfill build configurations.
+///
+/// @par "Example" @parblock
+/// @code{.cpp}
+/// std::string example(bsoncxx::v_noabi::stdx::string_view sv) {
+///   // This may not be supported depending on the polyfill library.
+///   // return std::string(sv);
+///
+///   // This is supported regardless of the polyfill library.
+///   return bsoncxx::v_noabi::string::to_string(sv);
+/// }
+/// @endcode
+/// @endparblock
+///
 template <class CharT,
           class Traits = std::char_traits<CharT>,
           class Allocator = std::allocator<CharT>>
 BSONCXX_INLINE std::basic_string<CharT, Traits, Allocator> to_string(
-    stdx::basic_string_view<CharT, Traits> value, const Allocator& alloc = Allocator()) {
+    v_noabi::stdx::basic_string_view<CharT, Traits> value, const Allocator& alloc = Allocator()) {
     return std::basic_string<CharT, Traits, Allocator>{value.data(), value.length(), alloc};
 }
 
@@ -46,3 +64,23 @@ using ::bsoncxx::v_noabi::string::to_string;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::string::to_string.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace string {
+
+/// @ref bsoncxx::v_noabi::string::to_string
+template <class CharT, class Traits, class Allocator>
+std::basic_string<CharT, Traits, Allocator> to_string(
+    v_noabi::stdx::basic_string_view<CharT, Traits> value, const Allocator& alloc);
+
+}  // namespace string
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value-fwd.hpp
@@ -35,3 +35,21 @@ using ::bsoncxx::v_noabi::string::view_or_value;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::string::view_or_value.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace string {
+
+/// @ref bsoncxx::v_noabi::string::view_or_value
+class view_or_value {};
+
+}  // namespace string
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
@@ -30,6 +30,10 @@ namespace string {
 ///
 /// Class representing a view-or-value variant type for strings.
 ///
+/// @par "Derived From" @parblock
+/// @li @ref bsoncxx::v_noabi::view_or_value<stdx::string_view, std::string>
+/// @endparblock
+///
 /// This class adds several string-specific methods to the bsoncxx::v_noabi::view_or_value template:
 /// - a constructor overload for const char*
 /// - a constructor overload for std::string by l-value reference
@@ -134,3 +138,30 @@ using ::bsoncxx::v_noabi::string::operator!=;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::string::view_or_value.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace string {
+
+/// @ref bsoncxx::v_noabi::string::operator==(const v_noabi::string::view_or_value& lhs, const char* rhs)
+inline bool operator==(const v_noabi::string::view_or_value& lhs, const char* rhs);
+
+/// @ref bsoncxx::v_noabi::string::operator!=(const v_noabi::string::view_or_value& lhs, const char* rhs)
+inline bool operator!=(const v_noabi::string::view_or_value& lhs, const char* rhs);
+
+/// @ref bsoncxx::v_noabi::string::operator==(const char* lhs, const v_noabi::string::view_or_value& rhs)
+inline bool operator==(const char* lhs, const v_noabi::string::view_or_value& rhs);
+
+/// @ref bsoncxx::v_noabi::string::operator!=(const char* lhs, const v_noabi::string::view_or_value& rhs)
+inline bool operator!=(const char* lhs, const v_noabi::string::view_or_value& rhs);
+
+}  // namespace string
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types-fwd.hpp
@@ -63,3 +63,81 @@ namespace types {
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares entities used to represent BSON types.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace types {
+
+/// @ref bsoncxx::v_noabi::types::b_double
+struct b_double {};
+
+/// @ref bsoncxx::v_noabi::types::b_string
+struct b_string {};
+
+/// @ref bsoncxx::v_noabi::types::b_document
+struct b_document {};
+
+/// @ref bsoncxx::v_noabi::types::b_array
+struct b_array {};
+
+/// @ref bsoncxx::v_noabi::types::b_binary
+struct b_binary {};
+
+/// @ref bsoncxx::v_noabi::types::b_undefined
+struct b_undefined {};
+
+/// @ref bsoncxx::v_noabi::types::b_oid
+struct b_oid {};
+
+/// @ref bsoncxx::v_noabi::types::b_bool
+struct b_bool {};
+
+/// @ref bsoncxx::v_noabi::types::b_date
+struct b_date {};
+
+/// @ref bsoncxx::v_noabi::types::b_null
+struct b_null {};
+
+/// @ref bsoncxx::v_noabi::types::b_regex
+struct b_regex {};
+
+/// @ref bsoncxx::v_noabi::types::b_dbpointer
+struct b_dbpointer {};
+
+/// @ref bsoncxx::v_noabi::types::b_code
+struct b_code {};
+
+/// @ref bsoncxx::v_noabi::types::b_symbol
+struct b_symbol {};
+
+/// @ref bsoncxx::v_noabi::types::b_codewscope
+struct b_codewscope {};
+
+/// @ref bsoncxx::v_noabi::types::b_int32
+struct b_int32 {};
+
+/// @ref bsoncxx::v_noabi::types::b_timestamp
+struct b_timestamp {};
+
+/// @ref bsoncxx::v_noabi::types::b_int64
+struct b_int64 {};
+
+/// @ref bsoncxx::v_noabi::types::b_decimal128
+struct b_decimal128 {};
+
+/// @ref bsoncxx::v_noabi::types::b_maxkey
+struct b_maxkey {};
+
+/// @ref bsoncxx::v_noabi::types::b_minkey
+struct b_minkey {};
+
+}  // namespace types
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types.hpp
@@ -153,9 +153,9 @@ BSONCXX_INLINE bool operator==(const b_string& lhs, const b_string& rhs) {
 }
 
 ///
-/// This class has been renamed to b_string
+/// Equivalent to @ref b_string.
 ///
-/// @deprecated use b_string instead.
+/// @deprecated Use @ref b_string instead.
 ///
 BSONCXX_DEPRECATED typedef b_string b_utf8;
 
@@ -878,3 +878,156 @@ static_assert(false, "BSONCXX_ENUM must be undef'ed");
 #pragma pop_macro("BSONCXX_ENUM")
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides entities used to represent BSON types.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+
+/// @ref bsoncxx::v_noabi::to_string(v_noabi::type rhs)
+std::string to_string(v_noabi::type rhs);
+
+/// @ref bsoncxx::v_noabi::to_string(v_noabi::binary_sub_type rhs)
+std::string to_string(v_noabi::binary_sub_type rhs);
+
+namespace types {
+
+/// @ref bsoncxx::v_noabi::types::b_utf8
+/// @deprecated Use @ref bsoncxx::types::b_string instead.
+struct b_utf8 {};
+
+/// @ref bsoncxx::v_noabi::types::operator==(const v_noabi::types::b_double& lhs, const v_noabi::types::b_double& rhs)
+bool operator==(const v_noabi::types::b_double& lhs, const v_noabi::types::b_double& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator==(const v_noabi::types::b_string& lhs, const v_noabi::types::b_string& rhs)
+bool operator==(const v_noabi::types::b_string& lhs, const v_noabi::types::b_string& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator==(const v_noabi::types::b_document& lhs, const v_noabi::types::b_document& rhs)
+bool operator==(const v_noabi::types::b_document& lhs, const v_noabi::types::b_document& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator==(const v_noabi::types::b_array& lhs, const v_noabi::types::b_array& rhs)
+bool operator==(const v_noabi::types::b_array& lhs, const v_noabi::types::b_array& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator==(const v_noabi::types::b_binary& lhs, const v_noabi::types::b_binary& rhs)
+bool operator==(const v_noabi::types::b_binary& lhs, const v_noabi::types::b_binary& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator==(const v_noabi::types::b_undefined&, const v_noabi::types::b_undefined&)
+bool operator==(const v_noabi::types::b_undefined&, const v_noabi::types::b_undefined&);
+
+/// @ref bsoncxx::v_noabi::types::operator==(const v_noabi::types::b_oid& lhs, const v_noabi::types::b_oid& rhs)
+bool operator==(const v_noabi::types::b_oid& lhs, const v_noabi::types::b_oid& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator==(const v_noabi::types::b_bool& lhs, const v_noabi::types::b_bool& rhs)
+bool operator==(const v_noabi::types::b_bool& lhs, const v_noabi::types::b_bool& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator==(const v_noabi::types::b_date& lhs, const v_noabi::types::b_date& rhs)
+bool operator==(const v_noabi::types::b_date& lhs, const v_noabi::types::b_date& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator==(const v_noabi::types::b_null&, const v_noabi::types::b_null&)
+bool operator==(const v_noabi::types::b_null&, const v_noabi::types::b_null&);
+
+/// @ref bsoncxx::v_noabi::types::operator==(const v_noabi::types::b_regex& lhs, const v_noabi::types::b_regex& rhs)
+bool operator==(const v_noabi::types::b_regex& lhs, const v_noabi::types::b_regex& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator==(const v_noabi::types::b_dbpointer& lhs, const v_noabi::types::b_dbpointer& rhs)
+bool operator==(const v_noabi::types::b_dbpointer& lhs, const v_noabi::types::b_dbpointer& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator==(const v_noabi::types::b_code& lhs, const v_noabi::types::b_code& rhs)
+bool operator==(const v_noabi::types::b_code& lhs, const v_noabi::types::b_code& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator==(const v_noabi::types::b_symbol& lhs, const v_noabi::types::b_symbol& rhs)
+bool operator==(const v_noabi::types::b_symbol& lhs, const v_noabi::types::b_symbol& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator==(const v_noabi::types::b_codewscope& lhs, const v_noabi::types::b_codewscope& rhs)
+bool operator==(const v_noabi::types::b_codewscope& lhs, const v_noabi::types::b_codewscope& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator==(const v_noabi::types::b_int32& lhs, const v_noabi::types::b_int32& rhs)
+bool operator==(const v_noabi::types::b_int32& lhs, const v_noabi::types::b_int32& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator==(const v_noabi::types::b_timestamp& lhs, const v_noabi::types::b_timestamp& rhs)
+bool operator==(const v_noabi::types::b_timestamp& lhs, const v_noabi::types::b_timestamp& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator==(const v_noabi::types::b_int64& lhs, const v_noabi::types::b_int64& rhs)
+bool operator==(const v_noabi::types::b_int64& lhs, const v_noabi::types::b_int64& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator==(const v_noabi::types::b_decimal128& lhs, const v_noabi::types::b_decimal128& rhs)
+bool operator==(const v_noabi::types::b_decimal128& lhs, const v_noabi::types::b_decimal128& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator==(const v_noabi::types::b_minkey&, const v_noabi::types::b_minkey&)
+bool operator==(const v_noabi::types::b_minkey&, const v_noabi::types::b_minkey&);
+
+/// @ref bsoncxx::v_noabi::types::operator==(const v_noabi::types::b_maxkey&, const v_noabi::types::b_maxkey&)
+bool operator==(const v_noabi::types::b_maxkey&, const v_noabi::types::b_maxkey&);
+
+/// @ref bsoncxx::v_noabi::types::operator!=(const v_noabi::types::b_double& lhs, const v_noabi::types::b_double& rhs)
+bool operator!=(const v_noabi::types::b_double& lhs, const v_noabi::types::b_double& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator!=(const v_noabi::types::b_string& lhs, const v_noabi::types::b_string& rhs)
+bool operator!=(const v_noabi::types::b_string& lhs, const v_noabi::types::b_string& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator!=(const v_noabi::types::b_document& lhs, const v_noabi::types::b_document& rhs)
+bool operator!=(const v_noabi::types::b_document& lhs, const v_noabi::types::b_document& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator!=(const v_noabi::types::b_array& lhs, const v_noabi::types::b_array& rhs)
+bool operator!=(const v_noabi::types::b_array& lhs, const v_noabi::types::b_array& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator!=(const v_noabi::types::b_binary& lhs, const v_noabi::types::b_binary& rhs)
+bool operator!=(const v_noabi::types::b_binary& lhs, const v_noabi::types::b_binary& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator!=(const v_noabi::types::b_undefined& lhs, const v_noabi::types::b_undefined& rhs)
+bool operator!=(const v_noabi::types::b_undefined& lhs, const v_noabi::types::b_undefined& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator!=(const v_noabi::types::b_oid& lhs, const v_noabi::types::b_oid& rhs)
+bool operator!=(const v_noabi::types::b_oid& lhs, const v_noabi::types::b_oid& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator!=(const v_noabi::types::b_bool& lhs, const v_noabi::types::b_bool& rhs)
+bool operator!=(const v_noabi::types::b_bool& lhs, const v_noabi::types::b_bool& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator!=(const v_noabi::types::b_date& lhs, const v_noabi::types::b_date& rhs)
+bool operator!=(const v_noabi::types::b_date& lhs, const v_noabi::types::b_date& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator!=(const v_noabi::types::b_null& lhs, const v_noabi::types::b_null& rhs)
+bool operator!=(const v_noabi::types::b_null& lhs, const v_noabi::types::b_null& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator!=(const v_noabi::types::b_regex& lhs, const v_noabi::types::b_regex& rhs)
+bool operator!=(const v_noabi::types::b_regex& lhs, const v_noabi::types::b_regex& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator!=(const v_noabi::types::b_dbpointer& lhs, const v_noabi::types::b_dbpointer& rhs)
+bool operator!=(const v_noabi::types::b_dbpointer& lhs, const v_noabi::types::b_dbpointer& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator!=(const v_noabi::types::b_code& lhs, const v_noabi::types::b_code& rhs)
+bool operator!=(const v_noabi::types::b_code& lhs, const v_noabi::types::b_code& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator!=(const v_noabi::types::b_symbol& lhs, const v_noabi::types::b_symbol& rhs)
+bool operator!=(const v_noabi::types::b_symbol& lhs, const v_noabi::types::b_symbol& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator!=(const v_noabi::types::b_codewscope& lhs, const v_noabi::types::b_codewscope& rhs)
+bool operator!=(const v_noabi::types::b_codewscope& lhs, const v_noabi::types::b_codewscope& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator!=(const v_noabi::types::b_int32& lhs, const v_noabi::types::b_int32& rhs)
+bool operator!=(const v_noabi::types::b_int32& lhs, const v_noabi::types::b_int32& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator!=(const v_noabi::types::b_timestamp& lhs, const v_noabi::types::b_timestamp& rhs)
+bool operator!=(const v_noabi::types::b_timestamp& lhs, const v_noabi::types::b_timestamp& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator!=(const v_noabi::types::b_int64& lhs, const v_noabi::types::b_int64& rhs)
+bool operator!=(const v_noabi::types::b_int64& lhs, const v_noabi::types::b_int64& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator!=(const v_noabi::types::b_decimal128& lhs, const v_noabi::types::b_decimal128& rhs)
+bool operator!=(const v_noabi::types::b_decimal128& lhs, const v_noabi::types::b_decimal128& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator!=(const v_noabi::types::b_minkey& lhs, const v_noabi::types::b_minkey& rhs)
+bool operator!=(const v_noabi::types::b_minkey& lhs, const v_noabi::types::b_minkey& rhs);
+
+/// @ref bsoncxx::v_noabi::types::operator!=(const v_noabi::types::b_maxkey& lhs, const v_noabi::types::b_maxkey& rhs)
+bool operator!=(const v_noabi::types::b_maxkey& lhs, const v_noabi::types::b_maxkey& rhs);
+
+}  // namespace types
+
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/make_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/make_value.hpp
@@ -51,3 +51,24 @@ using ::bsoncxx::v_noabi::types::bson_value::make_value;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::types::bson_value::make_value.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace types {
+namespace bson_value {
+
+/// @ref bsoncxx::v_noabi::types::bson_value::make_value
+template <typename T>
+v_noabi::types::bson_value::value make_value(T&& t);
+
+}  // namespace bson_value
+}  // namespace types
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value-fwd.hpp
@@ -39,3 +39,23 @@ using ::bsoncxx::v_noabi::types::bson_value::value;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::types::bson_value::value.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace types {
+namespace bson_value {
+
+/// @ref bsoncxx::v_noabi::types::bson_value::value
+class value {};
+
+}  // namespace bson_value
+}  // namespace types
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
@@ -291,7 +291,7 @@ BSONCXX_INLINE bool operator!=(const value& lhs, const value& rhs) {
 ///
 
 ///
-/// Compares a value with a view for (in)-equality.
+/// Compares a value with a view for (in)equality.
 ///
 /// @{
 
@@ -335,3 +335,44 @@ using ::bsoncxx::v_noabi::types::bson_value::operator!=;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::types::bson_value::value.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace types {
+namespace bson_value {
+
+/// @ref bsoncxx::v_noabi::types::bson_value::operator==(const v_noabi::types::bson_value::value& lhs, const v_noabi::types::bson_value::value& rhs)
+inline bool operator==(const v_noabi::types::bson_value::value& lhs,
+                       const v_noabi::types::bson_value::value& rhs);
+
+/// @ref bsoncxx::v_noabi::types::bson_value::operator!=(const v_noabi::types::bson_value::value& lhs, const v_noabi::types::bson_value::value& rhs)
+inline bool operator!=(const v_noabi::types::bson_value::value& lhs,
+                       const v_noabi::types::bson_value::value& rhs);
+
+/// @ref bsoncxx::v_noabi::types::bson_value::operator==(const v_noabi::types::bson_value::value& lhs, const v_noabi::types::bson_value::view& rhs)
+inline bool operator==(const v_noabi::types::bson_value::value& lhs,
+                       const v_noabi::types::bson_value::view& rhs);
+
+/// @ref bsoncxx::v_noabi::types::bson_value::operator==(const v_noabi::types::bson_value::view& lhs, const v_noabi::types::bson_value::value& rhs)
+inline bool operator==(const v_noabi::types::bson_value::view& lhs,
+                       const v_noabi::types::bson_value::value& rhs);
+
+/// @ref bsoncxx::v_noabi::types::bson_value::operator!=(const v_noabi::types::bson_value::value& lhs, const v_noabi::types::bson_value::view& rhs)
+inline bool operator!=(const v_noabi::types::bson_value::value& lhs,
+                       const v_noabi::types::bson_value::view& rhs);
+
+/// @ref bsoncxx::v_noabi::types::bson_value::operator!=(const v_noabi::types::bson_value::view& lhs, const v_noabi::types::bson_value::value& rhs)
+inline bool operator!=(const v_noabi::types::bson_value::view& lhs,
+                       const v_noabi::types::bson_value::value& rhs);
+
+}  // namespace bson_value
+}  // namespace types
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view-fwd.hpp
@@ -39,3 +39,23 @@ using ::bsoncxx::v_noabi::types::bson_value::view;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::types::bson_value::view.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace types {
+namespace bson_value {
+
+/// @ref bsoncxx::v_noabi::types::bson_value::view
+class view {};
+
+}  // namespace bson_value
+}  // namespace types
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
@@ -312,29 +312,45 @@ using is_bson_view_compatible = detail::conjunction<
 template <typename T>
 using not_view = is_bson_view_compatible<T>;
 
+///
+/// Compares a view with a type representable as a view.
+///
+/// @par "Constraints" @parblock
+/// @li @ref bsoncxx::v_noabi::types::bson_value::view is constructible from `T`.
+/// @endparblock
+///
+/// @{
+
+/// @relatesalso bsoncxx::v_noabi::types::bson_value::view
 template <typename T>
 BSONCXX_INLINE detail::requires_t<bool, is_bson_view_compatible<T>>  //
 operator==(const bson_value::view& lhs, T&& rhs) {
     return lhs == bson_value::view{std::forward<T>(rhs)};
 }
 
+/// @relatesalso bsoncxx::v_noabi::types::bson_value::view
 template <typename T>
 BSONCXX_INLINE detail::requires_t<bool, is_bson_view_compatible<T>>  //
 operator==(T&& lhs, const bson_value::view& rhs) {
     return bson_value::view{std::forward<T>(lhs)} == rhs;
 }
 
+/// @relatesalso bsoncxx::v_noabi::types::bson_value::view
 template <typename T>
 BSONCXX_INLINE detail::requires_t<bool, is_bson_view_compatible<T>>  //
 operator!=(const bson_value::view& lhs, T&& rhs) {
     return lhs != bson_value::view{std::forward<T>(rhs)};
 }
 
+/// @relatesalso bsoncxx::v_noabi::types::bson_value::view
 template <typename T>
 BSONCXX_INLINE detail::requires_t<bool, is_bson_view_compatible<T>>  //
 operator!=(T&& lhs, const bson_value::view& rhs) {
     return bson_value::view{std::forward<T>(lhs)} != rhs;
 }
+
+/// @}
+///
 
 }  // namespace bson_value
 }  // namespace types
@@ -353,3 +369,36 @@ using ::bsoncxx::v_noabi::types::bson_value::operator!=;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::types::bson_value::view.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace types {
+namespace bson_value {
+
+/// @ref bsoncxx::v_noabi::types::bson_value::operator==(const v_noabi::types::bson_value::view& lhs, T&& rhs)
+template <typename T>
+inline bool operator==(const v_noabi::types::bson_value::view& lhs, T&& rhs);
+
+/// @ref bsoncxx::v_noabi::types::bson_value::operator==(T&& lhs, const v_noabi::types::bson_value::view& rhs)
+template <typename T>
+inline bool operator==(T&& lhs, const v_noabi::types::bson_value::view& rhs);
+
+/// @ref bsoncxx::v_noabi::types::bson_value::operator!=(const v_noabi::types::bson_value::view& lhs, T&& rhs)
+template <typename T>
+inline bool operator!=(const v_noabi::types::bson_value::view& lhs, T&& rhs);
+
+/// @ref bsoncxx::v_noabi::types::bson_value::operator!=(T&& lhs, const v_noabi::types::bson_value::view& rhs)
+template <typename T>
+inline bool operator!=(T&& lhs, const v_noabi::types::bson_value::view& rhs);
+
+}  // namespace bson_value
+}  // namespace types
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view_or_value.hpp
@@ -25,6 +25,9 @@ namespace v_noabi {
 namespace types {
 namespace bson_value {
 
+///
+/// Equivalent to `v_noabi::view_or_value<view, value>`.
+///
 using view_or_value = bsoncxx::v_noabi::view_or_value<view, value>;
 
 }  // namespace bson_value
@@ -43,3 +46,23 @@ using ::bsoncxx::v_noabi::types::bson_value::view_or_value;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::types::bson_value::view_or_value.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace types {
+namespace bson_value {
+
+/// @ref bsoncxx::v_noabi::types::bson_value::view_or_value
+class view_or_value {};
+
+}  // namespace bson_value
+}  // namespace types
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/value.hpp
@@ -23,10 +23,9 @@ namespace v_noabi {
 namespace types {
 
 ///
-/// The bsoncxx::v_noabi::types::bson_value::view class has been renamed to
-/// bsoncxx::v_noabi::types::bson_value::view.
+/// Equivalent to @ref bsoncxx::v_noabi::types::bson_value::view.
 ///
-/// @deprecated use bsoncxx::v_noabi::types::bson_value::view instead.
+/// @deprecated Use @ref bsoncxx::v_noabi::types::bson_value::view instead.
 ///
 BSONCXX_DEPRECATED typedef types::bson_value::view value;
 
@@ -37,9 +36,30 @@ BSONCXX_DEPRECATED typedef types::bson_value::view value;
 namespace bsoncxx {
 namespace types {
 
-using ::bsoncxx::v_noabi::types::value;  // Deprecated
+using ::bsoncxx::v_noabi::types::value;  // Deprecated.
 
 }  // namespace types
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::types::value.
+///
+/// @deprecated Use @ref bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp instead.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+namespace types {
+
+/// @ref bsoncxx::v_noabi::types::value
+/// @deprecated Use @ref bsoncxx::v_noabi::types::bson_value::view instead.
+class value {};
+
+}  // namespace types
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/util/functor.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/util/functor.hpp
@@ -116,3 +116,10 @@ struct is_functor : functor::is_functor_impl<C, S, std::is_class<C>::value> {};
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// This header is deprecated.
+///
+/// @deprecated This header is deprecated.
+///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate-fwd.hpp
@@ -31,3 +31,19 @@ using ::bsoncxx::v_noabi::validator;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::validator.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+
+/// @ref bsoncxx::v_noabi::validator
+class validator {};
+
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate.hpp
@@ -167,3 +167,26 @@ using ::bsoncxx::v_noabi::validate;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides utilities to validate BSON document representations.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+
+/// @ref bsoncxx::v_noabi::validate(const std::uint8_t* data, std::size_t length)
+v_noabi::stdx::optional<v_noabi::document::view> validate(const std::uint8_t* data,
+                                                          std::size_t length);
+
+/// @ref bsoncxx::v_noabi::validate(const std::uint8_t* data, std::size_t length, const v_noabi::validator& validator, std::size_t* invalid_offset)
+v_noabi::stdx::optional<v_noabi::document::view> validate(const std::uint8_t* data,
+                                                          std::size_t length,
+                                                          const v_noabi::validator& validator,
+                                                          std::size_t* invalid_offset = nullptr);
+
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value-fwd.hpp
@@ -32,3 +32,19 @@ using ::bsoncxx::v_noabi::view_or_value;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v_noabi::view_or_value.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+
+/// @ref bsoncxx::v_noabi::view_or_value
+class view_or_value {};
+
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value.hpp
@@ -145,7 +145,7 @@ class view_or_value {
 };
 
 ///
-/// Compare view_or_value objects for (in)-equality.
+/// Compare view_or_value objects for (in)equality.
 ///
 /// @{
 
@@ -167,7 +167,7 @@ BSONCXX_INLINE bool operator!=(const view_or_value<View, Value>& lhs,
 ///
 
 ///
-/// Mixed (in)-equality operators for view_or_value against View or Value types
+/// Mixed (in)equality operators for view_or_value against View and Value types
 ///
 /// @{
 
@@ -233,3 +233,54 @@ using ::bsoncxx::v_noabi::operator!=;
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v_noabi::view_or_value.
+///
+
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+
+namespace bsoncxx {
+
+/// @ref bsoncxx::v_noabi::operator==(const v_noabi::view_or_value<View, Value>& lhs, const v_noabi::view_or_value<View, Value>& rhs)
+template <typename View, typename Value>
+bool operator==(const v_noabi::view_or_value<View, Value>& lhs,
+                const v_noabi::view_or_value<View, Value>& rhs);
+
+/// @ref bsoncxx::v_noabi::operator!=(const v_noabi::view_or_value<View, Value>& lhs, const v_noabi::view_or_value<View, Value>& rhs)
+template <typename View, typename Value>
+bool operator!=(const v_noabi::view_or_value<View, Value>& lhs,
+                const v_noabi::view_or_value<View, Value>& rhs);
+
+/// @ref bsoncxx::v_noabi::operator==(const v_noabi::view_or_value<View, Value>& lhs, View rhs)
+template <typename View, typename Value>
+bool operator==(const v_noabi::view_or_value<View, Value>& lhs, View rhs);
+
+/// @ref bsoncxx::v_noabi::operator==(View lhs, const v_noabi::view_or_value<View, Value>& rhs)
+template <typename View, typename Value>
+bool operator==(View lhs, const v_noabi::view_or_value<View, Value>& rhs);
+
+/// @ref bsoncxx::v_noabi::operator!=(const v_noabi::view_or_value<View, Value>& lhs, View rhs)
+template <typename View, typename Value>
+bool operator!=(const v_noabi::view_or_value<View, Value>& lhs, View rhs);
+
+/// @ref bsoncxx::v_noabi::operator!=(View lhs, const v_noabi::view_or_value<View, Value>& rhs)
+template <typename View, typename Value>
+bool operator!=(View lhs, const v_noabi::view_or_value<View, Value>& rhs);
+
+/// @ref bsoncxx::v_noabi::operator==(const v_noabi::view_or_value<View, Value>& lhs, const Value& rhs)
+template <typename View, typename Value>
+bool operator==(const v_noabi::view_or_value<View, Value>& lhs, const Value& rhs);
+
+/// @ref bsoncxx::v_noabi::operator==(const Value& lhs, const v_noabi::view_or_value<View, Value>& rhs)
+template <typename View, typename Value>
+bool operator==(const Value& lhs, const v_noabi::view_or_value<View, Value>& rhs);
+
+/// @ref bsoncxx::v_noabi::operator!=(const v_noabi::view_or_value<View, Value>& lhs, const Value& rhs)
+template <typename View, typename Value>
+bool operator!=(const v_noabi::view_or_value<View, Value>& lhs, const Value& rhs);
+
+}  // namespace bsoncxx
+
+#endif  // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/test/catch.hh
+++ b/src/bsoncxx/test/catch.hh
@@ -99,9 +99,9 @@ struct StringMaker<stdx::optional<bsoncxx::stdx::nullopt_t>> {
 template <>
 struct StringMaker<bsoncxx::detail::strong_ordering> {
     static std::string convert(bsoncxx::detail::strong_ordering o) {
-        if (o < 0) {
+        if (o < nullptr) {
             return "[less-than]";
-        } else if (o > 0) {
+        } else if (o > nullptr) {
             return "[greater-than]";
         } else {
             return "[equal/equivalent]";

--- a/src/bsoncxx/test/optional.test.cpp
+++ b/src/bsoncxx/test/optional.test.cpp
@@ -89,7 +89,7 @@ struct not_copyable {
 #define STATIC_ASSERT_EXPR_ALIKE(a, b) STATIC_ASSERT_EXPR_EQUAL(a, b)
 #endif
 
-template <bsoncxx_ttparam Trait, typename T>
+template <template <class...> class Trait, typename T>
 bool assert_alikeness() {
     STATIC_ASSERT_EXPR_ALIKE(Trait<T>::value, Trait<optional<T>>::value);
     return true;

--- a/src/bsoncxx/test/string_view.test.cpp
+++ b/src/bsoncxx/test/string_view.test.cpp
@@ -10,7 +10,7 @@
 #endif
 #endif
 
-#if __cpp_lib_string_view
+#if defined(__cpp_lib_string_view)
 #include <string_view>
 #endif
 

--- a/src/bsoncxx/test/type_traits.test.cpp
+++ b/src/bsoncxx/test/type_traits.test.cpp
@@ -21,18 +21,18 @@ struct assert_same {
 
 template <typename Expect, typename... Args>
 struct Case {
-    template <bsoncxx_ttparam F>
+    template <template <class...> class F>
     struct apply {
         using x = typename assert_same<F<Args...>, Expect>::x;
     };
 };
 
-template <bsoncxx_ttparam Op, typename Case>
+template <template <class...> class Op, typename Case>
 struct one_case {
     using x = typename Case::template apply<Op>::x;
 };
 
-template <bsoncxx_ttparam Oper, typename... Cases>
+template <template <class...> class Oper, typename... Cases>
 struct check_cases : one_case<Oper, Cases>... {};
 
 constexpr check_cases<  //

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -2154,10 +2154,10 @@ TEST_CASE("read_concern is inherited from parent", "[collection]") {
     }
 }
 
-void find_index_and_validate(
-    collection& coll,
-    stdx::string_view index_name,
-    const std::function<void(bsoncxx::document::view)>& validate = [](bsoncxx::document::view) {}) {
+void find_index_and_validate(collection& coll,
+                             stdx::string_view index_name,
+                             const std::function<void(bsoncxx::document::view)>& validate =
+                                 [](bsoncxx::document::view) {}) {
     auto cursor = coll.list_indexes();
 
     for (auto&& index : cursor) {


### PR DESCRIPTION
## Summary

Partially resolves CXX-3069. Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1173. Verified by [this patch](https://spruce.mongodb.com/version/66aa9cfc71f13f0007e6682c/).

A followup PR will resolve CXX-3069 by applying the same pattern of changes in this PR to mongocxx.

A thorough audit of the documentation of interfaces will be addressed by CXX-3082.

## File Documentation

This PR follows the pattern used in https://github.com/mongodb/mongo-cxx-driver/pull/1173 and adds `@file` Doxygen commands at the _bottom_ of all public header files under `include/`. This is to avoid Doxygen-specific code from intruding in the code they are meant to document (+ they are not expected to require frequent maintenance).

```cpp
// License notice.

#pragma once

#include <headers> // Include directives and etc.

namespace bsoncxx { ... } // Declarations and definitions.

///
/// @file
/// Documentation for this file.
///

///
/// More Doxygen-specific comments pertaining to entities provided by this file.
///
```

The result of these efforts is the complete documentation of all files in the File List page (for bsoncxx; mongocxx soon to follow).

🎉 **This completes the trifecta of Doxygen API doc page navigation via namespaces, classes, and files.** 🎉 

Files list, before:

![image](https://github.com/user-attachments/assets/2e17fa3d-c2de-4508-9c1d-1afd0da810f0)

Files list, after:

![image](https://github.com/user-attachments/assets/523233bd-2208-4315-835e-62bd9f4c9a17)

File page, before: none.

File page, after:

![image](https://github.com/user-attachments/assets/26110dd5-8e22-4e47-86f2-37298e6f1980)

> [!NOTE]
> File pages serve as a collection of references to _namespaces_ (and their immediate members) and _classes_ provided by the header. Accordingly, documentation for interfaces should always be primarily associated with the namespace or class, not the file it is declared/documented in. In short, `@file` documentation should be very brief.

## Root Namespace Redeclarations

As https://github.com/doxygen/doxygen/issues/3760 is yet to be resolved, Doxygen is completely blind to using-declarations. Therefore, great pains are taken to reproduce the documentation structure generated by `using namespace` prior to https://github.com/mongodb/mongo-cxx-driver/pull/1066 and https://github.com/mongodb/mongo-cxx-driver/pull/1070, as demonstrated by the [3.9.0 docs](https://mongocxx.org/api/mongocxx-3.9.0/namespaces.html):

![image](https://github.com/user-attachments/assets/be90997e-1a9b-4799-b068-87bf7004fdf2)

This PR uses the `#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)` pattern implemented in https://github.com/mongodb/mongo-cxx-driver/pull/1173 to _actually_ "redeclare" equivalents to the root namespace using-declarations as class/function stubs, solely to generate doc pages that redirect their aliased counterparts:

```cpp
namespace bsoncxx {

using v_noabi::foo;

} // namespace bsoncxx

///
/// @file
/// Documentation for this file.
///

#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

namespace bsoncxx {

/// @ref bsoncxx::v_noabi::foo
class foo {};

} // namespace bsoncxx

#endif // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
```

The result looks as follows (specifically the `bsoncxx::array` members at the top of the image):

![image](https://github.com/user-attachments/assets/1e859507-b0d7-4c6a-a8c7-2d6452b50b6a)

This pattern has the unexpected benefit of explicitly displaying the redeclared entity as a clickable link in the brief description on the Namespace List page (instead of repeating the brief of the redeclared entity). This should hopefully make the state of redeclarations easier to follow than it would have otherwise been.

The Doxygen documentation for redeclarations _always_ qualify entities with the ABI namespace. This is to avoid Doxygen associating types with a root namespace redeclaration (Doxygen does not appear to be smart enough to resolve namespace scoping rules for parameter types):

```cpp
#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

namespace bsoncxx {

/// @ref bsoncxx::v_noabi::bar
class bar {};

/// @ref bsoncxx::v_noabi::foo(bar b)
void foo(bar b);
//       ^~~ Should be `bsoncxx::v_noabi::bar`, not `bsoncxx::bar`!

} // namespace bsoncxx

#endif // defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
```

This principle is similar to the one which motivated ABI namespace qualification of `bsoncxx::` entities in `mongocxx` to ensure ABI stability across redeclaration updates, as described in https://github.com/mongodb/mongo-cxx-driver/pull/1070#issuecomment-1856779596. A redeclaration changing from `v1 -> v2` must not inadvertently change the meaning of interfaces in ABI-specific namespaces in either code _or_ in documentation.

## Deprecation, Internal Use, and Deliberate No-Documentation

This PR takes this opportunity to document `bsoncxx/util/functor.hpp` as deprecated (consistent with the directory-level deprecation notice).

Several header files are documented as "for internal use only" in an effort to discourage users from directly depending on certain interfaces:

- `bsoncxx/builder/basic/impl.hpp`
- `bsoncxx/config/compiler.hpp`
- `bsoncxx/config/util.hpp`
- `bsoncxx/stdx/make_unique.hpp`
- `bsoncxx/stdx/operators.hpp`
- `bsoncxx/stdx/type_traits.hpp`

These headers have been updated to deliberately contain _no_ documentation of the provided entities in an effort to discourage their use by users. Doxygen-aware tools appear to have no issue parsing and treating `//` (double, not triple) comments as Doxygen documentation despite not being included in doc generation; therefore, existing documentation of internal interfaces have been "demoted" from `///` or `/**` to `//` to avoid their inclusion in generated docs.

For example, this is the entirety of the `type_traits.hpp` doc page:

![image](https://github.com/user-attachments/assets/dbc13960-52e7-410e-b26b-39dd44808c96)

On the other hand, given the significance of `std::string_view` and `std::optional<T>` polyfills in C++ Driver interfaces, these headers (and the polyfills) are given special documentation with a note regarding their relationship with polyfill library configuration. This documentation is expected to be expanded in a followup PR.

Some old/niche/undocumented features have been given the `Deliberately undocumented.` note to avoid their inclusion in generated docs.

## Doxygen Parsing Problems

The `operators.hpp` and `type_traits.hpp` headers were known to give Doxygen trouble, hence their explicit exclusion via the `EXCLUDE` Doxygen option in https://github.com/mongodb/mongo-cxx-driver/pull/1062. This PR reverts their exclusion and instead makes adjustments for consistency with other (internal use) header files and applying the `@cond DOXYGEN_DISABLE` pattern (first used in https://github.com/mongodb/mongo-cxx-driver/pull/1170) to address Doxygen warnings. These changes address three `Found ';' while parsing initializer list!` warnings and four `Detected potential recursive class relation` warnings.

## bsoncxx::v_noabi::error_code

As a drive-by improvement, identified and (partially) fixed misplaced documentation for enumerators of `bsoncxx::v_noabi::error_code`.

Before:

![image](https://github.com/user-attachments/assets/cf4d040f-79e2-47ac-8db7-ac9824e348e9)

After:

![image](https://github.com/user-attachments/assets/a58892b9-172f-49ad-af46-c188bbb68cfa)

Addressing the missing documentation for enumerators relating to BSON types and binary subtypes is deferred to a followup PR.

## Miscellaneous

Warnings-related fixes are a followup to https://github.com/mongodb/mongo-cxx-driver/pull/1178 that extends compilation output to the `test_bson` and `test_driver` targets.

- Drive-by formatting fix to `mongocxx/test/collection.cpp` following https://github.com/mongodb/mongo-cxx-driver/commit/d373213181aaa13e3cfdbe6fa4ce2f683400b9e2.
- Addressed 617 (8 unique) `-Wzero-as-null-pointer-constant` warnings by `operators.hpp` and `catch.hh`.
- Addressed 92 (69 unique) `-Wundefined-func-template` warnings emitted by use of `soft_declval` (replaced with equivalent `std::declval` expressions).
- Silenced 33 (8 unique) `-Wfloat-equal` warnings emitted by `optional.hpp`.
- Address a `-Wundef` warning in `bsoncxx/test/string_view.test.cpp`.
- Silenced a `-Wweak-vtables` warning in `optional.hpp` (we do not export symbols in stdx).
- Set `EXAMPLES = examples` in Doxyfile (setup for CXX-3082).