### PR TITLE
Format src/mongocxx/test/spec/unified_tests/assert.cpp

### DIFF
--- a/src/mongocxx/test/spec/unified_tests/assert.cpp
+++ b/src/mongocxx/test/spec/unified_tests/assert.cpp
@@ -24,11 +24,11 @@
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/value.hpp>
 
+#include <bsoncxx/config/prelude.hpp>
+
 #include <bsoncxx/test/catch.hh>
 #include <bsoncxx/test/to_string.hh>
 #include <mongocxx/test/client_helpers.hh>
-
-#include <bsoncxx/config/prelude.hpp>
 
 using namespace bsoncxx;
 using namespace mongocxx;


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1201 which missed a file when applying new ClangFormat rules introduced in https://github.com/mongodb/mongo-cxx-driver/pull/1200.