### PR TITLE
CXX-3089 Ensure <string> is included in all components using std::string

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/core.hpp
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <stdexcept>
+#include <string>
 #include <type_traits>
 
 #include <bsoncxx/builder/core-fwd.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types.hpp
@@ -16,6 +16,7 @@
 
 #include <chrono>
 #include <cstring>
+#include <string>
 
 #include <bsoncxx/types-fwd.hpp>
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
@@ -16,6 +16,7 @@
 
 #include <iostream>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include <bsoncxx/document/element-fwd.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/element.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/element.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cstdlib>
+#include <string>
 
 #include <bsoncxx/document/element.hpp>
 #include <bsoncxx/exception/error_code.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include <mongocxx/client-fwd.hpp>
 #include <mongocxx/client_session-fwd.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <string>
+
 #include <mongocxx/client_encryption-fwd.hpp>
 #include <mongocxx/collection-fwd.hpp>
 #include <mongocxx/database-fwd.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 #include <mongocxx/events/heartbeat_failed_event-fwd.hpp>
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <string>
+
 #include <mongocxx/exception/operation_exception-fwd.hpp>
 
 #include <bsoncxx/document/value.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/hint.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/hint.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <string>
+
 #include <mongocxx/hint-fwd.hpp>
 
 #include <bsoncxx/document/value.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <string>
+
 #include <mongocxx/client_encryption-fwd.hpp>
 #include <mongocxx/options/encrypt-fwd.hpp>
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <chrono>
+#include <string>
 
 #include <mongocxx/options/index_view-fwd.hpp>
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <memory>
 #include <stdexcept>
+#include <string>
 
 #include <mongocxx/bulk_write-fwd.hpp>
 #include <mongocxx/client-fwd.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/change_stream.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/change_stream.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string>
+
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/builder/core.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/index_view.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/index_view.hh
@@ -25,6 +25,7 @@
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/exception/operation_exception.hpp>
 #include <mongocxx/exception/write_exception.hpp>
+#include <mongocxx/index_view.hpp>
 #include <mongocxx/options/index_view.hpp>
 #include <mongocxx/private/client_session.hh>
 #include <mongocxx/private/libbson.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/search_index_view.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/search_index_view.hh
@@ -10,6 +10,7 @@
 #include <mongocxx/private/client_session.hh>
 #include <mongocxx/private/libbson.hh>
 #include <mongocxx/private/libmongoc.hh>
+#include <mongocxx/search_index_view.hpp>
 
 #include <mongocxx/config/private/prelude.hh>
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/validation_criteria.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/validation_criteria.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string>
+
 #include <bsoncxx/builder/basic/document.hpp>
 #include <mongocxx/validation_criteria.hpp>
 


### PR DESCRIPTION
Resolves CXX-3089. Supercedes https://github.com/mongodb/mongo-cxx-driver/pull/1192. Verified by [this patch](https://spruce.mongodb.com/version/66bf670db574900007456c24).

Requesting an additional review from @vorlac to validate these changes in their environment. (I am unable to add you to the list of reviewers.)

`<string_view>` is not specified to include `<string>`. The [STL changes](https://github.com/microsoft/STL/blame/b191409cec71aa837072a5d1ebafb041989c71dd/stl/inc/string_view#L14-L16) cited in https://github.com/mongodb/mongo-cxx-driver/pull/1192 exposed pre-existing Include What You Use (IWYU) violations in C++ Driver headers (use of `std::string` without including `<string>`).

This PR fixes all IWYU violations for `std::string` (only!) in library code (not tests, examples, etc.). To keep the diff small, the include is added to the "top-most" layer of each component:

- If a `.cpp` uses `std::string`, include `<string>` unless its header(s) already includes it.
- If a private header uses `std::string`, include `<string>` unless its public header includes it.
- If a public header uses `std::string`, include `<string>` unless a fundamentally dependent header includes it.

> [!NOTE]
> I am of the opinion that every file, regardless of component membership or hierarchy, should IWYU, but this PR is deliberately kept small and focused. Auditing and addressing standalone inclusion and IWYU issues can be deferred to a followup task/PR.

The only case of the "unless" in the last bullet point is with the BSON document builder headers. All the builders directly depend on `<bsoncxx/builder/core.hpp>`, thus the `<string>` is added only to `core.hpp` to cover for all the dependent builder headers.

Some additional non-`<string>` include directives were added to the index_view and search_index_view components to properly satisfy their component include hierarchy.