### PR TITLE
CXX-3087 Replace single-argument FetchContent_Populate with FetchContent_MakeAvailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ## 3.11.0 [Unreleased]
 
-<!-- Will contain entries for the next minor release -->
+### Changed
+
+- `FetchContent_MakeAvailable()` is used to populate dependencies instead of `FetchContent_Populate()` for the Mongo C Driver (when not provided by `CMAKE_PREFIX_PATH`) and mnmlstc/core (when automatically selected or `BSONCXX_POLY_USE_MNMLSTC=ON`).
+  - Note: `FetchContent_Populate()` is still used for mnmlstc/core for CMake versions prior to 3.18 to avoid `add_subdirectory()` behavior.
 
 ### Deprecated
 
@@ -71,6 +74,7 @@ accordance with [MongoDB Software Lifecycle Schedules](https://www.mongodb.com/l
 - Add VERSIONINFO resource to bsoncxx.dll and mongocxx.dll.
 
 ### Changed
+
 - Do not build tests as part of `all` target. Configure with `BUILD_TESTING=ON` to build tests.
 - Bump minimum required CMake version to 3.15 to support the FetchContent module and for consistency with the C Driver.
 - Improve handling of downloaded (non-system) mnmlstc/core as the polyfill library.
@@ -79,11 +83,13 @@ accordance with [MongoDB Software Lifecycle Schedules](https://www.mongodb.com/l
 - Bump minimum C Driver version to [1.25.0](https://github.com/mongodb/mongo-c-driver/releases/tag/1.25.0).
 
 ### Fixed
+
 - Explicitly document that throwing an exception from an APM callback is undefined behavior.
 - Do not prematurely install mnmlstc/core headers during the CMake build step.
 - Require a C Driver CMake package is found via `find_dependency()` for all installed CXX Driver package configurations.
 
 ### Removed
+
 - Remove support for exported targets from the CMake project build tree.
 - Drop support for the following operating systems:
   - macOS 10.14 and 10.15

--- a/cmake/FetchMnmlstcCore.cmake
+++ b/cmake/FetchMnmlstcCore.cmake
@@ -12,6 +12,7 @@ FetchContent_Declare(
     EP_mnmlstc_core
 
     SOURCE_DIR "${core-src}"
+    SOURCE_SUBDIR ""
     SUBBUILD_DIR "${core-subbuild}"
     BINARY_DIR "${core-build}"
     INSTALL_DIR "${core-install}"
@@ -32,7 +33,12 @@ if(core_FOUND AND "$CACHE{INTERNAL_MONGOC_MNMLSTC_CORE_FOUND}")
 else()
     if(NOT ep_mnmlstc_core_POPULATED)
         message(STATUS "Downloading mnmlstc/core...")
-        FetchContent_Populate(EP_mnmlstc_core)
+        if("${CMAKE_VERSION}" VERSION_LESS "3.18.0")
+            # SOURCE_SUBDIR is not yet supported.
+            FetchContent_Populate(EP_mnmlstc_core)
+        else()
+            FetchContent_MakeAvailable(EP_mnmlstc_core)
+        endif()
         message(STATUS "Downloading mnmlstc/core... done.")
     endif()
 

--- a/cmake/FetchMnmlstcCore.cmake
+++ b/cmake/FetchMnmlstcCore.cmake
@@ -12,7 +12,7 @@ FetchContent_Declare(
     EP_mnmlstc_core
 
     SOURCE_DIR "${core-src}"
-    SOURCE_SUBDIR ""
+    SOURCE_SUBDIR "" # Disable `add_subdirectory()` in `FetchContent_MakeAvailable()`.
     SUBBUILD_DIR "${core-subbuild}"
     BINARY_DIR "${core-build}"
     INSTALL_DIR "${core-install}"

--- a/cmake/FetchMongoC.cmake
+++ b/cmake/FetchMongoC.cmake
@@ -21,8 +21,6 @@ if(NOT mongo-c-driver_POPULATED)
 
     set(ENABLE_EXTRA_ALIGNMENT OFF)
 
-    FetchContent_Populate(mongo-c-driver)
-
     # Set ENABLE_TESTS to OFF to disable the test-libmongoc target in the C driver.
     # This prevents the LoadTests.cmake script from attempting to execute test-libmongoc.
     # test-libmongoc is not built with the "all" target.
@@ -31,7 +29,7 @@ if(NOT mongo-c-driver_POPULATED)
     set(BUILD_TESTING OFF)
     string(REPLACE " -Werror" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     string(REPLACE " -Werror" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
-    add_subdirectory(${mongo-c-driver_SOURCE_DIR} ${mongo-c-driver_BINARY_DIR})
+    FetchContent_MakeAvailable(mongo-c-driver)
     set(CMAKE_CXX_FLAGS ${OLD_CMAKE_CXX_FLAGS})
     set(CMAKE_C_FLAGS ${OLD_CMAKE_C_FLAGS})
     set(ENABLE_TESTS ${OLD_ENABLE_TESTS})


### PR DESCRIPTION
Resolves CXX-3087. Verified by [this patch](https://spruce.mongodb.com/version/66b25d01d973d20007c4d59d).

Addresses the following warning emitted by CMake 3.30 and newer for `mongo-c-driver` and `EP_mnmlstc_core`:

```
CMake Warning (dev) at /snap/cmake/1409/share/cmake-3.30/Modules/FetchContent.cmake:1953 (message):
  Calling FetchContent_Populate(mongo-c-driver) is deprecated, call
  FetchContent_MakeAvailable(mongo-c-driver) instead.  Policy CMP0169 can be
  set to OLD to allow FetchContent_Populate(mongo-c-driver) to be called
  directly for now, but the ability to call it with declared details will be
  removed completely in a future version.
Call Stack (most recent call first):
  cmake/FetchMongoC.cmake:24 (FetchContent_Populate)
  CMakeLists.txt:78 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

This is caused by [CMP0169](https://cmake.org/cmake/help/latest/policy/CMP0169.html):

> Calling `FetchContent_Populate()` with a single argument (the name of a declared dependency) is deprecated. [...] The OLD behavior of this policy allows `FetchContent_Populate()` to be called with the name of a declared dependency. The NEW behavior halts with a fatal error in such cases.

This PR replaces such calls with `FetchContent_MakeAvailable()` accordingly.

This was straightforward for `mongo-c-driver` given it was (manually) implementing `add_subdirectory()` behavior, which is consistent with `FetchContent_MakeAvailable()`'s regular behavior, which internally calls `add_subdirectory()` on population.

`EP_mnmlstc_core` required a workaround due to the `SOURCE_SUBDIR` option only being supported in 3.18 and newer. Using `SOURCE_SUBDIR` to prevents the internal `add_subdirectory()` call is an officially supported pattern which is needed by FetchMnmlstcCore.cmake to prevent mnmlstc/core's configurations from leaking into the C Driver's configuration (see https://github.com/mongodb/mongo-cxx-driver/pull/1019 for details). This workaround can be removed once the minimum required CMake version is raised to 3.18 or newer.