### PR TITLE
clang-format: separate bsoncxx and mongocxx header groups

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,16 +12,24 @@ IncludeBlocks: Regroup
 IncludeCategories:
   - Regex: '".*"' # relative headers
     Priority: 10
-  - Regex: '(bsoncxx|mongocxx)/config(/private)?/prelude\.(hpp|hh)' # v_noabi preludes
+  - Regex: 'bsoncxx/config(/private)?/prelude\.(hpp|hh)' # v_noabi preludes
     Priority: 50
-  - Regex: '(bsoncxx|mongocxx)/test/.*' # test headers
+  - Regex: 'mongocxx/config(/private)?/prelude\.(hpp|hh)' # v_noabi preludes
+    Priority: 51
+  - Regex: 'bsoncxx/test/.*' # test headers
     Priority: 60
+  - Regex: 'mongocxx/test/.*' # test headers
+    Priority: 61
   - Regex: '<[[:alnum:]_.]+>' # system headers
     Priority: 20
-  - Regex: '(bsoncxx|mongocxx)/.*(-|\/)fwd\.(hpp|hh)' # all driver forwarding headers
+  - Regex: 'bsoncxx/.*(-|\/)fwd\.(hpp|hh)' # all driver forwarding headers
     Priority: 30
-  - Regex: '(bsoncxx|mongocxx)/.*' # all remaining (normal) driver headers
+  - Regex: 'mongocxx/.*(-|\/)fwd\.(hpp|hh)' # all driver forwarding headers
+    Priority: 31
+  - Regex: 'bsoncxx/.*' # all remaining (normal) driver headers
     Priority: 40
+  - Regex: 'mongocxx/.*' # all remaining (normal) driver headers
+    Priority: 41
   - Regex: '.*' # all other headers (third party)
     Priority: 90
 IndentWidth: 4

--- a/examples/add_subdirectory/hello_mongocxx.cpp
+++ b/examples/add_subdirectory/hello_mongocxx.cpp
@@ -17,6 +17,7 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/json.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>

--- a/examples/mongocxx/aggregate.cpp
+++ b/examples/mongocxx/aggregate.cpp
@@ -17,6 +17,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/json.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/pipeline.hpp>

--- a/examples/mongocxx/automatic_client_side_field_level_encryption.cpp
+++ b/examples/mongocxx/automatic_client_side_field_level_encryption.cpp
@@ -24,6 +24,7 @@
 #include <bsoncxx/builder/stream/helpers.hpp>
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/types/bson_value/make_value.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/client_encryption.hpp>
 #include <mongocxx/instance.hpp>

--- a/examples/mongocxx/bulk_write.cpp
+++ b/examples/mongocxx/bulk_write.cpp
@@ -18,6 +18,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/json.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>

--- a/examples/mongocxx/causal_consistency.cpp
+++ b/examples/mongocxx/causal_consistency.cpp
@@ -21,6 +21,7 @@
 #include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/builder/stream/helpers.hpp>
 #include <bsoncxx/json.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/client_session.hpp>
 #include <mongocxx/collection.hpp>

--- a/examples/mongocxx/change_streams.cpp
+++ b/examples/mongocxx/change_streams.cpp
@@ -20,6 +20,7 @@
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/to_string.hpp>
+
 #include <mongocxx/change_stream.hpp>
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>

--- a/examples/mongocxx/client_session.cpp
+++ b/examples/mongocxx/client_session.cpp
@@ -19,6 +19,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/json.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>

--- a/examples/mongocxx/connect.cpp
+++ b/examples/mongocxx/connect.cpp
@@ -19,6 +19,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/json.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/logger.hpp>

--- a/examples/mongocxx/create.cpp
+++ b/examples/mongocxx/create.cpp
@@ -18,6 +18,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/types.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>

--- a/examples/mongocxx/document_validation.cpp
+++ b/examples/mongocxx/document_validation.cpp
@@ -17,6 +17,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/instance.hpp>

--- a/examples/mongocxx/exception.cpp
+++ b/examples/mongocxx/exception.cpp
@@ -18,6 +18,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/json.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/exception/bulk_write_exception.hpp>
 #include <mongocxx/exception/error_code.hpp>

--- a/examples/mongocxx/explicit_encryption.cpp
+++ b/examples/mongocxx/explicit_encryption.cpp
@@ -23,6 +23,7 @@
 #include <bsoncxx/builder/stream/helpers.hpp>
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/types/bson_value/make_value.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/client_encryption.hpp>
 #include <mongocxx/instance.hpp>

--- a/examples/mongocxx/explicit_encryption_auto_decryption.cpp
+++ b/examples/mongocxx/explicit_encryption_auto_decryption.cpp
@@ -23,6 +23,7 @@
 #include <bsoncxx/builder/stream/helpers.hpp>
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/types/bson_value/make_value.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/client_encryption.hpp>
 #include <mongocxx/instance.hpp>

--- a/examples/mongocxx/get_values_from_documents.cpp
+++ b/examples/mongocxx/get_values_from_documents.cpp
@@ -17,6 +17,7 @@
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 

--- a/examples/mongocxx/gridfs.cpp
+++ b/examples/mongocxx/gridfs.cpp
@@ -17,6 +17,7 @@
 #include <ostream>
 
 #include <bsoncxx/json.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/gridfs/bucket.hpp>
 #include <mongocxx/instance.hpp>

--- a/examples/mongocxx/index.cpp
+++ b/examples/mongocxx/index.cpp
@@ -14,6 +14,7 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>

--- a/examples/mongocxx/inserted_id.cpp
+++ b/examples/mongocxx/inserted_id.cpp
@@ -17,6 +17,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/types.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/instance.hpp>

--- a/examples/mongocxx/instance_management.cpp
+++ b/examples/mongocxx/instance_management.cpp
@@ -18,6 +18,7 @@
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/logger.hpp>
 #include <mongocxx/pool.hpp>

--- a/examples/mongocxx/mongodb.com/aggregation_examples.cpp
+++ b/examples/mongocxx/mongodb.com/aggregation_examples.cpp
@@ -21,6 +21,7 @@
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/string/to_string.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/exception/logic_error.hpp>

--- a/examples/mongocxx/mongodb.com/documentation_examples.cpp
+++ b/examples/mongocxx/mongodb.com/documentation_examples.cpp
@@ -25,6 +25,7 @@
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/types.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/client_encryption.hpp>
 #include <mongocxx/exception/operation_exception.hpp>

--- a/examples/mongocxx/mongodb.com/index_examples.cpp
+++ b/examples/mongocxx/mongodb.com/index_examples.cpp
@@ -14,6 +14,7 @@
 
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 

--- a/examples/mongocxx/mongodb.com/runcommand_examples.cpp
+++ b/examples/mongocxx/mongodb.com/runcommand_examples.cpp
@@ -16,6 +16,7 @@
 
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 

--- a/examples/mongocxx/mongodb.com/usage_overview.cpp
+++ b/examples/mongocxx/mongodb.com/usage_overview.cpp
@@ -18,6 +18,7 @@
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/builder/basic/sub_array.hpp>
 #include <bsoncxx/json.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/database.hpp>

--- a/examples/mongocxx/pool.cpp
+++ b/examples/mongocxx/pool.cpp
@@ -22,6 +22,7 @@
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/types.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/pool.hpp>

--- a/examples/mongocxx/query.cpp
+++ b/examples/mongocxx/query.cpp
@@ -18,6 +18,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/json.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/find.hpp>

--- a/examples/mongocxx/query_projection.cpp
+++ b/examples/mongocxx/query_projection.cpp
@@ -17,6 +17,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/json.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/find.hpp>

--- a/examples/mongocxx/remove.cpp
+++ b/examples/mongocxx/remove.cpp
@@ -14,6 +14,7 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>

--- a/examples/mongocxx/server_side_field_level_encryption_enforcement.cpp
+++ b/examples/mongocxx/server_side_field_level_encryption_enforcement.cpp
@@ -23,6 +23,7 @@
 #include <bsoncxx/builder/stream/helpers.hpp>
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/types/bson_value/make_value.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/client_encryption.hpp>
 #include <mongocxx/instance.hpp>

--- a/examples/mongocxx/tailable_cursor.cpp
+++ b/examples/mongocxx/tailable_cursor.cpp
@@ -18,6 +18,7 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/json.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/database.hpp>

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -9,6 +9,7 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/json.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/stdx.hpp>

--- a/examples/mongocxx/update.cpp
+++ b/examples/mongocxx/update.cpp
@@ -15,6 +15,7 @@
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>

--- a/examples/mongocxx/view_or_value_variant.cpp
+++ b/examples/mongocxx/view_or_value_variant.cpp
@@ -15,6 +15,7 @@
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/stdx.hpp>

--- a/examples/mongocxx/with_transaction.cpp
+++ b/examples/mongocxx/with_transaction.cpp
@@ -19,6 +19,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/json.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/client_session.hpp>
 #include <mongocxx/collection.hpp>

--- a/examples/projects/mongocxx/hello_mongocxx.cpp
+++ b/examples/projects/mongocxx/hello_mongocxx.cpp
@@ -17,6 +17,7 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/json.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
@@ -22,6 +22,7 @@
 
 #include <bsoncxx/types/bson_value/value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
+
 #include <mongocxx/cursor.hpp>
 #include <mongocxx/options/client_encryption.hpp>
 #include <mongocxx/options/data_key.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
@@ -27,6 +27,7 @@
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/options/client_session.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
@@ -30,6 +30,7 @@
 #include <bsoncxx/oid.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
+
 #include <mongocxx/bulk_write.hpp>
 #include <mongocxx/change_stream.hpp>
 #include <mongocxx/client_session.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
@@ -24,6 +24,7 @@
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
+
 #include <mongocxx/client_session.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/gridfs/bucket.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_changed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_changed_event.hpp
@@ -18,6 +18,7 @@
 
 #include <bsoncxx/oid.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
+
 #include <mongocxx/events/server_description.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_changed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_changed_event.hpp
@@ -17,6 +17,7 @@
 #include <mongocxx/events/topology_changed_event-fwd.hpp>
 
 #include <bsoncxx/oid.hpp>
+
 #include <mongocxx/events/topology_description.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description.hpp
@@ -19,6 +19,7 @@
 #include <mongocxx/events/topology_description-fwd.hpp>
 
 #include <bsoncxx/stdx/string_view.hpp>
+
 #include <mongocxx/events/server_description.hpp>
 #include <mongocxx/read_preference.hpp>
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_opening_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_opening_event.hpp
@@ -17,6 +17,7 @@
 #include <mongocxx/events/topology_opening_event-fwd.hpp>
 
 #include <bsoncxx/oid.hpp>
+
 #include <mongocxx/events/topology_description.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/authentication_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/authentication_exception.hpp
@@ -17,6 +17,7 @@
 #include <mongocxx/exception/authentication_exception-fwd.hpp>
 
 #include <bsoncxx/document/value.hpp>
+
 #include <mongocxx/exception/operation_exception.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/bulk_write_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/bulk_write_exception.hpp
@@ -17,6 +17,7 @@
 #include <mongocxx/exception/bulk_write_exception-fwd.hpp>
 
 #include <bsoncxx/document/value.hpp>
+
 #include <mongocxx/exception/operation_exception.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/exception.hpp
@@ -20,6 +20,7 @@
 #include <mongocxx/exception/exception-fwd.hpp>
 
 #include <bsoncxx/config/prelude.hpp>
+
 #include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
@@ -50,6 +51,7 @@ BSONCXX_POP_WARNINGS();
 }  // namespace mongocxx
 
 #include <bsoncxx/config/postlude.hpp>
+
 #include <mongocxx/config/postlude.hpp>
 
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception.hpp
@@ -20,10 +20,12 @@
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/stdx.hpp>
 
 #include <bsoncxx/config/prelude.hpp>
+
 #include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
@@ -95,6 +97,7 @@ BSONCXX_POP_WARNINGS();
 }  // namespace mongocxx
 
 #include <bsoncxx/config/postlude.hpp>
+
 #include <mongocxx/config/postlude.hpp>
 
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
@@ -25,6 +25,7 @@
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
+
 #include <mongocxx/cursor.hpp>
 #include <mongocxx/gridfs/downloader.hpp>
 #include <mongocxx/gridfs/uploader.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/downloader.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/downloader.hpp
@@ -25,6 +25,7 @@
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
+
 #include <mongocxx/cursor.hpp>
 #include <mongocxx/stdx.hpp>
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/uploader.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/uploader.hpp
@@ -26,6 +26,7 @@
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
 #include <bsoncxx/view_or_value.hpp>
+
 #include <mongocxx/client_session.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/result/gridfs/upload.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/hint.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/hint.hpp
@@ -23,6 +23,7 @@
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
+
 #include <mongocxx/stdx.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_model.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_model.hpp
@@ -18,6 +18,7 @@
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
+
 #include <mongocxx/options/index.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view.hpp
@@ -22,6 +22,7 @@
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/client_session.hpp>
 #include <mongocxx/cursor.hpp>
 #include <mongocxx/index_model.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger.hpp
@@ -19,6 +19,7 @@
 #include <mongocxx/logger-fwd.hpp>
 
 #include <bsoncxx/stdx/string_view.hpp>
+
 #include <mongocxx/stdx.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_many.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_many.hpp
@@ -18,6 +18,7 @@
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/hint.hpp>
 #include <mongocxx/stdx.hpp>
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_one.hpp
@@ -18,6 +18,7 @@
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/hint.hpp>
 #include <mongocxx/stdx.hpp>
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/replace_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/replace_one.hpp
@@ -18,6 +18,7 @@
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/hint.hpp>
 #include <mongocxx/stdx.hpp>
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_many.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_many.hpp
@@ -19,6 +19,7 @@
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/hint.hpp>
 #include <mongocxx/pipeline.hpp>
 #include <mongocxx/stdx.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_one.hpp
@@ -19,6 +19,7 @@
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/hint.hpp>
 #include <mongocxx/pipeline.hpp>
 #include <mongocxx/stdx.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/write.hpp
@@ -19,6 +19,7 @@
 #include <mongocxx/model/write-fwd.hpp>
 
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/model/delete_many.hpp>
 #include <mongocxx/model/delete_one.hpp>
 #include <mongocxx/model/insert_one.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate.hpp
@@ -25,6 +25,7 @@
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
+
 #include <mongocxx/hint.hpp>
 #include <mongocxx/read_concern.hpp>
 #include <mongocxx/read_preference.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
@@ -22,6 +22,7 @@
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/stdx.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/bulk_write.hpp
@@ -19,6 +19,7 @@
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
+
 #include <mongocxx/write_concern.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream.hpp
@@ -25,6 +25,7 @@
 #include <bsoncxx/string/view_or_value.hpp>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
+
 #include <mongocxx/stdx.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client.hpp
@@ -19,6 +19,7 @@
 #include <mongocxx/options/client-fwd.hpp>
 
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/options/apm.hpp>
 #include <mongocxx/options/auto_encryption.hpp>
 #include <mongocxx/options/server_api.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption.hpp
@@ -22,6 +22,7 @@
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/stdx.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_session.hpp
@@ -18,6 +18,7 @@
 #include <mongocxx/options/client_session-fwd.hpp>
 
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/options/transaction.hpp>
 #include <mongocxx/stdx.hpp>
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count.hpp
@@ -23,6 +23,7 @@
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
+
 #include <mongocxx/hint.hpp>
 #include <mongocxx/read_preference.hpp>
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/create_collection.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/create_collection.hpp
@@ -16,6 +16,7 @@
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/validation_criteria.hpp>
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
@@ -22,6 +22,7 @@
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/stdx.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/delete.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/delete.hpp
@@ -19,6 +19,7 @@
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
+
 #include <mongocxx/hint.hpp>
 #include <mongocxx/write_concern.hpp>
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct.hpp
@@ -23,6 +23,7 @@
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
+
 #include <mongocxx/read_preference.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt.hpp
@@ -22,6 +22,7 @@
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
+
 #include <mongocxx/options/range.hpp>
 #include <mongocxx/stdx.hpp>
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/estimated_document_count.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/estimated_document_count.hpp
@@ -20,6 +20,7 @@
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
+
 #include <mongocxx/read_preference.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find.hpp
@@ -23,6 +23,7 @@
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
+
 #include <mongocxx/cursor.hpp>
 #include <mongocxx/hint.hpp>
 #include <mongocxx/read_preference.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.hpp
@@ -22,6 +22,7 @@
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
+
 #include <mongocxx/hint.hpp>
 #include <mongocxx/write_concern.hpp>
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.hpp
@@ -22,6 +22,7 @@
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
+
 #include <mongocxx/hint.hpp>
 #include <mongocxx/options/find_one_common_options.hpp>
 #include <mongocxx/stdx.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update.hpp
@@ -23,6 +23,7 @@
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
+
 #include <mongocxx/hint.hpp>
 #include <mongocxx/options/find_one_common_options.hpp>
 #include <mongocxx/stdx.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/bucket.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/bucket.hpp
@@ -19,6 +19,7 @@
 #include <mongocxx/options/gridfs/bucket-fwd.hpp>
 
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/read_concern.hpp>
 #include <mongocxx/read_preference.hpp>
 #include <mongocxx/stdx.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/upload.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/upload.hpp
@@ -18,6 +18,7 @@
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/stdx.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index.hpp
@@ -25,9 +25,11 @@
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
+
 #include <mongocxx/stdx.hpp>
 
 #include <bsoncxx/config/prelude.hpp>
+
 #include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
@@ -545,6 +547,7 @@ class index {
 }  // namespace mongocxx
 
 #include <bsoncxx/config/postlude.hpp>
+
 #include <mongocxx/config/postlude.hpp>
 
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view.hpp
@@ -20,6 +20,7 @@
 #include <mongocxx/options/index_view-fwd.hpp>
 
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/write_concern.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert.hpp
@@ -19,6 +19,7 @@
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
+
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/write_concern.hpp>
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/range.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/range.hpp
@@ -20,6 +20,7 @@
 
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
+
 #include <mongocxx/stdx.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace.hpp
@@ -20,6 +20,7 @@
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
+
 #include <mongocxx/hint.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/write_concern.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey.hpp
@@ -21,6 +21,7 @@
 #include <bsoncxx/string/view_or_value.hpp>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
+
 #include <mongocxx/stdx.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/server_api.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/server_api.hpp
@@ -22,6 +22,7 @@
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
+
 #include <mongocxx/stdx.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/tls.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/tls.hpp
@@ -20,6 +20,7 @@
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
+
 #include <mongocxx/stdx.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction.hpp
@@ -24,6 +24,7 @@
 #include <mongocxx/write_concern-fwd.hpp>
 
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/stdx.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/update.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/update.hpp
@@ -20,6 +20,7 @@
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
+
 #include <mongocxx/hint.hpp>
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/write_concern.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
@@ -21,6 +21,7 @@
 #include <mongocxx/pool-fwd.hpp>
 
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/database.hpp>
 #include <mongocxx/options/pool.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
@@ -26,6 +26,7 @@
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
+
 #include <mongocxx/options/transaction.hpp>
 #include <mongocxx/stdx.hpp>
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
@@ -31,6 +31,7 @@
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/options/transaction.hpp>
 #include <mongocxx/stdx.hpp>
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_many.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_many.hpp
@@ -22,6 +22,7 @@
 
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/types.hpp>
+
 #include <mongocxx/result/bulk_write.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_one.hpp
@@ -19,6 +19,7 @@
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
+
 #include <mongocxx/result/bulk_write.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/replace_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/replace_one.hpp
@@ -20,6 +20,7 @@
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types.hpp>
+
 #include <mongocxx/result/bulk_write.hpp>
 #include <mongocxx/stdx.hpp>
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey.hpp
@@ -18,6 +18,7 @@
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/bulk_write.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/update.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/update.hpp
@@ -20,6 +20,7 @@
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types.hpp>
+
 #include <mongocxx/result/bulk_write.hpp>
 #include <mongocxx/stdx.hpp>
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_view.hpp
@@ -8,6 +8,7 @@
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/cursor.hpp>
 #include <mongocxx/options/aggregate.hpp>
 #include <mongocxx/search_index_model.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
@@ -24,6 +24,7 @@
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/string/view_or_value.hpp>
+
 #include <mongocxx/read_concern.hpp>
 #include <mongocxx/read_preference.hpp>
 #include <mongocxx/write_concern.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/validation_criteria.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/validation_criteria.hpp
@@ -18,6 +18,7 @@
 
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/stdx.hpp>
 
 #include <mongocxx/config/prelude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
@@ -31,6 +31,7 @@
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
+
 #include <mongocxx/options/transaction.hpp>
 #include <mongocxx/stdx.hpp>
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/bulk_write.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/bulk_write.cpp
@@ -15,6 +15,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/stdx/make_unique.hpp>
+
 #include <mongocxx/bulk_write.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/exception/bulk_write_exception.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/change_stream.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/change_stream.cpp
@@ -15,6 +15,7 @@
 #include <string>
 
 #include <bsoncxx/stdx/make_unique.hpp>
+
 #include <mongocxx/change_stream.hpp>
 #include <mongocxx/private/change_stream.hh>
 #include <mongocxx/private/libmongoc.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client.cpp
@@ -14,6 +14,7 @@
 
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/stdx/make_unique.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client_encryption.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client_encryption.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/stdx/make_unique.hpp>
+
 #include <mongocxx/client_encryption.hpp>
 #include <mongocxx/private/client_encryption.hh>
 #include <mongocxx/private/database.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client_session.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client_session.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/stdx/make_unique.hpp>
+
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/exception/private/mongoc_error.hh>
 #include <mongocxx/private/client.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
@@ -29,6 +29,7 @@
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/types.hpp>
+
 #include <mongocxx/bulk_write.hpp>
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/cursor.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/cursor.cpp
@@ -14,6 +14,7 @@
 
 #include <bsoncxx/private/libbson.hh>
 #include <bsoncxx/stdx/make_unique.hpp>
+
 #include <mongocxx/cursor.hpp>
 #include <mongocxx/exception/private/mongoc_error.hh>
 #include <mongocxx/exception/query_exception.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/database.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/database.cpp
@@ -19,6 +19,7 @@
 #include <bsoncxx/builder/concatenate.hpp>
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/string/to_string.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/database.hpp>
 #include <mongocxx/exception/error_code.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_failed_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_failed_event.cpp
@@ -17,6 +17,7 @@
 #include <bsoncxx/private/libbson.hh>
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/events/command_failed_event.hpp>
 #include <mongocxx/private/libmongoc.hh>
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_started_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_started_event.cpp
@@ -14,6 +14,7 @@
 
 #include <bsoncxx/private/helpers.hh>
 #include <bsoncxx/stdx/make_unique.hpp>
+
 #include <mongocxx/events/command_started_event.hpp>
 #include <mongocxx/private/libmongoc.hh>
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_succeeded_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_succeeded_event.cpp
@@ -14,6 +14,7 @@
 
 #include <bsoncxx/private/helpers.hh>
 #include <bsoncxx/stdx/make_unique.hpp>
+
 #include <mongocxx/events/command_succeeded_event.hpp>
 #include <mongocxx/private/libmongoc.hh>
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/operation_exception.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/operation_exception.cpp
@@ -16,6 +16,7 @@
 #include <utility>
 
 #include <bsoncxx/string/to_string.hpp>
+
 #include <mongocxx/exception/operation_exception.hpp>
 #include <mongocxx/private/libbson.hh>
 #include <mongocxx/private/libmongoc.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/private/mongoc_error.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/private/mongoc_error.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <bsoncxx/document/value.hpp>
+
 #include <mongocxx/exception/operation_exception.hpp>
 #include <mongocxx/exception/server_error_code.hpp>
 #include <mongocxx/private/libmongoc.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/bucket.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/bucket.cpp
@@ -21,6 +21,7 @@
 #include <bsoncxx/oid.hpp>
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/database.hpp>
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/gridfs_exception.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/downloader.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/downloader.cpp
@@ -19,6 +19,7 @@
 
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/types.hpp>
+
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/gridfs/downloader.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/private/uploader.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/private/uploader.hh
@@ -19,6 +19,7 @@
 
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/string/to_string.hpp>
+
 #include <mongocxx/gridfs/uploader.hpp>
 
 #include <mongocxx/config/private/prelude.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/uploader.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/uploader.cpp
@@ -20,6 +20,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/types.hpp>
+
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/gridfs_exception.hpp>
 #include <mongocxx/exception/logic_error.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/hint.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/hint.cpp
@@ -15,6 +15,7 @@
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/builder/basic/sub_document.hpp>
 #include <bsoncxx/builder/concatenate.hpp>
+
 #include <mongocxx/hint.hpp>
 
 #include <mongocxx/config/private/prelude.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/index_view.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/index_view.cpp
@@ -14,6 +14,7 @@
 
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/string/to_string.hpp>
+
 #include <mongocxx/client_session.hpp>
 #include <mongocxx/exception/private/mongoc_error.hh>
 #include <mongocxx/index_view.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/instance.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/instance.cpp
@@ -18,6 +18,7 @@
 #include <utility>
 
 #include <bsoncxx/stdx/make_unique.hpp>
+
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/instance.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/update_many.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/update_many.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/array/view_or_value.hpp>
+
 #include <mongocxx/model/update_many.hpp>
 
 #include <mongocxx/config/private/prelude.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/update_one.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/model/update_one.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/array/view_or_value.hpp>
+
 #include <mongocxx/model/update_one.hpp>
 
 #include <mongocxx/config/private/prelude.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/aggregate.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/aggregate.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/options/aggregate.hpp>
 #include <mongocxx/private/append_aggregate_options.hh>
 #include <mongocxx/private/read_preference.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/change_stream.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/change_stream.cpp
@@ -17,6 +17,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/builder/core.hpp>
+
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/options/change_stream.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/create_collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/create_collection.cpp
@@ -16,6 +16,7 @@
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/builder/concatenate.hpp>
 #include <bsoncxx/types.hpp>
+
 #include <mongocxx/options/create_collection.hpp>
 
 #include <mongocxx/config/private/prelude.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/encrypt.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/encrypt.cpp
@@ -15,6 +15,7 @@
 #include <utility>
 
 #include <bsoncxx/types/private/convert.hh>
+
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/options/encrypt.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find_one_and_update.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find_one_and_update.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/array/view_or_value.hpp>
+
 #include <mongocxx/options/find_one_and_update.hpp>
 
 #include <mongocxx/config/private/prelude.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/gridfs/bucket.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/gridfs/bucket.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/options/gridfs/bucket.hpp>
 #include <mongocxx/read_concern.hpp>
 #include <mongocxx/read_preference.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/gridfs/upload.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/gridfs/upload.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/view_or_value.hpp>
+
 #include <mongocxx/options/gridfs/upload.hpp>
 
 #include <mongocxx/config/private/prelude.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/index.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/index.cpp
@@ -14,6 +14,7 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/stdx/make_unique.hpp>
+
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/options/index.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/index_view.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/index_view.cpp
@@ -15,6 +15,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/types.hpp>
+
 #include <mongocxx/options/index_view.hpp>
 
 #include <mongocxx/config/private/prelude.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/private/transaction.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/private/transaction.hh
@@ -18,6 +18,7 @@
 #include <memory>
 
 #include <bsoncxx/stdx/make_unique.hpp>
+
 #include <mongocxx/private/read_concern.hh>
 #include <mongocxx/private/read_preference.hh>
 #include <mongocxx/private/write_concern.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/replace.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/replace.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/document/view_or_value.hpp>
+
 #include <mongocxx/options/replace.hpp>
 
 #include <mongocxx/config/private/prelude.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/types/private/convert.hh>
+
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/options/rewrap_many_datakey.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/server_api.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/server_api.cpp
@@ -15,6 +15,7 @@
 #include <system_error>
 
 #include <bsoncxx/stdx/string_view.hpp>
+
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/options/server_api.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/transaction.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/transaction.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/stdx/make_unique.hpp>
+
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/options/private/transaction.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/update.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/update.cpp
@@ -14,6 +14,7 @@
 
 #include <bsoncxx/array/view_or_value.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
+
 #include <mongocxx/options/update.hpp>
 
 #include <mongocxx/config/private/prelude.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pipeline.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pipeline.cpp
@@ -15,6 +15,7 @@
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/builder/basic/sub_document.hpp>
 #include <bsoncxx/stdx/make_unique.hpp>
+
 #include <mongocxx/pipeline.hpp>
 #include <mongocxx/private/pipeline.hh>
 #include <mongocxx/stdx.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
@@ -15,6 +15,7 @@
 #include <utility>
 
 #include <bsoncxx/stdx/make_unique.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/exception.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/append_aggregate_options.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/append_aggregate_options.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/options/aggregate.hpp>
 
 #include <mongocxx/config/private/prelude.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/change_stream.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/change_stream.hh
@@ -16,6 +16,7 @@
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/change_stream.hpp>
 #include <mongocxx/exception/private/mongoc_error.hh>
 #include <mongocxx/exception/query_exception.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client_encryption.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client_encryption.hh
@@ -23,6 +23,7 @@
 #include <bsoncxx/types/bson_value/value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
 #include <bsoncxx/types/private/convert.hh>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/client_encryption.hpp>
 #include <mongocxx/exception/operation_exception.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client_session.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/client_session.hh
@@ -18,6 +18,7 @@
 
 #include <bsoncxx/private/helpers.hh>
 #include <bsoncxx/private/libbson.hh>
+
 #include <mongocxx/client_session.hpp>
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/collection.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/collection.hh
@@ -17,6 +17,7 @@
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/private/helpers.hh>
 #include <bsoncxx/stdx/string_view.hpp>
+
 #include <mongocxx/collection.hpp>
 #include <mongocxx/database.hpp>
 #include <mongocxx/private/database.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/cursor.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/cursor.hh
@@ -16,6 +16,7 @@
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/cursor.hpp>
 #include <mongocxx/private/libmongoc.hh>
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/index_view.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/index_view.hh
@@ -21,6 +21,7 @@
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/string/to_string.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
+
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/exception/operation_exception.hpp>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libbson.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/libbson.hh
@@ -19,6 +19,7 @@
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/private/libbson.hh>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/stdx.hpp>
 #include <mongocxx/test_util/export_for_testing.hh>
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/pipeline.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/pipeline.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <bsoncxx/builder/basic/array.hpp>
+
 #include <mongocxx/pipeline.hpp>
 
 #include <mongocxx/config/private/prelude.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/scoped_bson_value.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/scoped_bson_value.hh
@@ -18,6 +18,7 @@
 
 #include <bsoncxx/types/bson_value/view.hpp>
 #include <bsoncxx/types/private/convert.hh>
+
 #include <mongocxx/private/libbson.hh>
 
 namespace mongocxx {

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/search_index_model.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/search_index_model.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <bsoncxx/document/view_or_value.hpp>
+
 #include <mongocxx/search_index_model.hpp>
 
 #include <mongocxx/config/private/prelude.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/search_index_view.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/private/search_index_view.hh
@@ -6,6 +6,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/string/to_string.hpp>
+
 #include <mongocxx/private/append_aggregate_options.hh>
 #include <mongocxx/private/client_session.hh>
 #include <mongocxx/private/libbson.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/read_concern.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/read_concern.cpp
@@ -15,6 +15,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/string/to_string.hpp>
+
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/private/libmongoc.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/read_preference.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/read_preference.cpp
@@ -14,6 +14,7 @@
 
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/types.hpp>
+
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/private/conversions.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/gridfs/upload.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/gridfs/upload.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/builder/basic/array.hpp>
+
 #include <mongocxx/result/gridfs/upload.hpp>
 
 #include <mongocxx/config/private/prelude.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/insert_many.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/insert_many.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/types/bson_value/view.hpp>
+
 #include <mongocxx/result/insert_many.hpp>
 
 #include <mongocxx/config/private/prelude.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/insert_one.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/result/insert_one.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/builder/basic/array.hpp>
+
 #include <mongocxx/result/insert_one.hpp>
 
 #include <mongocxx/config/private/prelude.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/search_index_model.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/search_index_model.cpp
@@ -1,4 +1,5 @@
 #include <bsoncxx/stdx/make_unique.hpp>
+
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/private/search_index_model.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/search_index_view.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/search_index_view.cpp
@@ -1,4 +1,5 @@
 #include <bsoncxx/stdx/make_unique.hpp>
+
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/private/search_index_view.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/uri.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/uri.cpp
@@ -14,6 +14,7 @@
 
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/types.hpp>
+
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/private/libmongoc.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/validation_criteria.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/validation_criteria.cpp
@@ -15,6 +15,7 @@
 #include <string>
 
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/validation_criteria.hpp>
 
 #include <mongocxx/config/private/prelude.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/write_concern.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/write_concern.cpp
@@ -15,6 +15,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/string/to_string.hpp>
+
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/exception/logic_error.hpp>

--- a/src/mongocxx/test/bulk_write.cpp
+++ b/src/mongocxx/test/bulk_write.cpp
@@ -14,6 +14,7 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/types.hpp>
+
 #include <mongocxx/bulk_write.hpp>
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>
@@ -21,6 +22,7 @@
 #include <mongocxx/write_concern.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/client_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/change_streams.cpp
+++ b/src/mongocxx/test/change_streams.cpp
@@ -18,6 +18,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/private/libbson.hh>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/instance.hpp>
@@ -29,6 +30,7 @@
 #include <mongocxx/write_concern.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 #include <mongocxx/test/client_helpers.hh>
 

--- a/src/mongocxx/test/client.cpp
+++ b/src/mongocxx/test/client.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/string/to_string.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/instance.hpp>
@@ -24,6 +25,7 @@
 #include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 #include <mongocxx/test/client_helpers.hh>
 

--- a/src/mongocxx/test/client_helpers.cpp
+++ b/src/mongocxx/test/client_helpers.cpp
@@ -30,6 +30,7 @@
 #include <bsoncxx/string/to_string.hpp>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
@@ -37,9 +38,11 @@
 #include <mongocxx/private/libmongoc.hh>
 
 #include <bsoncxx/config/prelude.hpp>
+
 #include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/client_helpers.hh>
 
 namespace mongocxx {

--- a/src/mongocxx/test/client_helpers.hh
+++ b/src/mongocxx/test/client_helpers.hh
@@ -27,6 +27,7 @@
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/options/client.hpp>

--- a/src/mongocxx/test/client_session.cpp
+++ b/src/mongocxx/test/client_session.cpp
@@ -16,6 +16,7 @@
 
 #include <bsoncxx/private/helpers.hh>
 #include <bsoncxx/stdx/make_unique.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/exception/bulk_write_exception.hpp>
 #include <mongocxx/exception/logic_error.hpp>
@@ -24,6 +25,7 @@
 #include <mongocxx/private/libmongoc.hh>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 #include <mongocxx/test/client_helpers.hh>
 

--- a/src/mongocxx/test/client_side_encryption.cpp
+++ b/src/mongocxx/test/client_side_encryption.cpp
@@ -27,6 +27,7 @@
 #include <bsoncxx/types/bson_value/make_value.hpp>
 #include <bsoncxx/types/bson_value/value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/client_encryption.hpp>
 #include <mongocxx/exception/error_code.hpp>
@@ -42,6 +43,7 @@
 #include <mongocxx/config/prelude.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 #include <mongocxx/test/client_helpers.hh>
 #include <mongocxx/test/spec/monitoring.hh>

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -24,6 +24,7 @@
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/string/to_string.hpp>
 #include <bsoncxx/types.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/exception/bulk_write_exception.hpp>
@@ -40,6 +41,7 @@
 
 #include <bsoncxx/test/catch.hh>
 #include <bsoncxx/test/exception_guard.hh>
+
 #include <mongocxx/test/client_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/collection_mocked.cpp
+++ b/src/mongocxx/test/collection_mocked.cpp
@@ -21,6 +21,7 @@
 #include <bsoncxx/private/helpers.hh>
 #include <bsoncxx/private/libbson.hh>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/database.hpp>
@@ -35,6 +36,7 @@
 #include <mongocxx/read_preference.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/database.cpp
+++ b/src/mongocxx/test/database.cpp
@@ -16,6 +16,7 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/string/to_string.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/database.hpp>
 #include <mongocxx/exception/logic_error.hpp>
@@ -28,6 +29,7 @@
 #include <mongocxx/private/libmongoc.hh>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 #include <mongocxx/test/client_helpers.hh>
 

--- a/src/mongocxx/test/gridfs/bucket.cpp
+++ b/src/mongocxx/test/gridfs/bucket.cpp
@@ -28,6 +28,7 @@
 #include <bsoncxx/oid.hpp>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/database.hpp>
 #include <mongocxx/exception/gridfs_exception.hpp>
@@ -40,6 +41,7 @@
 #include <mongocxx/uri.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/client_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/hint.cpp
+++ b/src/mongocxx/test/hint.cpp
@@ -16,6 +16,7 @@
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/string/to_string.hpp>
+
 #include <mongocxx/hint.hpp>
 #include <mongocxx/instance.hpp>
 

--- a/src/mongocxx/test/index_view.cpp
+++ b/src/mongocxx/test/index_view.cpp
@@ -17,6 +17,7 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/string/to_string.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/exception/logic_error.hpp>
@@ -26,6 +27,7 @@
 #include <mongocxx/options/index_view.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/client_helpers.hh>
 
 #include <catch2/catch_case_sensitive.hpp>

--- a/src/mongocxx/test/logging.cpp
+++ b/src/mongocxx/test/logging.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include <bsoncxx/stdx/make_unique.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/logger.hpp>
 #include <mongocxx/private/libmongoc.hh>

--- a/src/mongocxx/test/model/delete_many.cpp
+++ b/src/mongocxx/test/model/delete_many.cpp
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/model/delete_many.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/model/delete_one.cpp
+++ b/src/mongocxx/test/model/delete_one.cpp
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/model/delete_one.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/model/insert_one.cpp
+++ b/src/mongocxx/test/model/insert_one.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/model/insert_one.hpp>
 

--- a/src/mongocxx/test/model/replace_one.cpp
+++ b/src/mongocxx/test/model/replace_one.cpp
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/model/replace_one.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/model/update_many.cpp
+++ b/src/mongocxx/test/model/update_many.cpp
@@ -14,10 +14,12 @@
 
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/model/update_many.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/model/update_one.cpp
+++ b/src/mongocxx/test/model/update_one.cpp
@@ -14,10 +14,12 @@
 
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/model/update_one.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/options/aggregate.cpp
+++ b/src/mongocxx/test/options/aggregate.cpp
@@ -16,10 +16,12 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/aggregate.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/options/bulk_write.cpp
+++ b/src/mongocxx/test/options/bulk_write.cpp
@@ -16,6 +16,7 @@
 #include <mongocxx/options/bulk_write.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/options/count.cpp
+++ b/src/mongocxx/test/options/count.cpp
@@ -15,10 +15,12 @@
 #include <chrono>
 
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/count.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/options/create_collection.cpp
+++ b/src/mongocxx/test/options/create_collection.cpp
@@ -18,10 +18,12 @@
 #include <bsoncxx/string/to_string.hpp>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/create_collection.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/options/delete.cpp
+++ b/src/mongocxx/test/options/delete.cpp
@@ -15,10 +15,12 @@
 #include <chrono>
 
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/delete.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/options/distinct.cpp
+++ b/src/mongocxx/test/options/distinct.cpp
@@ -15,10 +15,12 @@
 #include <chrono>
 
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/distinct.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/options/find.cpp
+++ b/src/mongocxx/test/options/find.cpp
@@ -15,10 +15,12 @@
 #include <chrono>
 
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/find.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/options/find_one_and_delete.cpp
+++ b/src/mongocxx/test/options/find_one_and_delete.cpp
@@ -15,10 +15,12 @@
 #include <chrono>
 
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/find_one_and_delete.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/options/find_one_and_replace.cpp
+++ b/src/mongocxx/test/options/find_one_and_replace.cpp
@@ -15,10 +15,12 @@
 #include <chrono>
 
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/find_one_and_replace.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/options/find_one_and_update.cpp
+++ b/src/mongocxx/test/options/find_one_and_update.cpp
@@ -16,10 +16,12 @@
 
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/find_one_and_update.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/options/gridfs/bucket.cpp
+++ b/src/mongocxx/test/options/gridfs/bucket.cpp
@@ -19,6 +19,7 @@
 #include <mongocxx/write_concern.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/options/gridfs/upload.cpp
+++ b/src/mongocxx/test/options/gridfs/upload.cpp
@@ -14,10 +14,12 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/gridfs/upload.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/options/index.cpp
+++ b/src/mongocxx/test/options/index.cpp
@@ -15,10 +15,12 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/types.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/index.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/options/insert.cpp
+++ b/src/mongocxx/test/options/insert.cpp
@@ -16,6 +16,7 @@
 #include <mongocxx/options/insert.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/options/replace.cpp
+++ b/src/mongocxx/test/options/replace.cpp
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/replace.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/options/update.cpp
+++ b/src/mongocxx/test/options/update.cpp
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/options/update.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/pool.cpp
+++ b/src/mongocxx/test/pool.cpp
@@ -25,6 +25,7 @@
 #include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 #include <mongocxx/test/client_helpers.hh>
 

--- a/src/mongocxx/test/private/numeric_casting.cpp
+++ b/src/mongocxx/test/private/numeric_casting.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/private/libbson.hh>
 #include <mongocxx/private/numeric_casting.hh>
 

--- a/src/mongocxx/test/private/scoped_bson_t.cpp
+++ b/src/mongocxx/test/private/scoped_bson_t.cpp
@@ -15,6 +15,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/stdx/optional.hpp>
+
 #include <mongocxx/private/libbson.hh>
 
 #include <bsoncxx/test/catch.hh>

--- a/src/mongocxx/test/read_concern.cpp
+++ b/src/mongocxx/test/read_concern.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/stdx/string_view.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/read_concern.hpp>
 

--- a/src/mongocxx/test/read_preference.cpp
+++ b/src/mongocxx/test/read_preference.cpp
@@ -15,12 +15,14 @@
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/document/view.hpp>
+
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/private/conversions.hh>
 #include <mongocxx/read_preference.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/result/bulk_write.cpp
+++ b/src/mongocxx/test/result/bulk_write.cpp
@@ -15,6 +15,7 @@
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/result/bulk_write.hpp>
 

--- a/src/mongocxx/test/result/delete.cpp
+++ b/src/mongocxx/test/result/delete.cpp
@@ -14,6 +14,7 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/json.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/result/delete.hpp>
 

--- a/src/mongocxx/test/result/gridfs/upload.cpp
+++ b/src/mongocxx/test/result/gridfs/upload.cpp
@@ -18,6 +18,7 @@
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/result/gridfs/upload.hpp>
 

--- a/src/mongocxx/test/result/insert_one.cpp
+++ b/src/mongocxx/test/result/insert_one.cpp
@@ -14,6 +14,7 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/result/insert_one.hpp>
 

--- a/src/mongocxx/test/result/replace_one.cpp
+++ b/src/mongocxx/test/result/replace_one.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/result/replace_one.hpp>
 

--- a/src/mongocxx/test/result/update.cpp
+++ b/src/mongocxx/test/result/update.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/builder/basic/document.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/result/update.hpp>
 

--- a/src/mongocxx/test/sdam-monitoring.cpp
+++ b/src/mongocxx/test/sdam-monitoring.cpp
@@ -16,12 +16,14 @@
 
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/to_string.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/instance.hpp>
 
 #include <bsoncxx/test/catch.hh>
 #include <bsoncxx/test/exception_guard.hh>
+
 #include <mongocxx/test/client_helpers.hh>
 #include <mongocxx/test/spec/operation.hh>
 

--- a/src/mongocxx/test/search_index_view.cpp
+++ b/src/mongocxx/test/search_index_view.cpp
@@ -4,12 +4,14 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/oid.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/cursor.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/search_index_view.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/client_helpers.hh>
 
 #include <catch2/catch_case_sensitive.hpp>

--- a/src/mongocxx/test/spec/client_side_encryption.cpp
+++ b/src/mongocxx/test/spec/client_side_encryption.cpp
@@ -16,11 +16,13 @@
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/string/to_string.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/instance.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/client_helpers.hh>
 #include <mongocxx/test/spec/monitoring.hh>
 #include <mongocxx/test/spec/operation.hh>

--- a/src/mongocxx/test/spec/command_monitoring.cpp
+++ b/src/mongocxx/test/spec/command_monitoring.cpp
@@ -16,12 +16,14 @@
 
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/string/to_string.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/instance.hpp>
 
 #include <bsoncxx/test/catch.hh>
 #include <bsoncxx/test/exception_guard.hh>
+
 #include <mongocxx/test/client_helpers.hh>
 #include <mongocxx/test/spec/operation.hh>
 #include <mongocxx/test/spec/util.hh>

--- a/src/mongocxx/test/spec/crud.cpp
+++ b/src/mongocxx/test/spec/crud.cpp
@@ -17,6 +17,7 @@
 #include <mongocxx/instance.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/spec/util.hh>
 
 namespace {

--- a/src/mongocxx/test/spec/gridfs.cpp
+++ b/src/mongocxx/test/spec/gridfs.cpp
@@ -30,6 +30,7 @@
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/string/to_string.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/cursor.hpp>
@@ -41,6 +42,7 @@
 #include <mongocxx/result/gridfs/upload.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/client_helpers.hh>
 #include <mongocxx/test/spec/util.hh>
 

--- a/src/mongocxx/test/spec/initial_dns_seedlist_discovery.cpp
+++ b/src/mongocxx/test/spec/initial_dns_seedlist_discovery.cpp
@@ -23,6 +23,7 @@
 #include <mongocxx/pool.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/spec/monitoring.hh>
 
 namespace {

--- a/src/mongocxx/test/spec/mongohouse.cpp
+++ b/src/mongocxx/test/spec/mongohouse.cpp
@@ -17,10 +17,12 @@
 #include <bsoncxx/string/to_string.hpp>
 #include <bsoncxx/types/bson_value/value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
+
 #include <mongocxx/exception/operation_exception.hpp>
 #include <mongocxx/instance.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/spec/monitoring.hh>
 #include <mongocxx/test/spec/operation.hh>
 #include <mongocxx/test/spec/util.hh>

--- a/src/mongocxx/test/spec/monitoring.cpp
+++ b/src/mongocxx/test/spec/monitoring.cpp
@@ -17,12 +17,14 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/json.hpp>
+
 #include <mongocxx/exception/error_code.hpp>
 
 #include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/test/catch.hh>
 #include <bsoncxx/test/to_string.hh>
+
 #include <mongocxx/test/client_helpers.hh>
 #include <mongocxx/test/spec/monitoring.hh>
 #include <mongocxx/test/spec/unified_tests/assert.hh>

--- a/src/mongocxx/test/spec/operation.cpp
+++ b/src/mongocxx/test/spec/operation.cpp
@@ -19,6 +19,7 @@
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/string/to_string.hpp>
 #include <bsoncxx/types.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/cursor.hpp>
@@ -43,6 +44,7 @@
 #include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/spec/operation.hh>
 
 namespace mongocxx {

--- a/src/mongocxx/test/spec/operation.hh
+++ b/src/mongocxx/test/spec/operation.hh
@@ -19,6 +19,7 @@
 
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
+
 #include <mongocxx/client_session.hpp>
 #include <mongocxx/pipeline.hpp>
 #include <mongocxx/private/libmongoc.hh>

--- a/src/mongocxx/test/spec/read_write_concern.cpp
+++ b/src/mongocxx/test/spec/read_write_concern.cpp
@@ -15,6 +15,7 @@
 #include <mongocxx/instance.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/spec/util.hh>
 
 namespace {

--- a/src/mongocxx/test/spec/retryable-reads.cpp
+++ b/src/mongocxx/test/spec/retryable-reads.cpp
@@ -16,10 +16,12 @@
 #include <set>
 
 #include <bsoncxx/string/to_string.hpp>
+
 #include <mongocxx/exception/operation_exception.hpp>
 #include <mongocxx/instance.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/spec/monitoring.hh>
 #include <mongocxx/test/spec/operation.hh>
 #include <mongocxx/test/spec/util.hh>

--- a/src/mongocxx/test/spec/transactions.cpp
+++ b/src/mongocxx/test/spec/transactions.cpp
@@ -15,6 +15,7 @@
 #include <mongocxx/instance.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/spec/util.hh>
 
 namespace {

--- a/src/mongocxx/test/spec/unified_tests/assert.cpp
+++ b/src/mongocxx/test/spec/unified_tests/assert.cpp
@@ -28,6 +28,7 @@
 
 #include <bsoncxx/test/catch.hh>
 #include <bsoncxx/test/to_string.hh>
+
 #include <mongocxx/test/client_helpers.hh>
 
 using namespace bsoncxx;

--- a/src/mongocxx/test/spec/unified_tests/entity.hh
+++ b/src/mongocxx/test/spec/unified_tests/entity.hh
@@ -18,6 +18,7 @@
 #include <unordered_map>
 
 #include <bsoncxx/types/bson_value/value.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/client_encryption.hpp>
 

--- a/src/mongocxx/test/spec/unified_tests/operations.cpp
+++ b/src/mongocxx/test/spec/unified_tests/operations.cpp
@@ -21,12 +21,14 @@
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/string/to_string.hpp>
 #include <bsoncxx/types/bson_value/value.hpp>
+
 #include <mongocxx/collection.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 
 #include <mongocxx/config/prelude.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/spec/monitoring.hh>
 
 namespace mongocxx {

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -28,6 +28,7 @@
 #include <bsoncxx/stdx/string_view.hpp>
 #include <bsoncxx/string/to_string.hpp>
 #include <bsoncxx/types/bson_value/value.hpp>
+
 #include <mongocxx/client_encryption.hpp>
 #include <mongocxx/exception/bulk_write_exception.hpp>
 #include <mongocxx/exception/exception.hpp>
@@ -35,6 +36,7 @@
 #include <mongocxx/instance.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/client_helpers.hh>
 #include <mongocxx/test/spec/monitoring.hh>
 #include <mongocxx/test/spec/util.hh>

--- a/src/mongocxx/test/spec/util.cpp
+++ b/src/mongocxx/test/spec/util.cpp
@@ -25,6 +25,7 @@
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 #include <bsoncxx/string/to_string.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/database.hpp>
@@ -41,6 +42,7 @@
 #include <mongocxx/config/private/prelude.hh>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/spec/monitoring.hh>
 #include <mongocxx/test/spec/operation.hh>
 #include <mongocxx/test/spec/util.hh>

--- a/src/mongocxx/test/spec/util.hh
+++ b/src/mongocxx/test/spec/util.hh
@@ -19,6 +19,7 @@
 #include <string>
 
 #include <bsoncxx/document/view.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/uri.hpp>
 

--- a/src/mongocxx/test/transactions.cpp
+++ b/src/mongocxx/test/transactions.cpp
@@ -21,6 +21,7 @@
 #include <mongocxx/instance.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/client_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/uri.cpp
+++ b/src/mongocxx/test/uri.cpp
@@ -18,6 +18,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/stdx/string_view.hpp>
+
 #include <mongocxx/exception/error_code.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/uri.hpp>

--- a/src/mongocxx/test/validation_criteria.cpp
+++ b/src/mongocxx/test/validation_criteria.cpp
@@ -15,10 +15,12 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/document/element.hpp>
 #include <bsoncxx/string/to_string.hpp>
+
 #include <mongocxx/instance.hpp>
 #include <mongocxx/validation_criteria.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/catch_helpers.hh>
 
 namespace {

--- a/src/mongocxx/test/versioned_api.cpp
+++ b/src/mongocxx/test/versioned_api.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/string/to_string.hpp>
+
 #include <mongocxx/client.hpp>
 #include <mongocxx/exception/operation_exception.hpp>
 #include <mongocxx/instance.hpp>
@@ -21,6 +22,7 @@
 #include <mongocxx/uri.hpp>
 
 #include <bsoncxx/test/catch.hh>
+
 #include <mongocxx/test/client_helpers.hh>
 
 #include <catch2/matchers/catch_matchers_string.hpp>

--- a/src/mongocxx/test/write_concern.cpp
+++ b/src/mongocxx/test/write_concern.cpp
@@ -14,6 +14,7 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
+
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/instance.hpp>


### PR DESCRIPTION
A minor adjustment to clang-format rules which separates bsoncxx and mongocxx headers into their own groups such that the library headers are separated by an empty newline:

```cpp
#include <bsoncxx/a.hpp>
#include <bsoncxx/b.hpp>
#include <bsoncxx/c.hpp>
                           // <-- Insert an empty newline here.
#include <mongocxx/a.hpp>
#include <mongocxx/b.hpp>
#include <mongocxx/c.hpp>
```