### PR TITLE
Reduce Warnings - implicit-fallthrough, switch-enum, extra-semi-stmt, unneeded-member-function

### DIFF
--- a/src/bsoncxx/test/type_traits.test.cpp
+++ b/src/bsoncxx/test/type_traits.test.cpp
@@ -10,6 +10,7 @@
 // We declare variables that are only used for compilation checking
 BSONCXX_DISABLE_WARNING(GNU("-Wunused"));
 BSONCXX_DISABLE_WARNING(Clang("-Wunused-template"));
+BSONCXX_DISABLE_WARNING(Clang("-Wunneeded-member-function"));
 
 namespace {
 

--- a/src/mongocxx/test/client_helpers.cpp
+++ b/src/mongocxx/test/client_helpers.cpp
@@ -116,6 +116,25 @@ bsoncxx::array::value transform_array(bsoncxx::array::view view,
                 builder.append(transform_array(v.get_array().value, fcn, context));
                 break;
 
+            case bsoncxx::type::k_double:
+            case bsoncxx::type::k_string:
+            case bsoncxx::type::k_binary:
+            case bsoncxx::type::k_undefined:
+            case bsoncxx::type::k_oid:
+            case bsoncxx::type::k_bool:
+            case bsoncxx::type::k_date:
+            case bsoncxx::type::k_null:
+            case bsoncxx::type::k_regex:
+            case bsoncxx::type::k_dbpointer:
+            case bsoncxx::type::k_code:
+            case bsoncxx::type::k_symbol:
+            case bsoncxx::type::k_codewscope:
+            case bsoncxx::type::k_int32:
+            case bsoncxx::type::k_timestamp:
+            case bsoncxx::type::k_int64:
+            case bsoncxx::type::k_decimal128:
+            case bsoncxx::type::k_maxkey:
+            case bsoncxx::type::k_minkey:
             default:
                 builder.append(v);
                 break;
@@ -159,6 +178,25 @@ bsoncxx::document::value transform_document_recursive(bsoncxx::document::view vi
                     k, transform_array(v.get_array().value, fcn, context)));
                 break;
 
+            case bsoncxx::type::k_double:
+            case bsoncxx::type::k_string:
+            case bsoncxx::type::k_binary:
+            case bsoncxx::type::k_undefined:
+            case bsoncxx::type::k_oid:
+            case bsoncxx::type::k_bool:
+            case bsoncxx::type::k_date:
+            case bsoncxx::type::k_null:
+            case bsoncxx::type::k_regex:
+            case bsoncxx::type::k_dbpointer:
+            case bsoncxx::type::k_code:
+            case bsoncxx::type::k_symbol:
+            case bsoncxx::type::k_codewscope:
+            case bsoncxx::type::k_int32:
+            case bsoncxx::type::k_timestamp:
+            case bsoncxx::type::k_int64:
+            case bsoncxx::type::k_decimal128:
+            case bsoncxx::type::k_maxkey:
+            case bsoncxx::type::k_minkey:
             default:
                 builder.append(bsoncxx::builder::basic::kvp(k, v));
                 break;

--- a/src/mongocxx/test/client_helpers.hh
+++ b/src/mongocxx/test/client_helpers.hh
@@ -235,8 +235,10 @@ cseeos_result client_side_encryption_enabled_or_skip_impl();
                 break;                                                                \
             case mongocxx::test_util::cseeos_result::skip:                            \
                 SKIP("CSE environemnt variables not set");                            \
+                break;                                                                \
             case mongocxx::test_util::cseeos_result::fail:                            \
                 FAIL("One or more CSE environment variable is missing");              \
+                break;                                                                \
         }                                                                             \
     } else                                                                            \
         ((void)0)

--- a/src/mongocxx/test/client_side_encryption.cpp
+++ b/src/mongocxx/test/client_side_encryption.cpp
@@ -3377,6 +3377,12 @@ TEST_CASE("Range Explicit Encryption", "[client_side_encryption]") {
                     // This test case should be skipped if the encrypted field is
                     // `encryptedDoubleNoPrecision` or `encryptedDecimalNoPrecision`.
                     break;
+
+                case RangeFieldType::DecimalPrecision:
+                case RangeFieldType::DoublePrecision:
+                case RangeFieldType::Date:
+                case RangeFieldType::Int:
+                case RangeFieldType::Long:
                 default: {
                     SECTION("Case 6: encrypting a document greater than the maximum errors") {
                         const auto original = to_field_value(201, field_type);
@@ -3413,6 +3419,12 @@ TEST_CASE("Range Explicit Encryption", "[client_side_encryption]") {
                     // This test case should be skipped if the encrypted field is
                     // `encryptedDoubleNoPrecision`.
                     break;
+
+                case RangeFieldType::DecimalPrecision:
+                case RangeFieldType::DoublePrecision:
+                case RangeFieldType::Date:
+                case RangeFieldType::Int:
+                case RangeFieldType::Long:
                 default: {
                     SECTION("Case 7: encrypting a document of a different type errors") {
                         // For all the tests below use these EncryptOpts:
@@ -3454,6 +3466,10 @@ TEST_CASE("Range Explicit Encryption", "[client_side_encryption]") {
                     // `encryptedDoublePrecision` or `encryptedDoubleNoPrecision` or
                     // `encryptedDecimalPrecision` or `encryptedDecimalNoPrecision`.
                     break;
+
+                case RangeFieldType::Date:
+                case RangeFieldType::Int:
+                case RangeFieldType::Long:
                 default: {
                     SECTION("Case 8: setting precision errors if the type is not a double") {
                         // Use `clientEncryption.encrypt()` to try to encrypt the value 6 with these

--- a/src/mongocxx/test/options/create_collection.cpp
+++ b/src/mongocxx/test/options/create_collection.cpp
@@ -44,8 +44,6 @@ TEST_CASE("create_collection accessors/mutators", "[create_collection]") {
     auto validation = validation_criteria{}.rule(make_document(kvp("a", 1)));
 
     CHECK_OPTIONAL_ARGUMENT(cc, capped, true);
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN;
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END;
     CHECK_OPTIONAL_ARGUMENT(cc, size, 5);
     CHECK_OPTIONAL_ARGUMENT(cc, max, 2);
     CHECK_OPTIONAL_ARGUMENT(cc, collation, collation.view());

--- a/src/mongocxx/test/spec/initial_dns_seedlist_discovery.cpp
+++ b/src/mongocxx/test/spec/initial_dns_seedlist_discovery.cpp
@@ -86,12 +86,33 @@ static void assert_elements_equal(bsoncxx::document::element expected_option,
         case bsoncxx::type::k_int32:
             REQUIRE(expected_option.get_int32() == my_option.get_int32());
             break;
+
         case bsoncxx::type::k_bool:
             REQUIRE(expected_option.get_bool() == my_option.get_bool());
             break;
+
         case bsoncxx::type::k_string:
             REQUIRE(expected_option.get_string() == my_option.get_string());
             break;
+
+        case bsoncxx::type::k_double:
+        case bsoncxx::type::k_document:
+        case bsoncxx::type::k_array:
+        case bsoncxx::type::k_binary:
+        case bsoncxx::type::k_undefined:
+        case bsoncxx::type::k_oid:
+        case bsoncxx::type::k_date:
+        case bsoncxx::type::k_null:
+        case bsoncxx::type::k_regex:
+        case bsoncxx::type::k_dbpointer:
+        case bsoncxx::type::k_code:
+        case bsoncxx::type::k_symbol:
+        case bsoncxx::type::k_codewscope:
+        case bsoncxx::type::k_timestamp:
+        case bsoncxx::type::k_int64:
+        case bsoncxx::type::k_decimal128:
+        case bsoncxx::type::k_maxkey:
+        case bsoncxx::type::k_minkey:
         default:
             std::string msg =
                 "option type not handled: " + bsoncxx::to_string(expected_option.type());

--- a/src/mongocxx/test/spec/operation.cpp
+++ b/src/mongocxx/test/spec/operation.cpp
@@ -572,6 +572,7 @@ document::value operation_runner::_run_find_one_and_update(document::view operat
             }
             break;
         }
+
         case bsoncxx::type::k_array: {
             pipeline update = build_pipeline(arguments["update"].get_array().value);
             if (session) {
@@ -581,6 +582,26 @@ document::value operation_runner::_run_find_one_and_update(document::view operat
             }
             break;
         }
+
+        case bsoncxx::type::k_double:
+        case bsoncxx::type::k_string:
+        case bsoncxx::type::k_binary:
+        case bsoncxx::type::k_undefined:
+        case bsoncxx::type::k_oid:
+        case bsoncxx::type::k_bool:
+        case bsoncxx::type::k_date:
+        case bsoncxx::type::k_null:
+        case bsoncxx::type::k_regex:
+        case bsoncxx::type::k_dbpointer:
+        case bsoncxx::type::k_code:
+        case bsoncxx::type::k_symbol:
+        case bsoncxx::type::k_codewscope:
+        case bsoncxx::type::k_int32:
+        case bsoncxx::type::k_timestamp:
+        case bsoncxx::type::k_int64:
+        case bsoncxx::type::k_decimal128:
+        case bsoncxx::type::k_maxkey:
+        case bsoncxx::type::k_minkey:
         default:
             throw std::logic_error{"update must be a document or an array"};
     }
@@ -778,6 +799,7 @@ document::value operation_runner::_run_update_many(document::view operation) {
             }
             break;
         }
+
         case bsoncxx::type::k_array: {
             pipeline update = build_pipeline(arguments["update"].get_array().value);
             if (session) {
@@ -787,6 +809,26 @@ document::value operation_runner::_run_update_many(document::view operation) {
             }
             break;
         }
+
+        case bsoncxx::type::k_double:
+        case bsoncxx::type::k_string:
+        case bsoncxx::type::k_binary:
+        case bsoncxx::type::k_undefined:
+        case bsoncxx::type::k_oid:
+        case bsoncxx::type::k_bool:
+        case bsoncxx::type::k_date:
+        case bsoncxx::type::k_null:
+        case bsoncxx::type::k_regex:
+        case bsoncxx::type::k_dbpointer:
+        case bsoncxx::type::k_code:
+        case bsoncxx::type::k_symbol:
+        case bsoncxx::type::k_codewscope:
+        case bsoncxx::type::k_int32:
+        case bsoncxx::type::k_timestamp:
+        case bsoncxx::type::k_int64:
+        case bsoncxx::type::k_decimal128:
+        case bsoncxx::type::k_maxkey:
+        case bsoncxx::type::k_minkey:
         default:
             throw std::logic_error{"update must be a document or an array"};
     }
@@ -870,6 +912,7 @@ document::value operation_runner::_run_update_one(document::view operation) {
             }
             break;
         }
+
         case bsoncxx::type::k_array: {
             pipeline update = build_pipeline(arguments["update"].get_array().value);
             if (session) {
@@ -879,6 +922,26 @@ document::value operation_runner::_run_update_one(document::view operation) {
             }
             break;
         }
+
+        case bsoncxx::type::k_double:
+        case bsoncxx::type::k_string:
+        case bsoncxx::type::k_binary:
+        case bsoncxx::type::k_undefined:
+        case bsoncxx::type::k_oid:
+        case bsoncxx::type::k_bool:
+        case bsoncxx::type::k_date:
+        case bsoncxx::type::k_null:
+        case bsoncxx::type::k_regex:
+        case bsoncxx::type::k_dbpointer:
+        case bsoncxx::type::k_code:
+        case bsoncxx::type::k_symbol:
+        case bsoncxx::type::k_codewscope:
+        case bsoncxx::type::k_int32:
+        case bsoncxx::type::k_timestamp:
+        case bsoncxx::type::k_int64:
+        case bsoncxx::type::k_decimal128:
+        case bsoncxx::type::k_maxkey:
+        case bsoncxx::type::k_minkey:
         default:
             throw std::logic_error{"update must be a document or an array"};
     }
@@ -966,10 +1029,31 @@ T _build_update_model(document::view arguments) {
         case bsoncxx::type::k_document: {
             return T(filter, arguments["update"].get_document().value);
         }
+
         case bsoncxx::type::k_array: {
             pipeline update = build_pipeline(arguments["update"].get_array().value);
             return T(filter, update);
         }
+
+        case bsoncxx::type::k_double:
+        case bsoncxx::type::k_string:
+        case bsoncxx::type::k_binary:
+        case bsoncxx::type::k_undefined:
+        case bsoncxx::type::k_oid:
+        case bsoncxx::type::k_bool:
+        case bsoncxx::type::k_date:
+        case bsoncxx::type::k_null:
+        case bsoncxx::type::k_regex:
+        case bsoncxx::type::k_dbpointer:
+        case bsoncxx::type::k_code:
+        case bsoncxx::type::k_symbol:
+        case bsoncxx::type::k_codewscope:
+        case bsoncxx::type::k_int32:
+        case bsoncxx::type::k_timestamp:
+        case bsoncxx::type::k_int64:
+        case bsoncxx::type::k_decimal128:
+        case bsoncxx::type::k_maxkey:
+        case bsoncxx::type::k_minkey:
         default:
             throw std::logic_error{"update must be a document or an array"};
     }

--- a/src/mongocxx/test/spec/unified_tests/assert.cpp
+++ b/src/mongocxx/test/spec/unified_tests/assert.cpp
@@ -247,9 +247,11 @@ void assert::matches(types::bson_value::view actual,
         case bsoncxx::type::k_document:
             matches_document(actual, expected, map, is_root);
             return;
+
         case bsoncxx::type::k_array:
             matches_array(actual, expected, map, is_array_of_root_docs);
             return;
+
         case bsoncxx::type::k_int32:
         case bsoncxx::type::k_int64:
         case bsoncxx::type::k_double: {
@@ -267,6 +269,23 @@ void assert::matches(types::bson_value::view actual,
             BSONCXX_POP_WARNINGS();
             return;
         }
+
+        case bsoncxx::type::k_string:
+        case bsoncxx::type::k_binary:
+        case bsoncxx::type::k_undefined:
+        case bsoncxx::type::k_oid:
+        case bsoncxx::type::k_bool:
+        case bsoncxx::type::k_date:
+        case bsoncxx::type::k_null:
+        case bsoncxx::type::k_regex:
+        case bsoncxx::type::k_dbpointer:
+        case bsoncxx::type::k_code:
+        case bsoncxx::type::k_symbol:
+        case bsoncxx::type::k_codewscope:
+        case bsoncxx::type::k_timestamp:
+        case bsoncxx::type::k_decimal128:
+        case bsoncxx::type::k_maxkey:
+        case bsoncxx::type::k_minkey:
         default: {
             CAPTURE(is_root,
                     to_string(actual.type()),

--- a/src/mongocxx/test/spec/unified_tests/operations.cpp
+++ b/src/mongocxx/test/spec/unified_tests/operations.cpp
@@ -302,10 +302,31 @@ T _build_update_model(document::view arguments) {
         case bsoncxx::type::k_document: {
             return T(filter, arguments["update"].get_document().value);
         }
+
         case bsoncxx::type::k_array: {
             pipeline update = build_pipeline(arguments["update"].get_array().value);
             return T(filter, update);
         }
+
+        case bsoncxx::type::k_double:
+        case bsoncxx::type::k_string:
+        case bsoncxx::type::k_binary:
+        case bsoncxx::type::k_undefined:
+        case bsoncxx::type::k_oid:
+        case bsoncxx::type::k_bool:
+        case bsoncxx::type::k_date:
+        case bsoncxx::type::k_null:
+        case bsoncxx::type::k_regex:
+        case bsoncxx::type::k_dbpointer:
+        case bsoncxx::type::k_code:
+        case bsoncxx::type::k_symbol:
+        case bsoncxx::type::k_codewscope:
+        case bsoncxx::type::k_int32:
+        case bsoncxx::type::k_timestamp:
+        case bsoncxx::type::k_int64:
+        case bsoncxx::type::k_decimal128:
+        case bsoncxx::type::k_maxkey:
+        case bsoncxx::type::k_minkey:
         default:
             throw std::logic_error{"update must be a document or an array"};
     }
@@ -1007,6 +1028,7 @@ document::value find_one_and_update(collection& coll,
             }
             break;
         }
+
         case bsoncxx::type::k_array: {
             pipeline update = build_pipeline(arguments["update"].get_array().value);
             if (session) {
@@ -1016,6 +1038,26 @@ document::value find_one_and_update(collection& coll,
             }
             break;
         }
+
+        case bsoncxx::type::k_double:
+        case bsoncxx::type::k_string:
+        case bsoncxx::type::k_binary:
+        case bsoncxx::type::k_undefined:
+        case bsoncxx::type::k_oid:
+        case bsoncxx::type::k_bool:
+        case bsoncxx::type::k_date:
+        case bsoncxx::type::k_null:
+        case bsoncxx::type::k_regex:
+        case bsoncxx::type::k_dbpointer:
+        case bsoncxx::type::k_code:
+        case bsoncxx::type::k_symbol:
+        case bsoncxx::type::k_codewscope:
+        case bsoncxx::type::k_int32:
+        case bsoncxx::type::k_timestamp:
+        case bsoncxx::type::k_int64:
+        case bsoncxx::type::k_decimal128:
+        case bsoncxx::type::k_maxkey:
+        case bsoncxx::type::k_minkey:
         default:
             throw std::logic_error{"update must be a document or an array"};
     }
@@ -1343,6 +1385,7 @@ document::value update_one(collection& coll, client_session* session, document::
                                             : coll.update_one(filter, doc, options);
                 break;
             }
+
             case bsoncxx::type::k_array: {
                 pipeline pipe;
                 pipe.append_stages(update.get_array().value);
@@ -1350,6 +1393,26 @@ document::value update_one(collection& coll, client_session* session, document::
                                             : coll.update_one(filter, pipe, options);
                 break;
             }
+
+            case bsoncxx::type::k_double:
+            case bsoncxx::type::k_string:
+            case bsoncxx::type::k_binary:
+            case bsoncxx::type::k_undefined:
+            case bsoncxx::type::k_oid:
+            case bsoncxx::type::k_bool:
+            case bsoncxx::type::k_date:
+            case bsoncxx::type::k_null:
+            case bsoncxx::type::k_regex:
+            case bsoncxx::type::k_dbpointer:
+            case bsoncxx::type::k_code:
+            case bsoncxx::type::k_symbol:
+            case bsoncxx::type::k_codewscope:
+            case bsoncxx::type::k_int32:
+            case bsoncxx::type::k_timestamp:
+            case bsoncxx::type::k_int64:
+            case bsoncxx::type::k_decimal128:
+            case bsoncxx::type::k_maxkey:
+            case bsoncxx::type::k_minkey:
             default:
                 throw std::logic_error("unexpected type '" + to_string(type) +
                                        "' for field 'update'");
@@ -1414,12 +1477,33 @@ document::value update_many(collection& coll, document::view operation) {
                 update_many_result = coll.update_many(filter, doc, options);
                 break;
             }
+
             case bsoncxx::type::k_array: {
                 pipeline pipe;
                 pipe.append_stages(update.get_array().value);
                 update_many_result = coll.update_many(filter, pipe, options);
                 break;
             }
+
+            case bsoncxx::type::k_double:
+            case bsoncxx::type::k_string:
+            case bsoncxx::type::k_binary:
+            case bsoncxx::type::k_undefined:
+            case bsoncxx::type::k_oid:
+            case bsoncxx::type::k_bool:
+            case bsoncxx::type::k_date:
+            case bsoncxx::type::k_null:
+            case bsoncxx::type::k_regex:
+            case bsoncxx::type::k_dbpointer:
+            case bsoncxx::type::k_code:
+            case bsoncxx::type::k_symbol:
+            case bsoncxx::type::k_codewscope:
+            case bsoncxx::type::k_int32:
+            case bsoncxx::type::k_timestamp:
+            case bsoncxx::type::k_int64:
+            case bsoncxx::type::k_decimal128:
+            case bsoncxx::type::k_maxkey:
+            case bsoncxx::type::k_minkey:
             default:
                 throw std::logic_error("unexpected type '" + to_string(type) +
                                        "' for field 'update'");

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -147,9 +147,30 @@ bsoncxx::document::value parse_kms_doc(bsoncxx::document::view_or_value test_kms
                 case bsoncxx::type::k_string:
                     variables_doc.append(kvp(variable, actual_value.get_string()));
                     break;
+
                 case bsoncxx::type::k_binary:
                     variables_doc.append(kvp(variable, actual_value.get_binary()));
                     break;
+
+                case bsoncxx::type::k_double:
+                case bsoncxx::type::k_document:
+                case bsoncxx::type::k_array:
+                case bsoncxx::type::k_undefined:
+                case bsoncxx::type::k_oid:
+                case bsoncxx::type::k_bool:
+                case bsoncxx::type::k_date:
+                case bsoncxx::type::k_null:
+                case bsoncxx::type::k_regex:
+                case bsoncxx::type::k_dbpointer:
+                case bsoncxx::type::k_code:
+                case bsoncxx::type::k_symbol:
+                case bsoncxx::type::k_codewscope:
+                case bsoncxx::type::k_int32:
+                case bsoncxx::type::k_timestamp:
+                case bsoncxx::type::k_int64:
+                case bsoncxx::type::k_decimal128:
+                case bsoncxx::type::k_maxkey:
+                case bsoncxx::type::k_minkey:
                 default:
                     FAIL("FAIL: unexpected variable type in KMS doc: '"
                          << bsoncxx::to_string(actual_value.type()) << "'");

--- a/src/mongocxx/test/spec/uri_options.cpp
+++ b/src/mongocxx/test/spec/uri_options.cpp
@@ -79,12 +79,33 @@ static void assert_elements_equal(bsoncxx::document::element expected_option,
         case bsoncxx::type::k_int32:
             REQUIRE(expected_option.get_int32() == my_option.get_int32());
             break;
+
         case bsoncxx::type::k_bool:
             REQUIRE(expected_option.get_bool() == my_option.get_bool());
             break;
+
         case bsoncxx::type::k_string:
             REQUIRE(expected_option.get_string() == my_option.get_string());
             break;
+
+        case bsoncxx::type::k_double:
+        case bsoncxx::type::k_document:
+        case bsoncxx::type::k_array:
+        case bsoncxx::type::k_binary:
+        case bsoncxx::type::k_undefined:
+        case bsoncxx::type::k_oid:
+        case bsoncxx::type::k_date:
+        case bsoncxx::type::k_null:
+        case bsoncxx::type::k_regex:
+        case bsoncxx::type::k_dbpointer:
+        case bsoncxx::type::k_code:
+        case bsoncxx::type::k_symbol:
+        case bsoncxx::type::k_codewscope:
+        case bsoncxx::type::k_timestamp:
+        case bsoncxx::type::k_int64:
+        case bsoncxx::type::k_decimal128:
+        case bsoncxx::type::k_maxkey:
+        case bsoncxx::type::k_minkey:
         default:
             std::string msg =
                 "option type not handled: " + bsoncxx::to_string(expected_option.type());


### PR DESCRIPTION
Addresses 40 Clang warnings (35 unique).

> [!NOTE]
> The value of `-Wswitch-enum` is denoting code which may need to be updated given changes to a set of enumerators. The value of `default:` in addition to explicit enumerators is to handle representable values which may not be covered by the set of enumerators. Therefore, having both in the same switch statement is an acceptable pattern, although the `default:` should ideally not be necessary.