### PR TITLE
Address task timeouts on VS 2015 distros due to KMS KMIP mock server

### DIFF
--- a/.evergreen/abi-stability-setup.sh
+++ b/.evergreen/abi-stability-setup.sh
@@ -26,6 +26,13 @@ declare cmake_binary
 cmake_binary="$(find_cmake_latest)"
 command -V "${cmake_binary:?}"
 
+# Use ccache if available.
+if [[ -f "./mongoc/.evergreen/scripts/find-ccache.sh" ]]; then
+  # shellcheck source=/dev/null
+  . "./mongoc/.evergreen/scripts/find-ccache.sh"
+  find_ccache_and_export_vars "$(pwd)" || true
+fi
+
 # To use a different base commit, replace `--abbrev 0` with the intended commit.
 # Note: EVG treat all changes relative to the EVG base commit as staged changes!
 declare base current
@@ -53,17 +60,6 @@ if command -V ninja; then
 else
   export CMAKE_BUILD_PARALLEL_LEVEL
   CMAKE_BUILD_PARALLEL_LEVEL="${parallel_level:?}"
-fi
-
-# Use ccache if available.
-if command -V ccache 2>/dev/null; then
-  export CMAKE_C_COMPILER_LAUNCHER=ccache
-  export CMAKE_CXX_COMPILER_LAUNCHER=ccache
-
-  # Allow reuse of ccache compilation results between different build directories.
-  export CCACHE_BASEDIR CCACHE_NOHASHDIR
-  CCACHE_BASEDIR="$(pwd)/mongo-cxx-driver"
-  CCACHE_NOHASHDIR=1
 fi
 
 # Install prefix to use for ABI compatibility scripts.

--- a/.evergreen/compile.sh
+++ b/.evergreen/compile.sh
@@ -66,17 +66,10 @@ CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
 export CMAKE_BUILD_PARALLEL_LEVEL
 
 # Use ccache if available.
-if command -V ccache 2>/dev/null; then
-  export CMAKE_CXX_COMPILER_LAUNCHER=ccache
-
-  # Allow reuse of ccache compilation results between different build directories.
-  export CCACHE_BASEDIR CCACHE_NOHASHDIR
-  if [[ "${OSTYPE:?}" == "cygwin" ]]; then
-    CCACHE_BASEDIR="$(cygpath -aw "$(pwd)")"
-  else
-    CCACHE_BASEDIR="$(pwd)"
-  fi
-  CCACHE_NOHASHDIR=1
+if [[ -f "${mongoc_prefix:?}/.evergreen/scripts/find-ccache.sh" ]]; then
+  # shellcheck source=/dev/null
+  . "${mongoc_prefix:?}/.evergreen/scripts/find-ccache.sh"
+  find_ccache_and_export_vars "$(pwd)" || true
 fi
 
 cmake_build_opts=()

--- a/.evergreen/install_c_driver.sh
+++ b/.evergreen/install_c_driver.sh
@@ -131,14 +131,10 @@ else
 fi
 
 # Use ccache if available.
-if command -V ccache 2>/dev/null; then
-  export CMAKE_C_COMPILER_LAUNCHER=ccache
-  export CMAKE_CXX_COMPILER_LAUNCHER=ccache
-
-  # Allow reuse of ccache compilation results between different build directories.
-  export CCACHE_BASEDIR CCACHE_NOHASHDIR
-  CCACHE_BASEDIR="${mongoc_idir}"
-  CCACHE_NOHASHDIR=1
+if [[ -f "${mongoc_dir:?}/.evergreen/scripts/find-ccache.sh" ]]; then
+  # shellcheck source=/dev/null
+  . "${mongoc_dir:?}/.evergreen/scripts/find-ccache.sh"
+  find_ccache_and_export_vars "$(pwd)" || true
 fi
 
 # Install libmongoc.

--- a/.evergreen/test.sh
+++ b/.evergreen/test.sh
@@ -202,7 +202,7 @@ else
     for _ in $(seq 60); do
       # Exit code 7: "Failed to connect to host".
       if
-        curl -s "localhost:${port:?}"
+        curl -s -m 1 "localhost:${port:?}"
         (($? != 7))
       then
         return 0

--- a/.evergreen/test.sh
+++ b/.evergreen/test.sh
@@ -106,6 +106,9 @@ export MONGOCXX_TEST_TLS_CA_FILE="${DRIVERS_TOOLS:?}/.evergreen/x509gen/ca.pem"
 
 if [ "$(uname -m)" == "ppc64le" ]; then
   echo "Skipping CSFLE test setup (CDRIVER-4246/CXX-2423)"
+elif [[ "${distro_id:?}" =~ windows-64-vs2015-* ]]; then
+  # Python: ImportError: DLL load failed while importing _rust: The specified procedure could not be found.
+  echo "Skipping CSFLE test setup (CXX-2628)"
 else
   # export environment variables for encryption tests
   set +o errexit

--- a/.mci.yml
+++ b/.mci.yml
@@ -419,6 +419,11 @@ functions:
           script: |-
             set -o errexit
             echo "Preparing CSFLE venv environment..."
+            if [[ "${distro_id:?}" =~ vs2015 ]]; then
+              # Python: ImportError: DLL load failed while importing _rust: The specified procedure could not be found.
+              echo "Preparing CSFLE venv environment... skipped."
+              exit 0
+            fi
             cd ./drivers-evergreen-tools/.evergreen/csfle
             # This function ensures future invocations of activate-kmstlsvenv.sh conducted in
             # parallel do not race to setup a venv environment; it has already been prepared.

--- a/.mci.yml
+++ b/.mci.yml
@@ -424,18 +424,7 @@ functions:
             # parallel do not race to setup a venv environment; it has already been prepared.
             # This primarily addresses the situation where the "test" and "run_kms_servers"
             # functions invoke 'activate-kmstlsvenv.sh' simultaneously.
-            if [[ "$OSTYPE" =~ cygwin && ! -d kmstlsvenv ]]; then
-                # Avoid using Python 3.10 on Windows due to incompatible cipher suites.
-                # See CXX-2628.
-                . ../venv-utils.sh
-                venvcreate "C:/python/Python39/python.exe" kmstlsvenv || # windows-2017
-                venvcreate "C:/python/Python38/python.exe" kmstlsvenv    # windows-2015
-                python -m pip install --upgrade boto3~=1.19 pykmip~=0.10.0 "sqlalchemy<2.0.0"
-                deactivate
-            else
-                . ./activate-kmstlsvenv.sh
-                deactivate
-            fi
+            . ./activate-kmstlsvenv.sh && deactivate
             echo "Preparing CSFLE venv environment... done."
       - command: shell.exec
         params:

--- a/.mci.yml
+++ b/.mci.yml
@@ -215,7 +215,7 @@ functions:
                 wait_for_mongohouse() {
                     for _ in $(seq 300); do
                         # Exit code 7: "Failed to connect to host".
-                        if curl -s localhost:$1; (("$?" != 7)); then
+                        if curl -s -m 1 localhost:$1; (("$?" != 7)); then
                             return 0
                         else
                             sleep 1

--- a/.mci.yml
+++ b/.mci.yml
@@ -1044,19 +1044,8 @@ tasks:
             export cmake_binary
             cmake_binary="$(find_cmake_latest)"
             # Use ccache if available.
-            if command -V ccache 2>/dev/null; then
-              export CMAKE_C_COMPILER_LAUNCHER=ccache
-              export CMAKE_CXX_COMPILER_LAUNCHER=ccache
-
-              # Allow reuse of ccache compilation results between different build directories.
-              export CCACHE_BASEDIR CCACHE_NOHASHDIR
-              if [[ "${OSTYPE:?}" == "cygwin" ]]; then
-                CCACHE_BASEDIR="$(cygpath -aw "$(pwd)")"
-              else
-                CCACHE_BASEDIR="$(pwd)"
-              fi
-              CCACHE_NOHASHDIR=1
-            fi
+            . ./mongo-c-driver/.evergreen/scripts/find-ccache.sh
+            find_ccache_and_export_vars "$(pwd)" || true
             command -v "$cmake_binary"
             "$cmake_binary" -S . -B build -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF
             "$cmake_binary" --build build

--- a/.mci.yml
+++ b/.mci.yml
@@ -419,7 +419,7 @@ functions:
           script: |-
             set -o errexit
             echo "Preparing CSFLE venv environment..."
-            if [[ "${distro_id:?}" =~ vs2015 ]]; then
+            if [[ "${distro_id}" =~ windows-64-vs2015-* ]]; then
               # Python: ImportError: DLL load failed while importing _rust: The specified procedure could not be found.
               echo "Preparing CSFLE venv environment... skipped."
               exit 0
@@ -438,6 +438,11 @@ functions:
           script: |-
             set -o errexit
             echo "Starting mock KMS servers..."
+            if [[ "${distro_id}" =~ windows-64-vs2015-* ]]; then
+              # Python: ImportError: DLL load failed while importing _rust: The specified procedure could not be found.
+              echo "Starting mock KMS servers... skipped."
+              exit 0
+            fi
             cd ./drivers-evergreen-tools/.evergreen/csfle
             . ./activate-kmstlsvenv.sh
             python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --port 8999 &


### PR DESCRIPTION
Verified by [this patch](https://spruce.mongodb.com/version/66ccc85588f0d50007b1526b).

Addresses task timeouts on VS 2015 distros since [2024-07-22](https://spruce.mongodb.com/version/mongo_cxx_driver_ae07bd2574ae7340f7a047f4dd99186c644a262b/tasks) due to what appears to be an incompatibility with the Python version/environment and its relation to the cryptography package as required by the KMS KMIP mock server:

```
Traceback (most recent call last):
  File "kms_kmip_server.py", line 6, in <module>
    from kmip.services.server import KmipServer
  File "drivers-evergreen-tools\.evergreen\csfle\kmstlsvenv\lib\site-packages\kmip\services\server\__init__.py", line 16, in <module>
    from kmip.services.server.server import KmipServer
  File "drivers-evergreen-tools\.evergreen\csfle\kmstlsvenv\lib\site-packages\kmip\services\server\server.py", line 33, in <module>
    from kmip.services.server import engine
  File "drivers-evergreen-tools\.evergreen\csfle\kmstlsvenv\lib\site-packages\kmip\services\server\engine.py", line 47, in <module>
    from kmip.services.server.crypto import engine
  File "drivers-evergreen-tools\.evergreen\csfle\kmstlsvenv\lib\site-packages\kmip\services\server\crypto\__init__.py", line 17, in <module>
    from kmip.services.server.crypto.engine import CryptographyEngine
  File "drivers-evergreen-tools\.evergreen\csfle\kmstlsvenv\lib\site-packages\kmip\services\server\crypto\engine.py", line 19, in <module>
    from cryptography import exceptions as errors
  File "drivers-evergreen-tools\.evergreen\csfle\kmstlsvenv\lib\site-packages\cryptography\exceptions.py", line 9, in <module>
    from cryptography.hazmat.bindings._rust import exceptions as rust_exceptions
ImportError: DLL load failed while importing _rust: The specified procedure could not be found.
```

This led to a task timeout after 1 hour (the EVG config's max timeout) due to the `wait_for_kms_server` function's curl command lacking a max-time argument (no response -> wait forever?). 

A brief investigation into the root cause of the ImportError exception did not yield any obvious solutions or workarounds.

Accordingly, this PR applies the following changes to the EVG config and scripts:

- Add `--max-time 1` (one second) to the curl command to correctly reflect its intended usage. (The `wait_for_kms_server` can be updated to use `--max-time 1 --retry 60` instead if preferred over the existing loop. Not yet applied due to not being entirely confident that the combination of flags is actually correct.)
- Replace the old CXX-2628 workaround (which applied to all Windows distros; no longer applicable...?) by skipping CSFLE tests entirely on VS 2015 distros only instead.
- Drive-by improvement: use `find-ccache.sh` added to C Driver in https://github.com/mongodb/mongo-c-driver/commit/35f38806bba00d17b4d7f0479d0d213b97b49553.
