### PR TITLE
CXX-3110 Standardize \see, \par, and \code command formatting

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
@@ -91,7 +91,8 @@ struct concatenate_array {
 ///
 /// @return concatenate_doc A concatenating struct.
 ///
-/// @see bsoncxx::v_noabi::builder::concatenate_doc
+/// @see
+/// - @ref bsoncxx::v_noabi::builder::concatenate_doc
 ///
 inline concatenate_doc concatenate(document::view_or_value doc) {
     return {std::move(doc)};
@@ -107,7 +108,8 @@ inline concatenate_doc concatenate(document::view_or_value doc) {
 ///
 /// @return concatenate_doc A concatenating struct.
 ///
-/// @see bsoncxx::v_noabi::builder::concatenate_doc
+/// @see
+/// - @ref bsoncxx::v_noabi::builder::concatenate_doc
 ///
 inline concatenate_array concatenate(array::view_or_value array) {
     return {std::move(array)};

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
@@ -60,7 +60,8 @@ class list {
     /// @param value
     ///     the BSON value
     ///
-    /// @see bsoncxx::v_noabi::types::bson_value::value.
+    /// @see
+    /// - @ref bsoncxx::v_noabi::types::bson_value::value.
     ///
     template <typename T>
     list(T value) : val{value} {}
@@ -81,15 +82,17 @@ class list {
     ///     bsoncxx::v_noabi::builder::document or bsoncxx::v_noabi::builder::array constructor,
     ///     respectively.
     ///
-    /// @see bsoncxx::v_noabi::builder::document
-    /// @see bsoncxx::v_noabi::builder::array
+    /// @see
+    /// - @ref bsoncxx::v_noabi::builder::document
+    /// - @ref bsoncxx::v_noabi::builder::array
     ///
     list(initializer_list_t init) : list(init, true, true) {}
 
     ///
     /// Provides a view of the underlying BSON value.
     ///
-    /// @see bsoncxx::v_noabi::types::bson_value::view.
+    /// @see
+    /// - @ref bsoncxx::v_noabi::types::bson_value::view.
     ///
     operator bson_value::view() {
         return view();
@@ -98,7 +101,8 @@ class list {
     ///
     /// Provides a view of the underlying BSON value.
     ///
-    /// @see bsoncxx::v_noabi::types::bson_value::view.
+    /// @see
+    /// - @ref bsoncxx::v_noabi::types::bson_value::view.
     ///
     bson_value::view view() {
         return val.view();
@@ -168,8 +172,9 @@ class document : public list {
     /// @param init
     ///     the initializer list used to construct the BSON document
     ///
-    /// @see bsoncxx::v_noabi::builder::list
-    /// @see bsoncxx::v_noabi::builder::array
+    /// @see
+    /// - @ref bsoncxx::v_noabi::builder::list
+    /// - @ref bsoncxx::v_noabi::builder::array
     ///
     document(initializer_list_t init) : list(init, false, false) {}
 };
@@ -192,8 +197,9 @@ class array : public list {
     /// @param init
     ///     the initializer list used to construct the BSON array
     ///
-    /// @see bsoncxx::v_noabi::builder::list
-    /// @see bsoncxx::v_noabi::builder::document
+    /// @see
+    /// - @ref bsoncxx::v_noabi::builder::list
+    /// - @ref bsoncxx::v_noabi::builder::document
     ///
     array(initializer_list_t init) : list(init, false, true) {}
 };

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/array_context.hpp
@@ -166,7 +166,8 @@ class array_context {
     ///
     /// Conversion operator for single_context.
     ///
-    /// @see bsoncxx::v_noabi::builder::stream::single_context
+    /// @see
+    /// - @ref bsoncxx::v_noabi::builder::stream::single_context
     ///
     operator single_context();
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp
@@ -61,8 +61,7 @@ struct open_array_type {
 /// A stream manipulator to open a subarray.
 ///
 /// @see
-/// https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/working-with-bson/#std-label-cpp-bson-builders
-/// for help building arrays in loops.
+/// - https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/working-with-bson/#std-label-cpp-bson-builders for help building arrays in loops.
 ///
 constexpr open_array_type open_array;
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context.hpp
@@ -108,7 +108,8 @@ class value_context {
     ///
     /// Conversion operator for single_context.
     ///
-    /// @see bsoncxx::v_noabi::builder::stream::single_context
+    /// @see
+    /// - @ref bsoncxx::v_noabi::builder::stream::single_context
     ///
     operator single_context();
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/postlude.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/postlude.hpp
@@ -104,5 +104,6 @@ static_assert(false, "BSONCXX_ENUM must be undef'ed");
 /// This header uses macro pragmas to guard macros defined by the bsoncxx library for internal use
 /// by "popping" their prior definition onto the stack after use by bsoncxx headers.
 ///
-/// @see bsoncxx/v_noabi/bsoncxx/config/prelude.hpp
+/// @see
+/// - @ref bsoncxx/v_noabi/bsoncxx/config/prelude.hpp
 ///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/prelude.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/prelude.hpp
@@ -131,13 +131,12 @@
 ///
 /// @warning For internal use only!
 ///
-/// @par "Includes" @parblock
-/// @li @ref bsoncxx/v_noabi/bsoncxx/config/compiler.hpp
-/// @li @ref bsoncxx-v_noabi-bsoncxx-config-config-hpp
-/// @li @ref bsoncxx-v_noabi-bsoncxx-config-export-hpp
-/// @li @ref bsoncxx/v_noabi/bsoncxx/config/util.hpp
-/// @li @ref bsoncxx-v_noabi-bsoncxx-config-version-hpp
-/// @endparblock
+/// @par Includes
+/// - @ref bsoncxx/v_noabi/bsoncxx/config/compiler.hpp
+/// - @ref bsoncxx-v_noabi-bsoncxx-config-config-hpp
+/// - @ref bsoncxx-v_noabi-bsoncxx-config-export-hpp
+/// - @ref bsoncxx/v_noabi/bsoncxx/config/util.hpp
+/// - @ref bsoncxx-v_noabi-bsoncxx-config-version-hpp
 ///
 /// This header uses macro pragmas to guard macros defined by the bsoncxx library for internal use
 /// by "pushing" their prior definition onto the stack before use by bsoncxx headers.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/prelude.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/prelude.hpp
@@ -142,5 +142,6 @@
 /// This header uses macro pragmas to guard macros defined by the bsoncxx library for internal use
 /// by "pushing" their prior definition onto the stack before use by bsoncxx headers.
 ///
-/// @see bsoncxx/v_noabi/bsoncxx/config/postlude.hpp
+/// @see
+/// - @ref bsoncxx/v_noabi/bsoncxx/config/postlude.hpp
 ///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
@@ -40,7 +40,8 @@ namespace document {
 /// interrogated by calling type(), the key can be extracted by calling key() and
 /// a specific value can be extracted through get_X() accessors.
 ///
-/// @see bsoncxx::v_noabi::array::element
+/// @see
+/// - @ref bsoncxx::v_noabi::array::element
 ///
 class element {
    public:

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/fwd.hpp
@@ -421,7 +421,8 @@
 /// @namespace bsoncxx::v_noabi::types
 /// @copydoc bsoncxx::types
 ///
-/// @see bsoncxx::v_noabi::types::bson_value
+/// @see
+/// - @ref bsoncxx::v_noabi::types::bson_value
 ///
 
 ///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/fwd.hpp
@@ -51,10 +51,8 @@
 /// @file
 /// Aggregate of all forward headers declaring entities in @ref bsoncxx::v_noabi.
 ///
-/// @par "Includes" @parblock
-/// @li All header files under @ref src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx
-/// "bsoncxx/v_noabi/bsoncxx" whose filename ends with `-fwd.hpp`.
-/// @endparblock
+/// @par Includes
+/// - All header files under @ref src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx "bsoncxx/v_noabi/bsoncxx" whose filename ends with `-fwd.hpp`.
 ///
 
 ///
@@ -95,13 +93,11 @@
 /// @dir bsoncxx/v_noabi/bsoncxx/config
 /// Provides headers related to bsoncxx library configuration.
 ///
-/// @par "Generated Headers"
-///
+/// @par Generated Headers
 /// Generated headers are documented by the following pages:
-///
-/// @li @ref bsoncxx-v_noabi-bsoncxx-config-config-hpp
-/// @li @ref bsoncxx-v_noabi-bsoncxx-config-export-hpp
-/// @li @ref bsoncxx-v_noabi-bsoncxx-config-version-hpp
+/// - @ref bsoncxx-v_noabi-bsoncxx-config-config-hpp
+/// - @ref bsoncxx-v_noabi-bsoncxx-config-export-hpp
+/// - @ref bsoncxx-v_noabi-bsoncxx-config-version-hpp
 ///
 
 #if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
@@ -35,7 +35,8 @@ namespace v_noabi {
 /// @note we use 'oid' to refer to this concrete class. We use 'ObjectId' to refer
 /// to the BSON type.
 ///
-/// @see https://www.mongodb.com/docs/manual/reference/object-id/
+/// @see
+/// - https://www.mongodb.com/docs/manual/reference/object-id/
 ///
 class oid {
    public:

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/optional.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/optional.hpp
@@ -853,8 +853,8 @@ using ::bsoncxx::v_noabi::stdx::optional;
 /// configuration variables and the `BSONCXX_POLY_USE_*` macros provided by @ref
 /// bsoncxx-v_noabi-bsoncxx-config-config-hpp.
 ///
-/// @see [Choosing a C++17
-/// Polyfill](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/polyfill-selection/)
+/// @see
+/// - [Choosing a C++17 Polyfill](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/polyfill-selection/)
 ///
 
 #if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/string_view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/string_view.hpp
@@ -483,8 +483,8 @@ using ::bsoncxx::v_noabi::stdx::string_view;
 /// configuration variables and the `BSONCXX_POLY_USE_*` macros provided by @ref
 /// bsoncxx-v_noabi-bsoncxx-config-config-hpp.
 ///
-/// @see [Choosing a C++17
-/// Polyfill](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/polyfill-selection/)
+/// @see
+/// - [Choosing a C++17 Polyfill](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/polyfill-selection/)
 ///
 
 #if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/to_string.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/to_string.hpp
@@ -31,8 +31,8 @@ namespace string {
 /// This function may be used in place of explicit conversion to `std::string`, which may not be
 /// supported across all polyfill build configurations.
 ///
-/// @par "Example" @parblock
-/// @code{.cpp}
+/// @par Example
+/// ```cpp
 /// std::string example(bsoncxx::v_noabi::stdx::string_view sv) {
 ///   // This may not be supported depending on the polyfill library.
 ///   // return std::string(sv);
@@ -40,8 +40,6 @@ namespace string {
 ///   // This is supported regardless of the polyfill library.
 ///   return bsoncxx::v_noabi::string::to_string(sv);
 /// }
-/// @endcode
-/// @endparblock
 ///
 template <class CharT,
           class Traits = std::char_traits<CharT>,

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
@@ -30,9 +30,8 @@ namespace string {
 ///
 /// Class representing a view-or-value variant type for strings.
 ///
-/// @par "Derived From" @parblock
-/// @li @ref bsoncxx::v_noabi::view_or_value<stdx::string_view, std::string>
-/// @endparblock
+/// @par Derived From
+/// - @ref bsoncxx::v_noabi::view_or_value<stdx::string_view, std::string>
 ///
 /// This class adds several string-specific methods to the bsoncxx::v_noabi::view_or_value template:
 /// - a constructor overload for const char*

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
@@ -325,9 +325,8 @@ using not_view = is_bson_view_compatible<T>;
 ///
 /// Compares a view with a type representable as a view.
 ///
-/// @par "Constraints" @parblock
-/// @li @ref bsoncxx::v_noabi::types::bson_value::view is constructible from `T`.
-/// @endparblock
+/// @par Constraints
+/// - @ref bsoncxx::v_noabi::types::bson_value::view is constructible from `T`.
 ///
 /// @{
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write.hpp
@@ -38,8 +38,9 @@ namespace v_noabi {
 /// method. Options that you would typically specify for individual write operations (such as write
 /// concern) are instead specified for the aggregate operation.
 ///
-/// @see https://www.mongodb.com/docs/manual/core/crud/
-/// @see https://www.mongodb.com/docs/manual/core/bulk-write-operations/
+/// @see
+/// - https://www.mongodb.com/docs/manual/core/crud/
+/// - https://www.mongodb.com/docs/manual/core/bulk-write-operations/
 ///
 class bulk_write {
    public:
@@ -96,7 +97,8 @@ class bulk_write {
     ///
     /// @return The optional result of the bulk operation execution, a result::bulk_write.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/bulk-write-operations/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/bulk-write-operations/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<result::bulk_write>) execute() const;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream.hpp
@@ -96,7 +96,8 @@ class change_stream {
     /// resume token of the most recently returned document in the stream, or a
     /// postBatchResumeToken if the current batch of documents has been exhausted.
     ///
-    /// @see https://www.mongodb.com/docs/manual/changeStreams/#resume-tokens
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/changeStreams/#resume-tokens
     ///
     /// The returned document::view is valid for the lifetime of the stream and
     /// its data may be updated if the change stream is iterated after this function.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
@@ -121,7 +121,8 @@ class client {
     /// @param rc
     ///   The new @c read_concern
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/read-concern/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/read-concern/
     ///
     MONGOCXX_DEPRECATED MONGOCXX_ABI_EXPORT_CDECL(void)
         read_concern(mongocxx::v_noabi::read_concern rc);
@@ -149,7 +150,8 @@ class client {
     /// @param rp
     ///   The new @c read_preference
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/read-preference/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/read-preference/
     ///
     MONGOCXX_DEPRECATED MONGOCXX_ABI_EXPORT_CDECL(void)
         read_preference(mongocxx::v_noabi::read_preference rp);
@@ -162,7 +164,8 @@ class client {
     ///
     /// @return The current @c read_preference
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/read-preference/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/read-preference/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(mongocxx::v_noabi::read_preference) read_preference() const;
 
@@ -243,7 +246,8 @@ class client {
     /// @throws mongocxx::v_noabi::operation_exception if the underlying 'listDatabases' command
     /// fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/listDatabases
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/listDatabases
     ///
     MONGOCXX_ABI_EXPORT_CDECL(cursor) list_databases() const;
 
@@ -262,7 +266,8 @@ class client {
     /// @throws mongocxx::v_noabi::operation_exception if the underlying 'listDatabases' command
     /// fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/listDatabases
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/listDatabases
     ///
     MONGOCXX_ABI_EXPORT_CDECL(cursor) list_databases(const client_session& session) const;
 
@@ -281,7 +286,8 @@ class client {
     /// @throws mongocxx::v_noabi::operation_exception if the underlying 'listDatabases' command
     /// fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/listDatabases
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/listDatabases
     ///
     MONGOCXX_ABI_EXPORT_CDECL(cursor)
     list_databases(const bsoncxx::v_noabi::document::view_or_value opts) const;
@@ -304,7 +310,8 @@ class client {
     /// @throws mongocxx::v_noabi::operation_exception if the underlying 'listDatabases' command
     /// fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/listDatabases
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/listDatabases
     ///
     MONGOCXX_ABI_EXPORT_CDECL(cursor)
     list_databases(const client_session& session,
@@ -321,7 +328,8 @@ class client {
     /// @throws mongocxx::v_noabi::operation_exception if the underlying 'listDatabases'
     /// command fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/listDatabases
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/listDatabases
     ///
     MONGOCXX_ABI_EXPORT_CDECL(std::vector<std::string>)
     list_database_names(const bsoncxx::v_noabi::document::view_or_value filter = {}) const;
@@ -340,7 +348,8 @@ class client {
     /// @throws mongocxx::v_noabi::operation_exception if the underlying 'listDatabases'
     /// command fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/listDatabases
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/listDatabases
     ///
     MONGOCXX_ABI_EXPORT_CDECL(std::vector<std::string>)
     list_database_names(const client_session& session,
@@ -370,7 +379,8 @@ class client {
     /// @return
     ///  A change stream on this client.
     ///
-    /// @see https://www.mongodb.com/docs/manual/changeStreams/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/changeStreams/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(change_stream) watch(const options::change_stream& options = {});
 
@@ -387,7 +397,8 @@ class client {
     /// @return
     ///  A change stream on this client.
     ///
-    /// @see https://www.mongodb.com/docs/manual/changeStreams/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/changeStreams/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(change_stream)
     watch(const client_session& session, const options::change_stream& options = {});
@@ -407,7 +418,8 @@ class client {
     /// @return
     ///  A change stream on this client.
     ///
-    /// @see https://www.mongodb.com/docs/manual/changeStreams/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/changeStreams/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(change_stream)
     watch(const pipeline& pipe, const options::change_stream& options = {});
@@ -427,7 +439,8 @@ class client {
     /// @return
     ///  A change stream on this client.
     ///
-    /// @see https://www.mongodb.com/docs/manual/changeStreams/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/changeStreams/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(change_stream)
     watch(const client_session& session,

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
@@ -51,11 +51,11 @@ namespace v_noabi {
 /// via a client object (databases, collections, cursors, etc...) @b must be a subset of the
 /// lifetime of the client that created them.
 ///
-/// Example:
-/// @code
-///   mongocxx::v_noabi::client mongo_client{mongocxx::v_noabi::uri{}};
-///   mongocxx::v_noabi::client mongo_client{mongocxx::v_noabi::uri{"mongodb://localhost:27017"}};
-/// @endcode
+/// @par Example
+/// ```cpp
+/// mongocxx::v_noabi::client mongo_client{mongocxx::v_noabi::uri{}};
+/// mongocxx::v_noabi::client mongo_client{mongocxx::v_noabi::uri{"mongodb://localhost:27017"}};
+/// ```
 ///
 /// Note that client is not thread-safe. See
 /// https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/thread-safety/ for more details.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
@@ -49,7 +49,7 @@ class client_encryption {
     ///   An object representing encryption options.
     ///
     /// @see
-    /// https://www.mongodb.com/docs/ecosystem/use-cases/client-side-field-level-encryption-guide
+    /// - https://www.mongodb.com/docs/ecosystem/use-cases/client-side-field-level-encryption-guide
     ///
     MONGOCXX_ABI_EXPORT_CDECL() client_encryption(options::client_encryption opts);
 
@@ -86,7 +86,7 @@ class client_encryption {
     /// @throws mongocxx::v_noabi::exception if there is an error creating the key.
     ///
     /// @see
-    /// https://www.mongodb.com/docs/ecosystem/use-cases/client-side-field-level-encryption-guide/#b-create-a-data-encryption-key
+    /// - https://www.mongodb.com/docs/ecosystem/use-cases/client-side-field-level-encryption-guide/#b-create-a-data-encryption-key
     ///
     MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v_noabi::types::bson_value::value)
     create_data_key(std::string kms_provider, const options::data_key& opts = {});
@@ -97,7 +97,7 @@ class client_encryption {
      *
      * @param db The database in which the collection will be created
      * @param coll_name The name of the new collection
-     * @param options The options for creating the collection. @see database::create_collection
+     * @param options The options for creating the collection. See @ref database::create_collection.
      * @param out_options Output parameter to receive the generated collection options.
      * @param kms_provider The KMS provider to use when creating data encryption keys for the
      * collection's encrypted fields
@@ -185,7 +185,7 @@ class client_encryption {
     /// @throws mongocxx::v_noabi::exception if there is an error rewrapping the key.
     ///
     /// @see
-    /// https://www.mongodb.com/docs/manual/reference/method/KeyVault.rewrapManyDataKey/
+    /// - https://www.mongodb.com/docs/manual/reference/method/KeyVault.rewrapManyDataKey/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(result::rewrap_many_datakey)
     rewrap_many_datakey(bsoncxx::v_noabi::document::view_or_value filter,
@@ -201,7 +201,8 @@ class client_encryption {
     ///
     /// @return the result of the internal deleteOne() operation on the key vault collection.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/KeyVault.deleteKey/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/KeyVault.deleteKey/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(result::delete_result)
     delete_key(bsoncxx::v_noabi::types::bson_value::view_or_value id);
@@ -215,7 +216,8 @@ class client_encryption {
     ///
     /// @return The result of the internal find() operation on the key vault collection.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/KeyVault.getKey/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/KeyVault.getKey/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<bsoncxx::v_noabi::document::value>)
     get_key(bsoncxx::v_noabi::types::bson_value::view_or_value id);
@@ -227,7 +229,8 @@ class client_encryption {
     ///
     /// @return the result of the internal find() operation on the key vault collection.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/KeyVault.getKeys/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/KeyVault.getKeys/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(mongocxx::v_noabi::cursor) get_keys();
 
@@ -243,7 +246,8 @@ class client_encryption {
     ///
     /// @return the previous version of the key document.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/KeyVault.addKeyAlternateName/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/KeyVault.addKeyAlternateName/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<bsoncxx::v_noabi::document::value>)
     add_key_alt_name(bsoncxx::v_noabi::types::bson_value::view_or_value id,
@@ -261,7 +265,8 @@ class client_encryption {
     ///
     /// @return The previous version of the key document.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/KeyVault.removeKeyAlternateName/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/KeyVault.removeKeyAlternateName/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<bsoncxx::v_noabi::document::value>)
     remove_key_alt_name(bsoncxx::v_noabi::types::bson_value::view_or_value id,
@@ -276,7 +281,8 @@ class client_encryption {
     ///
     /// @return A key document in the key vault collection with the given keyAltName.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/KeyVault.getKeyByAltName/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/KeyVault.getKeyByAltName/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<bsoncxx::v_noabi::document::value>)
     get_key_by_alt_name(bsoncxx::v_noabi::string::view_or_value key_alt_name);

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
@@ -43,7 +43,7 @@ namespace v_noabi {
 /// https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/thread-safety/ for more details.
 ///
 /// @see
-/// https://www.mongodb.com/docs/manual/core/read-isolation-consistency-recency/#causal-consistency
+/// - https://www.mongodb.com/docs/manual/core/read-isolation-consistency-recency/#causal-consistency
 ///
 class client_session {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
@@ -77,12 +77,12 @@ namespace v_noabi {
 /// different fields. While not a requirement, typically documents in a collection have a similar
 /// shape or related purpose.
 ///
-/// Example:
-/// @code
-///   // Connect and get a collection.
-///   mongocxx::v_noabi::client mongo_client{mongocxx::v_noabi::uri{}};
-///   auto coll = mongo_client["database"]["collection"];
-/// @endcode
+/// @par Example
+/// ```cpp
+/// // Connect and get a collection.
+/// mongocxx::v_noabi::client mongo_client{mongocxx::v_noabi::uri{}};
+/// auto coll = mongo_client["database"]["collection"];
+/// ```
 ///
 class collection {
     //

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
@@ -151,7 +151,8 @@ class collection {
     /// the cursor throws mongocxx::v_noabi::query_exception when the returned cursor
     /// is iterated.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     /// @note
     ///   In order to pass a read concern to this, you must use the
@@ -175,7 +176,8 @@ class collection {
     /// the cursor throws mongocxx::v_noabi::query_exception when the returned cursor
     /// is iterated.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     /// @note
     ///   In order to pass a read concern to this, you must use the
@@ -232,8 +234,9 @@ class collection {
     ///   mongocxx::v_noabi::bulk_write_exception when there are errors processing
     ///   the writes.
     ///
-    /// @see mongocxx::v_noabi::bulk_write
-    /// @see https://www.mongodb.com/docs/manual/core/bulk-write-operations/
+    /// @see
+    /// - @ref mongocxx::v_noabi::bulk_write
+    /// - https://www.mongodb.com/docs/manual/core/bulk-write-operations/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<result::bulk_write>)
     write(const model::write& write, const options::bulk_write& options = options::bulk_write()) {
@@ -259,8 +262,9 @@ class collection {
     ///   mongocxx::v_noabi::bulk_write_exception when there are errors processing
     ///   the writes.
     ///
-    /// @see mongocxx::v_noabi::bulk_write
-    /// @see https://www.mongodb.com/docs/manual/core/bulk-write-operations/
+    /// @see
+    /// - @ref mongocxx::v_noabi::bulk_write
+    /// - https://www.mongodb.com/docs/manual/core/bulk-write-operations/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<result::bulk_write>)
     write(const client_session& session,
@@ -287,8 +291,9 @@ class collection {
     ///
     /// @throws mongocxx::v_noabi::bulk_write_exception when there are errors processing the writes.
     ///
-    /// @see mongocxx::v_noabi::bulk_write
-    /// @see https://www.mongodb.com/docs/manual/core/bulk-write-operations/
+    /// @see
+    /// - @ref mongocxx::v_noabi::bulk_write
+    /// - https://www.mongodb.com/docs/manual/core/bulk-write-operations/
     ///
     template <typename container_type>
     stdx::optional<result::bulk_write> bulk_write(
@@ -316,8 +321,9 @@ class collection {
     ///
     /// @throws mongocxx::v_noabi::bulk_write_exception when there are errors processing the writes.
     ///
-    /// @see mongocxx::v_noabi::bulk_write
-    /// @see https://www.mongodb.com/docs/manual/core/bulk-write-operations/
+    /// @see
+    /// - @ref mongocxx::v_noabi::bulk_write
+    /// - https://www.mongodb.com/docs/manual/core/bulk-write-operations/
     ///
     template <typename container_type>
     stdx::optional<result::bulk_write> bulk_write(
@@ -346,8 +352,9 @@ class collection {
     ///
     /// @throws mongocxx::v_noabi::bulk_write_exception when there are errors processing the writes.
     ///
-    /// @see mongocxx::v_noabi::bulk_write
-    /// @see https://www.mongodb.com/docs/manual/core/bulk-write-operations/
+    /// @see
+    /// - @ref mongocxx::v_noabi::bulk_write
+    /// - https://www.mongodb.com/docs/manual/core/bulk-write-operations/
     ///
     template <typename write_model_iterator_type>
     stdx::optional<result::bulk_write> bulk_write(
@@ -380,8 +387,9 @@ class collection {
     ///
     /// @throws mongocxx::v_noabi::bulk_write_exception when there are errors processing the writes.
     ///
-    /// @see mongocxx::v_noabi::bulk_write
-    /// @see https://www.mongodb.com/docs/manual/core/bulk-write-operations/
+    /// @see
+    /// - @ref mongocxx::v_noabi::bulk_write
+    /// - https://www.mongodb.com/docs/manual/core/bulk-write-operations/
     ///
     template <typename write_model_iterator_type>
     stdx::optional<result::bulk_write> bulk_write(
@@ -414,7 +422,8 @@ class collection {
     /// estimatedDocumentCount are recommended to upgrade their server version to 5.0.8 or newer, or
     /// set `apiStrict: false` to avoid encountering errors.
     ///
-    /// @see mongocxx::v_noabi::collection::estimated_document_count
+    /// @see
+    /// - @ref mongocxx::v_noabi::collection::estimated_document_count
     ///
     MONGOCXX_ABI_EXPORT_CDECL(std::int64_t)
     count_documents(bsoncxx::v_noabi::document::view_or_value filter,
@@ -439,7 +448,8 @@ class collection {
     /// estimatedDocumentCount are recommended to upgrade their server version to 5.0.8 or newer, or
     /// set `apiStrict: false` to avoid encountering errors.
     ///
-    /// @see mongocxx::v_noabi::collection::estimated_document_count
+    /// @see
+    /// - @ref mongocxx::v_noabi::collection::estimated_document_count
     ///
     MONGOCXX_ABI_EXPORT_CDECL(std::int64_t)
     count_documents(const client_session& session,
@@ -459,7 +469,8 @@ class collection {
     /// @note This function is implemented in terms of the count server command. See:
     /// https://www.mongodb.com/docs/manual/reference/command/count/#behavior for more information.
     ///
-    /// @see mongocxx::v_noabi::collection::count_documents
+    /// @see
+    /// - @ref mongocxx::v_noabi::collection::count_documents
     ///
     MONGOCXX_ABI_EXPORT_CDECL(std::int64_t)
     estimated_document_count(
@@ -479,7 +490,7 @@ class collection {
     ///   mongocxx::v_noabi::operation_exception if index creation fails.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/createIndexes/
+    /// - https://www.mongodb.com/docs/manual/reference/command/createIndexes/
     ///
     /// @note
     ///   Write concern supported only for MongoDB 3.4+.
@@ -505,7 +516,7 @@ class collection {
     ///   mongocxx::v_noabi::operation_exception if index creation fails.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/createIndexes/
+    /// - https://www.mongodb.com/docs/manual/reference/command/createIndexes/
     ///
     /// @note
     ///   Write concern supported only for MongoDB 3.4+.
@@ -530,7 +541,8 @@ class collection {
     ///
     /// @throws mongocxx::v_noabi::bulk_write_exception if the delete fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/delete/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/delete/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<result::delete_result>)
     delete_many(bsoncxx::v_noabi::document::view_or_value filter,
@@ -552,7 +564,8 @@ class collection {
     ///
     /// @throws mongocxx::v_noabi::bulk_write_exception if the delete fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/delete/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/delete/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<result::delete_result>)
     delete_many(const client_session& session,
@@ -573,7 +586,8 @@ class collection {
     ///
     /// @throws mongocxx::v_noabi::bulk_write_exception if the delete fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/delete/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/delete/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<result::delete_result>)
     delete_one(bsoncxx::v_noabi::document::view_or_value filter,
@@ -595,7 +609,8 @@ class collection {
     ///
     /// @throws mongocxx::v_noabi::bulk_write_exception if the delete fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/delete/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/delete/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<result::delete_result>)
     delete_one(const client_session& session,
@@ -616,7 +631,8 @@ class collection {
     /// field.  If the operation fails, the cursor throws
     /// mongocxx::v_noabi::query_exception when the returned cursor is iterated.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/distinct/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/distinct/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(cursor)
     distinct(bsoncxx::v_noabi::string::view_or_value name,
@@ -639,7 +655,8 @@ class collection {
     /// field.  If the operation fails, the cursor throws
     /// mongocxx::v_noabi::query_exception when the returned cursor is iterated.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/distinct/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/distinct/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(cursor)
     distinct(const client_session& session,
@@ -661,7 +678,7 @@ class collection {
     ///   mongocxx::v_noabi::operation_exception if the operation fails.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/drop/
+    /// - https://www.mongodb.com/docs/manual/reference/command/drop/
     ///
     /// @note
     ///   Write concern supported only for MongoDB 3.4+.
@@ -686,7 +703,7 @@ class collection {
     ///   mongocxx::v_noabi::operation_exception if the operation fails.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/drop/
+    /// - https://www.mongodb.com/docs/manual/reference/command/drop/
     ///
     /// @note
     ///   Write concern supported only for MongoDB 3.4+.
@@ -712,7 +729,8 @@ class collection {
     /// @throws mongocxx::v_noabi::logic_error if the options are invalid, or if the unsupported
     /// option modifiers "$query" or "$explain" are used.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/read-operations-introduction/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/read-operations-introduction/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(cursor)
     find(bsoncxx::v_noabi::document::view_or_value filter,
@@ -735,7 +753,8 @@ class collection {
     /// @throws mongocxx::v_noabi::logic_error if the options are invalid, or if the unsupported
     /// option modifiers "$query" or "$explain" are used.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/read-operations-introduction/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/read-operations-introduction/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(cursor)
     find(const client_session& session,
@@ -754,7 +773,8 @@ class collection {
     ///
     /// @throws mongocxx::v_noabi::query_exception if the operation fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/read-operations-introduction/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/read-operations-introduction/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<bsoncxx::v_noabi::document::value>)
     find_one(bsoncxx::v_noabi::document::view_or_value filter,
@@ -774,7 +794,8 @@ class collection {
     ///
     /// @throws mongocxx::v_noabi::query_exception if the operation fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/read-operations-introduction/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/read-operations-introduction/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<bsoncxx::v_noabi::document::value>)
     find_one(const client_session& session,
@@ -1217,7 +1238,8 @@ class collection {
     ///
     /// @throws mongocxx::v_noabi::operation_exception if the operation fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/listIndexes/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/listIndexes/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(cursor) list_indexes() const;
 
@@ -1231,7 +1253,8 @@ class collection {
     ///
     /// @throws mongocxx::v_noabi::operation_exception if the operation fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/listIndexes/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/listIndexes/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(cursor) list_indexes(const client_session& session) const;
 
@@ -1257,7 +1280,7 @@ class collection {
     ///   mongocxx::v_noabi::operation_exception if the operation fails.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/renameCollection/
+    /// - https://www.mongodb.com/docs/manual/reference/command/renameCollection/
     ///
     /// @note
     ///   Write concern supported only for MongoDB 3.4+.
@@ -1283,7 +1306,7 @@ class collection {
     ///   mongocxx::v_noabi::operation_exception if the operation fails.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/renameCollection/
+    /// - https://www.mongodb.com/docs/manual/reference/command/renameCollection/
     ///
     /// @note
     ///   Write concern supported only for MongoDB 3.4+.
@@ -1301,7 +1324,8 @@ class collection {
     /// @param rc
     ///   The new @c read_concern
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/read-concern/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/read-concern/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(void) read_concern(mongocxx::v_noabi::read_concern rc);
 
@@ -1322,7 +1346,8 @@ class collection {
     /// @param rp
     ///   The read_preference to set.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/read-preference/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/read-preference/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(void) read_preference(mongocxx::v_noabi::read_preference rp);
 
@@ -1331,7 +1356,8 @@ class collection {
     ///
     /// @return The current read_preference.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/read-preference/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/read-preference/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(mongocxx::v_noabi::read_preference) read_preference() const;
 
@@ -1353,7 +1379,8 @@ class collection {
     ///   mongocxx::v_noabi::logic_error if the replacement is invalid, or
     ///   mongocxx::v_noabi::bulk_write_exception if the operation fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/update/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/update/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<result::replace_one>)
     replace_one(bsoncxx::v_noabi::document::view_or_value filter,
@@ -1380,7 +1407,8 @@ class collection {
     ///   mongocxx::v_noabi::logic_error if the replacement is invalid, or
     ///   mongocxx::v_noabi::bulk_write_exception if the operation fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/update/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/update/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<result::replace_one>)
     replace_one(const client_session& session,
@@ -1406,7 +1434,8 @@ class collection {
     ///   mongocxx::v_noabi::logic_error if the update is invalid, or
     ///   mongocxx::v_noabi::bulk_write_exception if the operation fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/update/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/update/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<result::update>)
     update_many(bsoncxx::v_noabi::document::view_or_value filter,
@@ -1431,7 +1460,8 @@ class collection {
     ///   mongocxx::v_noabi::logic_error if the update is invalid, or
     ///   mongocxx::v_noabi::bulk_write_exception if the operation fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/update/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/update/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<result::update>)
     update_many(bsoncxx::v_noabi::document::view_or_value filter,
@@ -1456,7 +1486,8 @@ class collection {
     ///   mongocxx::v_noabi::logic_error if the update is invalid, or
     ///   mongocxx::v_noabi::bulk_write_exception if the operation fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/update/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/update/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<result::update>)
     update_many(bsoncxx::v_noabi::document::view_or_value filter,
@@ -1483,7 +1514,8 @@ class collection {
     ///   mongocxx::v_noabi::logic_error if the update is invalid, or
     ///   mongocxx::v_noabi::bulk_write_exception if the operation fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/update/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/update/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<result::update>)
     update_many(const client_session& session,
@@ -1511,7 +1543,8 @@ class collection {
     ///   mongocxx::v_noabi::logic_error if the update is invalid, or
     ///   mongocxx::v_noabi::bulk_write_exception if the operation fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/update/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/update/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<result::update>)
     update_many(const client_session& session,
@@ -1539,7 +1572,8 @@ class collection {
     ///   mongocxx::v_noabi::logic_error if the update is invalid, or
     ///   mongocxx::v_noabi::bulk_write_exception if the operation fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/update/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/update/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<result::update>)
     update_many(const client_session& session,
@@ -1565,7 +1599,8 @@ class collection {
     ///   mongocxx::v_noabi::logic_error if the update is invalid, or
     ///   mongocxx::v_noabi::bulk_write_exception if the operation fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/update/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/update/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<result::update>)
     update_one(bsoncxx::v_noabi::document::view_or_value filter,
@@ -1590,7 +1625,8 @@ class collection {
     ///   mongocxx::v_noabi::logic_error if the update is invalid, or
     ///   mongocxx::v_noabi::bulk_write_exception if the operation fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/update/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/update/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<result::update>)
     update_one(bsoncxx::v_noabi::document::view_or_value filter,
@@ -1615,7 +1651,8 @@ class collection {
     ///   mongocxx::v_noabi::logic_error if the update is invalid, or
     ///   mongocxx::v_noabi::bulk_write_exception if the operation fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/update/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/update/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<result::update>)
     update_one(bsoncxx::v_noabi::document::view_or_value filter,
@@ -1642,7 +1679,8 @@ class collection {
     ///   mongocxx::v_noabi::logic_error if the update is invalid, or
     ///   mongocxx::v_noabi::bulk_write_exception if the operation fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/update/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/update/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<result::update>)
     update_one(const client_session& session,
@@ -1670,7 +1708,8 @@ class collection {
     ///   mongocxx::v_noabi::logic_error if the update is invalid, or
     ///   mongocxx::v_noabi::bulk_write_exception if the operation fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/update/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/update/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<result::update>)
     update_one(const client_session& session,
@@ -1698,7 +1737,8 @@ class collection {
     ///   mongocxx::v_noabi::logic_error if the update is invalid, or
     ///   mongocxx::v_noabi::bulk_write_exception if the operation fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/update/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/update/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<result::update>)
     update_one(const client_session& session,
@@ -1738,7 +1778,8 @@ class collection {
     /// @return
     ///  A change stream on this collection.
     ///
-    /// @see https://www.mongodb.com/docs/manual/changeStreams/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/changeStreams/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(change_stream) watch(const options::change_stream& options = {});
 
@@ -1751,7 +1792,8 @@ class collection {
     /// @return
     ///  A change stream on this collection.
     ///
-    /// @see https://www.mongodb.com/docs/manual/changeStreams/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/changeStreams/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(change_stream)
     watch(const client_session& session, const options::change_stream& options = {});
@@ -1770,7 +1812,8 @@ class collection {
     /// @return
     ///  A change stream on this collection.
     ///
-    /// @see https://www.mongodb.com/docs/manual/changeStreams/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/changeStreams/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(change_stream)
     watch(const pipeline& pipe, const options::change_stream& options = {});
@@ -1788,7 +1831,8 @@ class collection {
     /// @return
     ///  A change stream on this collection.
     ///
-    /// @see https://www.mongodb.com/docs/manual/changeStreams/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/changeStreams/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(change_stream)
     watch(const client_session& session,

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/config/postlude.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/config/postlude.hpp
@@ -63,5 +63,6 @@
 /// This header uses macro pragmas to guard macros defined by the mongocxx library for internal use
 /// by "popping" their prior definition onto the stack after use by mongocxx headers.
 ///
-/// @see mongocxx/v_noabi/mongocxx/config/prelude.hpp
+/// @see
+/// - @ref mongocxx/v_noabi/mongocxx/config/prelude.hpp
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/config/prelude.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/config/prelude.hpp
@@ -75,12 +75,11 @@
 ///
 /// @warning For internal use only!
 ///
-/// @par "Includes" @parblock
-/// @li @ref mongocxx/v_noabi/mongocxx/config/compiler.hpp
-/// @li @ref mongocxx-v_noabi-mongocxx-config-config-hpp
-/// @li @ref mongocxx-v_noabi-mongocxx-config-export-hpp
-/// @li @ref mongocxx-v_noabi-mongocxx-config-version-hpp
-/// @endparblock
+/// @par Includes
+/// - @ref mongocxx/v_noabi/mongocxx/config/compiler.hpp
+/// - @ref mongocxx-v_noabi-mongocxx-config-config-hpp
+/// - @ref mongocxx-v_noabi-mongocxx-config-export-hpp
+/// - @ref mongocxx-v_noabi-mongocxx-config-version-hpp
 ///
 /// This header uses macro pragmas to guard macros defined by the mongocxx library for internal use
 /// by "pushing" their prior definition onto the stack before use by mongocxx headers.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/config/prelude.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/config/prelude.hpp
@@ -85,5 +85,6 @@
 /// This header uses macro pragmas to guard macros defined by the mongocxx library for internal use
 /// by "pushing" their prior definition onto the stack before use by mongocxx headers.
 ///
-/// @see mongocxx/v_noabi/mongocxx/config/postlude.hpp
+/// @see
+/// - @ref mongocxx/v_noabi/mongocxx/config/postlude.hpp
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
@@ -98,7 +98,8 @@ class database {
     /// the cursor throws mongocxx::v_noabi::query_exception when the returned cursor
     /// is iterated.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/#dbcmd.aggregate
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/#dbcmd.aggregate
     ///
     /// @note
     ///   In order to pass a read concern to this, you must use the
@@ -124,7 +125,8 @@ class database {
     /// the cursor throws mongocxx::v_noabi::query_exception when the returned cursor
     /// is iterated.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/#dbcmd.aggregate
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/#dbcmd.aggregate
     ///
     /// @note
     ///   In order to pass a read concern to this, you must use the
@@ -139,7 +141,8 @@ class database {
     ///
     /// Runs a command against this database.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/db.runCommand/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/db.runCommand/
     ///
     /// @param command document representing the command to be run.
     /// @return the result of executing the command.
@@ -152,7 +155,8 @@ class database {
     ///
     /// Runs a command against this database.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/db.runCommand/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/db.runCommand/
     ///
     /// @param session The mongocxx::v_noabi::client_session with which to run the command.
     /// @param command document representing the command to be run.
@@ -166,7 +170,8 @@ class database {
     ///
     /// Executes a command on a specific server using this database.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/db.runCommand/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/db.runCommand/
     ///
     /// @param command document representing the command to be run.
     /// @param server_id specifying which server to use.
@@ -181,7 +186,7 @@ class database {
     /// Explicitly creates a collection in this database with the specified options.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/create/
+    /// - https://www.mongodb.com/docs/manual/reference/command/create/
     ///
     /// @note This function can also be used to create a Time Series Collection. See:
     /// https://www.mongodb.com/docs/manual/core/timeseries-collections/
@@ -206,7 +211,7 @@ class database {
     /// Explicitly creates a collection in this database with the specified options.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/create/
+    /// - https://www.mongodb.com/docs/manual/reference/command/create/
     ///
     /// @note This function can also be used to create a Time Series Collection. See:
     /// https://www.mongodb.com/docs/manual/core/timeseries-collections/
@@ -238,7 +243,7 @@ class database {
     ///   bsoncxx::v_noabi::document::view_or_value collection_options instead.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/create/
+    /// - https://www.mongodb.com/docs/manual/reference/command/create/
     ///
     /// @param name
     ///   the new collection's name.
@@ -271,7 +276,7 @@ class database {
     ///   bsoncxx::v_noabi::document::view_or_value collection_options instead.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/create/
+    /// - https://www.mongodb.com/docs/manual/reference/command/create/
     ///
     /// @param session
     ///   The mongocxx::v_noabi::client_session with which to perform the create operation.
@@ -302,7 +307,7 @@ class database {
     ///   bsoncxx::v_noabi::document::view_or_value collection_options instead.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/create/
+    /// - https://www.mongodb.com/docs/manual/reference/command/create/
     ///
     /// @param session
     ///   The mongocxx::v_noabi::client_session with which to perform the create operation.
@@ -334,7 +339,7 @@ class database {
     ///   mongocxx::v_noabi::operation_exception if the operation fails.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/dropDatabase/
+    /// - https://www.mongodb.com/docs/manual/reference/command/dropDatabase/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(void)
     drop(const bsoncxx::v_noabi::stdx::optional<mongocxx::v_noabi::write_concern>& write_concern =
@@ -353,7 +358,7 @@ class database {
     ///   mongocxx::v_noabi::operation_exception if the operation fails.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/dropDatabase/
+    /// - https://www.mongodb.com/docs/manual/reference/command/dropDatabase/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(void)
     drop(const client_session& session,
@@ -381,7 +386,8 @@ class database {
     ///
     /// @return mongocxx::v_noabi::cursor containing the collection information.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/listCollections/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/listCollections/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(cursor)
     list_collections(bsoncxx::v_noabi::document::view_or_value filter = {});
@@ -396,7 +402,8 @@ class database {
     ///
     /// @return mongocxx::v_noabi::cursor containing the collection information.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/listCollections/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/listCollections/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(cursor)
     list_collections(const client_session& session,
@@ -413,7 +420,8 @@ class database {
     /// @throws mongocxx::v_noabi::operation_exception if the underlying 'listCollections'
     /// command fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/listCollections/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/listCollections/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(std::vector<std::string>)
     list_collection_names(bsoncxx::v_noabi::document::view_or_value filter = {});
@@ -431,7 +439,8 @@ class database {
     /// @throws mongocxx::v_noabi::operation_exception if the underlying 'listCollections'
     /// command fails.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/listCollections/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/listCollections/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(std::vector<std::string>)
     list_collection_names(const client_session& session,
@@ -454,7 +463,8 @@ class database {
     /// @param rc
     ///   The new @c read_concern
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/read-concern/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/read-concern/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(void) read_concern(mongocxx::v_noabi::read_concern rc);
 
@@ -475,7 +485,8 @@ class database {
     /// from this database, but do affect new ones. New collections will receive a copy of the
     /// new read_preference for this database upon instantiation.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/read-preference/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/read-preference/
     ///
     /// @param rp the new read_preference.
     ///
@@ -484,7 +495,8 @@ class database {
     ///
     /// The current read preference for this database.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/read-preference/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/read-preference/
     ///
     /// @return the current read_preference
     ///
@@ -555,7 +567,8 @@ class database {
     /// @return
     ///  A change stream on this database.
     ///
-    /// @see https://www.mongodb.com/docs/manual/changeStreams/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/changeStreams/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(change_stream) watch(const options::change_stream& options = {});
 
@@ -568,7 +581,8 @@ class database {
     /// @return
     ///  A change stream on this database.
     ///
-    /// @see https://www.mongodb.com/docs/manual/changeStreams/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/changeStreams/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(change_stream)
     watch(const client_session& session, const options::change_stream& options = {});
@@ -587,7 +601,8 @@ class database {
     /// @return
     ///  A change stream on this database.
     ///
-    /// @see https://www.mongodb.com/docs/manual/changeStreams/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/changeStreams/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(change_stream)
     watch(const pipeline& pipe, const options::change_stream& options = {});
@@ -605,7 +620,8 @@ class database {
     /// @return
     ///  A change stream on this database.
     ///
-    /// @see https://www.mongodb.com/docs/manual/changeStreams/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/changeStreams/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(change_stream)
     watch(const client_session& session,

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_failed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_failed_event.hpp
@@ -31,8 +31,8 @@ namespace events {
 ///
 /// An event notification sent when the driver fails to execute a MongoDB command.
 ///
-/// @see "CommandFailedEvent" in
-/// https://github.com/mongodb/specifications/blob/master/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
+/// @see
+/// - "CommandFailedEvent" in https://github.com/mongodb/specifications/blob/master/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
 ///
 class command_failed_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_started_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_started_event.hpp
@@ -31,8 +31,8 @@ namespace events {
 ///
 /// An event notification sent when the driver begins executing a MongoDB command.
 ///
-/// @see "CommandStartedEvent" in
-/// https://github.com/mongodb/specifications/blob/master/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
+/// @see
+/// - "CommandStartedEvent" in https://github.com/mongodb/specifications/blob/master/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
 ///
 class command_started_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_succeeded_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_succeeded_event.hpp
@@ -31,8 +31,8 @@ namespace events {
 ///
 /// An event notification sent when the driver successfully executes a MongoDB command.
 ///
-/// @see "CommandSucceededEvent" in
-/// https://github.com/mongodb/specifications/blob/master/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
+/// @see
+/// - "CommandSucceededEvent" in https://github.com/mongodb/specifications/blob/master/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
 ///
 class command_succeeded_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event.hpp
@@ -31,8 +31,8 @@ namespace events {
 /// An event notification sent when the driver failed to send an "hello" command to check the
 /// status of a server.
 ///
-/// @see "ServerHeartbeatFailedEvent" in
-/// https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+/// @see
+/// - "ServerHeartbeatFailedEvent" in https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
 ///
 class heartbeat_failed_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event.hpp
@@ -30,8 +30,8 @@ namespace events {
 /// An event notification sent when the driver begins executing a "hello" command to check the
 /// status of a server.
 ///
-/// @see "ServerHeartbeatStartedEvent" in
-/// https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+/// @see
+/// - "ServerHeartbeatStartedEvent" in https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
 ///
 class heartbeat_started_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event.hpp
@@ -29,8 +29,8 @@ namespace events {
 /// An event notification sent when the driver completes a "hello" command to check the status
 /// of a server.
 ///
-/// @see "ServerHeartbeatSucceededEvent" in
-/// https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+/// @see
+/// - "ServerHeartbeatSucceededEvent" in https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
 ///
 class heartbeat_succeeded_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_changed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_changed_event.hpp
@@ -31,8 +31,8 @@ namespace events {
 /// An event notification sent when the driver observes a change in the status of a server it is
 /// connected to.
 ///
-/// @see "ServerDescriptionChangedEvent" in
-/// https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+/// @see
+/// - "ServerDescriptionChangedEvent" in https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
 ///
 class server_changed_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_closed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_closed_event.hpp
@@ -31,8 +31,8 @@ namespace events {
 /// An event notification sent when the driver stops monitoring a MongoDB server and removes it
 /// from the topology description.
 ///
-/// @see "ServerClosedEvent" in
-/// https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+/// @see
+/// - "ServerClosedEvent" in https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
 ///
 class server_closed_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_opening_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_opening_event.hpp
@@ -30,8 +30,8 @@ namespace events {
 /// An event notification sent when the driver adds a MongoDB server to the topology description
 /// and begins monitoring it.
 ///
-/// @see "ServerOpeningEvent" in
-/// https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+/// @see
+/// - "ServerOpeningEvent" in https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
 ///
 class server_opening_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_changed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_changed_event.hpp
@@ -30,8 +30,8 @@ namespace events {
 /// An event notification sent when the driver observes a change in any of the servers it is
 /// connected to or a change in the overall server topology.
 ///
-/// @see "TopologyDescriptionChangedEvent" in
-/// https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+/// @see
+/// - "TopologyDescriptionChangedEvent" in https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
 ///
 class topology_changed_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_closed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_closed_event.hpp
@@ -28,8 +28,8 @@ namespace events {
 /// An event notification sent when the driver stops monitoring a server topology and destroys its
 /// description.
 ///
-/// @see "TopologyClosedEvent" in
-/// https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+/// @see
+/// - "TopologyClosedEvent" in https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
 ///
 class topology_closed_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_opening_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_opening_event.hpp
@@ -29,8 +29,8 @@ namespace events {
 ///
 /// An event notification sent when the driver initializes a server topology.
 ///
-/// @see "TopologyOpeningEvent" in
-/// https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+/// @see
+/// - "TopologyOpeningEvent" in https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
 ///
 class topology_opening_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/authentication_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/authentication_exception.hpp
@@ -28,7 +28,8 @@ namespace v_noabi {
 ///
 /// Class representing an exception during authentication.
 ///
-/// @see mongocxx::v_noabi::operation_exception
+/// @see
+/// - @ref mongocxx::v_noabi::operation_exception
 ///
 class authentication_exception : public operation_exception {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/bulk_write_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/bulk_write_exception.hpp
@@ -28,7 +28,8 @@ namespace v_noabi {
 ///
 /// Class representing an exception during a bulk write operation.
 ///
-/// @see mongocxx::v_noabi::operation_exception
+/// @see
+/// - @ref mongocxx::v_noabi::operation_exception
 ///
 class bulk_write_exception : public operation_exception {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/gridfs_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/gridfs_exception.hpp
@@ -27,7 +27,8 @@ namespace v_noabi {
 /// Class representing an error encountered when attempting to perform the requested GridFS
 /// operation.
 ///
-/// @see mongocxx::v_noabi::exception
+/// @see
+/// - @ref mongocxx::v_noabi::exception
 ///
 class gridfs_exception : public exception {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/logic_error.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/logic_error.hpp
@@ -26,7 +26,8 @@ namespace v_noabi {
 ///
 /// Class representing an exception caused by using the mongocxx API improperly.
 ///
-/// @see mongocxx::v_noabi::exception
+/// @see
+/// - @ref mongocxx::v_noabi::exception
 ///
 class logic_error : public exception {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception.hpp
@@ -39,7 +39,8 @@ BSONCXX_DISABLE_WARNING(MSVC(4275));
 /// Class representing an exception received from a MongoDB server.  It includes the server-provided
 /// error code, if one was available.
 ///
-/// @see mongocxx::v_noabi::exception
+/// @see
+/// - @ref mongocxx::v_noabi::exception
 ///
 class operation_exception : public exception {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/query_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/query_exception.hpp
@@ -26,7 +26,8 @@ namespace v_noabi {
 ///
 /// Class representing an exception during a query operation.
 ///
-/// @see mongocxx::v_noabi::operation_exception
+/// @see
+/// - @ref mongocxx::v_noabi::operation_exception
 ///
 class query_exception : public operation_exception {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/write_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/write_exception.hpp
@@ -26,7 +26,8 @@ namespace v_noabi {
 ///
 /// Class representing an exception during a write operation.
 ///
-/// @see mongocxx::v_noabi::operation_exception
+/// @see
+/// - @ref mongocxx::v_noabi::operation_exception
 ///
 class write_exception : public operation_exception {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/fwd.hpp
@@ -116,10 +116,8 @@
 /// @file
 /// Aggregate of all forward headers declaring entities in @ref mongocxx::v_noabi.
 ///
-/// @par "Includes" @parblock
-/// @li All header files under @ref src/mongocxx/include/mongocxx/v_noabi/mongocxx
-/// "mongocxx/v_noabi/mongocxx" whose filename ends with `-fwd.hpp`.
-/// @endparblock
+/// @par Includes
+/// - All header files under @ref src/mongocxx/include/mongocxx/v_noabi/mongocxx "mongocxx/v_noabi/mongocxx" whose filename ends with `-fwd.hpp`.
 ///
 
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/fwd.hpp
@@ -401,7 +401,8 @@
 /// @namespace mongocxx::v_noabi::model
 /// @copydoc mongocxx::model
 ///
-/// @see mongocxx::v_noabi::bulk_write
+/// @see
+/// - @ref mongocxx::v_noabi::bulk_write
 ///
 
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
@@ -59,7 +59,8 @@ namespace gridfs {
 ///
 /// See also the method documentation for `mongocxx::v_noabi::database::gridfs_bucket()`.
 ///
-/// @see https://www.mongodb.com/display/DOCS/GridFS
+/// @see
+/// - https://www.mongodb.com/display/DOCS/GridFS
 ///
 class bucket {
    public:
@@ -592,7 +593,8 @@ class bucket {
     /// @throws mongocxx::v_noabi::logic_error if the options are invalid, or if the unsupported
     /// option modifiers "$query" or "$explain" are used.
     ///
-    /// @see mongocxx::v_noabi::collection::find.
+    /// @see
+    /// - @ref mongocxx::v_noabi::collection::find.
     ///
     MONGOCXX_ABI_EXPORT_CDECL(cursor)
     find(bsoncxx::v_noabi::document::view_or_value filter, const options::find& options = {});
@@ -617,7 +619,8 @@ class bucket {
     /// @throws mongocxx::v_noabi::logic_error if the options are invalid, or if the unsupported
     /// option modifiers "$query" or "$explain" are used.
     ///
-    /// @see mongocxx::v_noabi::collection::find.
+    /// @see
+    /// - @ref mongocxx::v_noabi::collection::find.
     ///
     MONGOCXX_ABI_EXPORT_CDECL(cursor)
     find(const client_session& session,

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
@@ -51,11 +51,13 @@ namespace gridfs {
 /// in the `<bucketname>.files` collection containing the information about the file. Users should
 /// not modify these collections directly.
 ///
-/// Example of how obtain the default GridFS bucket for a given database:
-/// @code
-///   mongocxx::v_noabi::client mongo_client{mongocxx::v_noabi::uri{}};
-///   auto gridfs_bucket = mongo_client["database"].gridfs_bucket();
-/// @endcode
+/// @par Example
+/// ```cpp
+/// mongocxx::v_noabi::client mongo_client{mongocxx::v_noabi::uri{}};
+///
+/// // Obtain the default GridFS bucket for a given database.
+/// auto gridfs_bucket = mongo_client["database"].gridfs_bucket();
+/// ```
 ///
 /// See also the method documentation for `mongocxx::v_noabi::database::gridfs_bucket()`.
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view.hpp
@@ -78,7 +78,8 @@ class index_view {
     ///    Throws operation_exception for any errors encountered by the server or if max_time_ms
     ///    option is present and the operation exceeds the time limit.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/db.collection.createIndex/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/db.collection.createIndex/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<std::string>)
     create_one(const bsoncxx::v_noabi::document::view_or_value& keys,
@@ -106,7 +107,8 @@ class index_view {
     ///    Throws operation_exception for any errors encountered by the server or if max_time_ms
     ///    option is present and the operation exceeds the time limit.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/db.collection.createIndex/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/db.collection.createIndex/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<std::string>)
     create_one(const client_session& session,
@@ -130,7 +132,8 @@ class index_view {
     ///    Throws operation_exception for any errors encountered by the server or if max_time_ms
     ///    option is present and the operation exceeds the time limit.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<std::string>)
     create_one(const index_model& index,
@@ -154,7 +157,8 @@ class index_view {
     ///    Throws operation_exception for any errors encountered by the server or if max_time_ms
     ///    option is present and the operation exceeds the time limit.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<std::string>)
     create_one(const client_session& session,
@@ -177,7 +181,8 @@ class index_view {
     ///     Throws operation_exception for any errors encountered by the server or if max_time_ms
     ///     option is present and the operation exceeds the time limit.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v_noabi::document::value)
     create_many(const std::vector<index_model>& indexes,
@@ -201,7 +206,8 @@ class index_view {
     ///     Throws operation_exception for any errors encountered by the server or if max_time_ms
     ///     option is present and the operation exceeds the time limit.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v_noabi::document::value)
     create_many(const client_session& session,
@@ -222,7 +228,8 @@ class index_view {
     /// @exception
     ///   Throws logic_error if "*" is passed in for the index name.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(void)
     drop_one(stdx::string_view name, const options::index_view& options = options::index_view{});
@@ -243,7 +250,8 @@ class index_view {
     /// @exception
     ///   Throws logic_error if "*" is passed in for the index name.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(void)
     drop_one(const client_session& session,
@@ -271,7 +279,8 @@ class index_view {
     /// @exception
     ///   Throws logic_error if "*" is passed in for the index name
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(void)
     drop_one(const bsoncxx::v_noabi::document::view_or_value& keys,
@@ -301,7 +310,8 @@ class index_view {
     /// @exception
     ///   Throws logic_error if "*" is passed in for the index name
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(void)
     drop_one(const client_session& session,
@@ -326,7 +336,8 @@ class index_view {
     /// @exception
     ///   Throws logic_error if "*" is passed in for the index name
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(void)
     drop_one(const index_model& index, const options::index_view& options = options::index_view{});
@@ -350,7 +361,8 @@ class index_view {
     /// @exception
     ///   Throws logic_error if "*" is passed in for the index name
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(void)
     drop_one(const client_session& session,
@@ -367,7 +379,8 @@ class index_view {
     ///   Throws operation_exception for any errors encountered by the server or if max_time_ms
     ///   option is present and the operation exceeds the time limit.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(void)
     drop_all(const options::index_view& options = options::index_view{});
@@ -384,7 +397,8 @@ class index_view {
     ///   Throws operation_exception for any errors encountered by the server or if max_time_ms
     ///   option is present and the operation exceeds the time limit.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/cursor.maxTimeMS/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(void)
     drop_all(const client_session& session,

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_many.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_many.hpp
@@ -60,7 +60,7 @@ class delete_many {
     ///   method chaining.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/collation/
+    /// - https://www.mongodb.com/docs/manual/reference/collation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(delete_many&)
     collation(bsoncxx::v_noabi::document::view_or_value collation);
@@ -72,7 +72,7 @@ class delete_many {
     ///   The optional value of the collation option.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/collation/
+    /// - https://www.mongodb.com/docs/manual/reference/collation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     collation() const;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_one.hpp
@@ -55,7 +55,7 @@ class delete_one {
     ///   The new collation.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/collation/
+    /// - https://www.mongodb.com/docs/manual/reference/collation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(delete_one&)
     collation(bsoncxx::v_noabi::document::view_or_value collation);
@@ -67,7 +67,7 @@ class delete_one {
     ///   The optional value of the collation option.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/collation/
+    /// - https://www.mongodb.com/docs/manual/reference/collation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     collation() const;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/replace_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/replace_one.hpp
@@ -66,7 +66,7 @@ class replace_one {
     ///   The new collation.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/collation/
+    /// - https://www.mongodb.com/docs/manual/reference/collation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(replace_one&)
     collation(bsoncxx::v_noabi::document::view_or_value collation);
@@ -78,7 +78,7 @@ class replace_one {
     ///   The optional value of the collation option.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/collation/
+    /// - https://www.mongodb.com/docs/manual/reference/collation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     collation() const;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_many.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_many.hpp
@@ -105,7 +105,7 @@ class update_many {
     ///   The new collation.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/collation/
+    /// - https://www.mongodb.com/docs/manual/reference/collation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(update_many&)
     collation(bsoncxx::v_noabi::document::view_or_value collation);
@@ -117,7 +117,7 @@ class update_many {
     ///   The optional value of the collation option.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/collation/
+    /// - https://www.mongodb.com/docs/manual/reference/collation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     collation() const;
@@ -171,7 +171,8 @@ class update_many {
     /// @param array_filters
     ///   Array representing filters determining which array elements to modify.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/update/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/update/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(update_many&)
     array_filters(bsoncxx::v_noabi::array::view_or_value array_filters);
@@ -182,7 +183,8 @@ class update_many {
     /// @return
     ///   The current array filters.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/update/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/update/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::array::view_or_value>&)
     array_filters() const;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_one.hpp
@@ -105,7 +105,7 @@ class update_one {
     ///   The new collation.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/collation/
+    /// - https://www.mongodb.com/docs/manual/reference/collation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(update_one&)
     collation(bsoncxx::v_noabi::document::view_or_value collation);
@@ -117,7 +117,7 @@ class update_one {
     ///   The optional value of the collation option.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/collation/
+    /// - https://www.mongodb.com/docs/manual/reference/collation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     collation() const;
@@ -172,7 +172,8 @@ class update_one {
     /// @param array_filters
     ///   Array representing filters determining which array elements to modify.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/update/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/update/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(update_one&)
     array_filters(bsoncxx::v_noabi::array::view_or_value array_filters);
@@ -183,7 +184,8 @@ class update_one {
     /// @return
     ///   The current array filters.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/update/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/update/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::array::view_or_value>&)
     array_filters() const;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate.hpp
@@ -54,7 +54,8 @@ class aggregate {
     ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(aggregate&) allow_disk_use(bool allow_disk_use);
 
@@ -63,7 +64,8 @@ class aggregate {
     ///
     /// @return Whether disk use is allowed.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bool>&) allow_disk_use() const;
 
@@ -77,7 +79,8 @@ class aggregate {
     ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(aggregate&) batch_size(std::int32_t batch_size);
 
@@ -86,7 +89,8 @@ class aggregate {
     ///
     /// @return The current batch size.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<std::int32_t>&) batch_size() const;
 
@@ -100,7 +104,8 @@ class aggregate {
     ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(aggregate&)
     collation(bsoncxx::v_noabi::document::view_or_value collation);
@@ -111,7 +116,8 @@ class aggregate {
     /// @return
     ///   The current collation.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     collation() const;
@@ -126,7 +132,8 @@ class aggregate {
     ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(aggregate&) let(bsoncxx::v_noabi::document::view_or_value let);
 
@@ -136,7 +143,8 @@ class aggregate {
     /// @return
     ///   The current variable mapping.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     let() const;
@@ -151,7 +159,8 @@ class aggregate {
     ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(aggregate&) max_time(std::chrono::milliseconds max_time);
 
@@ -161,7 +170,8 @@ class aggregate {
     /// @return
     ///   The current max time (in milliseconds).
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<std::chrono::milliseconds>&) max_time() const;
 
@@ -174,7 +184,8 @@ class aggregate {
     ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(aggregate&) read_preference(mongocxx::v_noabi::read_preference rp);
 
@@ -183,7 +194,8 @@ class aggregate {
     ///
     /// @return the current read_preference
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<mongocxx::v_noabi::read_preference>&)
     read_preference() const;
@@ -205,14 +217,16 @@ class aggregate {
     ///
     /// @return the current bypass_document_validation setting
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bool>&) bypass_document_validation() const;
 
     ///
     /// Sets the index to use for this operation.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     /// @note if the server already has a cached shape for this query, it may
     /// ignore a hint.
@@ -231,7 +245,8 @@ class aggregate {
     ///
     /// @return The current hint, if one is set.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<mongocxx::v_noabi::hint>&) hint() const;
 
@@ -240,7 +255,7 @@ class aggregate {
     /// the pipeline.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     /// @param write_concern
     ///   Object representing the write_concern.
@@ -259,7 +274,7 @@ class aggregate {
     ///   The current write concern, if it is set.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<mongocxx::v_noabi::write_concern>&)
     write_concern() const;
@@ -268,7 +283,7 @@ class aggregate {
     /// Sets the read concern to use for this operation.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     /// @param read_concern
     ///   Object representing the read_concern.
@@ -286,7 +301,7 @@ class aggregate {
     ///   The current read concern, if it is set.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<mongocxx::v_noabi::read_concern>&)
     read_concern() const;
@@ -295,7 +310,7 @@ class aggregate {
     /// Sets the comment to use for this operation.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     /// @param comment
     ///   Object representing the comment.
@@ -313,7 +328,7 @@ class aggregate {
     ///   The current comment, if it is set.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(
         const stdx::optional<bsoncxx::v_noabi::types::bson_value::view_or_value>&)

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
@@ -141,33 +141,33 @@ class auto_encryption {
     /// supported: "aws", "azure", "gcp", "kmip", and "local". The kmsProviders map values differ
     /// by provider:
     ///
-    /// @code{.unparsed}
-    ///    aws: {
-    ///      accessKeyId: String,
-    ///      secretAccessKey: String
-    ///    }
+    /// ```
+    /// aws: {
+    ///   accessKeyId: String,
+    ///   secretAccessKey: String
+    /// }
     ///
-    ///    azure: {
-    ///       tenantId: String,
-    ///       clientId: String,
-    ///       clientSecret: String,
-    ///       identityPlatformEndpoint: Optional<String> // Defaults to login.microsoftonline.com
-    ///    }
+    /// azure: {
+    ///    tenantId: String,
+    ///    clientId: String,
+    ///    clientSecret: String,
+    ///    identityPlatformEndpoint: Optional<String> // Defaults to login.microsoftonline.com
+    /// }
     ///
-    ///    gcp: {
-    ///       email: String,
-    ///       privateKey: byte[] or String, // May be passed as a base64 encoded string.
-    ///       endpoint: Optional<String> // Defaults to oauth2.googleapis.com
-    ///    }
+    /// gcp: {
+    ///    email: String,
+    ///    privateKey: byte[] or String, // May be passed as a base64 encoded string.
+    ///    endpoint: Optional<String> // Defaults to oauth2.googleapis.com
+    /// }
     ///
-    ///    kmip: {
-    ///       endpoint: String
-    ///    }
+    /// kmip: {
+    ///    endpoint: String
+    /// }
     ///
-    ///    local: {
-    ///      key: byte[96] // The master key used to encrypt/decrypt data keys.
-    ///    }
-    /// @endcode
+    /// local: {
+    ///   key: byte[96] // The master key used to encrypt/decrypt data keys.
+    /// }
+    /// ```
     ///
     /// @param kms_providers
     ///   A document containing the KMS providers.
@@ -196,13 +196,13 @@ class auto_encryption {
     /// Multiple KMS providers may be specified. Supported KMS providers are "aws", "azure", "gcp",
     /// and "kmip". The map value has the same form for all supported providers:
     ///
-    /// @code{.unparsed}
-    ///    <KMS provider name>: {
-    ///        tlsCaFile: Optional<String>
-    ///        tlsCertificateKeyFile: Optional<String>
-    ///        tlsCertificateKeyFilePassword: Optional<String>
-    ///    }
-    /// @endcode
+    /// ```
+    /// <KMS provider name>: {
+    ///     tlsCaFile: Optional<String>
+    ///     tlsCertificateKeyFile: Optional<String>
+    ///     tlsCertificateKeyFilePassword: Optional<String>
+    /// }
+    /// ```
     ///
     /// @param tls_opts
     ///   A document containing the TLS options.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
@@ -55,7 +55,8 @@ class auto_encryption {
     /// @return
     ///   A reference to this object to facilitate method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(auto_encryption&) key_vault_client(mongocxx::v_noabi::client* client);
 
@@ -86,7 +87,8 @@ class auto_encryption {
     /// @return
     ///   A reference to this object to facilitate method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(auto_encryption&) key_vault_pool(mongocxx::v_noabi::pool* pool);
 
@@ -118,7 +120,8 @@ class auto_encryption {
     /// @return
     ///   A reference to this object to facilitate method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(auto_encryption&) key_vault_namespace(ns_pair ns);
 
@@ -172,7 +175,8 @@ class auto_encryption {
     /// @return
     ///   A reference to this object to facilitate method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(auto_encryption&)
     kms_providers(bsoncxx::v_noabi::document::view_or_value kms_providers);
@@ -206,7 +210,8 @@ class auto_encryption {
     /// @return
     ///   A reference to this object to facilitate method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(auto_encryption&)
     tls_opts(bsoncxx::v_noabi::document::view_or_value tls_opts);
@@ -240,7 +245,8 @@ class auto_encryption {
     /// @return
     ///   A reference to this object to facilitate method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(auto_encryption&)
     schema_map(bsoncxx::v_noabi::document::view_or_value schema_map);
@@ -264,12 +270,14 @@ class auto_encryption {
     /// @param encrypted_fields_map
     ///   The mapping of which fields to encrypt.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
     ///
     /// @return
     ///   A reference to this object to facilitate method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(auto_encryption&)
     encrypted_fields_map(bsoncxx::v_noabi::document::view_or_value encrypted_fields_map);
@@ -293,7 +301,8 @@ class auto_encryption {
     /// @return
     ///   A reference to this object to facilitate method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(auto_encryption&) bypass_auto_encryption(bool should_bypass);
 
@@ -315,7 +324,8 @@ class auto_encryption {
     /// @return
     ///   A reference to this object to facilitate method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(auto_encryption&) bypass_query_analysis(bool should_bypass);
 
@@ -374,7 +384,8 @@ class auto_encryption {
     /// @return
     ///   A reference to this object to facilitate method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(auto_encryption&)
     extra_options(bsoncxx::v_noabi::document::view_or_value extra);

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/bulk_write.hpp
@@ -74,7 +74,8 @@ class bulk_write {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/write-concern/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/write-concern/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(bulk_write&) write_concern(mongocxx::v_noabi::write_concern wc);
 
@@ -84,7 +85,8 @@ class bulk_write {
     /// @return
     ///   The current write_concern.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/write-concern/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/write-concern/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<mongocxx::v_noabi::write_concern>&)
     write_concern() const;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption.hpp
@@ -47,7 +47,8 @@ class client_encryption {
     /// @return
     ///   A reference to this object to facilitate method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(client_encryption&)
     key_vault_client(mongocxx::v_noabi::client* client);
@@ -80,7 +81,8 @@ class client_encryption {
     /// @return
     ///   A reference to this object to facilitate method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(client_encryption&) key_vault_namespace(ns_pair ns);
 
@@ -134,7 +136,8 @@ class client_encryption {
     /// @return
     ///   A reference to this object to facilitate method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(client_encryption&)
     kms_providers(bsoncxx::v_noabi::document::view_or_value kms_providers);
@@ -168,7 +171,8 @@ class client_encryption {
     /// @return
     ///   A reference to this object to facilitate method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(client_encryption&)
     tls_opts(bsoncxx::v_noabi::document::view_or_value tls_opts);

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption.hpp
@@ -102,33 +102,33 @@ class client_encryption {
     /// "aws", "azure", "gcp", "kmip", and "local". The kmsProviders map values differ
     /// by provider:
     ///
-    /// @code{.unparsed}
-    ///    aws: {
-    ///      accessKeyId: String,
-    ///      secretAccessKey: String
-    ///    }
+    /// ```
+    /// aws: {
+    ///   accessKeyId: String,
+    ///   secretAccessKey: String
+    /// }
     ///
-    ///    azure: {
-    ///       tenantId: String,
-    ///       clientId: String,
-    ///       clientSecret: String,
-    ///       identityPlatformEndpoint: Optional<String> // Defaults to login.microsoftonline.com
-    ///    }
+    /// azure: {
+    ///    tenantId: String,
+    ///    clientId: String,
+    ///    clientSecret: String,
+    ///    identityPlatformEndpoint: Optional<String> // Defaults to login.microsoftonline.com
+    /// }
     ///
-    ///    gcp: {
-    ///       email: String,
-    ///       privateKey: byte[] or String, // May be passed as a base64 encoded string.
-    ///       endpoint: Optional<String> // Defaults to oauth2.googleapis.com
-    ///    }
+    /// gcp: {
+    ///    email: String,
+    ///    privateKey: byte[] or String, // May be passed as a base64 encoded string.
+    ///    endpoint: Optional<String> // Defaults to oauth2.googleapis.com
+    /// }
     ///
-    ///    kmip: {
-    ///       endpoint: String
-    ///    }
+    /// kmip: {
+    ///    endpoint: String
+    /// }
     ///
-    ///    local: {
-    ///      key: byte[96] // The master key used to encrypt/decrypt data keys.
-    ///    }
-    /// @endcode
+    /// local: {
+    ///   key: byte[96] // The master key used to encrypt/decrypt data keys.
+    /// }
+    /// ```
     ///
     /// @param kms_providers
     ///   A document containing the KMS providers.
@@ -157,13 +157,13 @@ class client_encryption {
     /// Multiple KMS providers may be specified. Supported KMS providers are "aws", "azure", "gcp",
     /// and "kmip". The map value has the same form for all supported providers:
     ///
-    /// @code{.unparsed}
-    ///    <KMS provider name>: {
-    ///        tlsCaFile: Optional<String>
-    ///        tlsCertificateKeyFile: Optional<String>
-    ///        tlsCertificateKeyFilePassword: Optional<String>
-    ///    }
-    /// @endcode
+    /// ```
+    /// <KMS provider name>: {
+    ///     tlsCaFile: Optional<String>
+    ///     tlsCertificateKeyFile: Optional<String>
+    ///     tlsCertificateKeyFilePassword: Optional<String>
+    /// }
+    /// ```
     ///
     /// @param tls_opts
     ///   A document containing the TLS options.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_session.hpp
@@ -49,7 +49,7 @@ class client_session {
     ///   method chaining.
     ///
     /// @see
-    /// https://www.mongodb.com/docs/manual/core/read-isolation-consistency-recency/#causal-consistency
+    /// - https://www.mongodb.com/docs/manual/core/read-isolation-consistency-recency/#causal-consistency
     ///
     MONGOCXX_ABI_EXPORT_CDECL(client_session&) causal_consistency(bool causal_consistency) noexcept;
 
@@ -67,7 +67,7 @@ class client_session {
     ///   method chaining.
     ///
     /// @see
-    /// https://www.mongodb.com/docs/manual/reference/read-concern-snapshot/
+    /// - https://www.mongodb.com/docs/manual/reference/read-concern-snapshot/
     ///
     /// @note Snapshot reads and causal consistency are mutually exclusive: only one or the
     /// other may be active at a time. Attempting to do so will result in an error being thrown

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count.hpp
@@ -48,7 +48,8 @@ class count {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(count&)
     collation(bsoncxx::v_noabi::document::view_or_value collation);
@@ -59,7 +60,8 @@ class count {
     /// @return
     ///   The current collation.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     collation() const;
@@ -74,7 +76,8 @@ class count {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(count&) hint(mongocxx::v_noabi::hint index_hint);
 
@@ -83,7 +86,8 @@ class count {
     ///
     /// @return The current hint, if one is set.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<mongocxx::v_noabi::hint>&) hint() const;
 
@@ -97,7 +101,8 @@ class count {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(count&)
     comment(bsoncxx::v_noabi::types::bson_value::view_or_value comment);
@@ -107,7 +112,8 @@ class count {
     ///
     /// @return The current comment option.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(
         const stdx::optional<bsoncxx::v_noabi::types::bson_value::view_or_value>&)
@@ -123,7 +129,8 @@ class count {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(count&) limit(std::int64_t limit);
 
@@ -132,7 +139,8 @@ class count {
     ///
     /// @return The current limit.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<std::int64_t>&) limit() const;
 
@@ -146,7 +154,8 @@ class count {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(count&) max_time(std::chrono::milliseconds max_time);
 
@@ -155,7 +164,8 @@ class count {
     ///
     /// @return The current max time (in milliseconds).
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<std::chrono::milliseconds>&) max_time() const;
 
@@ -169,7 +179,8 @@ class count {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(count&) skip(std::int64_t skip);
 
@@ -178,7 +189,8 @@ class count {
     ///
     /// @return The number of documents to skip.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<std::int64_t>&) skip() const;
 
@@ -192,7 +204,8 @@ class count {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(count&) read_preference(mongocxx::v_noabi::read_preference rp);
 
@@ -201,7 +214,8 @@ class count {
     ///
     /// @return the current read_preference
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/aggregate/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<mongocxx::v_noabi::read_preference>&)
     read_preference() const;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/create_collection.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/create_collection.hpp
@@ -46,7 +46,8 @@ class create_collection_deprecated {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/glossary/#term-capped-collection
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/glossary/#term-capped-collection
     ///
     MONGOCXX_ABI_EXPORT_CDECL(create_collection_deprecated&) capped(bool capped);
 
@@ -56,7 +57,8 @@ class create_collection_deprecated {
     /// @return
     ///   Whether or not this collection will be capped.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/glossary/#term-capped-collection
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/glossary/#term-capped-collection
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bool>&) capped() const;
 
@@ -71,7 +73,7 @@ class create_collection_deprecated {
     ///   method chaining.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/collation/
+    /// - https://www.mongodb.com/docs/manual/reference/collation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(create_collection_deprecated&)
     collation(bsoncxx::v_noabi::document::view_or_value collation);
@@ -83,7 +85,7 @@ class create_collection_deprecated {
     ///   The default collation for the collection.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/collation/
+    /// - https://www.mongodb.com/docs/manual/reference/collation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     collation() const;
@@ -116,7 +118,8 @@ class create_collection_deprecated {
     ///
     /// When true, disables the power of 2 sizes allocation for the collection.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/create/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/create/
     ///
     /// @param no_padding
     ///   When true, disables power of 2 sizing for this collection.
@@ -130,7 +133,8 @@ class create_collection_deprecated {
     ///
     /// Gets the current value of the "no padding" option for the collection.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/create/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/create/
     ///
     /// @return
     ///   When true, power of 2 sizing is disabled for this collection.
@@ -196,7 +200,8 @@ class create_collection_deprecated {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/document-validation/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/document-validation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(create_collection_deprecated&)
     validation_criteria(mongocxx::v_noabi::validation_criteria validation);
@@ -207,7 +212,8 @@ class create_collection_deprecated {
     /// @return
     ///   Validation criteria for this collection.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/document-validation/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/document-validation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<mongocxx::v_noabi::validation_criteria>&)
     validation_criteria() const;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
@@ -88,7 +88,7 @@ class data_key {
     ///   A reference to this object.
     ///
     /// @see
-    /// https://www.mongodb.com/docs/manual/core/security-client-side-encryption-key-management/
+    /// - https://www.mongodb.com/docs/manual/core/security-client-side-encryption-key-management/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(data_key&)
     master_key(bsoncxx::v_noabi::document::view_or_value master_key);
@@ -113,7 +113,8 @@ class data_key {
     /// @return
     ///   A reference to this object.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/getClientEncryption/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/getClientEncryption/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(data_key&) key_alt_names(std::vector<std::string> key_alt_names);
 
@@ -146,7 +147,8 @@ class data_key {
     /// @return
     ///   A reference to this object.
     ///
-    /// @see https://www.mongodb.com/docs/v6.0/reference/method/KeyVault.createKey/
+    /// @see
+    /// - https://www.mongodb.com/docs/v6.0/reference/method/KeyVault.createKey/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(data_key&) key_material(key_material_type key_material);
 
@@ -156,7 +158,8 @@ class data_key {
     /// @return
     ///   The binary data for the key material
     ///
-    /// @see https://www.mongodb.com/docs/v6.0/reference/method/KeyVault.createKey/
+    /// @see
+    /// - https://www.mongodb.com/docs/v6.0/reference/method/KeyVault.createKey/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<key_material_type>&) key_material();
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/delete.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/delete.hpp
@@ -45,7 +45,7 @@ class delete_options {
     ///   method chaining.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/collation/
+    /// - https://www.mongodb.com/docs/manual/reference/collation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(delete_options&)
     collation(bsoncxx::v_noabi::document::view_or_value collation);
@@ -57,7 +57,7 @@ class delete_options {
     ///   The current collation.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/collation/
+    /// - https://www.mongodb.com/docs/manual/reference/collation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     collation() const;
@@ -72,7 +72,8 @@ class delete_options {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/write-concern/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/write-concern/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(delete_options&) write_concern(write_concern wc);
 
@@ -82,8 +83,8 @@ class delete_options {
     /// @return
     ///   The current write_concern.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/write-concern/
-    ///
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/write-concern/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<mongocxx::v_noabi::write_concern>&)
     write_concern() const;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct.hpp
@@ -47,7 +47,8 @@ class distinct {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/distinct/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/distinct/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(distinct&)
     collation(bsoncxx::v_noabi::document::view_or_value collation);
@@ -58,7 +59,8 @@ class distinct {
     /// @return
     ///   The current collation.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/distinct/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/distinct/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     collation() const;
@@ -73,7 +75,8 @@ class distinct {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/distinct/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/distinct/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(distinct&) max_time(std::chrono::milliseconds max_time);
 
@@ -82,7 +85,8 @@ class distinct {
     ///
     /// @return The current max time (in milliseconds).
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/distinct/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/distinct/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<std::chrono::milliseconds>&) max_time() const;
 
@@ -96,7 +100,8 @@ class distinct {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/distinct/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/distinct/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(distinct&)
     comment(bsoncxx::v_noabi::types::bson_value::view_or_value comment);
@@ -106,7 +111,8 @@ class distinct {
     ///
     /// @return The current comment
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/distinct/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/distinct/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(
         const stdx::optional<bsoncxx::v_noabi::types::bson_value::view_or_value>&)
@@ -122,7 +128,8 @@ class distinct {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/distinct/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/distinct/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(distinct&) read_preference(mongocxx::v_noabi::read_preference rp);
 
@@ -131,7 +138,8 @@ class distinct {
     ///
     /// @return the current read_preference.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/distinct/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/distinct/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<mongocxx::v_noabi::read_preference>&)
     read_preference() const;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt.hpp
@@ -51,7 +51,8 @@ class encrypt {
     /// @return
     ///   A reference to this object to facilitate method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/security-client-side-encryption/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(encrypt&)
     key_id(bsoncxx::v_noabi::types::bson_value::view_or_value key_id);
@@ -76,7 +77,8 @@ class encrypt {
     /// @return
     ///   A reference to this obejct to facilitate method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/method/getClientEncryption/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/method/getClientEncryption/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(encrypt&) key_alt_name(std::string name);
 
@@ -150,7 +152,7 @@ class encrypt {
     /// mongocxx::v_noabi::options::auto_encryption::bypass_auto_encryption must be false.
     ///
     /// @see
-    /// https://www.mongodb.com/docs/manual/core/security-client-side-encryption/#encryption-algorithms
+    /// - https://www.mongodb.com/docs/manual/core/security-client-side-encryption/#encryption-algorithms
     ///
     MONGOCXX_ABI_EXPORT_CDECL(encrypt&) algorithm(encryption_algorithm algorithm);
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/estimated_document_count.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/estimated_document_count.hpp
@@ -45,7 +45,8 @@ class estimated_document_count {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/count/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/count/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(estimated_document_count&)
     max_time(std::chrono::milliseconds max_time);
@@ -55,7 +56,8 @@ class estimated_document_count {
     ///
     /// @return The current max time (in milliseconds).
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/count/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/count/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const bsoncxx::v_noabi::stdx::optional<std::chrono::milliseconds>&)
     max_time() const;
@@ -70,7 +72,8 @@ class estimated_document_count {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/count/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/count/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(estimated_document_count&)
     comment(bsoncxx::v_noabi::types::bson_value::view_or_value comment);
@@ -80,7 +83,8 @@ class estimated_document_count {
     ///
     /// @return The current comment
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/count/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/count/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(
         const bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::types::bson_value::view_or_value>&)
@@ -96,7 +100,8 @@ class estimated_document_count {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/count/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/count/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(estimated_document_count&)
     read_preference(mongocxx::v_noabi::read_preference rp);
@@ -106,7 +111,8 @@ class estimated_document_count {
     ///
     /// @return the current read_preference
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/count/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/count/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(
         const bsoncxx::v_noabi::stdx::optional<mongocxx::v_noabi::read_preference>&)

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find.hpp
@@ -54,7 +54,8 @@ class find {
     /// @return
     ///   A reference to this object to facilitate method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find&) allow_disk_use(bool allow_disk_use);
 
@@ -78,7 +79,8 @@ class find {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find&) allow_partial_results(bool allow_partial);
 
@@ -87,7 +89,8 @@ class find {
     ///
     /// @return Whether partial results from mongos are allowed.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bool>&) allow_partial_results() const;
 
@@ -101,7 +104,8 @@ class find {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find&) batch_size(std::int32_t batch_size);
 
@@ -110,7 +114,8 @@ class find {
     ///
     /// @return The current batch size.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<std::int32_t>&) batch_size() const;
 
@@ -124,7 +129,8 @@ class find {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find&) collation(bsoncxx::v_noabi::document::view_or_value collation);
 
@@ -134,7 +140,8 @@ class find {
     /// @return
     ///   The current collation.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     collation() const;
@@ -152,7 +159,8 @@ class find {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find&) comment(bsoncxx::v_noabi::string::view_or_value comment);
 
@@ -163,7 +171,8 @@ class find {
     ///
     /// @return The comment attached to this query.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::string::view_or_value>&)
     comment() const;
@@ -178,7 +187,8 @@ class find {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find&) cursor_type(cursor::type cursor_type);
 
@@ -187,14 +197,16 @@ class find {
     ///
     /// @return The current cursor type.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<cursor::type>&) cursor_type() const;
 
     ///
     /// Sets the index to use for this operation.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     /// @note if the server already has a cached shape for this query, it may
     /// ignore a hint.
@@ -213,7 +225,8 @@ class find {
     ///
     /// @return The current hint, if one is set.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<mongocxx::v_noabi::hint>&) hint() const;
 
@@ -227,7 +240,8 @@ class find {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find&) let(bsoncxx::v_noabi::document::view_or_value let);
 
@@ -237,7 +251,8 @@ class find {
     /// @return
     ///  The current let option.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>)
     let() const;
@@ -254,7 +269,8 @@ class find {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find&)
     comment_option(bsoncxx::v_noabi::types::bson_value::view_or_value comment);
@@ -267,7 +283,8 @@ class find {
     /// @return
     ///  The current comment option.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(
         const stdx::optional<bsoncxx::v_noabi::types::bson_value::view_or_value>&)
@@ -282,7 +299,8 @@ class find {
     /// @return
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find&) limit(std::int64_t limit);
 
@@ -291,7 +309,8 @@ class find {
     ///
     /// @return The current limit.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<std::int64_t>&) limit() const;
 
@@ -305,7 +324,8 @@ class find {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find&) max(bsoncxx::v_noabi::document::view_or_value max);
 
@@ -314,7 +334,8 @@ class find {
     ///
     /// @return The exclusive upper bound for a specific index.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     max() const;
@@ -334,7 +355,8 @@ class find {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find&) max_await_time(std::chrono::milliseconds max_await_time);
 
@@ -344,7 +366,8 @@ class find {
     ///
     /// @return The current max await time (in milliseconds).
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<std::chrono::milliseconds>&)
     max_await_time() const;
@@ -359,7 +382,8 @@ class find {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find&) max_time(std::chrono::milliseconds max_time);
 
@@ -368,7 +392,8 @@ class find {
     ///
     /// @return The current max time (in milliseconds).
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<std::chrono::milliseconds>&) max_time() const;
 
@@ -382,7 +407,8 @@ class find {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find&) min(bsoncxx::v_noabi::document::view_or_value min);
 
@@ -391,7 +417,8 @@ class find {
     ///
     /// @return The inclusive lower bound for a specific index.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     min() const;
@@ -407,7 +434,8 @@ class find {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find&) no_cursor_timeout(bool no_cursor_timeout);
 
@@ -416,7 +444,8 @@ class find {
     ///
     /// @return The current no_cursor_timeout setting.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bool>&) no_cursor_timeout() const;
 
@@ -430,7 +459,8 @@ class find {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find&)
     projection(bsoncxx::v_noabi::document::view_or_value projection);
@@ -440,7 +470,8 @@ class find {
     ///
     /// @return The current projection.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     projection() const;
@@ -455,7 +486,8 @@ class find {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find&) read_preference(mongocxx::v_noabi::read_preference rp);
 
@@ -465,7 +497,8 @@ class find {
     /// @return
     ///   The current read_preference.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<mongocxx::v_noabi::read_preference>&)
     read_preference() const;
@@ -482,7 +515,8 @@ class find {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find&) return_key(bool return_key);
 
@@ -494,7 +528,8 @@ class find {
     ///   Whether index keys associated with the query results are returned, instead of the actual
     ///   query results themselves.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bool>&) return_key() const;
 
@@ -508,7 +543,8 @@ class find {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find&) show_record_id(bool show_record_id);
 
@@ -519,7 +555,8 @@ class find {
     /// @return
     ///   Whether the record identifier is included.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bool>&) show_record_id() const;
 
@@ -533,7 +570,8 @@ class find {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find&) skip(std::int64_t skip);
 
@@ -542,7 +580,8 @@ class find {
     ///
     /// @return The number of documents to skip.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<std::int64_t>&) skip() const;
 
@@ -557,7 +596,8 @@ class find {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find&) sort(bsoncxx::v_noabi::document::view_or_value ordering);
 
@@ -566,7 +606,8 @@ class find {
     ///
     /// @return The current sort ordering.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/find/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/find/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     sort() const;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.hpp
@@ -46,7 +46,8 @@ class find_one_and_delete {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete&)
     collation(bsoncxx::v_noabi::document::view_or_value collation);
@@ -57,7 +58,8 @@ class find_one_and_delete {
     /// @return
     ///   The current collation.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     collation() const;
@@ -72,7 +74,8 @@ class find_one_and_delete {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete&) max_time(std::chrono::milliseconds max_time);
 
@@ -81,7 +84,8 @@ class find_one_and_delete {
     ///
     /// @return the current max time (in milliseconds).
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<std::chrono::milliseconds>&) max_time() const;
 
@@ -95,7 +99,8 @@ class find_one_and_delete {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete&)
     projection(bsoncxx::v_noabi::document::view_or_value projection);
@@ -105,7 +110,8 @@ class find_one_and_delete {
     ///
     /// @return The current projection.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     projection() const;
@@ -123,7 +129,8 @@ class find_one_and_delete {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete&)
     sort(bsoncxx::v_noabi::document::view_or_value ordering);
@@ -133,7 +140,8 @@ class find_one_and_delete {
     ///
     /// @return The current sort ordering.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     sort() const;
@@ -149,7 +157,7 @@ class find_one_and_delete {
     ///   method chaining.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete&)
     write_concern(mongocxx::v_noabi::write_concern write_concern);
@@ -161,7 +169,7 @@ class find_one_and_delete {
     ///   The current write concern.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<mongocxx::v_noabi::write_concern>&)
     write_concern() const;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.hpp
@@ -48,7 +48,8 @@ class find_one_and_replace {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace&)
     collation(bsoncxx::v_noabi::document::view_or_value collation);
@@ -59,7 +60,8 @@ class find_one_and_replace {
     /// @return
     ///   The current collation.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     collation() const;
@@ -78,7 +80,8 @@ class find_one_and_replace {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace&)
     bypass_document_validation(bool bypass_document_validation);
@@ -88,7 +91,8 @@ class find_one_and_replace {
     ///
     /// @return the current bypass document validation setting.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bool>&) bypass_document_validation() const;
 
@@ -169,7 +173,8 @@ class find_one_and_replace {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace&) max_time(std::chrono::milliseconds max_time);
 
@@ -178,7 +183,8 @@ class find_one_and_replace {
     ///
     /// @return the current max allowed running time (in milliseconds).
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<std::chrono::milliseconds>&) max_time() const;
 
@@ -192,7 +198,8 @@ class find_one_and_replace {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace&)
     projection(bsoncxx::v_noabi::document::view_or_value projection);
@@ -202,7 +209,8 @@ class find_one_and_replace {
     ///
     /// @return The current projection.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     projection() const;
@@ -218,8 +226,9 @@ class find_one_and_replace {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
-    /// @see mongocxx::v_noabi::options::return_document
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// - @ref mongocxx::v_noabi::options::return_document
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace&)
     return_document(return_document return_document);
@@ -229,8 +238,9 @@ class find_one_and_replace {
     ///
     /// @return Version of document to return, either original or replacement.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
-    /// @see mongocxx::v_noabi::options::return_document
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// - @ref mongocxx::v_noabi::options::return_document
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<mongocxx::v_noabi::options::return_document>&)
     return_document() const;
@@ -248,7 +258,8 @@ class find_one_and_replace {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace&)
     sort(bsoncxx::v_noabi::document::view_or_value ordering);
@@ -258,7 +269,8 @@ class find_one_and_replace {
     ///
     /// @return The current sort ordering.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     sort() const;
@@ -275,7 +287,8 @@ class find_one_and_replace {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace&) upsert(bool upsert);
 
@@ -284,7 +297,8 @@ class find_one_and_replace {
     ///
     /// @return The current upsert setting.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bool>&) upsert() const;
 
@@ -299,7 +313,7 @@ class find_one_and_replace {
     ///   method chaining.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace&)
     write_concern(mongocxx::v_noabi::write_concern write_concern);
@@ -311,7 +325,7 @@ class find_one_and_replace {
     ///   The current write concern.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<mongocxx::v_noabi::write_concern>&)
     write_concern() const;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update.hpp
@@ -49,7 +49,8 @@ class find_one_and_update {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update&)
     collation(bsoncxx::v_noabi::document::view_or_value collation);
@@ -60,7 +61,8 @@ class find_one_and_update {
     /// @return
     ///   The current collation.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     collation() const;
@@ -79,7 +81,8 @@ class find_one_and_update {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update&)
     bypass_document_validation(bool bypass_document_validation);
@@ -89,7 +92,8 @@ class find_one_and_update {
     ///
     /// @return the current bypass document validation setting.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bool>&) bypass_document_validation() const;
 
@@ -171,7 +175,8 @@ class find_one_and_update {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update&) max_time(std::chrono::milliseconds max_time);
 
@@ -180,7 +185,8 @@ class find_one_and_update {
     ///
     /// @return the current max allowed running time (in milliseconds).
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<std::chrono::milliseconds>&) max_time() const;
 
@@ -194,7 +200,8 @@ class find_one_and_update {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update&)
     projection(bsoncxx::v_noabi::document::view_or_value projection);
@@ -204,7 +211,8 @@ class find_one_and_update {
     ///
     /// @return The current projection.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     projection() const;
@@ -220,8 +228,9 @@ class find_one_and_update {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
-    /// @see mongocxx::v_noabi::options::return_document
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// - @ref mongocxx::v_noabi::options::return_document
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update&)
     return_document(return_document return_document);
@@ -231,8 +240,9 @@ class find_one_and_update {
     ///
     /// @return Version of document to return, either original or updated.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
-    /// @see mongocxx::v_noabi::options::return_document
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// - @ref mongocxx::v_noabi::options::return_document
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<mongocxx::v_noabi::options::return_document>&)
     return_document() const;
@@ -250,7 +260,8 @@ class find_one_and_update {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update&)
     sort(bsoncxx::v_noabi::document::view_or_value ordering);
@@ -260,7 +271,8 @@ class find_one_and_update {
     ///
     /// @return The current sort ordering.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     sort() const;
@@ -277,7 +289,8 @@ class find_one_and_update {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update&) upsert(bool upsert);
 
@@ -286,7 +299,8 @@ class find_one_and_update {
     ///
     /// @return The current upsert setting.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bool>&) upsert() const;
 
@@ -301,7 +315,7 @@ class find_one_and_update {
     ///   method chaining.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update&)
     write_concern(mongocxx::v_noabi::write_concern write_concern);
@@ -313,7 +327,7 @@ class find_one_and_update {
     ///   The current write concern.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<mongocxx::v_noabi::write_concern>&)
     write_concern() const;
@@ -328,7 +342,8 @@ class find_one_and_update {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update&)
     array_filters(bsoncxx::v_noabi::array::view_or_value array_filters);
@@ -339,7 +354,8 @@ class find_one_and_update {
     /// @return
     ///   The current array filters.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::array::view_or_value>&)
     array_filters() const;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index.hpp
@@ -39,7 +39,8 @@ namespace options {
 ///
 /// Class representing the optional arguments to a MongoDB create index operation.
 ///
-/// @see https://www.mongodb.com/docs/manual/reference/command/createIndexes
+/// @see
+/// - https://www.mongodb.com/docs/manual/reference/command/createIndexes
 ///
 class index {
    public:
@@ -119,7 +120,8 @@ class index {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/tutorial/build-indexes-in-the-background/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/tutorial/build-indexes-in-the-background/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(index&) background(bool background);
 
@@ -141,7 +143,8 @@ class index {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/index-unique/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/index-unique/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(index&) unique(bool unique);
 
@@ -163,7 +166,8 @@ class index {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/index-hidden/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/index-hidden/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(index&) hidden(bool hidden);
 
@@ -205,7 +209,7 @@ class index {
     ///   method chaining.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/collation/
+    /// - https://www.mongodb.com/docs/manual/reference/collation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(index&) collation(bsoncxx::v_noabi::document::view collation);
 
@@ -216,7 +220,7 @@ class index {
     ///   The current collation.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/collation/
+    /// - https://www.mongodb.com/docs/manual/reference/collation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view>&)
     collation() const;
@@ -232,7 +236,8 @@ class index {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/index-sparse/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/index-sparse/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(index&) sparse(bool sparse);
 
@@ -278,7 +283,8 @@ class index {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/index-ttl/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/index-ttl/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(index&) expire_after(std::chrono::seconds seconds);
 
@@ -475,7 +481,8 @@ class index {
     /// values; i.e. group in the same bucket those location values that are within the specified
     /// number of units to each other.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/geohaystack/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/geohaystack/
     ///
     /// @param haystack_bucket_size
     ///   The geoHaystack bucket size.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view.hpp
@@ -47,7 +47,7 @@ class index_view {
     ///   method chaining.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(index_view&) max_time(std::chrono::milliseconds max_time);
 
@@ -58,7 +58,7 @@ class index_view {
     ///   The current max allowed running time (in milliseconds).
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const bsoncxx::v_noabi::stdx::optional<std::chrono::milliseconds>&)
     max_time() const;
@@ -74,7 +74,7 @@ class index_view {
     ///   method chaining.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(index_view&)
     write_concern(mongocxx::v_noabi::write_concern write_concern);
@@ -86,7 +86,7 @@ class index_view {
     ///   The current write concern.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(
         const bsoncxx::v_noabi::stdx::optional<mongocxx::v_noabi::write_concern>&)
@@ -107,7 +107,7 @@ class index_view {
     ///   method chaining.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/createIndexes
+    /// - https://www.mongodb.com/docs/manual/reference/command/createIndexes
     ///
     MONGOCXX_ABI_EXPORT_CDECL(index_view&) commit_quorum(std::int32_t commit_quorum);
 
@@ -126,7 +126,7 @@ class index_view {
     ///   method chaining.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/createIndexes
+    /// - https://www.mongodb.com/docs/manual/reference/command/createIndexes
     ///
     MONGOCXX_ABI_EXPORT_CDECL(index_view&) commit_quorum(std::string commit_quorum);
 
@@ -139,7 +139,7 @@ class index_view {
     ///   The current commitQuorum setting.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/command/createIndexes
+    /// - https://www.mongodb.com/docs/manual/reference/command/createIndexes
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::value>)
     commit_quorum() const;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert.hpp
@@ -64,7 +64,8 @@ class insert {
     /// @param wc
     ///   The new write_concern.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/write-concern/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/write-concern/
     ///
     /// @return
     ///   A reference to the object on which this member function is being called.  This facilitates
@@ -77,7 +78,8 @@ class insert {
     ///
     /// @return The current write_concern.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/write-concern/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/write-concern/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<mongocxx::v_noabi::write_concern>&)
     write_concern() const;
@@ -97,7 +99,8 @@ class insert {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/insert/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/insert/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(insert&) ordered(bool ordered);
 
@@ -106,7 +109,8 @@ class insert {
     ///
     /// @return The current ordered value.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/insert/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/insert/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bool>&) ordered() const;
 
@@ -116,7 +120,8 @@ class insert {
     /// @param comment
     ///   The new comment.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/insert/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/insert/
     ///
     /// @return
     ///   A reference to the object on which this member function is being called.  This facilitates
@@ -130,7 +135,8 @@ class insert {
     ///
     /// @return The current comment.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/insert/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/insert/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(
         const stdx::optional<bsoncxx::v_noabi::types::bson_value::view_or_value>&)

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace.hpp
@@ -71,7 +71,7 @@ class replace {
     ///   method chaining.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/collation/
+    /// - https://www.mongodb.com/docs/manual/reference/collation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(replace&)
     collation(bsoncxx::v_noabi::document::view_or_value collation);
@@ -83,7 +83,7 @@ class replace {
     ///   The current collation.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/collation/
+    /// - https://www.mongodb.com/docs/manual/reference/collation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     collation() const;
@@ -123,7 +123,8 @@ class replace {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/write-concern/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/write-concern/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(replace&) write_concern(mongocxx::v_noabi::write_concern wc);
 
@@ -133,7 +134,8 @@ class replace {
     /// @return
     ///   The current write_concern
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/write-concern/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/write-concern/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<mongocxx::v_noabi::write_concern>&)
     write_concern() const;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey.hpp
@@ -49,7 +49,7 @@ class rewrap_many_datakey {
     ///   An optional document containing the TLS options.
     ///
     /// @see
-    /// https://www.mongodb.com/docs/manual/core/csfle/reference/kms-providers/#std-label-csfle-reference-kms-providers
+    /// - https://www.mongodb.com/docs/manual/core/csfle/reference/kms-providers/#std-label-csfle-reference-kms-providers
     ///
     MONGOCXX_ABI_EXPORT_CDECL(rewrap_many_datakey&)
     provider(bsoncxx::v_noabi::string::view_or_value provider);
@@ -65,7 +65,7 @@ class rewrap_many_datakey {
     ///   An optional string name of the provider.
     ///
     /// @see
-    /// https://www.mongodb.com/docs/manual/core/csfle/reference/kms-providers/#std-label-csfle-reference-kms-providers
+    /// - https://www.mongodb.com/docs/manual/core/csfle/reference/kms-providers/#std-label-csfle-reference-kms-providers
     ///
     MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v_noabi::string::view_or_value) provider() const;
 
@@ -82,7 +82,7 @@ class rewrap_many_datakey {
     ///   A reference to this object to facilitate method chaining.
     ///
     /// @see
-    /// https://www.mongodb.com/docs/manual/core/csfle/reference/kms-providers/#std-label-csfle-reference-kms-providers-create-and-store
+    /// - https://www.mongodb.com/docs/manual/core/csfle/reference/kms-providers/#std-label-csfle-reference-kms-providers-create-and-store
     ///
     MONGOCXX_ABI_EXPORT_CDECL(rewrap_many_datakey&)
     master_key(bsoncxx::v_noabi::document::view_or_value master_key);
@@ -98,7 +98,7 @@ class rewrap_many_datakey {
     ///   A reference to this object to facilitate method chaining.
     ///
     /// @see
-    /// https://www.mongodb.com/docs/manual/core/csfle/reference/kms-providers/#std-label-csfle-reference-kms-providers-create-and-store
+    /// - https://www.mongodb.com/docs/manual/core/csfle/reference/kms-providers/#std-label-csfle-reference-kms-providers-create-and-store
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     master_key() const;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/update.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/update.hpp
@@ -71,7 +71,7 @@ class update {
     ///   method chaining.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/collation/
+    /// - https://www.mongodb.com/docs/manual/reference/collation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(update&)
     collation(bsoncxx::v_noabi::document::view_or_value collation);
@@ -83,7 +83,7 @@ class update {
     ///   The current collation.
     ///
     /// @see
-    ///   https://www.mongodb.com/docs/manual/reference/collation/
+    /// - https://www.mongodb.com/docs/manual/reference/collation/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::document::view_or_value>&)
     collation() const;
@@ -189,7 +189,8 @@ class update {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/write-concern/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/write-concern/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(update&) write_concern(mongocxx::v_noabi::write_concern wc);
 
@@ -199,7 +200,8 @@ class update {
     /// @return
     ///   The current write_concern
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/write-concern/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/write-concern/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<mongocxx::v_noabi::write_concern>&)
     write_concern() const;
@@ -214,7 +216,8 @@ class update {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/update/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/update/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(update&)
     array_filters(bsoncxx::v_noabi::array::view_or_value array_filters);
@@ -225,7 +228,8 @@ class update {
     /// @return
     ///   The current array filters.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/command/update/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/update/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(const stdx::optional<bsoncxx::v_noabi::array::view_or_value>&)
     array_filters() const;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline.hpp
@@ -41,7 +41,8 @@ class pipeline {
     ///
     /// Creates a new aggregation pipeline.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/aggregation-pipeline/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/aggregation-pipeline/
     ///
     MONGOCXX_ABI_EXPORT_CDECL() pipeline();
 
@@ -66,7 +67,8 @@ class pipeline {
     ///
     /// Adds new fields to documents.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/addFields/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/addFields/
     ///
     /// @param fields_to_add
     ///   A document specifying the fields to add.  For each field specified in this parameter, a
@@ -84,7 +86,8 @@ class pipeline {
     /// Categorizes documents into groups, called buckets, based on a specified expression and
     /// bucket boundaries.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucket/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucket/
     ///
     /// @param bucket_args
     ///   The specification for the bucket operation.  The required fields `groupBy` and
@@ -102,7 +105,8 @@ class pipeline {
     /// specified expression.  Bucket boundaries are automatically determined in an attempt to
     /// evenly distribute the documents into the specified number of buckets.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucketAuto/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucketAuto/
     ///
     /// @param bucket_auto_args
     ///   The specification for the bucket_auto operation.  This required fields `groupBy` and
@@ -118,7 +122,8 @@ class pipeline {
     ///
     /// Returns statistics regarding a collection or view.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/collStats/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/collStats/
     ///
     /// @param coll_stats_args
     ///   The specification for the coll_stats operation.  See link above for a list of valid
@@ -135,7 +140,8 @@ class pipeline {
     ///
     /// Returns a document containing a count of the number of documents input to the stage.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/count/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/count/
     ///
     /// @param field
     ///   Name of the field for the count to be written to.
@@ -153,7 +159,8 @@ class pipeline {
     ///
     /// This stage must be used with database aggregate on the 'admin' database.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/currentOp/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/currentOp/
     ///
     /// @param current_op_args
     ///   A document containing the arguments for the current_op operation.
@@ -168,7 +175,8 @@ class pipeline {
     /// Processes multiple aggregation pipelines within a single stage on the same set of input
     /// documents.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/facet/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/facet/
     ///
     /// @param facet_args
     ///   The specification for the facet operation.  Each field in the the provided document should
@@ -220,7 +228,8 @@ class pipeline {
     ///
     /// Outputs documents in order of nearest to farthest from a specified point.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/geoNear/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/geoNear/
     ///
     /// @param geo_near_args
     ///   The specification for the geo_near operation.  The required fields `near` and
@@ -236,7 +245,8 @@ class pipeline {
     ///
     /// Performs a recursive search on a collection.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/graphLookup/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/graphLookup/
     ///
     /// @param graph_lookup_args
     ///   The specification for the graph_lookup operation.  The required fields `from`,
@@ -258,7 +268,8 @@ class pipeline {
     ///
     /// @note group does not order output documents.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/
     ///
     /// @param group_args
     ///   The specification for the group operation.  The required field `_id` must be included.
@@ -277,14 +288,16 @@ class pipeline {
     ///   A reference to the object on which this member function is being called.  This facilitates
     ///   method chaining.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/indexStats/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/indexStats/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(pipeline&) index_stats();
 
     ///
     /// Limits the number of documents passed to the next stage in the pipeline.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/limit/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/limit/
     ///
     /// @param limit
     ///   The number of documents to which output should be limited.
@@ -300,7 +313,8 @@ class pipeline {
     ///
     /// This option must be used with database aggregate.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/listLocalSessions/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/listLocalSessions/
     ///
     /// @param list_local_sessions_args
     ///   A document containing the arguments for list_local_sessions.
@@ -315,7 +329,8 @@ class pipeline {
     /// Lists all sessions stored in the system.sessions collection in the config database.
     /// These sessions are visible to all members of the MongoDB deployment.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSessions/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSessions/
     ///
     /// @param list_sessions_args
     ///   A document containing the arguments for list_sessions.
@@ -330,7 +345,8 @@ class pipeline {
     /// Performs a left outer join to an unsharded collection in the same database to filter in
     /// documents from the "joined" collection for processing.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/lookup/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/lookup/
     ///
     /// @param lookup_args
     ///   The specification for the lookup operation.  The required fields `from`, `localField`,
@@ -347,7 +363,8 @@ class pipeline {
     /// Filters the documents. Only the documents that match the condition(s) specified by the
     /// `filter` will continue to the next pipeline stage.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/match/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/match/
     ///
     /// @param filter
     ///   The filter.
@@ -361,7 +378,8 @@ class pipeline {
     ///
     /// Outputs the aggregation results to a collection.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/merge/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/merge/
     ///
     /// @param merge_args
     ///   The specification for the merge options. Must include an `into` field that
@@ -379,7 +397,8 @@ class pipeline {
     /// collection. This stage must be the last stage in the pipeline. The out operator lets the
     /// aggregation framework return result sets of any size.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/out/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/out/
     ///
     /// @param collection_name
     ///   The name of the collection where the output documents should go.
@@ -393,7 +412,8 @@ class pipeline {
     ///
     /// Projects a subset of the fields in the documents to the next stage of the pipeline.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/
     ///
     /// @param projection
     ///   The projection specification.
@@ -409,7 +429,8 @@ class pipeline {
     /// Restricts the contents of the documents based on information stored in the documents
     /// themselves.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/redact/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/redact/
     ///
     /// @param restrictions
     ///   The document restrictions.
@@ -424,7 +445,8 @@ class pipeline {
     ///
     /// Promotes a specified document to the top level and replaces all other fields.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceRoot/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceRoot/
     ///
     /// @param replace_root_args
     ///   The specification for the replace_root operation.  The required field `newRoot` must be
@@ -441,7 +463,8 @@ class pipeline {
     /// Randomly selects the specified number of documents that pass into the stage and passes the
     /// remaining documents to the next stage in the pipeline.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/
     ///
     /// @param size
     ///   The number of input documents to select.
@@ -456,7 +479,8 @@ class pipeline {
     /// Skips over the specified number of documents that pass into the stage and passes the
     /// remaining documents to the next stage in the pipeline.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/skip/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/skip/
     ///
     /// @param docs_to_skip
     ///   The number of input documents to skip.
@@ -470,7 +494,8 @@ class pipeline {
     ///
     /// Sorts all input documents and returns them to the pipeline in sorted order.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sort/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/sort/
     ///
     /// @param ordering
     ///   Document specifying the ordering by which the documents are sorted.
@@ -485,7 +510,8 @@ class pipeline {
     /// Groups incoming documents based on the value of a specified expression, then computes the
     /// count of documents in each distinct group.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortByCount/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortByCount/
     ///
     /// @param field_expression
     ///   The expression to group by, as an object.  The expression can not evaluate to an object.
@@ -505,7 +531,8 @@ class pipeline {
     /// Groups incoming documents based on the value of a specified expression, then computes the
     /// count of documents in each distinct group.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortByCount/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortByCount/
     ///
     /// @param field_expression
     ///   The expression to group by, as a string.  To specify a field path, prefix the field path
@@ -526,7 +553,8 @@ class pipeline {
     /// Each output document is an input document with the value of its array field replaced by
     /// an element from the unwound array.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/
     ///
     /// @param unwind_args
     ///   The specification for the unwind operation.  The required field path must be included.
@@ -547,7 +575,8 @@ class pipeline {
     /// Each output document is an input document with the value of its array field replaced by
     /// an element from the unwound array.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/
     ///
     /// @param field_name
     ///   The name of the field to unwind.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
@@ -39,7 +39,8 @@ namespace v_noabi {
 /// For interoperability with other MongoDB drivers, the minimum and maximum number of connections
 /// in the pool is configured using the 'minPoolSize' and 'maxPoolSize' connection string options.
 ///
-/// @see https://www.mongodb.com/docs/manual/reference/connection-string/#connection-string-options
+/// @see
+/// - https://www.mongodb.com/docs/manual/reference/connection-string/#connection-string-options
 ///
 /// @remark When connecting to a replica set, it is @b much more efficient to use a pool as opposed
 /// to manually constructing @c client objects. The pool will use a single background thread per

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
@@ -59,7 +59,8 @@ namespace v_noabi {
 /// in order to perform read operations on a direct connection to a secondary member of a replica
 /// set, you must set a read preference that allows reading from secondaries.
 ///
-/// @see https://www.mongodb.com/docs/manual/core/read-preference/
+/// @see
+/// - https://www.mongodb.com/docs/manual/core/read-preference/
 ///
 class read_preference {
    public:
@@ -72,7 +73,8 @@ class read_preference {
     /// replicate operations from the primary with some delay. Ensure that your application
     /// can tolerate stale data if you choose to use a non-primary mode.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/read-preference/#read-preference-modes
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/read-preference/#read-preference-modes
     ///
     enum class read_mode : std::uint8_t {
         ///
@@ -128,7 +130,8 @@ class read_preference {
     /// @param tags
     ///   A document representing tags to use for the read_preference.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/read-preference/#tag-sets
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/read-preference/#tag-sets
     ///
     /// @deprecated The tags() method should be used instead.
     ///
@@ -188,7 +191,8 @@ class read_preference {
     /// @param tag_set_list
     ///   Document representing the tag set list.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/read-preference-tags/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/read-preference-tags/
     ///
     /// @return
     ///   A reference to the object on which this member function is being called.  This facilitates
@@ -203,7 +207,8 @@ class read_preference {
     /// @param tag_set_list
     ///   Array of tag sets.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/read-preference-tags/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/read-preference-tags/
     ///
     /// @return
     ///   A reference to the object on which this member function is being called.  This facilitates
@@ -217,7 +222,8 @@ class read_preference {
     ///
     /// @return The optionally set current tag set list.
     ///
-    /// @see https://www.mongodb.com/docs/manual/core/read-preference-tags/
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/core/read-preference-tags/
     ///
     MONGOCXX_ABI_EXPORT_CDECL(stdx::optional<bsoncxx::v_noabi::document::view>) tags() const;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
@@ -37,9 +37,8 @@ namespace v_noabi {
 ///
 /// Class representing a MongoDB connection string URI.
 ///
-/// @see https://www.mongodb.com/docs/manual/reference/connection-string/
-/// @see https://mongoc.org/libmongoc/current/mongoc_uri_t.html for more information on supported
-/// URI options.
+/// @see
+/// - https://www.mongodb.com/docs/manual/reference/connection-string/
 ///
 class uri {
    public:
@@ -56,9 +55,8 @@ class uri {
     /// Constructs a uri from an optional MongoDB URI string. If no URI string is specified,
     /// uses the default URI string, 'mongodb://localhost:27017'.
     ///
-    /// @see The documentation for the version of libmongoc used for the list of supported
-    ///   URI options. For the latest libmongoc release:
-    ///   https://mongoc.org/libmongoc/current/mongoc_uri_t.html
+    /// @see
+    /// - https://mongoc.org/libmongoc/current/mongoc_uri_t.html
     ///
     /// @param uri_string
     ///   String representing a MongoDB connection string URI, defaults to k_default_uri.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/validation_criteria.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/validation_criteria.hpp
@@ -29,7 +29,8 @@ namespace v_noabi {
 ///
 /// Class representing criteria for document validation, to be applied to a collection.
 ///
-/// @see https://www.mongodb.com/docs/manual/core/document-validation/
+/// @see
+/// - https://www.mongodb.com/docs/manual/core/document-validation/
 ///
 class validation_criteria {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
@@ -134,7 +134,8 @@ class write_concern {
 
     ///
     /// Sets the acknowledge level.
-    /// @see https://www.mongodb.com/docs/manual/reference/write-concern/#w-option
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/write-concern/#w-option
     ///
     /// @param confirm_level
     ///   Either level::k_unacknowledged, level::k_acknowledged, level::k_default, or
@@ -205,7 +206,8 @@ class write_concern {
     ///
     /// This is unset by default.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/write-concern/#w-option
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/write-concern/#w-option
     ///
     /// @return The number of required nodes.
     ///
@@ -214,7 +216,8 @@ class write_concern {
     ///
     /// Gets the current acknowledgment level.
     ///
-    /// @see https://www.mongodb.com/docs/manual/reference/write-concern/#w-option
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/write-concern/#w-option
     ///
     /// @return The acknowledgment level.
     ///

--- a/src/mongocxx/test/spec/unified_tests/entity.hh
+++ b/src/mongocxx/test/spec/unified_tests/entity.hh
@@ -73,8 +73,9 @@ class map {
     // client must outlive the objects created from it, the client objects are held in a separate
     // map and declared first.
     //
-    // @see: https://mongoc.org/libmongoc/current/lifecycle.html#object-lifecycle
-    // @see: https://isocpp.org/wiki/faq/dtors#order-dtors-for-members
+    // See:
+    // - https://mongoc.org/libmongoc/current/lifecycle.html#object-lifecycle
+    // - https://isocpp.org/wiki/faq/dtors#order-dtors-for-members
     std::unordered_map<key_type, client> _client_map;
     std::unordered_map<key_type, mongocxx::database> _database_map;
     std::unordered_map<key_type, mongocxx::collection> _collection_map;


### PR DESCRIPTION
Resolves CXX-3110. Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1211.

Applies a standard format to use of the `\par`, `\see`, and `\code` Doxygen commands for visual consistency and to avoid the Clang `-Wdocumentation (false-positive) warnings:

```
warning: empty paragraph passed to '@see' command [-Wdocumentation]
warning: empty paragraph passed to '@par' command [-Wdocumentation]
```

All usage of the `\see` command is updated to use Markdown list syntax and ensure the paragraph is correctly associated with the `\see` section in the HTML structure.

Before:

![image](https://github.com/user-attachments/assets/c226c53d-0cb6-474d-9728-e98d6b8468af)

After:

![image](https://github.com/user-attachments/assets/f70a7f4e-14bd-412e-8565-a4686f238f97)

A similar pattern is used for titled paragraphs (`\par <title>`) for consistency and to avoid `-Wdocumentation` warnings.

Before:

```cpp
/// @par "Includes" @parblock
/// @li @ref mongocxx/v_noabi/mongocxx/config/compiler.hpp
/// @li @ref mongocxx-v_noabi-mongocxx-config-config-hpp
/// @li @ref mongocxx-v_noabi-mongocxx-config-export-hpp
/// @li @ref mongocxx-v_noabi-mongocxx-config-version-hpp
/// @endparblock
```

After:

```cpp
/// @par Includes
/// - @ref mongocxx/v_noabi/mongocxx/config/compiler.hpp
/// - @ref mongocxx-v_noabi-mongocxx-config-config-hpp
/// - @ref mongocxx-v_noabi-mongocxx-config-export-hpp
/// - @ref mongocxx-v_noabi-mongocxx-config-version-hpp
```

The pattern is also extended to inline code blocks used for examples (`\par Example`), again for consistency and to avoid `-Wdocumentation` warnings, but also as part of gradually moving towards more Markdown usage in Doxygen documentation comments.

Before:

```cpp
/// Example:
/// @code
///   mongocxx::v_noabi::client mongo_client{mongocxx::v_noabi::uri{}};
///   mongocxx::v_noabi::client mongo_client{mongocxx::v_noabi::uri{"mongodb://localhost:27017"}};
/// @endcode
```

After:

```cpp
/// @par Example
/// ```cpp
/// // Connect and get a collection.
/// mongocxx::v_noabi::client mongo_client{mongocxx::v_noabi::uri{}};
/// auto coll = mongo_client["database"]["collection"];
/// ```
```