### PR TITLE
CXX-3102 Remove use of BSONCXX_ENUM in public headers

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1726,7 +1726,7 @@ FULL_SIDEBAR           = NO
 # Minimum value: 0, maximum value: 20, default value: 4.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-ENUM_VALUES_PER_LINE   = 4
+ENUM_VALUES_PER_LINE   = 1
 
 # If the treeview is enabled (see GENERATE_TREEVIEW) then this tag can be used
 # to set the initial width (in pixels) of the frame in which the tree is shown.

--- a/Doxyfile
+++ b/Doxyfile
@@ -237,7 +237,7 @@ QT_AUTOBRIEF           = NO
 # not recognized any more.
 # The default value is: NO.
 
-MULTILINE_CPP_IS_BRIEF = NO
+MULTILINE_CPP_IS_BRIEF = YES
 
 # By default Python docstrings are displayed as preformatted text and doxygen's
 # special commands cannot be used. By setting PYTHON_DOCSTRING to NO the

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/error_code.hpp
@@ -43,11 +43,30 @@ enum class error_code : std::int32_t {
     /// A document operation was performed while building an array.
     k_cannot_perform_document_operation_on_array,
 
-// @cond DOXYGEN_DISABLE
-#define BSONCXX_ENUM(name, value) k_need_element_type_k_##name,
-#include <bsoncxx/enums/type.hpp>
-#undef BSONCXX_ENUM
-    // @endcond DOXYGEN_DISABLE
+    /// The underlying value does not have the requested type.
+    /// @{
+    k_need_element_type_k_double,
+    k_need_element_type_k_string,
+    k_need_element_type_k_document,
+    k_need_element_type_k_array,
+    k_need_element_type_k_binary,
+    k_need_element_type_k_undefined,
+    k_need_element_type_k_oid,
+    k_need_element_type_k_bool,
+    k_need_element_type_k_date,
+    k_need_element_type_k_null,
+    k_need_element_type_k_regex,
+    k_need_element_type_k_dbpointer,
+    k_need_element_type_k_code,
+    k_need_element_type_k_symbol,
+    k_need_element_type_k_codewscope,
+    k_need_element_type_k_int32,
+    k_need_element_type_k_timestamp,
+    k_need_element_type_k_int64,
+    k_need_element_type_k_decimal128,
+    k_need_element_type_k_maxkey,
+    k_need_element_type_k_minkey,
+    /// @}
 
     /// No key was provided when one was needed.
     k_need_key,
@@ -97,13 +116,32 @@ enum class error_code : std::int32_t {
     /// Invalid type.
     k_invalid_bson_type_id,
 
-// @cond DOXYGEN_DISABLE
-#define BSONCXX_ENUM(name, value) k_cannot_append_##name,
-#include <bsoncxx/enums/type.hpp>
-#undef BSONCXX_ENUM
-    // @endcond DOXYGEN_DISABLE
+    /// Failed to append a value of the given type.
+    /// @{
+    k_cannot_append_double,
+    k_cannot_append_string,
+    k_cannot_append_document,
+    k_cannot_append_array,
+    k_cannot_append_binary,
+    k_cannot_append_undefined,
+    k_cannot_append_oid,
+    k_cannot_append_bool,
+    k_cannot_append_date,
+    k_cannot_append_null,
+    k_cannot_append_regex,
+    k_cannot_append_dbpointer,
+    k_cannot_append_code,
+    k_cannot_append_symbol,
+    k_cannot_append_codewscope,
+    k_cannot_append_int32,
+    k_cannot_append_timestamp,
+    k_cannot_append_int64,
+    k_cannot_append_decimal128,
+    k_cannot_append_maxkey,
+    k_cannot_append_minkey,
+    /// @}
 
-    /// A value failed to append.
+    /// Failed to append a value of the given type.
     k_cannot_append_utf8 = k_cannot_append_string,
 
     /// @deprecated Use `k_need_element_type_k_string` instead.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types-fwd.hpp
@@ -31,12 +31,27 @@ namespace bsoncxx {
 namespace v_noabi {
 namespace types {
 
-#pragma push_macro("BSONCXX_ENUM")
-#undef BSONCXX_ENUM
-#define BSONCXX_ENUM(name, val) struct b_##name;
-#include <bsoncxx/enums/type.hpp>
-#undef BSONCXX_ENUM
-#pragma pop_macro("BSONCXX_ENUM")
+struct b_double;
+struct b_string;
+struct b_document;
+struct b_array;
+struct b_binary;
+struct b_undefined;
+struct b_oid;
+struct b_bool;
+struct b_date;
+struct b_null;
+struct b_regex;
+struct b_dbpointer;
+struct b_code;
+struct b_symbol;
+struct b_codewscope;
+struct b_int32;
+struct b_timestamp;
+struct b_int64;
+struct b_decimal128;
+struct b_maxkey;
+struct b_minkey;
 
 }  // namespace types
 }  // namespace v_noabi
@@ -52,12 +67,27 @@ using ::bsoncxx::v_noabi::type;
 namespace bsoncxx {
 namespace types {
 
-#pragma push_macro("BSONCXX_ENUM")
-#undef BSONCXX_ENUM
-#define BSONCXX_ENUM(name, val) using ::bsoncxx::v_noabi::types::b_##name;
-#include <bsoncxx/enums/type.hpp>
-#undef BSONCXX_ENUM
-#pragma pop_macro("BSONCXX_ENUM")
+using ::bsoncxx::v_noabi::types::b_double;
+using ::bsoncxx::v_noabi::types::b_string;
+using ::bsoncxx::v_noabi::types::b_document;
+using ::bsoncxx::v_noabi::types::b_array;
+using ::bsoncxx::v_noabi::types::b_binary;
+using ::bsoncxx::v_noabi::types::b_undefined;
+using ::bsoncxx::v_noabi::types::b_oid;
+using ::bsoncxx::v_noabi::types::b_bool;
+using ::bsoncxx::v_noabi::types::b_date;
+using ::bsoncxx::v_noabi::types::b_null;
+using ::bsoncxx::v_noabi::types::b_regex;
+using ::bsoncxx::v_noabi::types::b_dbpointer;
+using ::bsoncxx::v_noabi::types::b_code;
+using ::bsoncxx::v_noabi::types::b_symbol;
+using ::bsoncxx::v_noabi::types::b_codewscope;
+using ::bsoncxx::v_noabi::types::b_int32;
+using ::bsoncxx::v_noabi::types::b_timestamp;
+using ::bsoncxx::v_noabi::types::b_int64;
+using ::bsoncxx::v_noabi::types::b_decimal128;
+using ::bsoncxx::v_noabi::types::b_maxkey;
+using ::bsoncxx::v_noabi::types::b_minkey;
 
 }  // namespace types
 }  // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types.hpp
@@ -29,9 +29,6 @@
 
 #include <bsoncxx/config/prelude.hpp>
 
-#pragma push_macro("BSONCXX_ENUM")
-#undef BSONCXX_ENUM
-
 BSONCXX_PUSH_WARNINGS();
 BSONCXX_DISABLE_WARNING(GNU("-Wfloat-equal"));
 
@@ -40,36 +37,46 @@ namespace v_noabi {
 
 ///
 /// An enumeration of each BSON type.
-/// These x-macros will expand to be of the form:
-///    k_double = 0x01,
-///    k_string = 0x02,
-///    k_document = 0x03,
-///    k_array = 0x04 ...
 ///
 enum class type : std::uint8_t {
-#define BSONCXX_ENUM(name, val) k_##name = val,
-#include <bsoncxx/enums/type.hpp>
-#undef BSONCXX_ENUM
-    k_utf8 = 0x02,
+    k_double = 0x01,      ///< 64-bit binary floating point.
+    k_string = 0x02,      ///< UTF-8 string.
+    k_utf8 = 0x02,        ///< Equivalent to @ref k_string. @deprecated
+    k_document = 0x03,    ///< Embedded document.
+    k_array = 0x04,       ///< Array.
+    k_binary = 0x05,      ///< Binary data.
+    k_undefined = 0x06,   ///< Undefined value. @deprecated
+    k_oid = 0x07,         ///< ObjectId.
+    k_bool = 0x08,        ///< Boolean.
+    k_date = 0x09,        ///< UTC datetime.
+    k_null = 0x0A,        ///< Null value.
+    k_regex = 0x0B,       ///< Regular expression.
+    k_dbpointer = 0x0C,   ///< DBPointer. @deprecated
+    k_code = 0x0D,        ///< JavaScript code.
+    k_symbol = 0x0E,      ///< Symbol. @deprecated
+    k_codewscope = 0x0F,  ///< JavaScript code with scope.
+    k_int32 = 0x10,       ///< 32-bit integer.
+    k_timestamp = 0x11,   ///< Timestamp.
+    k_int64 = 0x12,       ///< 64-bit integer.
+    k_decimal128 = 0x13,  ///< 128-bit decimal floating point.
+    k_maxkey = 0x7F,      ///< Min key.
+    k_minkey = 0xFF,      ///< Max key.
 };
 
 ///
 /// An enumeration of each BSON binary sub type.
-/// These x-macros will expand to be of the form:
-///   k_binary = 0x00,
-///   k_function = 0x01,
-///   k_binary_deprecated = 0x02,
-///   k_uuid_deprecated = 0x03,
-///   k_uuid = 0x04,
-///   k_md5 = 0x05,
-///   k_encrypted = 0x06,
-///   k_column = 0x07,
-///   k_user = 0x80
 ///
 enum class binary_sub_type : std::uint8_t {
-#define BSONCXX_ENUM(name, val) k_##name = val,
-#include <bsoncxx/enums/binary_sub_type.hpp>
-#undef BSONCXX_ENUM
+    k_binary = 0x00,             ///< Generic binary subtype.
+    k_function = 0x01,           ///< Function.
+    k_binary_deprecated = 0x02,  ///< Binary (Old). @deprecated
+    k_uuid_deprecated = 0x03,    ///< UUID (Old). @deprecated
+    k_uuid = 0x04,               ///< UUID.
+    k_md5 = 0x05,                ///< MD5.
+    k_encrypted = 0x06,          ///< Encrypted BSON value.
+    k_column = 0x07,             ///< Compressed BSON column.
+    k_sensitive = 0x08,          ///< Sensitive.
+    k_user = 0x80,               ///< User defined.
 };
 
 ///
@@ -870,11 +877,6 @@ using ::bsoncxx::v_noabi::types::operator!=;
 
 }  // namespace types
 }  // namespace bsoncxx
-
-#ifdef BSONCXX_ENUM
-static_assert(false, "BSONCXX_ENUM must be undef'ed");
-#endif
-#pragma pop_macro("BSONCXX_ENUM")
 
 #include <bsoncxx/config/postlude.hpp>
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
@@ -46,18 +46,33 @@ namespace bson_value {
 ///
 class value {
    public:
-///
-/// Constructor for each BSON type.
-///
-/// These x-macros will expand to:
-///    value(b_double v);
-///    value(b_string v);
-///    value(b_document v);
-///    value(b_array v); ...
-///
-#define BSONCXX_ENUM(name, val) BSONCXX_ABI_EXPORT_CDECL() value(b_##name v);
-#include <bsoncxx/enums/type.hpp>
-#undef BSONCXX_ENUM
+    ///
+    /// Construct a bson_value::value from the provided BSON type.
+    ///
+    /// @{
+    BSONCXX_ABI_EXPORT_CDECL() value(b_double v);
+    BSONCXX_ABI_EXPORT_CDECL() value(b_string v);
+    BSONCXX_ABI_EXPORT_CDECL() value(b_document v);
+    BSONCXX_ABI_EXPORT_CDECL() value(b_array v);
+    BSONCXX_ABI_EXPORT_CDECL() value(b_binary v);
+    BSONCXX_ABI_EXPORT_CDECL() value(b_undefined v);
+    BSONCXX_ABI_EXPORT_CDECL() value(b_oid v);
+    BSONCXX_ABI_EXPORT_CDECL() value(b_bool v);
+    BSONCXX_ABI_EXPORT_CDECL() value(b_date v);
+    BSONCXX_ABI_EXPORT_CDECL() value(b_null);
+    BSONCXX_ABI_EXPORT_CDECL() value(b_regex v);
+    BSONCXX_ABI_EXPORT_CDECL() value(b_dbpointer v);
+    BSONCXX_ABI_EXPORT_CDECL() value(b_code v);
+    BSONCXX_ABI_EXPORT_CDECL() value(b_symbol v);
+    BSONCXX_ABI_EXPORT_CDECL() value(b_codewscope v);
+    BSONCXX_ABI_EXPORT_CDECL() value(b_int32 v);
+    BSONCXX_ABI_EXPORT_CDECL() value(b_timestamp v);
+    BSONCXX_ABI_EXPORT_CDECL() value(b_int64 v);
+    BSONCXX_ABI_EXPORT_CDECL() value(b_decimal128 v);
+    BSONCXX_ABI_EXPORT_CDECL() value(b_maxkey v);
+    BSONCXX_ABI_EXPORT_CDECL() value(b_minkey v);
+    /// @}
+    ///
 
     ///
     /// Constructs a BSON UTF-8 string value.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
@@ -42,7 +42,7 @@ namespace bson_value {
 /// For accessors into this type and to extract the various BSON types out,
 /// please use bson_value::view.
 ///
-/// @see bsoncxx::v_noabi::bson_value::view
+/// @see @ref bsoncxx::v_noabi::types::bson_value::view
 ///
 class value {
    public:

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
@@ -83,12 +83,12 @@ class view {
     ///
 
     ///
-    /// @return The type of the underlying BSON value stored in this object.
+    /// Returns the type of the underlying BSON value stored in this object.
     ///
     BSONCXX_ABI_EXPORT_CDECL(bsoncxx::v_noabi::type) type() const;
 
     ///
-    /// @return The underlying BSON double value.
+    /// Returns the underlying BSON double value.
     ///
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.
@@ -96,7 +96,7 @@ class view {
     BSONCXX_ABI_EXPORT_CDECL(const b_double&) get_double() const;
 
     ///
-    /// @return The underlying BSON UTF-8 string value.
+    /// Returns the underlying BSON UTF-8 string value.
     ///
     /// @deprecated use get_string instead.
     ///
@@ -106,7 +106,7 @@ class view {
     BSONCXX_DEPRECATED BSONCXX_ABI_EXPORT_CDECL(const b_string&) get_utf8() const;
 
     ///
-    /// @return The underlying BSON UTF-8 string value.
+    /// Returns the underlying BSON UTF-8 string value.
     ///
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.
@@ -114,7 +114,7 @@ class view {
     BSONCXX_ABI_EXPORT_CDECL(const b_string&) get_string() const;
 
     ///
-    /// @return The underlying BSON document value.
+    /// Returns the underlying BSON document value.
     ///
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.
@@ -122,7 +122,7 @@ class view {
     BSONCXX_ABI_EXPORT_CDECL(const b_document&) get_document() const;
 
     ///
-    /// @return The underlying BSON array value.
+    /// Returns the underlying BSON array value.
     ///
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.
@@ -130,7 +130,7 @@ class view {
     BSONCXX_ABI_EXPORT_CDECL(const b_array&) get_array() const;
 
     ///
-    /// @return The underlying BSON binary data value.
+    /// Returns the underlying BSON binary data value.
     ///
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.
@@ -138,7 +138,7 @@ class view {
     BSONCXX_ABI_EXPORT_CDECL(const b_binary&) get_binary() const;
 
     ///
-    /// @return The underlying BSON undefined value.
+    /// Returns the underlying BSON undefined value.
     ///
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.
@@ -146,7 +146,7 @@ class view {
     BSONCXX_ABI_EXPORT_CDECL(const b_undefined&) get_undefined() const;
 
     ///
-    /// @return The underlying BSON ObjectId value.
+    /// Returns the underlying BSON ObjectId value.
     ///
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.
@@ -154,7 +154,7 @@ class view {
     BSONCXX_ABI_EXPORT_CDECL(const b_oid&) get_oid() const;
 
     ///
-    /// @return The underlying BSON boolean value.
+    /// Returns the underlying BSON boolean value.
     ///
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.
@@ -162,7 +162,7 @@ class view {
     BSONCXX_ABI_EXPORT_CDECL(const b_bool&) get_bool() const;
 
     ///
-    /// @return The underlying BSON date value.
+    /// Returns the underlying BSON date value.
     ///
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.
@@ -170,7 +170,7 @@ class view {
     BSONCXX_ABI_EXPORT_CDECL(const b_date&) get_date() const;
 
     ///
-    /// @return The underlying BSON null value.
+    /// Returns the underlying BSON null value.
     ///
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.
@@ -178,7 +178,7 @@ class view {
     BSONCXX_ABI_EXPORT_CDECL(const b_null&) get_null() const;
 
     ///
-    /// @return The underlying BSON regex value.
+    /// Returns the underlying BSON regex value.
     ///
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.
@@ -186,7 +186,7 @@ class view {
     BSONCXX_ABI_EXPORT_CDECL(const b_regex&) get_regex() const;
 
     ///
-    /// @return The underlying BSON DBPointer value.
+    /// Returns the underlying BSON DBPointer value.
     ///
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.
@@ -194,7 +194,7 @@ class view {
     BSONCXX_ABI_EXPORT_CDECL(const b_dbpointer&) get_dbpointer() const;
 
     ///
-    /// @return The underlying BSON JavaScript code value.
+    /// Returns the underlying BSON JavaScript code value.
     ///
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.
@@ -202,7 +202,7 @@ class view {
     BSONCXX_ABI_EXPORT_CDECL(const b_code&) get_code() const;
 
     ///
-    /// @return The underlying BSON symbol value.
+    /// Returns the underlying BSON symbol value.
     ///
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.
@@ -210,7 +210,7 @@ class view {
     BSONCXX_ABI_EXPORT_CDECL(const b_symbol&) get_symbol() const;
 
     ///
-    /// @return The underlying BSON JavaScript code with scope value.
+    /// Returns the underlying BSON JavaScript code with scope value.
     ///
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.
@@ -218,7 +218,7 @@ class view {
     BSONCXX_ABI_EXPORT_CDECL(const b_codewscope&) get_codewscope() const;
 
     ///
-    /// @return The underlying BSON 32-bit signed integer value.
+    /// Returns the underlying BSON 32-bit signed integer value.
     ///
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.
@@ -226,7 +226,7 @@ class view {
     BSONCXX_ABI_EXPORT_CDECL(const b_int32&) get_int32() const;
 
     ///
-    /// @return The underlying BSON replication timestamp value.
+    /// Returns the underlying BSON replication timestamp value.
     ///
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.
@@ -234,7 +234,7 @@ class view {
     BSONCXX_ABI_EXPORT_CDECL(const b_timestamp&) get_timestamp() const;
 
     ///
-    /// @return The underlying BSON 64-bit signed integer value.
+    /// Returns the underlying BSON 64-bit signed integer value.
     ///
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.
@@ -242,7 +242,7 @@ class view {
     BSONCXX_ABI_EXPORT_CDECL(const b_int64&) get_int64() const;
 
     ///
-    /// @return The underlying BSON Decimal128 value.
+    /// Returns the underlying BSON Decimal128 value.
     ///
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.
@@ -250,7 +250,7 @@ class view {
     BSONCXX_ABI_EXPORT_CDECL(const b_decimal128&) get_decimal128() const;
 
     ///
-    /// @return The underlying BSON min-key value.
+    /// Returns the underlying BSON min-key value.
     ///
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.
@@ -258,7 +258,7 @@ class view {
     BSONCXX_ABI_EXPORT_CDECL(const b_minkey&) get_minkey() const;
 
     ///
-    /// @return The underlying BSON max-key value.
+    /// Returns the underlying BSON max-key value.
     ///
     /// @warning
     ///   Calling the wrong get_<type> method will cause an exception to be thrown.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
@@ -40,23 +40,33 @@ namespace bson_value {
 ///
 class view {
    public:
-///
-/// Construct a bson_value::view from any of the various BSON types. Defines
-/// constructors of the following form for each type:
-///
-///   explicit view(type) noexcept;
-///
-/// Like this:
-///
-///   explicit view(b_double) noexcept;
-///   explicit view(b_string) noexcept;
-///   explicit view(b_bool) noexcept;
-///
-/// etc.
-///
-#define BSONCXX_ENUM(type, val) explicit BSONCXX_ABI_EXPORT_CDECL() view(b_##type) noexcept;
-#include <bsoncxx/enums/type.hpp>
-#undef BSONCXX_ENUM
+    ///
+    /// Construct a bson_value::view from the provided BSON type.
+    ///
+    /// @{
+    explicit BSONCXX_ABI_EXPORT_CDECL() view(b_double v) noexcept;
+    explicit BSONCXX_ABI_EXPORT_CDECL() view(b_string v) noexcept;
+    explicit BSONCXX_ABI_EXPORT_CDECL() view(b_document v) noexcept;
+    explicit BSONCXX_ABI_EXPORT_CDECL() view(b_array v) noexcept;
+    explicit BSONCXX_ABI_EXPORT_CDECL() view(b_binary v) noexcept;
+    explicit BSONCXX_ABI_EXPORT_CDECL() view(b_undefined v) noexcept;
+    explicit BSONCXX_ABI_EXPORT_CDECL() view(b_oid v) noexcept;
+    explicit BSONCXX_ABI_EXPORT_CDECL() view(b_bool v) noexcept;
+    explicit BSONCXX_ABI_EXPORT_CDECL() view(b_date v) noexcept;
+    explicit BSONCXX_ABI_EXPORT_CDECL() view(b_null v) noexcept;
+    explicit BSONCXX_ABI_EXPORT_CDECL() view(b_regex v) noexcept;
+    explicit BSONCXX_ABI_EXPORT_CDECL() view(b_dbpointer v) noexcept;
+    explicit BSONCXX_ABI_EXPORT_CDECL() view(b_code v) noexcept;
+    explicit BSONCXX_ABI_EXPORT_CDECL() view(b_symbol v) noexcept;
+    explicit BSONCXX_ABI_EXPORT_CDECL() view(b_codewscope v) noexcept;
+    explicit BSONCXX_ABI_EXPORT_CDECL() view(b_int32 v) noexcept;
+    explicit BSONCXX_ABI_EXPORT_CDECL() view(b_timestamp v) noexcept;
+    explicit BSONCXX_ABI_EXPORT_CDECL() view(b_int64 v) noexcept;
+    explicit BSONCXX_ABI_EXPORT_CDECL() view(b_decimal128 v) noexcept;
+    explicit BSONCXX_ABI_EXPORT_CDECL() view(b_maxkey v) noexcept;
+    explicit BSONCXX_ABI_EXPORT_CDECL() view(b_minkey v) noexcept;
+    /// @}
+    ///
 
     ///
     /// Default constructs a bson_value::view. The resulting view will be initialized

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.cpp
@@ -46,8 +46,8 @@ view::view() noexcept : view(nullptr) {}
 // so we can't rely on automatic noexcept propagation. It really is though, so it is OK.
 #if !defined(BSONCXX_POLY_USE_BOOST)
 #define BSONCXX_ENUM(name, val)                                                                \
-    view::view(b_##name value) noexcept                                                        \
-        : _type(static_cast<bsoncxx::v_noabi::type>(val)), _b_##name(std::move(value)) {       \
+    view::view(b_##name v) noexcept                                                        \
+        : _type(static_cast<bsoncxx::v_noabi::type>(val)), _b_##name(std::move(v)) {       \
         static_assert(std::is_nothrow_copy_constructible<b_##name>::value, "Copy may throw");  \
         static_assert(std::is_nothrow_copy_assignable<b_##name>::value, "Copy may throw");     \
         static_assert(std::is_nothrow_destructible<b_##name>::value, "Destruction may throw"); \


### PR DESCRIPTION
Resolves CXX-3102.

The X macro headers under `bsoncxx/v_noabi/enum/` have long cause trouble with Doxygen documentation.

These troubles have worsened following https://github.com/mongodb/mongo-cxx-driver/pull/1182, especially in enumerations:

![image](https://github.com/user-attachments/assets/ece50280-93bb-4e58-9519-135dff852ddb)

![image](https://github.com/user-attachments/assets/310e659a-29fa-4798-be48-a36ad7b984e7)

These are in addition to numerous functions and enumerators which are not properly documented, e.g. `k_need_element_type_k_*` and `k_cannot_append_*` error codes:

![image](https://github.com/user-attachments/assets/08107e21-8d5e-46bb-997b-b077ba1e40f8)

![image](https://github.com/user-attachments/assets/ac9a3505-482d-4098-969f-168fd25bce5b)

as well as ctor overloads for `bsoncxx::v_noabi::types::bson_value::value` and `bsoncxx::v_noabi::types::bson_value::view`.

This PR proposes replacing all use of `BSONCXX_ENUM` (specifically the X macro headers themselves) in favor of fully expanding and properly documenting each BSON type and binary subtype. The X macro headers may still be used in internal code which does not require API documentation for convenience.

The examples shown above are fixed to looks as follows:

![image](https://github.com/user-attachments/assets/7c72ec00-1bb7-4a4a-ab0c-d3d6e2ef48f4)

![image](https://github.com/user-attachments/assets/64034fc1-44ad-444a-baf5-16a5e3577ed8)

![image](https://github.com/user-attachments/assets/2964807f-2512-4c04-9718-532246fb0cfb)

![image](https://github.com/user-attachments/assets/10f9b49c-abd0-4226-9240-a8856b7a023d)
