### PR TITLE
remove homebrew release step

### DIFF
--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -722,14 +722,6 @@ The C++ Driver Team
 
 ## Packaging
 
-### Homebrew
-
-This requires a macOS machine.
-If this is a stable release, update the [mongo-cxx-driver](https://github.com/Homebrew/homebrew-core/blob/master/Formula/mongo-cxx-driver.rb) homebrew formula, using: `brew bump-formula-pr mongo-cxx-driver --url <tarball url>`
-
-Example:
-`brew bump-formula-pr mongo-cxx-driver --url https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.7.3/mongo-cxx-driver-r3.7.3.tar.gz`
-
 ### vcpkg
 
 Submit a PR or create an issue to update the vc-pkg file for mongo-cxx-driver.


### PR DESCRIPTION
# Summary

Remove Homebrew release step.

# Background & Motivation

Homebrew steps were also removed from C driver in https://github.com/mongodb/mongo-c-driver/pull/1687.

Trying to manually update results in this message:

```bash
% brew bump-formula-pr mongo-cxx-driver --url https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.10.2/mongo-cxx-driver-r3.10.2.tar.gz
Error: Whoops, the mongo-cxx-driver formula has its version update
pull requests automatically opened by BrewTestBot every ~3 hours!
We'd still love your contributions, though, so try another one
that's not in the autobump list:
  https://github.com/Homebrew/homebrew-core/blob/master/.github/autobump.txt
```
