### PR TITLE
CXX-3088 fix build with GCC 4.8.5

### DIFF
--- a/.evergreen/compile.sh
+++ b/.evergreen/compile.sh
@@ -159,6 +159,9 @@ linux*)
 
   if [[ "${distro_id:?}" != rhel7* ]]; then
     cxx_flags+=("-Wno-expansion-to-defined")
+  else
+    cc_flags+=("-Wno-unused-parameter") # TODO: remove once C driver is upgraded to include fix of CDRIVER-5673.
+    cxx_flags+=("-Wno-unused-parameter") # TODO: remove once C driver is upgraded to include fix of CDRIVER-5673.
   fi
   ;;
 *)

--- a/.evergreen/compile.sh
+++ b/.evergreen/compile.sh
@@ -160,7 +160,6 @@ linux*)
   if [[ "${distro_id:?}" != rhel7* ]]; then
     cxx_flags+=("-Wno-expansion-to-defined")
   else
-    cc_flags+=("-Wno-unused-parameter") # TODO: remove once C driver is upgraded to include fix of CDRIVER-5673.
     cxx_flags+=("-Wno-unused-parameter") # TODO: remove once C driver is upgraded to include fix of CDRIVER-5673.
   fi
   ;;

--- a/.evergreen/compile.sh
+++ b/.evergreen/compile.sh
@@ -155,7 +155,11 @@ darwin*)
   ;;
 linux*)
   cc_flags+=("${cc_flags_init[@]}")
-  cxx_flags+=("${cxx_flags_init[@]}" -Wno-expansion-to-defined -Wno-missing-field-initializers)
+  cxx_flags+=("${cxx_flags_init[@]}" -Wno-missing-field-initializers)
+
+  if [[ "${distro_id:?}" != rhel7* ]]; then
+    cxx_flags+=("-Wno-expansion-to-defined")
+  fi
   ;;
 *)
   echo "unrecognized operating system ${OSTYPE:?}" 1>&2

--- a/.mci.yml
+++ b/.mci.yml
@@ -2221,3 +2221,13 @@ buildvariants:
       display_name: silk
       tasks:
         - name: .silk
+
+    - name: rhel79-compile
+      display_name: "RHEL 7.9 (gcc 4.8.5)"
+      expansions:
+          build_type: "Release"
+          BSONCXX_POLYFILL: impls
+      run_on:
+          - rhel79-small
+      tasks:
+          - name: compile_without_tests

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
@@ -82,7 +82,7 @@ BSONCXX_API document::value BSONCXX_CALL from_json(stdx::string_view json);
 ///
 /// @throws bsoncxx::v_noabi::exception with error details if the conversion failed.
 ///
-BSONCXX_API document::value BSONCXX_CALL operator""_bson(const char* json, size_t len);
+BSONCXX_API document::value BSONCXX_CALL operator"" _bson(const char* json, size_t len);
 
 }  // namespace v_noabi
 }  // namespace bsoncxx
@@ -92,7 +92,7 @@ namespace bsoncxx {
 using ::bsoncxx::v_noabi::from_json;
 using ::bsoncxx::v_noabi::to_json;
 
-using ::bsoncxx::v_noabi::operator""_bson;
+using ::bsoncxx::v_noabi::operator"" _bson;
 
 }  // namespace bsoncxx
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/string_view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/string_view.hpp
@@ -438,7 +438,7 @@ class basic_string_view : bsoncxx::detail::equality_operators, bsoncxx::detail::
 // Required to define this here for compatibility with C++14 and older. Can be removed in C++17 or
 // newer.
 template <typename C, typename Tr>
-const std::size_t basic_string_view<C, Tr>::npos;
+constexpr std::size_t basic_string_view<C, Tr>::npos;
 
 using string_view = basic_string_view<char>;
 

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/json.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/json.cpp
@@ -99,7 +99,7 @@ document::value BSONCXX_CALL from_json(stdx::string_view json) {
     return document::value{buf, length, bson_free_deleter};
 }
 
-document::value BSONCXX_CALL operator""_bson(const char* str, size_t len) {
+document::value BSONCXX_CALL operator"" _bson(const char* str, size_t len) {
     return from_json(stdx::string_view{str, len});
 }
 


### PR DESCRIPTION
# Summary

Fix build with GCC 4.8.5.

Verified with this [patch build](https://spruce.mongodb.com/version/66c6161c488c38000703c3e4).

# Description

Supporting build with GCC 4.8.5 is motivated by a request to build on a customer RHEL 7.9 system. See [slack thread](https://mongodb.slack.com/archives/C0328AQA3/p1723037627729639).

This PR resolves errors observed when building with RHEL 7 with GCC 4.8.5.

## Error: redeclaration differs in 'constexpr'

```
/root/mongo-cxx-driver/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/string_view.hpp:571:45: error: redeclaration 'bsoncxx::v_noabi::stdx::basic_string_view<Char, Traits>::npos' differs in 'constexpr'
const std::size_t basic_string_view<C, Tr>::npos;
                                            ^
/root/mongo-cxx-driver/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/string_view.hpp:136:32: error: from previous declaration 'bsoncxx::v_noabi::stdx::basic_string_view<Char, Traits>::npos'
    static constexpr size_type npos = static_cast<size_type>(-1);
```

I expect this is a quirk in old GCC. See: https://stackoverflow.com/a/17074539/774658. This PR adds `constexpr` to match.

## Error: missing space

```
/root/mongo-cxx-driver/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp:83:42: error: missing space between '""' and suffix identifier
BSONCXX_API document::value BSONCXX_CALL operator""_bson(const char* json, size_t len);
```

This PR adds a space for C++11 compliance.

C++11 [user-defined literals](https://timsong-cpp.github.io/cppwp/n3337/over.literal) note a space is required:

> ```
> float operator ""E(const char*);                    // error: ""E (with no intervening space)
>                                                     // is a single token
> ```

C++14 [user-defined literals](https://timsong-cpp.github.io/cppwp/n4140/over.literal) permit no space:

> ```
> float operator ""_e(const char*);                   // OK
> ```

## Ignoring unused parameters

Building the C driver resulted in errors due to `unused-parameter` warnings:

```
../../_deps/mongo-c-driver-src/src/libbson/src/bson/bson-atomic.h:202:28: error: unused parameter 'order' [-Werror=unused-parameter]
    static BSON_INLINE Type bson_atomic_##NamePart##_fetch (      
```

This was addressed in CDRIVER-5673. However, trying to upgrade the C driver to include the fix resulted in [test failures](https://spruce.mongodb.com/version/66c004af4dfaa40007985227) in In-Use Encryption tests due to "rangePreview" being removed. I expect the In-Use Encryption test updates will be addressed in CXX-3014. To limit scope of this PR, `-Wno-unused-parameter` is added to compile flags on RHEL 7 as a temporary workaround until the C driver is upgraded to include CDRIVER-5673.
