### PR TITLE
Update main() declarations in examples

### DIFF
--- a/examples/bsoncxx/builder_basic.cpp
+++ b/examples/bsoncxx/builder_basic.cpp
@@ -21,7 +21,7 @@
 
 using namespace bsoncxx;
 
-int main(int, char**) {
+int main() {
     // bsoncxx::builder::basic presents a BSON-construction interface familiar to users of the
     // server's
     // BSON library or the Java driver.

--- a/examples/bsoncxx/builder_core.cpp
+++ b/examples/bsoncxx/builder_core.cpp
@@ -17,7 +17,7 @@
 
 using namespace bsoncxx;
 
-int main(int, char**) {
+int main() {
     // bsoncxx::builder::core is a low-level primitive that can be useful for building other
     // BSON abstractions. Most users should just use builder::stream or builder::basic.
 

--- a/examples/bsoncxx/builder_list.cpp
+++ b/examples/bsoncxx/builder_list.cpp
@@ -20,7 +20,7 @@
 
 using namespace bsoncxx;
 
-int main(int, char**) {
+int main() {
     using namespace bsoncxx::builder;
 
     //

--- a/examples/bsoncxx/builder_stream.cpp
+++ b/examples/bsoncxx/builder_stream.cpp
@@ -19,7 +19,7 @@
 
 using namespace bsoncxx;
 
-int main(int, char**) {
+int main() {
     using builder::stream::array;
     using builder::stream::document;
 

--- a/examples/bsoncxx/builder_stream_customization.cpp
+++ b/examples/bsoncxx/builder_stream_customization.cpp
@@ -68,7 +68,7 @@ range_kvp_appender<begin_t, end_t> make_range_kvp_appender(begin_t&& begin, end_
                                               std::forward<end_t>(end));
 }
 
-int main(int, char**) {
+int main() {
     using builder::stream::array;
     using builder::stream::document;
     using builder::stream::finalize;

--- a/examples/bsoncxx/decimal128.cpp
+++ b/examples/bsoncxx/decimal128.cpp
@@ -22,7 +22,7 @@
 
 using namespace bsoncxx;
 
-int main(int, char**) {
+int main() {
     // Convert a string to BSON Decimal128.
     decimal128 d128;
     try {

--- a/examples/bsoncxx/getting_values.cpp
+++ b/examples/bsoncxx/getting_values.cpp
@@ -23,7 +23,7 @@
 
 using namespace bsoncxx;
 
-int main(int, char**) {
+int main() {
     using namespace builder::stream;
 
     builder::stream::document build_doc;

--- a/examples/bsoncxx/view_and_value.cpp
+++ b/examples/bsoncxx/view_and_value.cpp
@@ -31,7 +31,7 @@
 
 using namespace bsoncxx;
 
-int main(int, char**) {
+int main() {
     // This example will cover the read-only BSON interface.
 
     // Lets first build up a non-trivial BSON document using the builder interface.

--- a/examples/mongocxx/aggregate.cpp
+++ b/examples/mongocxx/aggregate.cpp
@@ -25,7 +25,7 @@
 using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_document;
 
-int main(int, char**) {
+int main() {
     // The mongocxx::instance constructor and destructor initialize and shut down the driver,
     // respectively. Therefore, a mongocxx::instance must be created before using the driver and
     // must remain alive for as long as the driver is in use.

--- a/examples/mongocxx/automatic_client_side_field_level_encryption.cpp
+++ b/examples/mongocxx/automatic_client_side_field_level_encryption.cpp
@@ -92,7 +92,7 @@ bsoncxx::document::value doc_from_file(std::string path) {
     return bsoncxx::from_json(file_contents);
 }
 
-int main(int, char**) {
+int main() {
     instance inst{};
 
     // This must be the same master key that was used to create

--- a/examples/mongocxx/bulk_write.cpp
+++ b/examples/mongocxx/bulk_write.cpp
@@ -25,7 +25,7 @@
 using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_document;
 
-int main(int, char**) {
+int main() {
     // The mongocxx::instance constructor and destructor initialize and shut down the driver,
     // respectively. Therefore, a mongocxx::instance must be created before using the driver and
     // must remain alive for as long as the driver is in use.

--- a/examples/mongocxx/create.cpp
+++ b/examples/mongocxx/create.cpp
@@ -26,7 +26,7 @@ using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_array;
 using bsoncxx::builder::basic::make_document;
 
-int main(int, char**) {
+int main() {
     // The mongocxx::instance constructor and destructor initialize and shut down the driver,
     // respectively. Therefore, a mongocxx::instance must be created before using the driver and
     // must remain alive for as long as the driver is in use.

--- a/examples/mongocxx/document_validation.cpp
+++ b/examples/mongocxx/document_validation.cpp
@@ -28,7 +28,7 @@ using bsoncxx::stdx::string_view;
 using mongocxx::collection;
 using mongocxx::validation_criteria;
 
-int main(int, char**) {
+int main() {
     // The mongocxx::instance constructor and destructor initialize and shut down the driver,
     // respectively. Therefore, a mongocxx::instance must be created before using the driver and
     // must remain alive for as long as the driver is in use.

--- a/examples/mongocxx/exception.cpp
+++ b/examples/mongocxx/exception.cpp
@@ -30,7 +30,7 @@
 using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_document;
 
-int main(int, char**) {
+int main() {
     // The mongocxx::instance constructor and destructor initialize and shut down the driver,
     // respectively. Therefore, a mongocxx::instance must be created before using the driver and
     // must remain alive for as long as the driver is in use.

--- a/examples/mongocxx/explicit_encryption.cpp
+++ b/examples/mongocxx/explicit_encryption.cpp
@@ -44,7 +44,7 @@ using namespace mongocxx;
 
 const int kKeyLength = 96;
 
-int main(int, char**) {
+int main() {
     instance inst{};
 
     // This must be the same master key that was used to create

--- a/examples/mongocxx/explicit_encryption_auto_decryption.cpp
+++ b/examples/mongocxx/explicit_encryption_auto_decryption.cpp
@@ -44,7 +44,7 @@ using namespace mongocxx;
 
 const int kKeyLength = 96;
 
-int main(int, char**) {
+int main() {
     instance inst{};
 
     // This must be the same master key that was used to create

--- a/examples/mongocxx/index.cpp
+++ b/examples/mongocxx/index.cpp
@@ -21,7 +21,7 @@
 using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_document;
 
-int main(int, char**) {
+int main() {
     // The mongocxx::instance constructor and destructor initialize and shut down the driver,
     // respectively. Therefore, a mongocxx::instance must be created before using the driver and
     // must remain alive for as long as the driver is in use.

--- a/examples/mongocxx/inserted_id.cpp
+++ b/examples/mongocxx/inserted_id.cpp
@@ -24,7 +24,7 @@
 using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_document;
 
-int main(int, char**) {
+int main() {
     // The mongocxx::instance constructor and destructor initialize and shut down the driver,
     // respectively. Therefore, a mongocxx::instance must be created before using the driver and
     // must remain alive for as long as the driver is in use.

--- a/examples/mongocxx/query.cpp
+++ b/examples/mongocxx/query.cpp
@@ -27,7 +27,7 @@ using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_array;
 using bsoncxx::builder::basic::make_document;
 
-int main(int, char**) {
+int main() {
     // The mongocxx::instance constructor and destructor initialize and shut down the driver,
     // respectively. Therefore, a mongocxx::instance must be created before using the driver and
     // must remain alive for as long as the driver is in use.

--- a/examples/mongocxx/query_projection.cpp
+++ b/examples/mongocxx/query_projection.cpp
@@ -25,7 +25,7 @@
 using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_document;
 
-int main(int, char**) {
+int main() {
     // The mongocxx::instance constructor and destructor initialize and shut down the driver,
     // respectively. Therefore, a mongocxx::instance must be created before using the driver and
     // must remain alive for as long as the driver is in use.

--- a/examples/mongocxx/remove.cpp
+++ b/examples/mongocxx/remove.cpp
@@ -21,7 +21,7 @@
 using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_document;
 
-int main(int, char**) {
+int main() {
     // The mongocxx::instance constructor and destructor initialize and shut down the driver,
     // respectively. Therefore, a mongocxx::instance must be created before using the driver and
     // must remain alive for as long as the driver is in use.

--- a/examples/mongocxx/server_side_field_level_encryption_enforcement.cpp
+++ b/examples/mongocxx/server_side_field_level_encryption_enforcement.cpp
@@ -46,7 +46,7 @@ using namespace mongocxx;
 
 const int kKeyLength = 96;
 
-int main(int, char**) {
+int main() {
     instance inst{};
 
     // This must be the same master key that was used to create

--- a/examples/mongocxx/tailable_cursor.cpp
+++ b/examples/mongocxx/tailable_cursor.cpp
@@ -68,7 +68,7 @@ void insert_docs(mongocxx::collection* coll) {
     }
 }
 
-int main(int, char**) {
+int main() {
     // The mongocxx::instance constructor and destructor initialize and shut down the driver,
     // respectively. Therefore, a mongocxx::instance must be created before using the driver and
     // must remain alive for as long as the driver is in use.

--- a/examples/mongocxx/update.cpp
+++ b/examples/mongocxx/update.cpp
@@ -23,7 +23,7 @@ using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_array;
 using bsoncxx::builder::basic::make_document;
 
-int main(int, char**) {
+int main() {
     // The mongocxx::instance constructor and destructor initialize and shut down the driver,
     // respectively. Therefore, a mongocxx::instance must be created before using the driver and
     // must remain alive for as long as the driver is in use.

--- a/examples/mongocxx/view_or_value_variant.cpp
+++ b/examples/mongocxx/view_or_value_variant.cpp
@@ -24,7 +24,7 @@ using bsoncxx::builder::basic::array;
 using bsoncxx::builder::basic::kvp;
 using bsoncxx::builder::basic::make_document;
 
-int main(int, char**) {
+int main() {
     // The mongocxx::instance constructor and destructor initialize and shut down the driver,
     // respectively. Therefore, a mongocxx::instance must be created before using the driver and
     // must remain alive for as long as the driver is in use.


### PR DESCRIPTION
Simple drive-by improvement simplifying the declaration of `main()` in example code.