### PR TITLE
CXX-3100 Check return when acquiring client from pool

### DIFF
--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/error_code.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/error_code.hpp
@@ -107,6 +107,9 @@ enum class error_code : std::int32_t {
     // A default-constructed or moved-from mongocxx::v_noabi::search_index_view object has been
     // used.
     k_invalid_search_index_view,
+    
+    /// Acquired a NULL mongocxx::v_noabi::client object.
+    k_invalid_client_acquired,
 
     // Add new constant string message to error_code.cpp as well!
 };

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/error_code.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/error_code.hpp
@@ -108,8 +108,8 @@ enum class error_code : std::int32_t {
     // used.
     k_invalid_search_index_view,
     
-    /// Acquired a NULL mongocxx::v_noabi::client object.
-    k_invalid_client_acquired,
+    // Timed out while waiting for a client to be returned to the pool
+    k_pool_wait_queue_timeout,
 
     // Add new constant string message to error_code.cpp as well!
 };

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/error_code.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/error_code.hpp
@@ -107,7 +107,7 @@ enum class error_code : std::int32_t {
     // A default-constructed or moved-from mongocxx::v_noabi::search_index_view object has been
     // used.
     k_invalid_search_index_view,
-    
+
     // Timed out while waiting for a client to be returned to the pool
     k_pool_wait_queue_timeout,
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/error_code.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/error_code.cpp
@@ -92,7 +92,6 @@ class error_category final : public std::error_category {
             case error_code::k_invalid_search_index_view:
                 return "invalid use of default constructed or moved-from "
                        "mongocxx::search_index_view object";
-            case error_code::k_invalid_client_acquired:
             case error_code::k_pool_wait_queue_timeout:
                 return "timed out while waiting for a client to be returned to the pool";
             default:

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/error_code.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/error_code.cpp
@@ -92,6 +92,9 @@ class error_category final : public std::error_category {
             case error_code::k_invalid_search_index_view:
                 return "invalid use of default constructed or moved-from "
                        "mongocxx::search_index_view object";
+            case error_code::k_invalid_client_acquired:
+                return "invalid mongocxx::v_noabi::client object was acquired, "
+                       "possibly due to curi-parameter 'waitQueueTimeoutMS' limits";
             default:
                 return "unknown mongocxx error";
         }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/error_code.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/error_code.cpp
@@ -93,8 +93,8 @@ class error_category final : public std::error_category {
                 return "invalid use of default constructed or moved-from "
                        "mongocxx::search_index_view object";
             case error_code::k_invalid_client_acquired:
-                return "invalid mongocxx::v_noabi::client object was acquired, "
-                       "possibly due to curi-parameter 'waitQueueTimeoutMS' limits";
+            case error_code::k_pool_wait_queue_timeout:
+                return "timed out while waiting for a client to be returned to the pool";
             default:
                 return "unknown mongocxx error";
         }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
@@ -134,7 +134,7 @@ pool::entry pool::acquire() {
     auto cli = libmongoc::client_pool_pop(_impl->client_pool_t);
     if (!cli)
         throw exception{ error_code::k_invalid_client_object,
-                        "mongoc_client_pool returned a null client, possibly due to parameter 'waitQueueTimeoutMS' limits." };
+                        "failed to acquire client, possibly due to parameter 'waitQueueTimeoutMS' limits." };
 
     return entry(entry::unique_client(new client(cli), [this](client* client) { _release(client); }));
 }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
@@ -133,10 +133,12 @@ pool::entry::entry(pool::entry::unique_client p) : _client(std::move(p)) {}
 pool::entry pool::acquire() {
     auto cli = libmongoc::client_pool_pop(_impl->client_pool_t);
     if (!cli)
-        throw exception{ error_code::k_pool_wait_queue_timeout,
-                        "failed to acquire client, possibly due to parameter 'waitQueueTimeoutMS' limits." };
+        throw exception{ 
+            error_code::k_pool_wait_queue_timeout,
+            "failed to acquire client, possibly due to parameter 'waitQueueTimeoutMS' limits." };
 
-    return entry(entry::unique_client(new client(cli), [this](client* client) { _release(client); }));
+    return entry(
+        entry::unique_client(new client(cli), [this](client* client) { _release(client); }));
 }
 
 stdx::optional<pool::entry> pool::try_acquire() {

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
@@ -133,7 +133,7 @@ pool::entry::entry(pool::entry::unique_client p) : _client(std::move(p)) {}
 pool::entry pool::acquire() {
     auto cli = libmongoc::client_pool_pop(_impl->client_pool_t);
     if (!cli)
-        throw exception{ error_code::k_invalid_client_object,
+        throw exception{ error_code::k_invalid_client_acquired,
                         "failed to acquire client, possibly due to parameter 'waitQueueTimeoutMS' limits." };
 
     return entry(entry::unique_client(new client(cli), [this](client* client) { _release(client); }));

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
@@ -133,7 +133,7 @@ pool::entry::entry(pool::entry::unique_client p) : _client(std::move(p)) {}
 pool::entry pool::acquire() {
     auto cli = libmongoc::client_pool_pop(_impl->client_pool_t);
     if (!cli)
-        throw exception{ error_code::k_invalid_client_acquired,
+        throw exception{ error_code::k_pool_wait_queue_timeout,
                         "failed to acquire client, possibly due to parameter 'waitQueueTimeoutMS' limits." };
 
     return entry(entry::unique_client(new client(cli), [this](client* client) { _release(client); }));

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
@@ -133,9 +133,9 @@ pool::entry::entry(pool::entry::unique_client p) : _client(std::move(p)) {}
 pool::entry pool::acquire() {
     auto cli = libmongoc::client_pool_pop(_impl->client_pool_t);
     if (!cli)
-        throw exception{ 
+        throw exception{
             error_code::k_pool_wait_queue_timeout,
-            "failed to acquire client, possibly due to parameter 'waitQueueTimeoutMS' limits." };
+            "failed to acquire client, possibly due to parameter 'waitQueueTimeoutMS' limits."};
 
     return entry(
         entry::unique_client(new client(cli), [this](client* client) { _release(client); }));

--- a/src/mongocxx/test/pool.cpp
+++ b/src/mongocxx/test/pool.cpp
@@ -193,7 +193,6 @@ TEST_CASE("acquiring a client throws if waitQueueTimeoutMS expires", "[pool]") {
     // Acquire only available client:
     auto client = pool.acquire();
     CHECK(client);
-    CHECK(client);
     // Try to acquire again. Expect timeout:
     REQUIRE_THROWS_WITH(pool.acquire(),
                         Catch::Matchers::ContainsSubstring("failed to acquire client"));

--- a/src/mongocxx/test/pool.cpp
+++ b/src/mongocxx/test/pool.cpp
@@ -191,6 +191,7 @@ TEST_CASE("acquiring a client throws if waitQueueTimeoutMS expires", "[pool]") {
     mongocxx::pool pool{uri, options::pool(test_util::add_test_server_api())};
     // Acquire only available client:
     auto client = pool.acquire();
+    CHECK(client);
     // Try to acquire again. Expect timeout:
     REQUIRE_THROWS_WITH(pool.acquire(),
                         Catch::Matchers::ContainsSubstring("failed to acquire client"));

--- a/src/mongocxx/test/pool.cpp
+++ b/src/mongocxx/test/pool.cpp
@@ -183,4 +183,16 @@ TEST_CASE("a pool is created with an invalid connection string", "[pool]") {
 
     REQUIRE_THROWS_AS(pool{mongocxx::uri(uristr)}, operation_exception);
 }
+
+TEST_CASE("acquiring a client throws if waitQueueTimeoutMS expires", "[pool]") {
+    instance::current();
+    auto uri = mongocxx::uri{"mongodb://localhost:27017/?waitQueueTimeoutMS=1&maxPoolSize=1"};
+    mongocxx::pool pool{uri, options::pool(test_util::add_test_server_api())};
+    // Acquire only available client:
+    auto client = pool.acquire();
+    // Try to acquire again. Expect timeout:
+    REQUIRE_THROWS_WITH(pool.acquire(),
+                        Catch::Matchers::ContainsSubstring("failed to acquire client"));
+}
+
 }  // namespace

--- a/src/mongocxx/test/pool.cpp
+++ b/src/mongocxx/test/pool.cpp
@@ -26,6 +26,7 @@
 
 #include <bsoncxx/test/catch.hh>
 #include <mongocxx/test/catch_helpers.hh>
+#include <mongocxx/test/client_helpers.hh>
 
 namespace {
 using namespace mongocxx;

--- a/src/mongocxx/test/pool.cpp
+++ b/src/mongocxx/test/pool.cpp
@@ -193,6 +193,7 @@ TEST_CASE("acquiring a client throws if waitQueueTimeoutMS expires", "[pool]") {
     // Acquire only available client:
     auto client = pool.acquire();
     CHECK(client);
+    CHECK(client);
     // Try to acquire again. Expect timeout:
     REQUIRE_THROWS_WITH(pool.acquire(),
                         Catch::Matchers::ContainsSubstring("failed to acquire client"));

--- a/src/mongocxx/test/pool.cpp
+++ b/src/mongocxx/test/pool.cpp
@@ -187,8 +187,9 @@ TEST_CASE("a pool is created with an invalid connection string", "[pool]") {
 
 TEST_CASE("acquiring a client throws if waitQueueTimeoutMS expires", "[pool]") {
     instance::current();
-    auto uri = mongocxx::uri{"mongodb://localhost:27017/?waitQueueTimeoutMS=1&maxPoolSize=1"};
-    mongocxx::pool pool{uri, options::pool(test_util::add_test_server_api())};
+    mongocxx::pool pool{
+        mongocxx::uri{"mongodb://localhost:27017/?waitQueueTimeoutMS=1&maxPoolSize=1"},
+        options::pool(test_util::add_test_server_api())};
     // Acquire only available client:
     auto client = pool.acquire();
     CHECK(client);


### PR DESCRIPTION
(This pull request fix one minor bug)
Symptom: When the uri parameter 'waitQueueTimeoutMS' was enabled and set to a smaller value (e.g. 100), the function 'mongoc_client_pool' may return a NULL client.
Solution:  Add a check in the function 'pool::entry pool::acquire()', and throw an exception when correct client was not returned.