### PR TITLE
CXX-3097 Set SITEMAP_URL for upcoming releases

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1592,7 +1592,7 @@ TOC_EXPAND             = NO
 # protocol see https://www.sitemaps.org
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-SITEMAP_URL            =
+SITEMAP_URL            = https://mongocxx.org/api/mongocxx-3.10.2/
 
 # If the GENERATE_QHP tag is set to YES and both QHP_NAMESPACE and
 # QHP_VIRTUAL_FOLDER are set, an additional index file will be generated that

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -554,6 +554,8 @@ Example (using Jira syntax formatting):
 
 Set `$LATEST_DOC_TAG` in `etc/generate-latest-apidocs.pl` to the latest release tag.
 
+Change the version number for `SITEMAP_URL` in `Doxyfile` to the latest release version.
+
 Commit these changes to the `post-release-changes` branch:
 
 ```bash


### PR DESCRIPTION
Related to CXX-3097.

In advance of the next upcoming release, enables the `SITEMAP_URL` so that the generated Doxygen API doc pages will include a `sitemap.xml` which may be referenced by the gh-pages sitemap via manual post-release modifications until a more thorough solution to CXX-3097 is implemented.