### PR TITLE
CXX-3098 Throw from to_json when bson_init_static returns false

### DIFF
--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/json.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/json.cpp
@@ -38,13 +38,17 @@ void bson_free_deleter(std::uint8_t* ptr) {
 
 std::string to_json_helper(document::view view, decltype(bson_as_json) converter) {
     bson_t bson;
-    bson_init_static(&bson, view.data(), view.length());
+
+    if (!bson_init_static(&bson, view.data(), view.length())) {
+        throw exception(error_code::k_failed_converting_bson_to_json);
+    }
 
     size_t size;
     auto result = converter(&bson, &size);
 
-    if (!result)
+    if (!result) {
         throw exception(error_code::k_failed_converting_bson_to_json);
+    }
 
     const auto deleter = [](char* result) { bson_free(result); };
     const std::unique_ptr<char[], decltype(deleter)> cleanup(result, deleter);


### PR DESCRIPTION
Addresses CXX-3098. Identified while working on CXX-3082. See CXX-3098 for details.