### PR TITLE
CXX-3110 Fix missing end of code block

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/to_string.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/to_string.hpp
@@ -40,6 +40,7 @@ namespace string {
 ///   // This is supported regardless of the polyfill library.
 ///   return bsoncxx::v_noabi::string::to_string(sv);
 /// }
+/// ```
 ///
 template <class CharT,
           class Traits = std::char_traits<CharT>,


### PR DESCRIPTION
A small followup to https://github.com/mongodb/mongo-cxx-driver/pull/1213 which adds a missing code block terminator to the documentation of `bsoncxx::v_noabi::string::to_string`.

Before:

![image](https://github.com/user-attachments/assets/43299445-7d58-456a-b572-867784b58447)

After:

![image](https://github.com/user-attachments/assets/8914ec6f-eff1-490e-82f5-6e7cdf929f41)
