### PR TITLE
CXX-3085 Upgrade to Doxygen 1.12.0

### DIFF
--- a/docs/DoxygenLayout.xml
+++ b/docs/DoxygenLayout.xml
@@ -8,7 +8,7 @@
       <tab type="filelist" visible="yes" title="" intro=""/>
       <tab type="globals" visible="yes" title="" intro=""/>
     </tab>
-    <tab type="modules" visible="yes">
+    <tab type="modules" visible="yes" title="" intro="">
       <tab type="modulelist" visible="yes" title="" intro=""/>
       <tab type="modulemembers" visible="yes" title="" intro=""/>
     </tab>

--- a/etc/generate-apidocs-from-tag.pl
+++ b/etc/generate-apidocs-from-tag.pl
@@ -11,7 +11,7 @@ use List::Util qw/first/;
 
 # The required Doxygen version.
 # The generated results are sensitive to the release version.
-our $doxygen_version_required = "1.11.0";
+our $doxygen_version_required = "1.12.0";
 
 # Allow specifying a custom Doxygen binary via the `$DOXYGEN_BINARY` environment variable.
 our $doxygen_binary = $ENV{DOXYGEN_BINARY} || "doxygen";

--- a/src/bsoncxx/include/bsoncxx/doc.hpp
+++ b/src/bsoncxx/include/bsoncxx/doc.hpp
@@ -65,11 +65,6 @@
 ///
 
 ///
-/// @namespace bsoncxx::exception
-/// Declares entities related to bsoncxx exceptions and error codes.
-///
-
-///
 /// @namespace bsoncxx::stdx
 /// Declares C++17 standard library polyfills.
 ///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/helpers.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/helpers.hpp
@@ -57,8 +57,8 @@ namespace basic {
 /// @ref bsoncxx::v_noabi::builder::concatenate(v_noabi::document::view_or_value doc)
 v_noabi::concatenate_doc concatenate(v_noabi::document::view_or_value doc);
 
-/// @ref bsoncxx::v_noabi::builder::concatenate(v_noabi::array::view_or_value doc)
-v_noabi::concatenate_doc concatenate(v_noabi::array::view_or_value doc);
+/// @ref bsoncxx::v_noabi::builder::concatenate(v_noabi::array::view_or_value array)
+v_noabi::concatenate_array concatenate(v_noabi::array::view_or_value array);
 
 }  // namespace basic
 }  // namespace builder

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
@@ -140,8 +140,8 @@ namespace builder {
 /// @ref bsoncxx::v_noabi::builder::concatenate(v_noabi::document::view_or_value doc)
 v_noabi::builder::concatenate_doc concatenate(v_noabi::document::view_or_value doc);
 
-/// @ref bsoncxx::v_noabi::builder::concatenate(v_noabi::array::view_or_value doc)
-v_noabi::builder::concatenate_doc concatenate(v_noabi::array::view_or_value doc);
+/// @ref bsoncxx::v_noabi::builder::concatenate(v_noabi::array::view_or_value array)
+v_noabi::builder::concatenate_array concatenate(v_noabi::array::view_or_value array);
 
 }  // namespace builder
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/fwd.hpp
@@ -376,11 +376,6 @@
 ///
 
 ///
-/// @namespace bsoncxx::v_noabi::exception
-/// @copydoc bsoncxx::exception
-///
-
-///
 /// @namespace bsoncxx::v_noabi::stdx
 /// @copydoc bsoncxx::stdx
 ///


### PR DESCRIPTION
## Summary

Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1185:

> Aside: Doxygen 1.12.0 was notably released.

The Doxygen changelog was updated with 1.12.0 release notes. I believe the upgrade to be worth implementing now. This PR also demonstrates the relatively few changes required for a less-significant Doxygen version upgrade compared to all the additional diffs to config and layout files in https://github.com/mongodb/mongo-cxx-driver/pull/1185.

## Comparisons

The most notable change is the omission of classes in the Namespaces List page.

With 1.11.0:

![image](https://github.com/user-attachments/assets/9645b84b-b90b-49c4-a526-444ce184ac7b)

With 1.12.0:

![image](https://github.com/user-attachments/assets/90a1cc2c-7b00-4ba2-88bd-645b78d49ff6)

imo this is a very worthwhile improvement which makes the Namespaces List much easier to navigate. This also lessens the importance of CXX-3086 (although I would still like for it to be implemented if able).

The simpler Namespaces Page also made more apparent stray `@namespace` docs of nonexistent `bsoncxx::v_noabi::exception` and `bsoncxx::exception` namespaces (which was confused with the class), introduced in https://github.com/mongodb/mongo-cxx-driver/pull/1173. This PR removes these stray docs accordingly.

Although we do not yet heavily use Markdown syntax yet in Doxygen docs, 1.12.0 fixes several parsing and rendering issues for Markdown syntax. Addressing this issue now will help with writing more comprehensive examples in CXX-3082, which is expected to heavily rely on Markdown syntax for topic page layout and formatting.

The PR also includes a drive-by fix of an incorrect return type and parameter name used for the new `concatenate` overloads for arrays added in https://github.com/mongodb/mongo-cxx-driver/pull/1185.