### PR TITLE
Update CHANGELOG with 3.10.2 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,19 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 - A future minor release plans to raise the minimum supported MongoDB Server version from 3.6 to 4.0. This is in
 accordance with [MongoDB Software Lifecycle Schedules](https://www.mongodb.com/legal/support-policy/lifecycles).
 
-## 3.10.2 [Unreleased]
+## 3.10.3 [Unreleased]
 
 <!-- Will contain entries for the next patch release -->
+
+## 3.10.2
+
+### Added
+
+- SSDLC Compliance Report and related release artifacts.
+
+### Fixed
+
+- Undefined behavior when moving a `mongocxx::v_noabi::events::topology_description::server_descriptions` object due to uninitialized data member access.
 
 ## 3.10.1
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -673,17 +673,27 @@ Commit the changes to the `releases/vX.Y` branch and push the branch to the remo
 
 Checkout the `post-release-changes` branch.
 
-Add a section for the new patch release containing the same entries as in the release, e.g. following a `1.2.3` release:
+Sync the entries in the patch release section to be consistent with the entries on the release branch, e.g. following a `1.2.3` release:
 
 ```md
 ## 1.3.0 [Unreleased]
+
+<!-- Will contain entries for the next minor release. -->
+<!-- Ensure these entries are not removed during the sync. -->
+
+## 1.2.4 [Unreleased]
 
 <!-- Will contain entries for the next patch release. -->
 
 ## 1.2.3 <!-- Just released. -->
 
+<!-- Ensure these entries match those in the release. -->
+
 ## 1.2.2 <!-- Prior release. -->
 ```
+
+> [!TIP]
+> Use `git restore --source=rX.Y.Z --worktree CHANGELOG.md` to obtain the `CHANGELOG.md` in `rX.Y.Z` as unstaged changes.
 
 #### ... for a Non-Patch Release
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -679,7 +679,7 @@ Sync the entries in the patch release section to be consistent with the entries 
 ## 1.3.0 [Unreleased]
 
 <!-- Will contain entries for the next minor release. -->
-<!-- Ensure these entries are not removed during the sync. -->
+<!-- Ensure any existing entries are not removed during the sync. -->
 
 ## 1.2.4 [Unreleased]
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -671,6 +671,20 @@ Add a section for the next patch release, e.g. following a `1.2.3` release:
 
 Commit the changes to the `releases/vX.Y` branch and push the branch to the remote repository (a PR is not required for this step).
 
+Checkout the `post-release-changes` branch.
+
+Add a section for the new patch release containing the same entries as in the release, e.g. following a `1.2.3` release:
+
+```md
+## 1.3.0 [Unreleased]
+
+<!-- Will contain entries for the next patch release. -->
+
+## 1.2.3 <!-- Just released. -->
+
+## 1.2.2 <!-- Prior release. -->
+```
+
 #### ... for a Non-Patch Release
 
 Checkout the `post-release-changes` branch.


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1160 which forgot to include CHANGELOG entries in the post-release changes PR due to release instructions only committing the patch entries to the release branch. Instructions are also updated accordingly.