### PR TITLE
CXX-3082 Add comprehensive examples (mongocxx)

### DIFF
--- a/.evergreen/test.sh
+++ b/.evergreen/test.sh
@@ -297,6 +297,9 @@ else
   # API version to example clients, so examples will fail when requireApiVersion
   # is true.
   if [[ -z "${MONGODB_API_VERSION:-}" ]]; then
+    # Avoid `[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.` errors on MacOS.
+    export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+
     echo "Running examples..."
     if ! "${cmake_binary:?}" --build . --target run-examples --parallel 1 >|output.txt 2>&1; then
       # Only emit output on failure.

--- a/docs/api/mongocxx/examples/clients.md
+++ b/docs/api/mongocxx/examples/clients.md
@@ -1,0 +1,83 @@
+# Create a Client
+
+## Single
+
+### Basic Usage
+
+@snippet api/mongocxx/examples/clients/create/single/basic.cpp Example
+
+### With a Custom URI
+
+@snippet api/mongocxx/examples/clients/create/single/with_uri.cpp Example
+
+### With Client Options
+
+#### Stable API Options
+
+@snippet api/mongocxx/examples/clients/create/single/options/stable_api.cpp Example
+
+#### TLS Options
+
+@snippet api/mongocxx/examples/clients/create/single/options/tls.cpp Example
+
+#### Automatic Encryption Options
+
+@snippet api/mongocxx/examples/clients/create/single/options/auto_encryption.cpp Example
+
+#### APM Options
+
+@snippet api/mongocxx/examples/clients/create/single/options/apm.cpp Example
+
+## Pool
+
+### Basic Usage
+
+@snippet api/mongocxx/examples/clients/create/pool/basic.cpp Example
+
+### With Client Options
+
+@snippet api/mongocxx/examples/clients/create/pool/options.cpp Example
+
+### Try Acquire
+
+@snippet api/mongocxx/examples/clients/create/pool/try_acquire.cpp Example
+
+# Use a Client
+
+## List Databases
+
+@snippet api/mongocxx/examples/clients/use/list_databases.cpp Example
+
+## List Databases With Options
+
+@snippet api/mongocxx/examples/clients/use/list_databases_with_options.cpp Example
+
+## List Database Names
+
+@snippet api/mongocxx/examples/clients/use/list_database_names.cpp Example
+
+## List Database Names With Options
+
+@snippet api/mongocxx/examples/clients/use/list_database_names_with_options.cpp Example
+
+# Error Handling
+
+## Invalid Client
+
+@snippet api/mongocxx/examples/clients/errors/invalid_client.cpp Example
+
+## Wait Queue Timeout
+
+@snippet api/mongocxx/examples/clients/errors/wait_queue_timeout.cpp Example
+
+## Invalid Stable API Options
+
+@snippet api/mongocxx/examples/clients/errors/stable_api.cpp Example
+
+## TLS Not Enabled
+
+@snippet api/mongocxx/examples/clients/errors/tls.cpp Example
+
+## Invalid Auto Encryption Options
+
+@snippet api/mongocxx/examples/clients/errors/auto_encryption.cpp Example

--- a/docs/api/mongocxx/examples/collections.md
+++ b/docs/api/mongocxx/examples/collections.md
@@ -1,0 +1,113 @@
+# Obtain a Collection
+
+@snippet examples/api/mongocxx/examples/collections/obtain.cpp Example
+
+# Collection Operations
+
+## Drop a Collection
+
+@snippet examples/api/mongocxx/examples/collections/drop.cpp Example
+
+## Rename a Collection
+
+@snippet examples/api/mongocxx/examples/collections/rename.cpp Example
+
+## Set a Read Concern
+
+@snippet examples/api/mongocxx/examples/collections/rc.cpp Example
+
+## Set a Write Concern
+
+@snippet examples/api/mongocxx/examples/collections/wc.cpp Example
+
+## Set a Read Preference
+
+@snippet examples/api/mongocxx/examples/collections/rp.cpp Example
+
+# Index Operations
+
+## List Indexes
+
+@snippet examples/api/mongocxx/examples/collections/list_indexes.cpp Example
+
+## Create an Index
+
+@snippet examples/api/mongocxx/examples/collections/create_index.cpp Example
+
+## Create an Index With Options
+
+@snippet examples/api/mongocxx/examples/collections/create_index_with_options.cpp Example
+
+# Document Operations
+
+## Query the Number of Documents
+
+@snippet examples/api/mongocxx/examples/collections/count.cpp Example
+
+## Estimate the Number of Documents
+
+@snippet examples/api/mongocxx/examples/collections/estimate_count.cpp Example
+
+## Find a Document
+
+@snippet examples/api/mongocxx/examples/collections/find_one.cpp Example
+
+## Find Multiple Documents
+
+@snippet examples/api/mongocxx/examples/collections/find.cpp Example
+
+## Delete a Document
+
+@snippet examples/api/mongocxx/examples/collections/delete_one.cpp Example
+
+## Delete Many Documents
+
+@snippet examples/api/mongocxx/examples/collections/delete_many.cpp Example
+
+## Insert a Document
+
+@snippet examples/api/mongocxx/examples/collections/insert_one.cpp Example
+
+## Insert Many Documents
+
+@snippet examples/api/mongocxx/examples/collections/insert_many.cpp Example
+
+## Replace a Document
+
+@snippet examples/api/mongocxx/examples/collections/replace_one.cpp Example
+
+## Update a Document
+
+@snippet examples/api/mongocxx/examples/collections/update_one.cpp Example
+
+## Update Multiple Documents
+
+@snippet examples/api/mongocxx/examples/collections/update_many.cpp Example
+
+## Find and Delete a Document
+
+@snippet examples/api/mongocxx/examples/collections/find_one_and_delete.cpp Example
+
+## Find and Replace a Document
+
+@snippet examples/api/mongocxx/examples/collections/find_one_and_replace.cpp Example
+
+## Find and Update a Document
+
+@snippet examples/api/mongocxx/examples/collections/find_one_and_update.cpp Example
+
+## Find Distinct Values
+
+@snippet examples/api/mongocxx/examples/collections/distinct.cpp Example
+
+## Execute a Single Bulk Write Operation
+
+@snippet examples/api/mongocxx/examples/collections/write.cpp Example
+
+## Execute Multiple Bulk Write Operations
+
+@snippet examples/api/mongocxx/examples/collections/bulk_write.cpp Example
+
+## Execute an Aggregation Operation
+
+@snippet examples/api/mongocxx/examples/collections/aggregate.cpp Example

--- a/docs/api/mongocxx/examples/databases.md
+++ b/docs/api/mongocxx/examples/databases.md
@@ -1,0 +1,43 @@
+# Obtain a Database
+
+@snippet examples/api/mongocxx/examples/databases/obtain.cpp Example
+
+# Database Operations
+
+## Drop a Database
+
+@snippet examples/api/mongocxx/examples/databases/drop.cpp Example
+
+## Run a Command
+
+@snippet examples/api/mongocxx/examples/databases/run_command.cpp Example
+
+## Set a Read Concern
+
+@snippet examples/api/mongocxx/examples/databases/rc.cpp Example
+
+## Set a Write Concern
+
+@snippet examples/api/mongocxx/examples/databases/wc.cpp Example
+
+# Collection Operations
+
+## Create a Collection
+
+@snippet examples/api/mongocxx/examples/databases/create_collection.cpp Example
+
+## Create a Collection With Options
+
+@snippet examples/api/mongocxx/examples/databases/create_collection_with_options.cpp Example
+
+## Query a Collection Exists
+
+@snippet examples/api/mongocxx/examples/databases/has_collection.cpp Example
+
+## List Collections in the Database
+
+@snippet examples/api/mongocxx/examples/databases/list_collections.cpp Example
+
+## List Collection Names in the Database
+
+@snippet examples/api/mongocxx/examples/databases/list_collection_names.cpp Example

--- a/docs/api/mongocxx/examples/instance.md
+++ b/docs/api/mongocxx/examples/instance.md
@@ -1,0 +1,21 @@
+# Initialize the C++ Driver
+
+## Basic Usage
+
+@snippet api/mongocxx/examples/instance/basic_usage.cpp Example
+
+## With Static Lifetime
+
+@warning This pattern depends on an exit-time destructor with indeterminate order relative to other objects with static lifetime being destroyed.
+
+@snippet api/mongocxx/examples/instance/current.cpp Example
+
+# Errors
+
+## Instance Recreation
+
+@snippet api/mongocxx/examples/instance/recreation.cpp Example
+
+## Destroyed Instance
+
+@snippet api/mongocxx/examples/instance/destroyed.cpp Example

--- a/docs/api/mongocxx/examples/logger.md
+++ b/docs/api/mongocxx/examples/logger.md
@@ -1,0 +1,7 @@
+# Basic Usage
+
+@snippet api/mongocxx/examples/logger/basic_usage.cpp Example
+
+# Convert a Log Level to a String
+
+@snippet api/mongocxx/examples/logger/to_string.cpp Example

--- a/docs/api/mongocxx/examples/operation_exceptions.md
+++ b/docs/api/mongocxx/examples/operation_exceptions.md
@@ -1,0 +1,11 @@
+# As a Regular Exception
+
+@warning The @ref mongocxx::server_error_category error category is overloaded ([CXX-834](https://jira.mongodb.org/browse/CXX-834)). The error code value may belong to the server, libmongoc, or libmongocrypt depending on the context. Use error code values with caution.
+
+@snippet examples/api/mongocxx/examples/operation_exceptions/regular.cpp Example
+
+# As an Operation Exception
+
+@note Using @ref mongocxx::exception for error handling is recommended for forward compatibility. ([CXX-2377](https://jira.mongodb.org/browse/CXX-2377))
+
+@snippet examples/api/mongocxx/examples/operation_exceptions/operation.cpp Example

--- a/docs/api/mongocxx/examples/uri.md
+++ b/docs/api/mongocxx/examples/uri.md
@@ -1,0 +1,33 @@
+# Create a URI
+
+## Basic Usage
+
+@snippet api/mongocxx/examples/uri/basic_usage.cpp Example
+
+## Default Value
+
+@snippet api/mongocxx/examples/uri/default_value.cpp Example
+
+# Query a URI
+
+## User Credentials
+
+@snippet api/mongocxx/examples/uri/userpass.cpp Example
+
+## List of Hosts
+
+@snippet api/mongocxx/examples/uri/hosts.cpp Example
+
+## Optional Options
+
+@snippet api/mongocxx/examples/uri/optional.cpp Example
+
+## All URI Options
+
+@snippet api/mongocxx/examples/uri/all_options.cpp Example
+
+# Error Handling
+
+## Invalid URI
+
+@snippet api/mongocxx/examples/uri/invalid.cpp Example

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -170,6 +170,8 @@ function (add_abi_examples)
     # Avoid MAX_PATH errors on Windows due to long target names by using a single `api-runner` .
     add_examples_executable(api/runner.cpp LIBRARIES mongocxx_target Threads::Threads)
 
+    target_sources (api-runner PRIVATE "api/runner.cpp")
+
     # Define a unique entry function name per component.
     foreach (source ${api_examples_sources})
         target_sources (api-runner PRIVATE ${source})

--- a/examples/api/bsoncxx/examples/bson_errors/big_string.hh
+++ b/examples/api/bsoncxx/examples/bson_errors/big_string.hh
@@ -26,7 +26,8 @@ namespace examples {
 // Used to trigger builder append failure.
 struct big_string {
     // BSON_SIZE_MAX == 0x7FFFFFFF
-    std::size_t length{static_cast<std::size_t>(std::numeric_limits<std::int32_t>::max())};
+    // Leave some room for CDRIVER-5732.
+    std::size_t length{static_cast<std::size_t>(std::numeric_limits<std::int32_t>::max() - 32u)};
 
     // Allocate an UNINITIALIZED blob of data that will not be accessed due to length checks.
     // Leaving memory unitialized (rather than zero-init) should hopefully avoid slow and expensive

--- a/examples/api/concern.cpp
+++ b/examples/api/concern.cpp
@@ -1,0 +1,48 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+
+#include <mongocxx/collection.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/read_concern.hpp>
+#include <mongocxx/write_concern.hpp>
+
+#include <examples/api/concern.hh>
+
+// Preferred default for most operations.
+mongocxx::collection set_rw_concern_majority(mongocxx::collection coll) {
+    coll.read_concern(rc_majority());
+    coll.write_concern(wc_majority());
+    return coll;
+}
+
+// Preferred default for most operations.
+mongocxx::database set_rw_concern_majority(mongocxx::database db) {
+    db.read_concern(rc_majority());
+    db.write_concern(wc_majority());
+    return db;
+}
+
+mongocxx::read_concern rc_majority() {
+    mongocxx::read_concern rc;
+    rc.acknowledge_level(mongocxx::read_concern::level::k_majority);
+    return rc;
+}
+
+mongocxx::write_concern wc_majority() {
+    mongocxx::write_concern wc;
+    wc.majority(std::chrono::milliseconds(0));
+    return wc;
+}

--- a/examples/api/concern.hh
+++ b/examples/api/concern.hh
@@ -1,0 +1,27 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/collection-fwd.hpp>
+#include <mongocxx/database-fwd.hpp>
+#include <mongocxx/read_concern-fwd.hpp>
+#include <mongocxx/write_concern-fwd.hpp>
+
+// Preferred default for most operations.
+mongocxx::collection set_rw_concern_majority(mongocxx::collection coll);
+mongocxx::database set_rw_concern_majority(mongocxx::database db);
+
+mongocxx::read_concern rc_majority();
+mongocxx::write_concern wc_majority();

--- a/examples/api/db_lock.cpp
+++ b/examples/api/db_lock.cpp
@@ -1,0 +1,49 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mutex>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/database.hpp>
+
+#include <examples/api/db_lock.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+std::unordered_map<std::string, std::mutex> db_locks;
+std::mutex db_locks_mut;
+
+}  // namespace
+
+db_lock::~db_lock() {
+    this->get().drop();
+}
+
+db_lock::db_lock(mongocxx::client& client, std::string name) : _client_ptr(&client), _name(name) {
+    ((void)std::lock_guard<std::mutex>{db_locks_mut},
+     _lock = std::unique_lock<std::mutex>(db_locks[name]));
+
+    this->get().drop();
+}
+
+mongocxx::database db_lock::get() const& {
+    ASSERT(_client_ptr);
+
+    return _client_ptr->database(_name);
+}

--- a/examples/api/db_lock.hh
+++ b/examples/api/db_lock.hh
@@ -1,0 +1,42 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mutex>
+#include <string>
+
+#include <mongocxx/client-fwd.hpp>
+#include <mongocxx/database-fwd.hpp>
+
+// Ensure exclusive access to the associated database.
+// For convenience, drops the database on both lock and unlock.
+class db_lock {
+   private:
+    mongocxx::client* _client_ptr;
+    std::string _name;
+    std::unique_lock<std::mutex> _lock;
+
+   public:
+    ~db_lock();
+
+    db_lock(db_lock&&) = delete;
+    db_lock& operator=(db_lock&&) = delete;
+    db_lock(const db_lock&) = delete;
+    db_lock& operator=(const db_lock&) = delete;
+
+    db_lock(mongocxx::client& client, std::string name);
+
+    mongocxx::database get() const&;
+};

--- a/examples/api/mongocxx/examples/clients/create/pool/basic.cpp
+++ b/examples/api/mongocxx/examples/clients/create/pool/basic.cpp
@@ -1,0 +1,59 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/pool.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example() {
+    {
+        mongocxx::pool pool;
+
+        mongocxx::pool::entry entry = pool.acquire();
+
+        ASSERT(entry);
+
+        mongocxx::client& client = *entry;
+
+        ASSERT(client);
+        ASSERT(client.uri().to_string() == mongocxx::uri::k_default_uri);
+    }
+
+    {
+        mongocxx::uri uri{"mongodb://localhost:27017/?serverSelectionTryOnce=true"};
+        mongocxx::pool pool{uri};
+
+        mongocxx::pool::entry entry = pool.acquire();
+
+        ASSERT(entry);
+
+        mongocxx::client& client = *entry;
+
+        ASSERT(client);
+        ASSERT(client.uri().to_string() == uri.to_string());
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
+    example();
+}

--- a/examples/api/mongocxx/examples/clients/create/pool/options.cpp
+++ b/examples/api/mongocxx/examples/clients/create/pool/options.cpp
@@ -1,0 +1,50 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/options/client.hpp>
+#include <mongocxx/options/pool.hpp>
+#include <mongocxx/pool.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example() {
+    mongocxx::options::client client_opts;
+
+    // ... set client options.
+
+    mongocxx::uri uri;
+    mongocxx::pool pool{uri, mongocxx::options::pool{client_opts}};
+
+    mongocxx::pool::entry entry = pool.acquire();
+
+    ASSERT(entry);
+
+    mongocxx::client& client = *entry;
+
+    ASSERT(client);
+    ASSERT(client.uri().to_string() == mongocxx::uri::k_default_uri);
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    example();
+}

--- a/examples/api/mongocxx/examples/clients/create/pool/try_acquire.cpp
+++ b/examples/api/mongocxx/examples/clients/create/pool/try_acquire.cpp
@@ -1,0 +1,55 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/pool.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example() {
+    mongocxx::uri uri{"mongodb://localhost:27017/?maxPoolSize=1&waitQueueTimeoutMS=1"};
+    mongocxx::pool pool{uri};
+
+    auto entry_opt = pool.try_acquire();
+
+    ASSERT(entry_opt);
+    ASSERT(*entry_opt);
+
+    {
+        mongocxx::pool::entry hold = std::move(*entry_opt);
+
+        ASSERT(hold);
+
+        entry_opt = pool.try_acquire();
+
+        ASSERT(!entry_opt);
+    }
+
+    entry_opt = pool.try_acquire();
+
+    ASSERT(entry_opt);
+    ASSERT(*entry_opt);
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    example();
+}

--- a/examples/api/mongocxx/examples/clients/create/single/basic.cpp
+++ b/examples/api/mongocxx/examples/clients/create/single/basic.cpp
@@ -1,0 +1,44 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example() {
+    {
+        mongocxx::client client;
+
+        ASSERT(!client);
+    }
+
+    {
+        mongocxx::client client{mongocxx::uri{}};
+
+        ASSERT(client);
+        ASSERT(client.uri().to_string() == mongocxx::uri::k_default_uri);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
+    example();
+}

--- a/examples/api/mongocxx/examples/clients/create/single/options/apm.cpp
+++ b/examples/api/mongocxx/examples/clients/create/single/options/apm.cpp
@@ -1,0 +1,56 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstring>
+
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/events/command_started_event.hpp>
+#include <mongocxx/options/apm.hpp>
+#include <mongocxx/options/client.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void on_command_started_callback(const mongocxx::events::command_started_event& event);
+
+void example() {
+    mongocxx::options::apm apm_opts;
+
+    apm_opts.on_command_started(&on_command_started_callback);
+    // ... other APM options.
+
+    mongocxx::options::client client_opts;
+    client_opts.apm_opts(apm_opts);
+
+    mongocxx::client client{mongocxx::uri{}, client_opts};
+
+    ASSERT(client);
+}
+// [Example]
+
+void on_command_started_callback(const mongocxx::events::command_started_event& event) {
+    (void)event;
+}
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
+    example();
+}

--- a/examples/api/mongocxx/examples/clients/create/single/options/auto_encryption.cpp
+++ b/examples/api/mongocxx/examples/clients/create/single/options/auto_encryption.cpp
@@ -1,0 +1,73 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdint>
+#include <cstring>
+
+#include <bsoncxx/builder/basic/document.hpp>
+#include <bsoncxx/builder/basic/kvp.hpp>
+#include <bsoncxx/document/view.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/exception/exception.hpp>
+#include <mongocxx/options/auto_encryption.hpp>
+#include <mongocxx/options/client.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(bsoncxx::document::view kms_providers) {
+    mongocxx::options::auto_encryption auto_encryption_opts;
+
+    auto_encryption_opts.key_vault_namespace({"keyvault", "datakeys"});
+    auto_encryption_opts.kms_providers(kms_providers);
+    // ... other automatic encryption options.
+
+    mongocxx::options::client client_opts;
+    client_opts.auto_encryption_opts(auto_encryption_opts);
+
+    mongocxx::uri uri;
+    mongocxx::client client{uri, client_opts};
+
+    ASSERT(client);
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
+    using bsoncxx::builder::basic::kvp;
+    using bsoncxx::builder::basic::make_document;
+
+    try {
+        std::uint8_t local_key[96]{};
+
+        example(make_document(kvp(
+            "local",
+            make_document(kvp(
+                "key",
+                bsoncxx::types::b_binary{bsoncxx::binary_sub_type::k_binary, 96, local_key})))));
+    } catch (const mongocxx::exception& ex) {
+        if (std::strstr(ex.what(), "ENABLE_CLIENT_SIDE_ENCRYPTION") != nullptr) {
+            // Library may not be configured with TLS/SSL support enabled.
+        } else {
+            throw;
+        }
+    }
+}

--- a/examples/api/mongocxx/examples/clients/create/single/options/stable_api.cpp
+++ b/examples/api/mongocxx/examples/clients/create/single/options/stable_api.cpp
@@ -1,0 +1,57 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/options/client.hpp>
+#include <mongocxx/options/server_api.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+mongocxx::client example() {
+    mongocxx::options::server_api server_api_opts{
+        mongocxx::options::server_api::version::k_version_1};
+
+    server_api_opts.strict(true);
+    // ... other Stable API options.
+
+    mongocxx::options::client client_opts;
+
+    client_opts.server_api_opts(server_api_opts);
+
+    mongocxx::uri uri;
+    mongocxx::client client{uri, client_opts};
+
+    ASSERT(client);
+    ASSERT(client.uri().to_string() == mongocxx::uri::k_default_uri);
+
+    return client;
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    auto client = example();
+
+    auto reply = client["admin"].run_command(bsoncxx::from_json(R"({"ping": 1})"));
+
+    ASSERT(reply["ok"] && reply["ok"].get_double().value == 1.0);
+}

--- a/examples/api/mongocxx/examples/clients/create/single/options/tls.cpp
+++ b/examples/api/mongocxx/examples/clients/create/single/options/tls.cpp
@@ -1,0 +1,68 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstring>
+
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/exception/exception.hpp>
+#include <mongocxx/options/client.hpp>
+#include <mongocxx/options/tls.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+mongocxx::client example() {
+    mongocxx::options::tls tls_opts;
+
+    // ... set TLS options.
+
+    mongocxx::options::client client_opts;
+    client_opts.tls_opts(tls_opts);
+
+    mongocxx::uri uri{"mongodb://bob:pwd123@localhost:27017/?tls=true"};
+    mongocxx::client client{uri, client_opts};
+
+    ASSERT(client);
+    ASSERT(client.uri().to_string() == uri.to_string());
+
+    return client;
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    try {
+        auto client = example();
+
+        auto reply = client["admin"].run_command(bsoncxx::from_json(R"({"ping": 1})"));
+
+        ASSERT(reply["ok"] && reply["ok"].get_double().value == 1.0);
+    } catch (const mongocxx::exception& ex) {
+        if (ex.code() == mongocxx::error_code::k_ssl_not_supported) {
+            // Library may not be configured with TLS/SSL support enabled.
+        } else if (std::strstr(ex.what(), "suitable server") != nullptr) {
+            // Authentication may not be supported by the live server.
+        } else {
+            throw;
+        }
+    }
+}

--- a/examples/api/mongocxx/examples/clients/create/single/with_uri.cpp
+++ b/examples/api/mongocxx/examples/clients/create/single/with_uri.cpp
@@ -1,0 +1,37 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example() {
+    mongocxx::uri uri{"mongodb://localhost:27017/?serverSelectionTryOnce=true"};
+    mongocxx::client client{uri};
+
+    ASSERT(client);
+    ASSERT(client.uri().to_string() == uri.to_string());
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
+    example();
+}

--- a/examples/api/mongocxx/examples/clients/errors/auto_encryption.cpp
+++ b/examples/api/mongocxx/examples/clients/errors/auto_encryption.cpp
@@ -1,0 +1,99 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdint>
+#include <cstring>
+
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/exception/exception.hpp>
+#include <mongocxx/exception/server_error_code.hpp>
+#include <mongocxx/options/auto_encryption.hpp>
+#include <mongocxx/options/client.hpp>
+#include <mongocxx/pool.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example() {
+    // Missing keyvault namespace.
+    try {
+        mongocxx::client client{mongocxx::uri{},
+                                mongocxx::options::client{}.auto_encryption_opts(
+                                    mongocxx::options::auto_encryption{})};  // Throws.
+
+        ASSERT(false && "should not reach this point");
+    } catch (const mongocxx::exception& ex) {
+        // CXX-834: libmongoc error code.
+        ASSERT(ex.code().category() == mongocxx::server_error_category());
+        ASSERT(ex.code().value() == 58);  // MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG
+    }
+
+    // Invalid KMS providers.
+    try {
+        mongocxx::client client{
+            mongocxx::uri{},
+            mongocxx::options::client{}.auto_encryption_opts(
+                mongocxx::options::auto_encryption{}
+                    .key_vault_namespace({"keyvault", "datakeys"})
+                    .kms_providers(bsoncxx::from_json(R"({"invalid": 1})")))};  // Throws.
+
+        ASSERT(false && "should not reach this point");
+    } catch (const mongocxx::exception& ex) {
+        // CXX-834: libmongocrypt error code.
+        ASSERT(ex.code().category() == mongocxx::server_error_category());
+        ASSERT(ex.code().value() == 1);  // MONGOCRYPT_GENERIC_ERROR_CODE
+    }
+
+    // Incompatible options.
+    try {
+        mongocxx::client client{
+            mongocxx::uri{},
+            mongocxx::options::client{}.auto_encryption_opts(
+                mongocxx::options::auto_encryption{}.key_vault_client(nullptr).key_vault_pool(
+                    nullptr))};  // Throws.
+
+        ASSERT(false && "should not reach this point");
+    } catch (const mongocxx::exception& ex) {
+        ASSERT(ex.code() == mongocxx::error_code::k_invalid_parameter);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
+    using bsoncxx::builder::basic::sub_document;
+
+    try {
+        (void)mongocxx::client{
+            mongocxx::uri{},
+            mongocxx::options::client{}.auto_encryption_opts(mongocxx::options::auto_encryption{})};
+
+        ASSERT(false && "should not reach this point");
+    } catch (const mongocxx::exception& ex) {
+        if (std::strstr(ex.what(), "ENABLE_CLIENT_SIDE_ENCRYPTION") != nullptr) {
+            // Library may not be configured with TLS/SSL support enabled.
+        } else {
+            example();
+        }
+    }
+}

--- a/examples/api/mongocxx/examples/clients/errors/invalid_client.cpp
+++ b/examples/api/mongocxx/examples/clients/errors/invalid_client.cpp
@@ -1,0 +1,45 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/exception/exception.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example() {
+    mongocxx::client client;
+
+    ASSERT(!client);
+
+    try {
+        mongocxx::uri uri = client.uri();  // DO NOT DO THIS. Throws.
+
+        ASSERT(false && "should not reach this point");
+    } catch (const mongocxx::exception& ex) {
+        ASSERT(ex.code() == mongocxx::error_code::k_invalid_client_object);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
+    example();
+}

--- a/examples/api/mongocxx/examples/clients/errors/stable_api.cpp
+++ b/examples/api/mongocxx/examples/clients/errors/stable_api.cpp
@@ -1,0 +1,50 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/exception/exception.hpp>
+#include <mongocxx/options/server_api.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example() {
+    try {
+        mongocxx::options::server_api::version version =
+            mongocxx::options::server_api::version_from_string("0");  // Throws.
+
+        ASSERT(false && "should not reach this point");
+    } catch (const mongocxx::exception& ex) {
+        ASSERT(ex.code() == mongocxx::error_code::k_invalid_parameter);
+    }
+
+    try {
+        std::string version = mongocxx::options::server_api::version_to_string(
+            static_cast<mongocxx::options::server_api::version>(1));  // Throws.
+
+        ASSERT(false && "should not reach this point");
+    } catch (const mongocxx::exception& ex) {
+        ASSERT(ex.code() == mongocxx::error_code::k_invalid_parameter);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
+    example();
+}

--- a/examples/api/mongocxx/examples/clients/errors/tls.cpp
+++ b/examples/api/mongocxx/examples/clients/errors/tls.cpp
@@ -1,0 +1,52 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/exception/exception.hpp>
+#include <mongocxx/options/client.hpp>
+#include <mongocxx/options/tls.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example() {
+    try {
+        mongocxx::client client{
+            mongocxx::uri{},
+            mongocxx::options::client{}.tls_opts(mongocxx::options::tls{})};  // Throws.
+
+        ASSERT(false && "should not reach this point");
+    } catch (const mongocxx::exception& ex) {
+        ASSERT(
+            // When TLS/SSL is enabled for both mongocxx and libmongoc.
+            ex.code() == mongocxx::error_code::k_invalid_parameter ||
+
+            // When TLS/SSL is not enabled for either mongocxx or libmongoc.
+            ex.code() == mongocxx::error_code::k_ssl_not_supported ||
+
+            false);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
+    example();
+}

--- a/examples/api/mongocxx/examples/clients/errors/wait_queue_timeout.cpp
+++ b/examples/api/mongocxx/examples/clients/errors/wait_queue_timeout.cpp
@@ -1,0 +1,50 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/stdx/optional.hpp>
+
+#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/exception/exception.hpp>
+#include <mongocxx/pool.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example() {
+    try {
+        mongocxx::pool pool{
+            mongocxx::uri{"mongodb://localhost:27017/?maxPoolSize=1&waitQueueTimeoutMS=1"}};
+
+        mongocxx::pool::entry hold = pool.acquire();
+
+        ASSERT(hold);
+
+        mongocxx::pool::entry entry = pool.acquire();  // Throws.
+
+        ASSERT(false && "should not reach this point");
+    } catch (const mongocxx::exception& ex) {
+        ASSERT(ex.code() == mongocxx::error_code::k_pool_wait_queue_timeout);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
+    example();
+}

--- a/examples/api/mongocxx/examples/clients/use/list_database_names.cpp
+++ b/examples/api/mongocxx/examples/clients/use/list_database_names.cpp
@@ -1,0 +1,44 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/string/to_string.hpp>
+#include <bsoncxx/types.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/cursor.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::client client) {
+    std::vector<std::string> names = client.list_database_names();
+
+    ASSERT(std::count(names.begin(), names.end(), "admin") == 1);
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    example(mongocxx::client{mongocxx::uri{}});
+}

--- a/examples/api/mongocxx/examples/clients/use/list_database_names_with_options.cpp
+++ b/examples/api/mongocxx/examples/clients/use/list_database_names_with_options.cpp
@@ -1,0 +1,45 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/cursor.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::client client) {
+    auto opts = bsoncxx::from_json(R"({"authorizedDatabases": true})");
+    // ... other listDatabases options.
+
+    std::vector<std::string> names = client.list_database_names(opts.view());
+
+    ASSERT(std::count(names.begin(), names.end(), "admin") == 0);
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    example(mongocxx::client{mongocxx::uri{}});
+}

--- a/examples/api/mongocxx/examples/clients/use/list_databases.cpp
+++ b/examples/api/mongocxx/examples/clients/use/list_databases.cpp
@@ -1,0 +1,50 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/document/view.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/cursor.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::client client) {
+    mongocxx::cursor databases = client.list_databases();
+
+    int count = 0;
+
+    for (bsoncxx::document::view doc : databases) {
+        ASSERT(doc["name"]);
+        ASSERT(doc["sizeOnDisk"]);
+        ASSERT(doc["empty"]);
+
+        if (doc["name"].get_string().value.compare("admin") == 0) {
+            ++count;
+        }
+    }
+
+    ASSERT(count == 1);
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    example(mongocxx::client{mongocxx::uri{}});
+}

--- a/examples/api/mongocxx/examples/clients/use/list_databases_with_options.cpp
+++ b/examples/api/mongocxx/examples/clients/use/list_databases_with_options.cpp
@@ -1,0 +1,55 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/cursor.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::client client) {
+    auto opts = bsoncxx::from_json(R"({"nameOnly": true})");
+    // ... other listDatabases options.
+
+    mongocxx::cursor databases = client.list_databases(opts.view());
+
+    int count = 0;
+
+    for (bsoncxx::document::view doc : databases) {
+        ASSERT(doc["name"]);
+        ASSERT(!doc["sizeOnDisk"]);
+        ASSERT(!doc["empty"]);
+
+        if (doc["name"].get_string().value.compare("admin") == 0) {
+            ++count;
+        }
+    }
+
+    ASSERT(count == 1);
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    example(mongocxx::client{mongocxx::uri{}});
+}

--- a/examples/api/mongocxx/examples/collections/aggregate.cpp
+++ b/examples/api/mongocxx/examples/collections/aggregate.cpp
@@ -1,0 +1,92 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <chrono>
+
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/cursor.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/model/insert_one.hpp>
+#include <mongocxx/options/aggregate.hpp>
+#include <mongocxx/pipeline.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/concern.hh>
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+// [
+//   {"x": 1},
+//   {"x": 2},
+// ]
+void example(mongocxx::collection coll) {
+    // Basic usage.
+    {
+        mongocxx::pipeline pipeline;
+
+        pipeline.match(bsoncxx::from_json(R"({"x": 1})"));
+        pipeline.sample(1);
+        // ... other pipeline stages.
+
+        mongocxx::cursor cursor = coll.aggregate(pipeline);
+
+        auto has_field_x = [](bsoncxx::document::view doc) -> bool {
+            return doc.find("x") != doc.end();
+        };
+
+        ASSERT(std::count_if(cursor.begin(), cursor.end(), has_field_x) == 1);
+    }
+
+    // With options.
+    {
+        mongocxx::options::aggregate opts;
+
+        // ... set aggregate options.
+
+        mongocxx::cursor cursor = coll.aggregate(mongocxx::pipeline{}, opts);
+
+        ASSERT(std::distance(cursor.begin(), cursor.end()) == 2);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        auto coll = set_rw_concern_majority(guard.get().create_collection("coll"));
+
+        using insert = mongocxx::model::insert_one;
+
+        ASSERT(coll.create_bulk_write()
+                   .append(insert{bsoncxx::from_json(R"({"x": 1})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 2})")})
+                   .execute());
+
+        example(coll);
+    }
+}

--- a/examples/api/mongocxx/examples/collections/bulk_write.cpp
+++ b/examples/api/mongocxx/examples/collections/bulk_write.cpp
@@ -1,0 +1,70 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/bulk_write.hpp>
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/model/insert_one.hpp>
+#include <mongocxx/model/update_one.hpp>
+#include <mongocxx/result/bulk_write.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/concern.hh>
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::collection coll) {
+    ASSERT(coll.count_documents(bsoncxx::from_json(R"({"x": {"$exists": 1}})")) == 0);
+
+    mongocxx::model::insert_one insert{bsoncxx::from_json(R"({"x": 10})")};
+    mongocxx::model::update_one update{bsoncxx::from_json(R"({"x": {"$exists": 1}})"),
+                                       bsoncxx::from_json(R"({"$set": {"x": 20}})")};
+
+    mongocxx::bulk_write bulk_write = coll.create_bulk_write();
+
+    bulk_write.append(insert);
+    bulk_write.append(update);
+    // ... other bulk write operations.
+
+    auto result_opt = bulk_write.execute();
+
+    ASSERT(result_opt);
+
+    mongocxx::result::bulk_write& result = *result_opt;
+
+    ASSERT(result.inserted_count() == 1);
+    ASSERT(result.modified_count() == 1);
+
+    ASSERT(coll.count_documents(bsoncxx::from_json(R"({"x": 20})")) == 1);
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        example(set_rw_concern_majority(guard.get().create_collection("coll")));
+    }
+}

--- a/examples/api/mongocxx/examples/collections/bulk_write_with_options.cpp
+++ b/examples/api/mongocxx/examples/collections/bulk_write_with_options.cpp
@@ -1,0 +1,76 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/bulk_write.hpp>
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/cursor.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/model/insert_one.hpp>
+#include <mongocxx/options/bulk_write.hpp>
+#include <mongocxx/result/bulk_write.hpp>
+#include <mongocxx/uri.hpp>
+#include <mongocxx/write_concern.hpp>
+
+#include <examples/api/concern.hh>
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::collection coll) {
+    ASSERT(coll.count_documents(bsoncxx::from_json(R"({"x": {"$exists": 1}})")) == 0);
+
+    mongocxx::options::bulk_write opts;
+
+    opts.ordered(true);
+    // ... other bulk write options.
+
+    auto result_opt =
+        coll.create_bulk_write(opts)
+            .append(mongocxx::model::insert_one{bsoncxx::from_json(R"({"x": 10})")})
+            .append(mongocxx::model::update_one{bsoncxx::from_json(R"({"x": {"$exists": 1}})"),
+                                                bsoncxx::from_json(R"({"$set": {"x": 20}})")})
+            .execute();
+
+    ASSERT(result_opt);
+
+    mongocxx::result::bulk_write& result = *result_opt;
+
+    ASSERT(result.inserted_count() == 1);
+    ASSERT(result.modified_count() == 1);
+
+    ASSERT(coll.count_documents(bsoncxx::from_json(R"({"x": 20})")) == 1);
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        auto coll = set_rw_concern_majority(guard.get().create_collection("coll"));
+
+        example(coll);
+    }
+}

--- a/examples/api/mongocxx/examples/collections/count.cpp
+++ b/examples/api/mongocxx/examples/collections/count.cpp
@@ -1,0 +1,78 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/model/insert_one.hpp>
+#include <mongocxx/options/count.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/concern.hh>
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+// [
+//     {"x": 1},
+//     {"x": 2},
+//     {"x": 3},
+// ]
+void example(mongocxx::collection coll) {
+    // Basic usage.
+    {
+        ASSERT(coll.count_documents(bsoncxx::from_json(R"({"x": {"$exists": 1}})")) == 3);
+        ASSERT(coll.count_documents(bsoncxx::from_json(R"({"x": {"$gt": 1}})")) == 2);
+        ASSERT(coll.count_documents(bsoncxx::from_json(R"({"x": {"$gt": 2}})")) == 1);
+    }
+
+    // With options.
+    {
+        mongocxx::options::count opts;
+
+        opts.limit(1);
+        // ... other count options.
+
+        ASSERT(coll.count_documents(bsoncxx::from_json(R"({"x": {"$exists": 1}})"), opts) == 1);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        auto db = set_rw_concern_majority(guard.get());
+
+        auto coll = db.create_collection("coll");
+
+        using insert = mongocxx::model::insert_one;
+
+        ASSERT(coll.create_bulk_write()
+                   .append(insert{bsoncxx::from_json(R"({"x": 1})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 2})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 3})")})
+                   .execute());
+
+        example(coll);
+    }
+}

--- a/examples/api/mongocxx/examples/collections/create_index_with_options.cpp
+++ b/examples/api/mongocxx/examples/collections/create_index_with_options.cpp
@@ -1,0 +1,88 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+
+#include <bsoncxx/builder/basic/document.hpp>
+#include <bsoncxx/document/value.hpp>
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/json.hpp>
+#include <bsoncxx/types.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/options/index_view.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/concern.hh>
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::collection coll) {
+    // Index options.
+    {
+        auto opts = bsoncxx::from_json(R"({"name": "custom_name", "unique": true})");
+        // ... other index options.
+
+        bsoncxx::document::value result =
+            coll.create_index(bsoncxx::from_json(R"({"key_a": 1})"), opts.view());
+
+        ASSERT(result["name"]);
+        ASSERT(result["name"].get_string().value.compare("custom_name") == 0);
+    }
+
+    // Create index options.
+    {
+        auto opts = bsoncxx::builder::basic::make_document();
+
+        mongocxx::options::index_view create_opts;
+
+        // ... set create index options.
+
+        bsoncxx::document::value result =
+            coll.create_index(bsoncxx::from_json(R"({"key_b": 1})"), opts.view());
+
+        ASSERT(result["name"]);
+        ASSERT(result["name"].get_string().value.compare("key_b_1") == 0);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        auto db = set_rw_concern_majority(guard.get());
+
+        example(db.create_collection("coll"));
+
+        for (auto doc : db["coll"].list_indexes()) {
+            ASSERT(doc["name"]);
+
+            if (doc["name"].get_string().value.compare("custom_name") == 0) {
+                ASSERT(doc["unique"]);
+                ASSERT(doc["unique"].get_bool().value == true);
+            }
+        }
+    }
+}

--- a/examples/api/mongocxx/examples/collections/delete_many.cpp
+++ b/examples/api/mongocxx/examples/collections/delete_many.cpp
@@ -1,0 +1,98 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/model/insert_one.hpp>
+#include <mongocxx/result/delete.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/concern.hh>
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+// [
+//     {"x": 1},
+//     {"x": 2},
+//     {"x": 3},
+// ]
+void example(mongocxx::collection coll) {
+    auto x1 = bsoncxx::from_json(R"({"x": 1})");
+    auto x2 = bsoncxx::from_json(R"({"x": 2})");
+    auto x3 = bsoncxx::from_json(R"({"x": 3})");
+
+    // Basic usage.
+    {
+        ASSERT(coll.count_documents(x1.view()) == 1);
+        ASSERT(coll.count_documents(x2.view()) == 1);
+        ASSERT(coll.count_documents(x3.view()) == 1);
+
+        auto result_opt = coll.delete_many(bsoncxx::from_json(R"({"x": {"$gt": 1}})"));
+
+        ASSERT(result_opt);
+
+        mongocxx::result::delete_result& result = *result_opt;
+
+        ASSERT(result.deleted_count() == 2);
+        ASSERT(result.result().deleted_count() == 2);
+
+        ASSERT(coll.count_documents(x1.view()) == 1);
+        ASSERT(coll.count_documents(x2.view()) == 0);
+        ASSERT(coll.count_documents(x3.view()) == 0);
+    }
+
+    // With options.
+    {
+        ASSERT(coll.count_documents(x1.view()) == 1);
+
+        mongocxx::options::delete_options opts;
+
+        // ... set delete options.
+
+        ASSERT(coll.delete_many(bsoncxx::from_json(R"({"x": {"$exists": 1}})"), opts));
+
+        ASSERT(coll.count_documents(x1.view()) == 0);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        auto db = set_rw_concern_majority(guard.get());
+
+        auto coll = db.create_collection("coll");
+
+        using insert = mongocxx::model::insert_one;
+
+        ASSERT(coll.create_bulk_write()
+                   .append(insert{bsoncxx::from_json(R"({"x": 1})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 2})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 3})")})
+                   .execute());
+
+        example(coll);
+    }
+}

--- a/examples/api/mongocxx/examples/collections/delete_one.cpp
+++ b/examples/api/mongocxx/examples/collections/delete_one.cpp
@@ -1,0 +1,96 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/model/insert_one.hpp>
+#include <mongocxx/result/delete.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/concern.hh>
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+// [
+//     {"x": 1},
+//     {"x": 2},
+//     {"x": 3},
+// ]
+void example(mongocxx::collection coll) {
+    auto x1 = bsoncxx::from_json(R"({"x": 1})");
+    auto x2 = bsoncxx::from_json(R"({"x": 2})");
+    auto x3 = bsoncxx::from_json(R"({"x": 3})");
+
+    // Basic usage.
+    {
+        ASSERT(coll.count_documents(x1.view()) == 1);
+
+        auto result_opt = coll.delete_one(x1.view());
+
+        ASSERT(result_opt);
+
+        mongocxx::result::delete_result& result = *result_opt;
+
+        ASSERT(result.deleted_count() == 1);
+        ASSERT(result.result().deleted_count() == 1);
+
+        ASSERT(coll.count_documents(x1.view()) == 0);
+    }
+
+    // With options.
+    {
+        ASSERT(coll.count_documents(x2.view()) == 1);
+
+        mongocxx::options::delete_options opts;
+
+        // ... set delete options.
+
+        ASSERT(coll.delete_one(x2.view(), opts));
+
+        ASSERT(coll.count_documents(x2.view()) == 0);
+    }
+
+    ASSERT(coll.count_documents(x3.view()) == 1);
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        auto db = set_rw_concern_majority(guard.get());
+
+        auto coll = db.create_collection("coll");
+
+        using insert = mongocxx::model::insert_one;
+
+        ASSERT(coll.create_bulk_write()
+                   .append(insert{bsoncxx::from_json(R"({"x": 1})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 2})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 3})")})
+                   .execute());
+
+        example(coll);
+    }
+}

--- a/examples/api/mongocxx/examples/collections/distinct.cpp
+++ b/examples/api/mongocxx/examples/collections/distinct.cpp
@@ -1,0 +1,98 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <vector>
+
+#include <bsoncxx/array/view.hpp>
+#include <bsoncxx/document/value.hpp>
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/json.hpp>
+#include <bsoncxx/types.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/model/insert_one.hpp>
+#include <mongocxx/options/distinct.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/concern.hh>
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+// [
+//   {"x": 1, "flag": 1},
+//   {"x": 2, "flag": 1},
+//   {"x": 3, "flag": 0},
+// ]
+void example(mongocxx::collection coll) {
+    // Basic usage.
+    {
+        mongocxx::cursor cursor = coll.distinct("x", bsoncxx::from_json(R"({"flag": 1})"));
+
+        std::vector<bsoncxx::document::value> docs{cursor.begin(), cursor.end()};
+
+        ASSERT(docs.size() == 1u);
+
+        auto doc = docs[0].view();
+
+        ASSERT(doc["values"]);
+        ASSERT(doc["values"].type() == bsoncxx::type::k_array);
+
+        auto arr = doc["values"].get_array().value;
+
+        ASSERT(std::distance(arr.begin(), arr.end()) == 2);
+
+        ASSERT(arr[0].get_int32().value == 1);
+        ASSERT(arr[1].get_int32().value == 2);
+    }
+
+    // With options.
+    {
+        mongocxx::options::distinct opts;
+
+        // ... set distinct options.
+
+        mongocxx::cursor cursor = coll.distinct("x", bsoncxx::from_json(R"({"flag": 1})"), opts);
+
+        ASSERT(std::distance(cursor.begin(), cursor.end()) == 1);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        auto coll = set_rw_concern_majority(guard.get().create_collection("coll"));
+
+        using insert = mongocxx::model::insert_one;
+
+        ASSERT(coll.create_bulk_write()
+                   .append(insert{bsoncxx::from_json(R"({"x": 1, "flag": 1})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 2, "flag": 1})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 3, "flag": 0})")})
+                   .execute());
+
+        example(coll);
+    }
+}

--- a/examples/api/mongocxx/examples/collections/drop.cpp
+++ b/examples/api/mongocxx/examples/collections/drop.cpp
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/json.hpp>
-
 #include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
 #include <mongocxx/database.hpp>
 #include <mongocxx/uri.hpp>
 
@@ -27,15 +26,13 @@ namespace {
 
 // [Example]
 void example(mongocxx::database db) {
-    ASSERT(!db.has_collection("coll"));
+    mongocxx::collection coll = db["coll"];
 
-    auto opts = bsoncxx::from_json(R"({"validationLevel": "strict", "validationAction": "error"})");
-    // ... other create options.
-
-    mongocxx::collection coll = db.create_collection("coll", opts.view());
-
-    ASSERT(coll);
     ASSERT(db.has_collection("coll"));
+
+    coll.drop();
+
+    ASSERT(!db.has_collection("coll"));
 }
 // [Example]
 
@@ -47,6 +44,10 @@ RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
     {
         db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
 
-        example(set_rw_concern_majority(guard.get()));
+        auto db = set_rw_concern_majority(guard.get());
+
+        (void)db.create_collection("coll");
+
+        example(db);
     }
 }

--- a/examples/api/mongocxx/examples/collections/find.cpp
+++ b/examples/api/mongocxx/examples/collections/find.cpp
@@ -1,0 +1,104 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+
+#include <bsoncxx/builder/basic/document.hpp>
+#include <bsoncxx/document/value.hpp>
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/cursor.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/concern.hh>
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]A
+// [
+//   {"x": 1, "found": true},
+//   {"x": 2, "found": false},
+//   {"x": 3, "found": true},
+// ]
+void example(mongocxx::collection coll) {
+    // Basic usage.
+    {
+        auto filter = bsoncxx::from_json(R"({"found": true})");
+
+        mongocxx::cursor cursor = coll.find(filter.view());
+
+        int count = 0;
+
+        for (bsoncxx::document::view doc : cursor) {
+            ASSERT(doc["_id"]);
+
+            ASSERT(doc["x"]);
+            ASSERT(doc["x"].get_int32().value != 2);
+
+            ++count;
+        }
+
+        ASSERT(count == 2);
+    }
+
+    // With options.
+    {
+        mongocxx::options::find opts;
+
+        opts.projection(bsoncxx::from_json(R"({"_id": 0, "x": 1})"));
+        opts.sort(bsoncxx::from_json(R"({"x": 1})"));
+        // ... other find options.
+
+        mongocxx::cursor cursor = coll.find(bsoncxx::builder::basic::make_document(), opts);
+
+        std::vector<bsoncxx::document::value> docs{cursor.begin(), cursor.end()};
+
+        ASSERT(docs.size() == 3u);
+
+        ASSERT(docs[0] == bsoncxx::from_json(R"({"x": 1})"));
+        ASSERT(docs[1] == bsoncxx::from_json(R"({"x": 2})"));
+        ASSERT(docs[2] == bsoncxx::from_json(R"({"x": 3})"));
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        auto db = set_rw_concern_majority(guard.get());
+
+        auto coll = db.create_collection("coll");
+
+        using insert = mongocxx::model::insert_one;
+
+        ASSERT(coll.create_bulk_write()
+                   .append(insert{bsoncxx::from_json(R"({"x": 1, "found": true})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 2, "found": false})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 3, "found": true})")})
+                   .execute());
+
+        example(coll);
+    }
+}

--- a/examples/api/mongocxx/examples/collections/find_one.cpp
+++ b/examples/api/mongocxx/examples/collections/find_one.cpp
@@ -1,0 +1,91 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/builder/basic/document.hpp>
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/concern.hh>
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+// [
+//   {"x": 1, "found": false},
+//   {"x": 2, "found": true},
+//   {"x": 3, "found": false},
+// ]
+void example(mongocxx::collection coll) {
+    // Basic usage.
+    {
+        auto filter = bsoncxx::from_json(R"({"found": true})");
+
+        auto result_opt = coll.find_one(filter.view());
+
+        ASSERT(result_opt);
+
+        bsoncxx::document::view doc = result_opt->view();
+
+        ASSERT(doc["_id"]);
+
+        ASSERT(doc["x"]);
+        ASSERT(doc["x"].get_int32().value == 2);
+    }
+
+    // With options.
+    {
+        mongocxx::options::find opts;
+
+        opts.projection(bsoncxx::from_json(R"({"_id": 0, "x": 1})"));
+        opts.sort(bsoncxx::from_json(R"({"x": 1})"));
+        // ... other find options.
+
+        auto result_opt = coll.find_one(bsoncxx::builder::basic::make_document(), opts);
+
+        ASSERT(result_opt);
+        ASSERT(*result_opt == bsoncxx::from_json(R"({"x": 1})"));
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        auto db = set_rw_concern_majority(guard.get());
+
+        auto coll = db.create_collection("coll");
+
+        using insert = mongocxx::model::insert_one;
+
+        ASSERT(coll.create_bulk_write()
+                   .append(insert{bsoncxx::from_json(R"({"x": 1, "found": false})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 2, "found": true})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 3, "found": false})")})
+                   .execute());
+
+        example(coll);
+    }
+}

--- a/examples/api/mongocxx/examples/collections/find_one_and_delete.cpp
+++ b/examples/api/mongocxx/examples/collections/find_one_and_delete.cpp
@@ -1,0 +1,104 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/options/find_one_and_delete.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/concern.hh>
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+// [
+//   {"x": 1},
+//   {"x": 2},
+//   {"x": 3},
+// ]
+void example(mongocxx::collection coll) {
+    auto has_field_x = bsoncxx::from_json(R"({"x": {"$exists": true}})");
+
+    auto x1 = bsoncxx::from_json(R"({"x": 1})");
+    auto x2 = bsoncxx::from_json(R"({"x": 2})");
+    auto x3 = bsoncxx::from_json(R"({"x": 3})");
+
+    // Basic usage.
+    {
+        ASSERT(coll.count_documents(has_field_x.view()) == 3);
+
+        auto result_opt = coll.find_one_and_delete(x2.view());
+
+        ASSERT(result_opt);
+
+        bsoncxx::document::view doc = result_opt->view();
+
+        ASSERT(doc["_id"]);
+
+        ASSERT(doc["x"]);
+        ASSERT(doc["x"].get_int32().value == 2);
+
+        ASSERT(coll.count_documents(has_field_x.view()) == 2);
+    }
+
+    // With options.
+    {
+        ASSERT(coll.count_documents(has_field_x.view()) == 2);
+
+        mongocxx::options::find_one_and_delete opts;
+
+        opts.projection(bsoncxx::from_json(R"({"_id": 0, "x": 1})"));
+        // ... other findOneAndDelete options.
+
+        auto result_opt = coll.find_one_and_delete(x3.view(), opts);
+
+        ASSERT(result_opt);
+        ASSERT(*result_opt == x3);
+
+        ASSERT(coll.count_documents(has_field_x.view()) == 1);
+    }
+
+    ASSERT(coll.count_documents(x1.view()) == 1);
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        auto db = set_rw_concern_majority(guard.get());
+
+        auto coll = db.create_collection("coll");
+
+        using insert = mongocxx::model::insert_one;
+
+        ASSERT(coll.create_bulk_write()
+                   .append(insert{bsoncxx::from_json(R"({"x": 1})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 2})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 3})")})
+                   .execute());
+
+        example(coll);
+    }
+}

--- a/examples/api/mongocxx/examples/collections/find_one_and_replace.cpp
+++ b/examples/api/mongocxx/examples/collections/find_one_and_replace.cpp
@@ -1,0 +1,103 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/options/find_one_and_replace.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/concern.hh>
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+// [
+//   {"x": 1},
+//   {"x": 2},
+//   {"x": 3},
+// ]
+void example(mongocxx::collection coll) {
+    auto x0 = bsoncxx::from_json(R"({"x": 0})");
+    auto x1 = bsoncxx::from_json(R"({"x": 1})");
+    auto x2 = bsoncxx::from_json(R"({"x": 2})");
+    auto x3 = bsoncxx::from_json(R"({"x": 3})");
+
+    // Basic usage.
+    {
+        ASSERT(coll.count_documents(x0.view()) == 0);
+
+        auto result_opt = coll.find_one_and_replace(x2.view(), x0.view());
+
+        ASSERT(result_opt);
+
+        bsoncxx::document::view doc = result_opt->view();
+
+        ASSERT(doc["_id"]);
+
+        ASSERT(doc["x"]);
+        ASSERT(doc["x"].get_int32().value == 2);
+
+        ASSERT(coll.count_documents(x0.view()) == 1);
+    }
+
+    // With options.
+    {
+        ASSERT(coll.count_documents(x0.view()) == 1);
+
+        mongocxx::options::find_one_and_replace opts;
+
+        opts.projection(bsoncxx::from_json(R"({"_id": 0, "x": 1})"));
+        // ... other findOneAndReplace options.
+
+        auto result_opt = coll.find_one_and_replace(x3.view(), x0.view(), opts);
+
+        ASSERT(result_opt);
+        ASSERT(*result_opt == x3);
+
+        ASSERT(coll.count_documents(x0.view()) == 2);
+    }
+
+    ASSERT(coll.count_documents(x1.view()) == 1);
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        auto db = set_rw_concern_majority(guard.get());
+
+        auto coll = db.create_collection("coll");
+
+        using insert = mongocxx::model::insert_one;
+
+        ASSERT(coll.create_bulk_write()
+                   .append(insert{bsoncxx::from_json(R"({"x": 1})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 2})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 3})")})
+                   .execute());
+
+        example(coll);
+    }
+}

--- a/examples/api/mongocxx/examples/collections/find_one_and_update.cpp
+++ b/examples/api/mongocxx/examples/collections/find_one_and_update.cpp
@@ -1,0 +1,110 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/options/find_one_and_update.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/concern.hh>
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+// [
+//   {"x": 1, "updated": false},
+//   {"x": 2, "updated": false},
+//   {"x": 3, "updated": false},
+// ]
+void example(mongocxx::collection coll) {
+    auto updated = bsoncxx::from_json(R"({"updated": true})");
+
+    auto x1 = bsoncxx::from_json(R"({"x": 1})");
+    auto x2 = bsoncxx::from_json(R"({"x": 2})");
+    auto x3 = bsoncxx::from_json(R"({"x": 3})");
+
+    auto update = bsoncxx::from_json(R"({"$set": {"updated": true}})");
+
+    // Basic usage.
+    {
+        ASSERT(coll.count_documents(x2.view()) == 1);
+        ASSERT(coll.count_documents(updated.view()) == 0);
+
+        auto result_opt = coll.find_one_and_update(x2.view(), update.view());
+
+        ASSERT(result_opt);
+
+        bsoncxx::document::view doc = result_opt->view();
+
+        ASSERT(doc["_id"]);
+
+        ASSERT(doc["x"]);
+        ASSERT(doc["x"].get_int32().value == 2);
+
+        ASSERT(coll.count_documents(x2.view()) == 1);
+        ASSERT(coll.count_documents(updated.view()) == 1);
+    }
+
+    // With options.
+    {
+        ASSERT(coll.count_documents(x3.view()) == 1);
+        ASSERT(coll.count_documents(updated.view()) == 1);
+
+        mongocxx::options::find_one_and_update opts;
+
+        opts.projection(bsoncxx::from_json(R"({"_id": 0, "x": 1})"));
+        // ... other findOneAndReplace options.
+
+        auto result_opt = coll.find_one_and_update(x3.view(), update.view(), opts);
+
+        ASSERT(result_opt);
+        ASSERT(*result_opt == x3);
+
+        ASSERT(coll.count_documents(x3.view()) == 1);
+        ASSERT(coll.count_documents(updated.view()) == 2);
+    }
+
+    ASSERT(coll.count_documents(x1.view()) == 1);
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        auto db = set_rw_concern_majority(guard.get());
+
+        auto coll = db.create_collection("coll");
+
+        using insert = mongocxx::model::insert_one;
+
+        ASSERT(coll.create_bulk_write()
+                   .append(insert{bsoncxx::from_json(R"({"x": 1, "updated": false})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 2, "updated": false})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 3, "updated": false})")})
+                   .execute());
+
+        example(coll);
+    }
+}

--- a/examples/api/mongocxx/examples/collections/insert_many.cpp
+++ b/examples/api/mongocxx/examples/collections/insert_many.cpp
@@ -1,0 +1,93 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <array>
+#include <vector>
+
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/result/insert_many.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/concern.hh>
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::collection coll) {
+    auto x1 = bsoncxx::from_json(R"({"x": 1})");
+    auto x2 = bsoncxx::from_json(R"({"x": 2})");
+    auto y1 = bsoncxx::from_json(R"({"y": 1})");
+    auto y2 = bsoncxx::from_json(R"({"y": 2})");
+    auto z1 = bsoncxx::from_json(R"({"z": 1})");
+    auto z2 = bsoncxx::from_json(R"({"z": 2})");
+
+    // Basic usage.
+    {
+        std::vector<bsoncxx::document::view> docs = {x1.view(), x2.view()};
+
+        auto result_opt = coll.insert_many(docs);
+
+        ASSERT(result_opt);
+
+        mongocxx::result::insert_many& result = *result_opt;
+
+        ASSERT(result.inserted_count() == 2);
+        ASSERT(result.result().inserted_count() == 2);
+    }
+
+    // Iterators.
+    {
+        bsoncxx::document::view docs[] = {y1.view(), y2.view()};
+
+        auto result_opt = coll.insert_many(std::begin(docs), std::end(docs));
+
+        ASSERT(result_opt);
+
+        mongocxx::result::insert_many& result = *result_opt;
+
+        ASSERT(result.inserted_count() == 2);
+        ASSERT(result.result().inserted_count() == 2);
+    }
+
+    // With options.
+    {
+        std::array<bsoncxx::document::view, 2> docs = {z1.view(), z2.view()};
+
+        mongocxx::options::insert opts;
+
+        // ... set insert options.
+
+        ASSERT(coll.insert_many(docs, opts));
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        example(set_rw_concern_majority(guard.get().create_collection("coll")));
+    }
+}

--- a/examples/api/mongocxx/examples/collections/obtain.cpp
+++ b/examples/api/mongocxx/examples/collections/obtain.cpp
@@ -12,14 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/json.hpp>
-
 #include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
 #include <mongocxx/database.hpp>
 #include <mongocxx/uri.hpp>
 
-#include <examples/api/concern.hh>
-#include <examples/api/db_lock.hh>
 #include <examples/api/runner.hh>
 #include <examples/macros.hh>
 
@@ -27,26 +24,19 @@ namespace {
 
 // [Example]
 void example(mongocxx::database db) {
-    ASSERT(!db.has_collection("coll"));
-
-    auto opts = bsoncxx::from_json(R"({"validationLevel": "strict", "validationAction": "error"})");
-    // ... other create options.
-
-    mongocxx::collection coll = db.create_collection("coll", opts.view());
+    mongocxx::collection coll = db["coll"];
 
     ASSERT(coll);
-    ASSERT(db.has_collection("coll"));
+    ASSERT(coll.name().compare("coll") == 0);
+
+    ASSERT(db.collection("coll").name().compare("coll") == 0);
 }
 // [Example]
 
 }  // namespace
 
-RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
     mongocxx::client client{mongocxx::uri{}};
 
-    {
-        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
-
-        example(set_rw_concern_majority(guard.get()));
-    }
+    example(client["db"]);
 }

--- a/examples/api/mongocxx/examples/collections/rc.cpp
+++ b/examples/api/mongocxx/examples/collections/rc.cpp
@@ -12,41 +12,46 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/json.hpp>
-
 #include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
 #include <mongocxx/database.hpp>
 #include <mongocxx/uri.hpp>
 
-#include <examples/api/concern.hh>
-#include <examples/api/db_lock.hh>
 #include <examples/api/runner.hh>
 #include <examples/macros.hh>
 
 namespace {
 
 // [Example]
-void example(mongocxx::database db) {
-    ASSERT(!db.has_collection("coll"));
+void example(mongocxx::collection coll) {
+    using rc_level = mongocxx::read_concern::level;
 
-    auto opts = bsoncxx::from_json(R"({"validationLevel": "strict", "validationAction": "error"})");
-    // ... other create options.
+    // Default.
+    {
+        mongocxx::read_concern rc = coll.read_concern();
 
-    mongocxx::collection coll = db.create_collection("coll", opts.view());
+        ASSERT(rc.acknowledge_level() == rc_level::k_server_default);
+    }
 
-    ASSERT(coll);
-    ASSERT(db.has_collection("coll"));
+    // Explicit.
+    {
+        mongocxx::read_concern rc;
+
+        rc.acknowledge_level(rc_level::k_majority);
+        // ... other read concern options.
+
+        coll.read_concern(rc);
+
+        ASSERT(coll.read_concern() == rc);
+        ASSERT(coll.read_concern().acknowledge_level() == rc_level::k_majority);
+    }
 }
 // [Example]
 
 }  // namespace
 
-RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
     mongocxx::client client{mongocxx::uri{}};
 
-    {
-        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
-
-        example(set_rw_concern_majority(guard.get()));
-    }
+    example(client["db"]["coll"]);
 }

--- a/examples/api/mongocxx/examples/collections/replace_one.cpp
+++ b/examples/api/mongocxx/examples/collections/replace_one.cpp
@@ -1,0 +1,110 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/result/replace_one.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/concern.hh>
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+// [
+//   {"x": 1, "replaced": false},
+//   {"x": 2, "replaced": false},
+//   {"x": 3, "replaced": false},
+// ]
+void example(mongocxx::collection coll) {
+    auto is_original = bsoncxx::from_json(R"({"replaced": false})");
+    auto is_replaced = bsoncxx::from_json(R"({"replaced": true})");
+
+    auto x0 = bsoncxx::from_json(R"({"x": 0, "replaced": true})");
+
+    // Basic usage.
+    {
+        ASSERT(coll.count_documents(x0.view()) == 0);
+
+        auto filter = bsoncxx::from_json(R"({"x": 2})");
+
+        auto result_opt = coll.replace_one(filter.view(), x0.view());
+
+        ASSERT(result_opt);
+
+        mongocxx::result::replace_one& result = *result_opt;
+
+        ASSERT(result.matched_count() == 1);
+        ASSERT(result.modified_count() == 1);
+        ASSERT(result.result().matched_count() == 1);
+        ASSERT(result.result().modified_count() == 1);
+
+        ASSERT(coll.count_documents(x0.view()) == 1);
+    }
+
+    // With options.
+    {
+        ASSERT(coll.count_documents(is_original.view()) == 2);
+        ASSERT(coll.count_documents(is_replaced.view()) == 1);
+
+        mongocxx::options::replace opts;
+
+        opts.upsert(true);
+        // ... other replace options.
+
+        auto filter = bsoncxx::from_json(R"({"replaced": false})");
+
+        ASSERT(coll.replace_one(filter.view(), x0.view(), opts));
+        ASSERT(coll.count_documents(is_original.view()) == 1);
+        ASSERT(coll.count_documents(is_replaced.view()) == 2);
+
+        ASSERT(coll.replace_one(filter.view(), x0.view(), opts));
+        ASSERT(coll.count_documents(is_original.view()) == 0);
+        ASSERT(coll.count_documents(is_replaced.view()) == 3);
+
+        ASSERT(coll.replace_one(filter.view(), x0.view(), opts));
+        ASSERT(coll.count_documents(is_original.view()) == 0);
+        ASSERT(coll.count_documents(is_replaced.view()) == 4);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        auto db = set_rw_concern_majority(guard.get());
+
+        auto coll = db.create_collection("coll");
+
+        using insert = mongocxx::model::insert_one;
+
+        ASSERT(coll.create_bulk_write()
+                   .append(insert(bsoncxx::from_json(R"({"x": 1, "replaced": false})")))
+                   .append(insert(bsoncxx::from_json(R"({"x": 2, "replaced": false})")))
+                   .append(insert(bsoncxx::from_json(R"({"x": 3, "replaced": false})")))
+                   .execute());
+
+        example(coll);
+    }
+}

--- a/examples/api/mongocxx/examples/collections/update_many.cpp
+++ b/examples/api/mongocxx/examples/collections/update_many.cpp
@@ -1,0 +1,109 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/builder/basic/document.hpp>
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/result/update.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/concern.hh>
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+// [
+//   {"x": 1, "updated": false},
+//   {"x": 2, "updated": false},
+//   {"x": 3, "updated": false},
+// ]
+void example(mongocxx::collection coll) {
+    auto original = bsoncxx::from_json(R"({"updated": false})");
+    auto updated = bsoncxx::from_json(R"({"updated": true})");
+
+    auto update = bsoncxx::from_json(R"({"$set": {"updated": true}})");
+
+    // Basic usage.
+    {
+        ASSERT(coll.count_documents(updated.view()) == 0);
+
+        auto filter = bsoncxx::from_json(R"({"x": {"$gt": 1}})");
+
+        auto result_opt = coll.update_many(filter.view(), update.view());
+
+        ASSERT(result_opt);
+
+        mongocxx::result::update& result = *result_opt;
+
+        ASSERT(result.matched_count() == 2);
+        ASSERT(result.modified_count() == 2);
+        ASSERT(result.result().matched_count() == 2);
+        ASSERT(result.result().modified_count() == 2);
+
+        ASSERT(coll.count_documents(updated.view()) == 2);
+        ASSERT(coll.count_documents(bsoncxx::from_json(R"({"x": 1, "updated": false})")) == 1);
+    }
+
+    // With options.
+    {
+        ASSERT(coll.count_documents(original.view()) == 1);
+        ASSERT(coll.count_documents(updated.view()) == 2);
+
+        mongocxx::options::update opts;
+
+        opts.upsert(true);
+        // ... other update options.
+
+        ASSERT(coll.update_many(original.view(), update.view(), opts));
+
+        ASSERT(coll.count_documents(original.view()) == 0);
+        ASSERT(coll.count_documents(updated.view()) == 3);
+
+        ASSERT(coll.update_many(original.view(), update.view(), opts));
+
+        ASSERT(coll.count_documents(original.view()) == 0);
+        ASSERT(coll.count_documents(updated.view()) == 4);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        auto db = set_rw_concern_majority(guard.get());
+
+        auto coll = db.create_collection("coll");
+
+        using insert = mongocxx::model::insert_one;
+
+        ASSERT(coll.create_bulk_write()
+                   .append(insert{bsoncxx::from_json(R"({"x": 1, "updated": false})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 2, "updated": false})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 3, "updated": false})")})
+                   .execute());
+
+        example(coll);
+    }
+}

--- a/examples/api/mongocxx/examples/collections/update_one.cpp
+++ b/examples/api/mongocxx/examples/collections/update_one.cpp
@@ -1,0 +1,107 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/builder/basic/document.hpp>
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/result/update.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/concern.hh>
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+// [
+//   {"x": 1, "updated": false},
+//   {"x": 2, "updated": false},
+//   {"x": 3, "updated": false},
+// ]
+void example(mongocxx::collection coll) {
+    auto updated = bsoncxx::from_json(R"({"updated": true})");
+
+    // Basic usage.
+    {
+        ASSERT(coll.count_documents(updated.view()) == 0);
+
+        auto filter = bsoncxx::from_json(R"({"x": 2})");
+        auto update = bsoncxx::from_json(R"({"$set": {"updated": true}})");
+
+        auto result_opt = coll.update_one(filter.view(), update.view());
+
+        ASSERT(result_opt);
+
+        mongocxx::result::update& result = *result_opt;
+
+        ASSERT(result.matched_count() == 1);
+        ASSERT(result.modified_count() == 1);
+        ASSERT(result.result().matched_count() == 1);
+        ASSERT(result.result().modified_count() == 1);
+
+        ASSERT(coll.count_documents(bsoncxx::from_json(R"({"x": 2, "updated": true})")) == 1);
+        ASSERT(coll.count_documents(updated.view()) == 1);
+    }
+
+    // With options.
+    {
+        ASSERT(coll.count_documents(updated.view()) == 1);
+
+        auto x4 = bsoncxx::from_json(R"({"x": 4, "updated": true})");
+
+        ASSERT(coll.count_documents(x4.view()) == 0);
+
+        mongocxx::options::update opts;
+
+        opts.upsert(true);
+        // ... other update options.
+
+        ASSERT(coll.update_one(bsoncxx::from_json(R"({"x": 4})"),
+                               bsoncxx::from_json(R"({"$set": {"updated": true}})"),
+                               opts));
+
+        ASSERT(coll.count_documents(x4.view()) == 1);
+        ASSERT(coll.count_documents(updated.view()) == 2);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        auto db = set_rw_concern_majority(guard.get());
+
+        auto coll = db.create_collection("coll");
+
+        using insert = mongocxx::model::insert_one;
+
+        ASSERT(coll.create_bulk_write()
+                   .append(insert{bsoncxx::from_json(R"({"x": 1, "updated": false})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 2, "updated": false})")})
+                   .append(insert{bsoncxx::from_json(R"({"x": 3, "updated": false})")})
+                   .execute());
+
+        example(coll);
+    }
+}

--- a/examples/api/mongocxx/examples/collections/wc.cpp
+++ b/examples/api/mongocxx/examples/collections/wc.cpp
@@ -12,41 +12,48 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bsoncxx/json.hpp>
-
 #include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
 #include <mongocxx/database.hpp>
 #include <mongocxx/uri.hpp>
 
-#include <examples/api/concern.hh>
-#include <examples/api/db_lock.hh>
 #include <examples/api/runner.hh>
 #include <examples/macros.hh>
 
 namespace {
 
 // [Example]
-void example(mongocxx::database db) {
-    ASSERT(!db.has_collection("coll"));
+void example(mongocxx::collection coll) {
+    using wc_level = mongocxx::write_concern::level;
 
-    auto opts = bsoncxx::from_json(R"({"validationLevel": "strict", "validationAction": "error"})");
-    // ... other create options.
+    // Default.
+    {
+        mongocxx::write_concern wc = coll.write_concern();
 
-    mongocxx::collection coll = db.create_collection("coll", opts.view());
+        ASSERT(wc.acknowledge_level() == wc_level::k_default);
+        ASSERT(wc.timeout() == std::chrono::milliseconds(0));
+    }
 
-    ASSERT(coll);
-    ASSERT(db.has_collection("coll"));
+    // Explicit.
+    {
+        mongocxx::write_concern wc;
+
+        wc.majority(std::chrono::milliseconds(5000));
+        // ... other write concern options.
+
+        coll.write_concern(wc);
+
+        ASSERT(coll.write_concern() == wc);
+        ASSERT(coll.write_concern().acknowledge_level() == wc_level::k_majority);
+        ASSERT(coll.write_concern().timeout() == std::chrono::seconds(5));
+    }
 }
 // [Example]
 
 }  // namespace
 
-RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
     mongocxx::client client{mongocxx::uri{}};
 
-    {
-        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
-
-        example(set_rw_concern_majority(guard.get()));
-    }
+    example(client["db"]["coll"]);
 }

--- a/examples/api/mongocxx/examples/collections/write.cpp
+++ b/examples/api/mongocxx/examples/collections/write.cpp
@@ -1,0 +1,75 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/document/value.hpp>
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/bulk_write.hpp>
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/cursor.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/model/insert_one.hpp>
+#include <mongocxx/result/bulk_write.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/concern.hh>
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::collection coll) {
+    {
+        ASSERT(coll.count_documents(bsoncxx::from_json(R"({"x": 1})")) == 0);
+
+        mongocxx::model::insert_one insert{bsoncxx::from_json(R"({"x": 1})")};
+
+        auto result_opt = coll.write(insert);
+
+        ASSERT(result_opt);
+        ASSERT(result_opt->inserted_count() == 1);
+
+        ASSERT(coll.count_documents(bsoncxx::from_json(R"({"x": 1})")) == 1);
+    }
+
+    {
+        ASSERT(coll.count_documents(bsoncxx::from_json(R"({"y": 1})")) == 0);
+
+        mongocxx::options::bulk_write opts;
+
+        opts.ordered(true);
+        // ... other bulk write options.
+
+        ASSERT(coll.write(mongocxx::model::insert_one{bsoncxx::from_json(R"({"y": 1})")}, opts));
+
+        ASSERT(coll.count_documents(bsoncxx::from_json(R"({"y": 1})")) == 1);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        example(set_rw_concern_majority(guard.get().create_collection("coll")));
+    }
+}

--- a/examples/api/mongocxx/examples/databases/create_collection.cpp
+++ b/examples/api/mongocxx/examples/databases/create_collection.cpp
@@ -1,0 +1,49 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/concern.hh>
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::database db) {
+    ASSERT(!db.has_collection("coll"));
+
+    mongocxx::collection coll = db.create_collection("coll");
+
+    ASSERT(coll);
+
+    ASSERT(db.has_collection("coll"));
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        example(set_rw_concern_majority(guard.get()));
+    }
+}

--- a/examples/api/mongocxx/examples/databases/create_collection_with_options.cpp
+++ b/examples/api/mongocxx/examples/databases/create_collection_with_options.cpp
@@ -1,0 +1,53 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/concern.hh>
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::database db) {
+    ASSERT(!db.has_collection("coll"));
+
+    auto opts = bsoncxx::from_json(R"({"validationLevel": "strict", "validationAction": "error"})");
+    // ... other create options.
+
+    mongocxx::collection coll = db.create_collection("coll", opts.view());
+
+    ASSERT(coll);
+
+    ASSERT(db.has_collection("coll"));
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        example(set_rw_concern_majority(guard.get()));
+    }
+}

--- a/examples/api/mongocxx/examples/databases/drop.cpp
+++ b/examples/api/mongocxx/examples/databases/drop.cpp
@@ -1,0 +1,61 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::client& client) {
+    mongocxx::database db = client["db"];
+
+    {
+        std::vector<std::string> names = client.list_database_names();
+
+        ASSERT(std::count(names.begin(), names.end(), "db") == 1);
+    }
+
+    db.drop();
+
+    {
+        std::vector<std::string> names = client.list_database_names();
+
+        ASSERT(std::count(names.begin(), names.end(), "db") == 0);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, "db"};
+
+        (void)guard.get().create_collection("coll");
+
+        example(client);
+    }
+}

--- a/examples/api/mongocxx/examples/databases/has_collection.cpp
+++ b/examples/api/mongocxx/examples/databases/has_collection.cpp
@@ -1,0 +1,46 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::database db) {
+    ASSERT(db.has_collection("present"));
+    ASSERT(!db.has_collection("missing"));
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        auto db = guard.get();
+
+        (void)db.create_collection("present");
+
+        example(db);
+    }
+}

--- a/examples/api/mongocxx/examples/databases/list_collection_names.cpp
+++ b/examples/api/mongocxx/examples/databases/list_collection_names.cpp
@@ -1,0 +1,73 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/cursor.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/concern.hh>
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::database db) {
+    // Basic usage.
+    {
+        std::vector<std::string> names = db.list_collection_names();
+
+        ASSERT(std::count(names.begin(), names.end(), "a") == 1);  // Present.
+        ASSERT(std::count(names.begin(), names.end(), "b") == 1);  // Present.
+        ASSERT(std::count(names.begin(), names.end(), "c") == 0);  // Missing.
+    }
+
+    // With a filter.
+    {
+        auto filter = bsoncxx::from_json(R"({"name": {"$ne": "b"}})");
+
+        std::vector<std::string> names = db.list_collection_names(filter.view());
+
+        ASSERT(std::count(names.begin(), names.end(), "a") == 1);  // Present.
+        ASSERT(std::count(names.begin(), names.end(), "b") == 0);  // Filtered.
+        ASSERT(std::count(names.begin(), names.end(), "c") == 0);  // Missing.
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        auto db = set_rw_concern_majority(guard.get());
+
+        (void)db.create_collection("a");
+        (void)db.create_collection("b");
+        // (void)db.create_collection("c");
+
+        example(db);
+    }
+}

--- a/examples/api/mongocxx/examples/databases/list_collections.cpp
+++ b/examples/api/mongocxx/examples/databases/list_collections.cpp
@@ -1,0 +1,95 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/json.hpp>
+#include <bsoncxx/string/to_string.hpp>
+#include <bsoncxx/types.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/cursor.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::database db) {
+    int a = 0;
+    int b = 0;
+    int c = 0;
+
+    auto count_fields = [&a, &b, &c](mongocxx::cursor cursor) {
+        a = 0;
+        b = 0;
+        c = 0;
+
+        for (bsoncxx::document::view doc : cursor) {
+            ASSERT(doc["name"]);
+
+            auto name = bsoncxx::string::to_string(doc["name"].get_string().value);
+
+            if (name == "a") {
+                ++a;
+            } else if (name == "b") {
+                ++b;
+            } else if (name == "c") {
+                ++c;
+            }
+        }
+    };
+
+    // Basic usage.
+    {
+        count_fields(db.list_collections());
+
+        ASSERT(a == 1);  // Present.
+        ASSERT(b == 1);  // Present.
+        ASSERT(c == 0);  // Missing.
+    }
+
+    // With a filter.
+    {
+        auto filter = bsoncxx::from_json(R"({"name": {"$ne": "b"}})");
+
+        count_fields(db.list_collections(filter.view()));
+
+        ASSERT(a == 1);  // Present.
+        ASSERT(b == 0);  // Filtered.
+        ASSERT(c == 0);  // Missing.
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    {
+        db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR};
+
+        auto db = guard.get();
+
+        (void)db.create_collection("a");
+        (void)db.create_collection("b");
+        // (void)db.create_collection("c");
+
+        example(db);
+    }
+}

--- a/examples/api/mongocxx/examples/databases/obtain.cpp
+++ b/examples/api/mongocxx/examples/databases/obtain.cpp
@@ -1,0 +1,39 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::client client) {
+    mongocxx::database db = client["db"];
+
+    ASSERT(db);
+    ASSERT(db.name().compare("db") == 0);
+
+    ASSERT(client.database("db").name().compare("db") == 0);
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
+    example(mongocxx::client{mongocxx::uri{}});
+}

--- a/examples/api/mongocxx/examples/databases/rc.cpp
+++ b/examples/api/mongocxx/examples/databases/rc.cpp
@@ -1,0 +1,60 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/read_concern.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/db_lock.hh>
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::database db) {
+    using rc_level = mongocxx::read_concern::level;
+
+    // Default.
+    {
+        mongocxx::read_concern rc = db.read_concern();
+
+        ASSERT(rc.acknowledge_level() == rc_level::k_server_default);
+    }
+
+    // Explicit.
+    {
+        mongocxx::read_concern rc;
+
+        rc.acknowledge_level(rc_level::k_majority);
+        // ... other read concern options.
+
+        db.read_concern(rc);
+
+        ASSERT(db.read_concern() == rc);
+        ASSERT(db.read_concern().acknowledge_level() == rc_level::k_majority);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    ASSERT(client.read_concern() == mongocxx::read_concern{});
+
+    example(client["db"]);
+}

--- a/examples/api/mongocxx/examples/databases/rp.cpp
+++ b/examples/api/mongocxx/examples/databases/rp.cpp
@@ -1,0 +1,57 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/read_preference.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::database db) {
+    // Default.
+    {
+        mongocxx::read_preference rp;
+
+        ASSERT(db.read_preference() == rp);
+        ASSERT(db.read_preference().mode() == mongocxx::read_preference::read_mode::k_primary);
+    }
+
+    // Explicit.
+    {
+        mongocxx::read_preference rp;
+
+        rp.mode(mongocxx::read_preference::read_mode::k_secondary);
+        // ... other read preference options.
+
+        db.read_preference(rp);
+
+        ASSERT(db.read_preference() == rp);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    ASSERT(client.read_preference() == mongocxx::read_preference{});
+
+    example(client["db"]);
+}

--- a/examples/api/mongocxx/examples/databases/run_command.cpp
+++ b/examples/api/mongocxx/examples/databases/run_command.cpp
@@ -1,0 +1,44 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/document/value.hpp>
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::database db) {
+    auto cmd = bsoncxx::from_json(R"({"ping": 1})");
+
+    bsoncxx::document::value reply = db.run_command(cmd.view());
+
+    ASSERT(reply["ok"]);
+    ASSERT(reply["ok"].get_double().value == 1.0);
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    example(client["db"]);
+}

--- a/examples/api/mongocxx/examples/databases/wc.cpp
+++ b/examples/api/mongocxx/examples/databases/wc.cpp
@@ -1,0 +1,63 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/uri.hpp>
+#include <mongocxx/write_concern.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::database db) {
+    using wc_level = mongocxx::write_concern::level;
+
+    // Default.
+    {
+        mongocxx::write_concern wc = db.write_concern();
+
+        ASSERT(wc.acknowledge_level() == wc_level::k_default);
+        ASSERT(wc.timeout() == std::chrono::milliseconds(0));
+    }
+
+    // Explicit.
+    {
+        mongocxx::write_concern wc;
+
+        wc.majority(std::chrono::milliseconds(5000));
+        // ... other write concern options.
+
+        db.write_concern(wc);
+
+        ASSERT(db.write_concern() == wc);
+        ASSERT(db.write_concern().acknowledge_level() == wc_level::k_majority);
+        ASSERT(db.write_concern().timeout() == std::chrono::seconds(5));
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    ASSERT(client.write_concern() == mongocxx::write_concern{});
+
+    example(client["db"]);
+}

--- a/examples/api/mongocxx/examples/instance/basic_usage.cpp
+++ b/examples/api/mongocxx/examples/instance/basic_usage.cpp
@@ -1,0 +1,51 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/instance.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+template <typename... Args>
+void use(Args&&...) {}
+
+// [Example]
+void example() {
+    // Do not use mongocxx library interfaces at this point!
+
+    {
+        // Initialize the MongoDB C++ Driver.
+        mongocxx::instance instance;
+
+        ASSERT(&mongocxx::instance::current() == &instance);
+
+        // Use mongocxx library interfaces at this point.
+        use(mongocxx::client{});
+
+        // Cleanup the MongoDB C++ Driver.
+    }
+
+    // Do not use mongocxx library interfaces at this point!
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_FORKING_COMPONENT() {
+    example();
+}

--- a/examples/api/mongocxx/examples/instance/current.cpp
+++ b/examples/api/mongocxx/examples/instance/current.cpp
@@ -1,0 +1,53 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/instance.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+template <typename... Args>
+void use(Args&&...) {}
+
+// [Example]
+void example() {
+    // Do not use mongocxx library interfaces at this point!
+
+    {
+        // Initialize the MongoDB C++ Driver.
+        auto& instance = mongocxx::instance::current();
+
+        ASSERT(&mongocxx::instance::current() == &instance);
+
+        // Use mongocxx library interfaces at this point.
+        use(mongocxx::client{});
+    }
+
+    // Use mongocxx library interfaces at this point.
+    use(mongocxx::client{});
+}
+
+// Cleanup the MongoDB C++ Driver after returning from `main()` with indeterminate order relative to
+// other objects with static lifetime being destroyed.
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_FORKING_COMPONENT() {
+    example();
+}

--- a/examples/api/mongocxx/examples/instance/destroyed.cpp
+++ b/examples/api/mongocxx/examples/instance/destroyed.cpp
@@ -1,0 +1,50 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/exception/exception.hpp>
+#include <mongocxx/instance.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example() {
+    { mongocxx::instance instance; }  // Initialize and cleanup.
+
+    try {
+        mongocxx::instance instance;  // Throws.
+
+        ASSERT(false && "should not reach this point");
+    } catch (const mongocxx::exception& ex) {
+        ASSERT(ex.code() == mongocxx::error_code::k_cannot_recreate_instance);
+    }
+
+    try {
+        auto& instance = mongocxx::instance::current();  // Throws.
+
+        ASSERT(false && "should not reach this point");
+    } catch (const mongocxx::exception& ex) {
+        ASSERT(ex.code() == mongocxx::error_code::k_instance_destroyed);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_FORKING_COMPONENT() {
+    example();
+}

--- a/examples/api/mongocxx/examples/instance/recreation.cpp
+++ b/examples/api/mongocxx/examples/instance/recreation.cpp
@@ -1,0 +1,48 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/exception/exception.hpp>
+#include <mongocxx/instance.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example() {
+    {
+        mongocxx::instance instance;
+
+        ASSERT(&mongocxx::instance::current() == &instance);
+
+        try {
+            mongocxx::instance another_instance;  // Throws.
+
+            ASSERT(false && "should not reach this point");
+        } catch (const mongocxx::exception& ex) {
+            ASSERT(ex.code() == mongocxx::error_code::k_cannot_recreate_instance);
+        }
+
+        ASSERT(&mongocxx::instance::current() == &instance);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_FORKING_COMPONENT() {
+    example();
+}

--- a/examples/api/mongocxx/examples/logger/basic_usage.cpp
+++ b/examples/api/mongocxx/examples/logger/basic_usage.cpp
@@ -1,0 +1,63 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <utility>
+
+#include <bsoncxx/stdx/string_view.hpp>
+
+#include <mongocxx/instance.hpp>
+#include <mongocxx/logger.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+class example_logger : public mongocxx::logger {
+   private:
+    int* counter_ptr;
+
+   public:
+    explicit example_logger(int* ptr) : counter_ptr(ptr) {}
+
+    void operator()(mongocxx::log_level level,
+                    bsoncxx::stdx::string_view domain,
+                    bsoncxx::stdx::string_view message) noexcept override {
+        ASSERT(level == mongocxx::log_level::k_info);
+        ASSERT(domain.compare("mongocxx") == 0);
+        ASSERT(message.compare("libmongoc logging callback enabled") == 0);
+
+        *counter_ptr += 1;
+    }
+};
+
+void example() {
+    int counter = 0;
+
+    // Use `std::make_unique` with C++14 or newer.
+    auto logger = std::unique_ptr<mongocxx::logger>(new example_logger{&counter});
+
+    // Emit the informational mongocxx log message: "libmongoc logging callback enabled".
+    mongocxx::instance instance{std::move(logger)};
+
+    ASSERT(counter == 1);
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_FORKING_COMPONENT() {
+    example();
+}

--- a/examples/api/mongocxx/examples/logger/to_string.cpp
+++ b/examples/api/mongocxx/examples/logger/to_string.cpp
@@ -1,0 +1,51 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <utility>
+
+#include <bsoncxx/stdx/string_view.hpp>
+
+#include <mongocxx/instance.hpp>
+#include <mongocxx/logger.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example() {
+    bsoncxx::stdx::string_view error = mongocxx::to_string(mongocxx::log_level::k_error);
+    bsoncxx::stdx::string_view critical = mongocxx::to_string(mongocxx::log_level::k_critical);
+    bsoncxx::stdx::string_view warning = mongocxx::to_string(mongocxx::log_level::k_warning);
+    bsoncxx::stdx::string_view message = mongocxx::to_string(mongocxx::log_level::k_message);
+    bsoncxx::stdx::string_view info = mongocxx::to_string(mongocxx::log_level::k_info);
+    bsoncxx::stdx::string_view debug = mongocxx::to_string(mongocxx::log_level::k_debug);
+    bsoncxx::stdx::string_view trace = mongocxx::to_string(mongocxx::log_level::k_trace);
+
+    ASSERT(error.compare("error") == 0);
+    ASSERT(critical.compare("critical") == 0);
+    ASSERT(warning.compare("warning") == 0);
+    ASSERT(message.compare("message") == 0);
+    ASSERT(info.compare("info") == 0);
+    ASSERT(debug.compare("debug") == 0);
+    ASSERT(trace.compare("trace") == 0);
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_FORKING_COMPONENT() {
+    example();
+}

--- a/examples/api/mongocxx/examples/operation_exceptions/operation.cpp
+++ b/examples/api/mongocxx/examples/operation_exceptions/operation.cpp
@@ -1,0 +1,73 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <cstring>
+
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/exception/operation_exception.hpp>
+#include <mongocxx/exception/server_error_code.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::database db) {
+    ASSERT(db.name().compare("db") == 0);
+
+    // The `getParameter` command can only be run in the `admin` database.
+    auto cmd = bsoncxx::from_json(R"({"getParameter": "*"})");
+
+    // This error handling pattern applies to all commands which may throw a
+    // `mongocxx::operation_exception` exception.
+    try {
+        auto reply = db.run_command(cmd.view());
+
+        ASSERT(false && "should not reach this point");
+    } catch (const mongocxx::operation_exception& ex) {
+        ASSERT(ex.code().category() == mongocxx::server_error_category());
+        ASSERT(ex.code().value() == 13);  // Unauthorized
+        ASSERT(std::strstr(ex.what(), "admin") != nullptr);
+
+        if (auto server_error_opt = ex.raw_server_error()) {
+            bsoncxx::document::view server_error = server_error_opt->view();
+
+            ASSERT(server_error["ok"]);
+            ASSERT(server_error["ok"].get_double().value == 0.0);
+
+            ASSERT(server_error["code"]);
+            ASSERT(server_error["code"].get_int32().value == ex.code().value());
+
+            ASSERT(server_error["codeName"]);
+            ASSERT(server_error["errmsg"]);
+            // ... other error fields.
+        }
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    example(client["db"]);
+}

--- a/examples/api/mongocxx/examples/operation_exceptions/regular.cpp
+++ b/examples/api/mongocxx/examples/operation_exceptions/regular.cpp
@@ -1,0 +1,57 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstring>
+
+#include <bsoncxx/json.hpp>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/exception/exception.hpp>
+#include <mongocxx/exception/server_error_code.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example(mongocxx::database db) {
+    ASSERT(db.name().compare("db") == 0);
+
+    // The `getParameter` command can only be run in the `admin` database.
+    auto cmd = bsoncxx::from_json(R"({"getParameter": "*"})");
+
+    // This error handling pattern applies to all commands which may throw a
+    // `mongocxx::operation_exception` exception.
+    try {
+        auto reply = db.run_command(cmd.view());
+
+        ASSERT(false && "should not reach this point");
+    } catch (const mongocxx::exception& ex) {
+        ASSERT(ex.code().category() == mongocxx::server_error_category());
+        ASSERT(ex.code().value() == 13);  // Unauthorized
+        ASSERT(std::strstr(ex.what(), "admin") != nullptr);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
+    mongocxx::client client{mongocxx::uri{}};
+
+    example(client["db"]);
+}

--- a/examples/api/mongocxx/examples/uri/all_options.cpp
+++ b/examples/api/mongocxx/examples/uri/all_options.cpp
@@ -1,0 +1,49 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/stdx/optional.hpp>
+#include <bsoncxx/types.hpp>
+
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example() {
+    mongocxx::uri uri{"mongodb://localhost:27017/?appName=example&tls=true&maxPoolSize=10"};
+
+    bsoncxx::document::view options = uri.options();
+
+    ASSERT(options["appname"]);
+    ASSERT(options["appname"].get_string().value.compare("example") == 0);
+
+    ASSERT(options["tls"]);
+    ASSERT(options["tls"].get_bool().value == true);
+
+    ASSERT(options["maxpoolsize"]);
+    ASSERT(options["maxpoolsize"].get_int32().value == 10);
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
+    example();
+}

--- a/examples/api/mongocxx/examples/uri/basic_usage.cpp
+++ b/examples/api/mongocxx/examples/uri/basic_usage.cpp
@@ -1,0 +1,40 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example() {
+    const auto uri_str = "mongodb://bob:pwd123@localhost:27017/?tls=true";
+
+    mongocxx::uri uri{uri_str};
+
+    ASSERT(uri.to_string() == uri_str);
+
+    ASSERT(uri.username().compare("bob") == 0);
+    ASSERT(uri.password() == "pwd123");
+    ASSERT(uri.tls() == true);
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
+    example();
+}

--- a/examples/api/mongocxx/examples/uri/default_value.cpp
+++ b/examples/api/mongocxx/examples/uri/default_value.cpp
@@ -1,0 +1,40 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example() {
+    const auto uri_str = "mongodb://localhost:27017";
+
+    mongocxx::uri a;
+    mongocxx::uri b{uri_str};
+    mongocxx::uri c{mongocxx::uri::k_default_uri};
+
+    ASSERT(a.to_string() == uri_str);
+    ASSERT(b.to_string() == uri_str);
+    ASSERT(c.to_string() == uri_str);
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
+    example();
+}

--- a/examples/api/mongocxx/examples/uri/hosts.cpp
+++ b/examples/api/mongocxx/examples/uri/hosts.cpp
@@ -1,0 +1,54 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example() {
+    mongocxx::uri uri{"mongodb://127.0.0.1,[::1]:27018,%2Fpath%2Fto.socket:27019"};
+
+    std::vector<mongocxx::uri::host> hosts = uri.hosts();
+
+    ASSERT(hosts.size() == 3u);
+
+    const mongocxx::uri::host& first = hosts[0];
+    const mongocxx::uri::host& second = hosts[1];
+    const mongocxx::uri::host& third = hosts[2];
+
+    ASSERT(first.name == "127.0.0.1");
+    ASSERT(first.port == 27017u);
+    ASSERT(first.family == 0);  // AF_UNSPEC (AP_INET).
+
+    ASSERT(second.name == "::1");
+    ASSERT(second.port == 27018u);
+    ASSERT(second.family != 0);  // AF_INET6.
+
+    ASSERT(third.name == "/path/to.socket");
+    ASSERT(third.port == 27019u);
+    ASSERT(third.family != 0);  // AF_UNIX.
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
+    example();
+}

--- a/examples/api/mongocxx/examples/uri/invalid.cpp
+++ b/examples/api/mongocxx/examples/uri/invalid.cpp
@@ -1,0 +1,59 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/exception/error_code.hpp>
+#include <mongocxx/exception/exception.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example() {
+    try {
+        // Missing `mongodb://`.
+        mongocxx::uri invalid_uri{"invalid"};
+
+        ASSERT(false && "should not reach this point");
+    } catch (const mongocxx::exception& ex) {
+        ASSERT(ex.code() == mongocxx::error_code::k_invalid_uri);
+    }
+
+    try {
+        // Missing `=`.
+        mongocxx::uri invalid_uri{"mongodb://localhost:27017/?tls"};
+
+        ASSERT(false && "should not reach this point");
+    } catch (const mongocxx::exception& ex) {
+        ASSERT(ex.code() == mongocxx::error_code::k_invalid_uri);
+    }
+
+    try {
+        // Missing user credentials when authMechanism is provided.
+        mongocxx::uri invalid_uri{"mongodb://localhost:27017/?authMechanism=SCRAM-SHA-256"};
+
+        ASSERT(false && "should not reach this point");
+    } catch (const mongocxx::exception& ex) {
+        ASSERT(ex.code() == mongocxx::error_code::k_invalid_uri);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
+    example();
+}

--- a/examples/api/mongocxx/examples/uri/optional.cpp
+++ b/examples/api/mongocxx/examples/uri/optional.cpp
@@ -1,0 +1,64 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <vector>
+
+#include <bsoncxx/stdx/string_view.hpp>
+
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example() {
+    {
+        mongocxx::uri uri{"mongodb://localhost:27017/"};
+
+        std::string database = uri.database();
+        ASSERT(database.empty());
+
+        auto try_once_opt = uri.server_selection_try_once();
+        ASSERT(!try_once_opt);
+
+        auto appname_opt = uri.appname();
+        ASSERT(!appname_opt);
+    }
+
+    {
+        mongocxx::uri uri{
+            "mongodb://localhost:27017/dbName?appName=example&serverSelectionTryOnce=false"};
+
+        auto database = uri.database();
+        ASSERT(database.compare("dbName") == 0);
+
+        auto try_once_opt = uri.server_selection_try_once();
+        ASSERT(try_once_opt);
+        ASSERT(*try_once_opt == false);
+
+        auto appname_opt = uri.appname();
+        ASSERT(appname_opt);
+        ASSERT(appname_opt->compare("example") == 0);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
+    example();
+}

--- a/examples/api/mongocxx/examples/uri/userpass.cpp
+++ b/examples/api/mongocxx/examples/uri/userpass.cpp
@@ -1,0 +1,50 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+
+#include <mongocxx/uri.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example() {
+    {
+        mongocxx::uri uri{"mongodb://localhost:27017/"};
+
+        ASSERT(uri.username().empty());
+        ASSERT(uri.password().empty());
+
+        ASSERT(uri.tls() == false);
+    }
+
+    {
+        mongocxx::uri uri{"mongodb://bob:pwd123@localhost:27017/?tls=true"};
+
+        ASSERT(uri.username().compare("bob") == 0);
+        ASSERT(uri.password() == "pwd123");
+
+        ASSERT(uri.tls() == true);
+    }
+}
+// [Example]
+
+}  // namespace
+
+RUNNER_REGISTER_COMPONENT_WITH_INSTANCE() {
+    example();
+}

--- a/examples/api/runner.cpp
+++ b/examples/api/runner.cpp
@@ -30,6 +30,8 @@
 #include <thread>
 #include <vector>
 
+#include <mongocxx/instance.hpp>
+
 #include <examples/macros.hh>
 
 #if !defined(_MSC_VER)
@@ -55,6 +57,7 @@ class runner_type {
 
    private:
     std::vector<component> components;
+    std::vector<component> components_with_instance;
     std::vector<component> forking_components;
     std::minstd_rand::result_type seed = 0u;
     std::minstd_rand gen;
@@ -154,9 +157,19 @@ class runner_type {
     }
 #endif  // !defined(_MSC_VER)
 
+    void run_components_with_instance() {
+        mongocxx::instance instance;
+
+        run_with_jobs(components_with_instance, jobs);
+    }
+
    public:
     void add_component(fn_type fn, const char* name) {
         components.emplace_back(fn, name);
+    }
+
+    void add_component_with_instance(fn_type fn, const char* name) {
+        components_with_instance.emplace_back(fn, name);
     }
 
     void add_forking_component(fn_type fn, const char* name) {
@@ -197,6 +210,8 @@ class runner_type {
                 return EXIT_SUCCESS;  // Return directly from forked processes.
         }
 
+        run_components_with_instance();
+
         return EXIT_SUCCESS;
     }
 };
@@ -207,6 +222,10 @@ runner_type runner;
 
 void runner_register_component(void (*fn)(), const char* name) {
     runner.add_component(fn, name);
+}
+
+void runner_register_component_with_instance(void (*fn)(), const char* name) {
+    runner.add_component_with_instance(fn, name);
 }
 
 void runner_register_forking_component(void (*fn)(), const char* name) {

--- a/examples/api/runner.hh
+++ b/examples/api/runner.hh
@@ -20,6 +20,10 @@ void runner_register_component(void (*fn)(), const char* name);
 
 void runner_register_component_with_instance(void (*fn)(), const char* name);
 
+void runner_register_component_for_single(void (*fn)(), const char* name);
+void runner_register_component_for_replica(void (*fn)(), const char* name);
+void runner_register_component_for_sharded(void (*fn)(), const char* name);
+
 void runner_register_forking_component(void (*fn)(), const char* name);
 
 // Defined by examples/CMakeLists.txt.
@@ -39,6 +43,15 @@ void runner_register_forking_component(void (*fn)(), const char* name);
 #define RUNNER_REGISTER_COMPONENT_WITH_INSTANCE()           \
     RUNNER_REGISTER_COMPONENT_IMPL(EXAMPLES_COMPONENT_NAME, \
                                    ::runner_register_component_with_instance)
+
+#define RUNNER_REGISTER_COMPONENT_FOR_SINGLE() \
+    RUNNER_REGISTER_COMPONENT_IMPL(EXAMPLES_COMPONENT_NAME, ::runner_register_component_for_single)
+
+#define RUNNER_REGISTER_COMPONENT_FOR_REPLICA() \
+    RUNNER_REGISTER_COMPONENT_IMPL(EXAMPLES_COMPONENT_NAME, ::runner_register_component_for_replica)
+
+#define RUNNER_REGISTER_COMPONENT_FOR_SHARDED() \
+    RUNNER_REGISTER_COMPONENT_IMPL(EXAMPLES_COMPONENT_NAME, ::runner_register_component_for_sharded)
 
 #define RUNNER_REGISTER_FORKING_COMPONENT() \
     RUNNER_REGISTER_COMPONENT_IMPL(EXAMPLES_COMPONENT_NAME, ::runner_register_forking_component)

--- a/examples/api/runner.hh
+++ b/examples/api/runner.hh
@@ -16,15 +16,23 @@
 
 #include <examples/macros.hh>
 
-void runner_register_fn(void (*fn)());
+void runner_register_component(void (*fn)(), const char* name);
+
+void runner_register_forking_component(void (*fn)(), const char* name);
 
 // Defined by examples/CMakeLists.txt.
 #if !defined(EXAMPLES_COMPONENT_NAME)
 #error "EXAMPLES_COMPONENT_NAME is not defined!"
 #endif  // !defined(EXAMPLES_COMPONENT_NAME)
 
-#define RUNNER_REGISTER_COMPONENT()                                                         \
-    static void EXAMPLES_CONCAT(EXAMPLES_COMPONENT_NAME, _entry_point)(void);               \
-    static int EXAMPLES_CONCAT(EXAMPLES_COMPONENT_NAME, _registerator) =                    \
-        (::runner_register_fn(&EXAMPLES_CONCAT(EXAMPLES_COMPONENT_NAME, _entry_point)), 0); \
-    static void EXAMPLES_CONCAT(EXAMPLES_COMPONENT_NAME, _entry_point)(void)
+#define RUNNER_REGISTER_COMPONENT_IMPL(name, register_fn)                                         \
+    static void EXAMPLES_CONCAT3(name, _entry_point_, __LINE__)(void);                            \
+    static int EXAMPLES_CONCAT2(name, _registrator) =                                             \
+        ((register_fn)(&EXAMPLES_CONCAT3(name, _entry_point_, __LINE__), EXAMPLES_STR(name)), 0); \
+    static void EXAMPLES_CONCAT3(EXAMPLES_COMPONENT_NAME, _entry_point_, __LINE__)(void)
+
+#define RUNNER_REGISTER_COMPONENT() \
+    RUNNER_REGISTER_COMPONENT_IMPL(EXAMPLES_COMPONENT_NAME, ::runner_register_component)
+
+#define RUNNER_REGISTER_FORKING_COMPONENT() \
+    RUNNER_REGISTER_COMPONENT_IMPL(EXAMPLES_COMPONENT_NAME, ::runner_register_forking_component)

--- a/examples/api/runner.hh
+++ b/examples/api/runner.hh
@@ -33,6 +33,9 @@ void runner_register_forking_component(void (*fn)(), const char* name);
 #error "EXAMPLES_COMPONENT_NAME is not defined!"
 #endif  // !defined(EXAMPLES_COMPONENT_NAME)
 
+#define EXAMPLES_COMPONENT_NAME_STR EXAMPLES_COMPONENT_NAME_STR_IMPL(EXAMPLES_COMPONENT_NAME)
+#define EXAMPLES_COMPONENT_NAME_STR_IMPL(name) EXAMPLES_STR(name)
+
 #define RUNNER_REGISTER_COMPONENT_IMPL(name, register_fn)                                 \
     static void EXAMPLES_CONCAT3(name, _entry_point_, __LINE__)(void);                    \
     static void EXAMPLES_CONCAT4(name, _entry_point_, __LINE__, _guarded)(void) try {     \

--- a/examples/api/runner.hh
+++ b/examples/api/runner.hh
@@ -18,6 +18,8 @@
 
 void runner_register_component(void (*fn)(), const char* name);
 
+void runner_register_component_with_instance(void (*fn)(), const char* name);
+
 void runner_register_forking_component(void (*fn)(), const char* name);
 
 // Defined by examples/CMakeLists.txt.
@@ -33,6 +35,10 @@ void runner_register_forking_component(void (*fn)(), const char* name);
 
 #define RUNNER_REGISTER_COMPONENT() \
     RUNNER_REGISTER_COMPONENT_IMPL(EXAMPLES_COMPONENT_NAME, ::runner_register_component)
+
+#define RUNNER_REGISTER_COMPONENT_WITH_INSTANCE()           \
+    RUNNER_REGISTER_COMPONENT_IMPL(EXAMPLES_COMPONENT_NAME, \
+                                   ::runner_register_component_with_instance)
 
 #define RUNNER_REGISTER_FORKING_COMPONENT() \
     RUNNER_REGISTER_COMPONENT_IMPL(EXAMPLES_COMPONENT_NAME, ::runner_register_forking_component)

--- a/examples/macros.hh
+++ b/examples/macros.hh
@@ -23,8 +23,13 @@
 #define EXAMPLES_CDECL
 #endif
 
-#define EXAMPLES_CONCAT(a, b) EXAMPLES_CONCAT_1(a, b)
-#define EXAMPLES_CONCAT_1(a, b) a##b
+#define EXAMPLES_CONCAT2(a, b) EXAMPLES_CONCAT_IMPL(a, b)
+#define EXAMPLES_CONCAT3(a, b, c) EXAMPLES_CONCAT2(EXAMPLES_CONCAT2(a, b), c)
+#define EXAMPLES_CONCAT4(a, b, c, d) \
+    EXAMPLES_CONCAT2(EXAMPLES_CONCAT2(a, b), EXAMPLES_CONCAT2(c, d))
+#define EXAMPLES_CONCAT_IMPL(a, b) a##b
+
+#define EXAMPLES_STR(e) #e
 
 // Unconditionally define `assert()` for examples.
 #define ASSERT(...)                                                                           \

--- a/src/mongocxx/include/mongocxx/doc.hpp
+++ b/src/mongocxx/include/mongocxx/doc.hpp
@@ -99,6 +99,7 @@
 /// @li @subpage topic-mongocxx-examples-logger
 /// @li @subpage topic-mongocxx-examples-uri
 /// @li @subpage topic-mongocxx-examples-clients
+/// @li @subpage topic-mongocxx-examples-databases
 ///
 
 ///
@@ -129,6 +130,13 @@
 /// @brief How to use clients and client pools.
 /// @tableofcontents
 /// @include{doc} api/mongocxx/examples/clients.md
+///
+
+///
+/// @page topic-mongocxx-examples-databases Databases
+/// @brief How to obtain and use databases.
+/// @tableofcontents
+/// @include{doc} api/mongocxx/examples/databases.md
 ///
 
 ///

--- a/src/mongocxx/include/mongocxx/doc.hpp
+++ b/src/mongocxx/include/mongocxx/doc.hpp
@@ -98,6 +98,7 @@
 /// @li @subpage topic-mongocxx-examples-instance
 /// @li @subpage topic-mongocxx-examples-logger
 /// @li @subpage topic-mongocxx-examples-uri
+/// @li @subpage topic-mongocxx-examples-clients
 ///
 
 ///
@@ -121,6 +122,13 @@
 /// @see [Connection Strings (MongoDB
 /// Manual)](https://www.mongodb.com/docs/manual/reference/connection-string/)
 /// @include{doc} api/mongocxx/examples/uri.md
+///
+
+///
+/// @page topic-mongocxx-examples-clients Clients
+/// @brief How to use clients and client pools.
+/// @tableofcontents
+/// @include{doc} api/mongocxx/examples/clients.md
 ///
 
 ///

--- a/src/mongocxx/include/mongocxx/doc.hpp
+++ b/src/mongocxx/include/mongocxx/doc.hpp
@@ -97,6 +97,7 @@
 /// @brief Examples of how to use the mongocxx library.
 /// @li @subpage topic-mongocxx-examples-instance
 /// @li @subpage topic-mongocxx-examples-logger
+/// @li @subpage topic-mongocxx-examples-uri
 ///
 
 ///
@@ -111,6 +112,15 @@
 /// @brief How to use a custom logger with a MongoDB C++ Driver instance.
 /// @tableofcontents
 /// @include{doc} api/mongocxx/examples/logger.md
+///
+
+///
+/// @page topic-mongocxx-examples-uri URI
+/// @brief How to create and use URIs.
+/// @tableofcontents
+/// @see [Connection Strings (MongoDB
+/// Manual)](https://www.mongodb.com/docs/manual/reference/connection-string/)
+/// @include{doc} api/mongocxx/examples/uri.md
 ///
 
 ///

--- a/src/mongocxx/include/mongocxx/doc.hpp
+++ b/src/mongocxx/include/mongocxx/doc.hpp
@@ -101,6 +101,7 @@
 /// @li @subpage topic-mongocxx-examples-clients
 /// @li @subpage topic-mongocxx-examples-databases
 /// @li @subpage topic-mongocxx-examples-collections
+/// @li @subpage topic-mongocxx-examples-operation-exceptions
 ///
 
 ///
@@ -145,6 +146,13 @@
 /// @brief How to obtain and use collections.
 /// @tableofcontents
 /// @include{doc} api/mongocxx/examples/collections.md
+///
+
+///
+/// @page topic-mongocxx-examples-operation-exceptions Operation Exceptions
+/// @brief How to handle exceptions thrown by database and collection operations.
+/// @tableofcontents
+/// @include{doc} api/mongocxx/examples/operation_exceptions.md
 ///
 
 ///

--- a/src/mongocxx/include/mongocxx/doc.hpp
+++ b/src/mongocxx/include/mongocxx/doc.hpp
@@ -96,6 +96,7 @@
 /// @page topic-mongocxx-examples How-To Guides
 /// @brief Examples of how to use the mongocxx library.
 /// @li @subpage topic-mongocxx-examples-instance
+/// @li @subpage topic-mongocxx-examples-logger
 ///
 
 ///
@@ -103,6 +104,13 @@
 /// @brief How to use a MongoDB C++ Driver instance.
 /// @tableofcontents
 /// @include{doc} api/mongocxx/examples/instance.md
+///
+
+///
+/// @page topic-mongocxx-examples-logger Logger
+/// @brief How to use a custom logger with a MongoDB C++ Driver instance.
+/// @tableofcontents
+/// @include{doc} api/mongocxx/examples/logger.md
 ///
 
 ///

--- a/src/mongocxx/include/mongocxx/doc.hpp
+++ b/src/mongocxx/include/mongocxx/doc.hpp
@@ -95,6 +95,14 @@
 ///
 /// @page topic-mongocxx-examples How-To Guides
 /// @brief Examples of how to use the mongocxx library.
+/// @li @subpage topic-mongocxx-examples-instance
+///
+
+///
+/// @page topic-mongocxx-examples-instance Instance
+/// @brief How to use a MongoDB C++ Driver instance.
+/// @tableofcontents
+/// @include{doc} api/mongocxx/examples/instance.md
 ///
 
 ///

--- a/src/mongocxx/include/mongocxx/doc.hpp
+++ b/src/mongocxx/include/mongocxx/doc.hpp
@@ -100,6 +100,7 @@
 /// @li @subpage topic-mongocxx-examples-uri
 /// @li @subpage topic-mongocxx-examples-clients
 /// @li @subpage topic-mongocxx-examples-databases
+/// @li @subpage topic-mongocxx-examples-collections
 ///
 
 ///
@@ -137,6 +138,13 @@
 /// @brief How to obtain and use databases.
 /// @tableofcontents
 /// @include{doc} api/mongocxx/examples/databases.md
+///
+
+///
+/// @page topic-mongocxx-examples-collections Collections
+/// @brief How to obtain and use collections.
+/// @tableofcontents
+/// @include{doc} api/mongocxx/examples/collections.md
 ///
 
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
@@ -49,11 +49,14 @@ class uri {
         std::int32_t family;
     };
 
+    ///
+    /// The default URI string: `"mongodb://localhost:27017"`.
+    ///
     static MONGOCXX_ABI_EXPORT const std::string k_default_uri;
 
     ///
     /// Constructs a uri from an optional MongoDB URI string. If no URI string is specified,
-    /// uses the default URI string, 'mongodb://localhost:27017'.
+    /// uses the default URI string: `"mongodb://localhost:27017"`.
     ///
     /// @see
     /// - https://mongoc.org/libmongoc/current/mongoc_uri_t.html


### PR DESCRIPTION
## Summary

Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1208. Partially resolves CXX-3082. Verified by [this patch](https://spruce.mongodb.com/version/66fc41855ef8c00007694198).

As before, API docs must be generated locally for review in their displayed state.

Adds comprehensive examples for _most_ mongocxx interfaces. Due to the size of mongocxx (this PR is already the same size as the PR for bsoncxx despite being incomplete), this PR is posted as a Part 1? for mongocxx to allow for pipelining changes for a followup PR during review of this PR.

Examples for the following are planned but not yet ready for review (pipelined):

- Databases Error Handling (that are not operation exceptions)
- Collections Error Handling (that are not operation exceptions)
- Change Streams
- Sessions
- Transactions

Examples for the following and _not_ planned and deliberately skipped:

- CSFLE
- GridFS Buckets
- Range Indexes
- Search Indexes

See "Regarding Skipped Examples" below for more detail.

## API Examples Runner

To accomodate the mongocxx library's use of `mongocxx::instance` for global initialization and cleanup, the API examples runner requires some additional features not present in https://github.com/mongodb/mongo-cxx-driver/pull/1208.

There are now three different "kinds" of components:

- Normal: does not require a mongocxx instance (i.e. bsoncxx API examples).
- Forking: requires the component to be executed in its own process. This is used by `mongocxx::instance` examples that create-and-destroy their own mongocxx instance objects.
- With Instance: requires a mongocxx instance, but does not create or destroy one itself (most mongocxx examples).
    - For Server: a subset of "with instance" components that require a live connection to a MongoDB server.

"Normal" components are executed in the same way they were in https://github.com/mongodb/mongo-cxx-driver/pull/1208 (with some minor improvements to support reuse + handle `--jobs 1` better).

"Forking" components execute each component in its own forked process. This permits creating and destroying a `mongocxx::instance` object in each forking component without affecting other components (since only one instance object is allowed per application). When `fork()` is not available (specifically, with MSVC), these components are skipped entirely.

"With Instance" components execute each component just like normal components, but are executed _after_ creating a single `mongocxx::instance` object. This instance object is shared across all subsequently executed components such that they do not require repeatedly invoking `mongocxx::instance::current()` to handle indeterminate execution ordering (as is currently done in the test suite).

> [!IMPORTANT]
> "With Instance" components must be executed _after_ executing forking components. Otherwise, forking components will observe an instance object was already created before the fork takes place.

"For Server" components are a subset of "With Instance" components that are only executed if a live server is available. To maximize coverage, components that require a single server topology are also executed against replica and sharded topologies, and components that require a replica set are also executed against sharded topologies (coverage size: Single > Replica > Sharded). This behavior can be changed or removed if deemed unnecessary.

> [!NOTE]
> Currently, all examples only require a single server topology. Examples which depend on a specific topology are likely unnecessary and are better left to the test suite.

## DB Locker

The API examples are deliberately executed concurrently (for performance) and in a random order (for independence). To avoid examples that operate on a given database from conflicting with one another, the `db_lock` utility is used to guard access to a given database by name. This is implemented as a `db_name -> db_mutex` map. The access of the map itself also requires a mutex that is held only for as long as is required to obtain a `db_mutex` lock.

```cpp
{
  db_lock guard{client, "db"}; // Guard access to "db" for purpose of this example.
  example(client);
}
```
```cpp
void example(mongocxx::client& client) {
  auto db = client["db"]; // Use in example code block without concern.
  // ...
}
```

> [!NOTE]
> The high lock contention of the map mutex is not expected to be a significant problem for the purpose of executing API examples, as most time will likely be spent locking a `db_mutex` and running example code blocks. `db_mutex` locks for components using unique database names could be elided, but this was deliberately not done to keep things simple and easier to maintain.

This permits examples to use common names in examples (i.e. `client["db"]`, `db["coll"]`) without concern for concurrency database access problems. When not required by the example code block, the database name can be made unique to the component via `EXAMPLES_COMPONENT_NAME_STR`. This helps avoid unnecessary `db_mutex` lock contention.

```cpp
{
  db_lock guard{client, EXAMPLES_COMPONENT_NAME_STR}; // Unique database name for this example.
  example(guard.get());
}
```
```cpp
// Example code does not need to reveal the name of the database.
void example(mongocxx::database db) {
  auto coll = db["coll"]; // Use in example code block without concern.
  // ...
}
```

For convenience, `db_lock` drops the database on lock _and_ unlock to ensure every example component is given a clean slate to work with. This permits easily setting up collections and documents for use by the example code block.

## Read/Write Concern

To ensure examples behave correctly regardless of server topology, a convenience function `set_rw_concern_majority()` is used to set the read concern and write concern for databases and collections to "majority". This ensures any examples that expect writes to be reliably observed by subsequent reads will work even for replica sets and sharded clusters without requiring boilerplate in the example code block.

## Writing mongocxx Examples

Given the large scope of interfaces and overloads in mongocxx, some shortcuts are taken to avoid redundancy and verbosity of examples:

- A "representative example" is used for function overloads and class types that fulfill a similar purpose using a similar code pattern, e.g. bulk write models, APM callbacks, etc. (author's judgement). The API documentation itself may be used to translate and extend representative examples to related types/overloads.
- Some examples return a value from the example code block for further correctness validation that is not required by the example code block itself. This is an extension of the parameter(s) used by example code block and is not expected to impact the readability of examples for regular users.
- "Inline" code (e.g. temporary objects, method chaining, etc.) and `auto` are usually avoided in example code to aid in interface clarity, unless it is not directly related to the primary function/task itself. This is best observed in example code blocks that have both a "Basic Usage" block (little-to-no inline code) and a subsequent "With Options" block (inline code for already-demonstrated routines), as well as for bsoncxx interface usage in mongocxx example code blocks.

Error handling for databases and collections for interfaces that may throw a `mongocxx::operation_exception` exception have been summarized in a dedicated "Operation Exceptions" page. The page also includes an important warning regarding `mongocxx::server_error_category()` deficiencies (overloaded error codes: CXX-834) as well as a recommendation to use `mongocxx::exception` instead for forward-compatibility (error handling redesign: CXX-2377).

## Regarding Skipped Examples

- CSFLE: despite high value for users, writing even "simple" examples for these interfaces is incredibly difficult. I have deliberately elected to skip these examples in the interest of time and task priorities.
    - The error code and exception hierarchy situation (CXX-2377) is hurting CSFLE interfaces the most: an error code thrown by a single function may come from the server, libmongoc, _or_ libmongocrypt, with no means of reliably discerning them from one another (see: `mongocxx/examples/clients/create/single/options/auto_encryption.cpp`). 😢
- GridFS Buckets: low priority / low value to users?
- Range Indexes: requires Atlas. Examples may need to be unverified (not executed) if written.
- Search Indexes: requires Atlas. Examples may need to be unverified (not executed) if written.

These examples may be reconsidered for inclusion if their value to users is sufficiently high.

## Miscellaneous

- Added missing docs for `mongocxx::v_noabi::uri::k_default_uri` (was not referencable by Doxygen).
- Added a temporary workaround for CDRIVER-5732 in "big string" examples.
- Added an uncaught exception handler for components to make identifying the failing component easier when executed as a thread.
- Runs components in current thread rather than per-thread give `--jobs 1` for simplicity and improved debugging experience.