### PR TITLE
note 3.11.0 drops server 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,12 +40,12 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ### Deprecated
 
-- Support for MongoDB Server 3.6. See [MongoDB Software Lifecycle Schedules](https://www.mongodb.com/legal/support-policy/lifecycles).
 - The `bsoncxx/util/functor.hpp` header.
 - The `bsoncxx::util` namespace.
 
 ### Removed
 
+- Support for MongoDB Server 3.6. See [MongoDB Software Lifecycle Schedules](https://www.mongodb.com/legal/support-policy/lifecycles).
 - Export of private member functions in the bsoncxx ABI:
   - `bsoncxx::v_noabi::types::bson_value::value::value(const uint8_t*, uint32_t, uint32_t, uint32_t)`
   - `bsoncxx::v_noabi::types::bson_value::view::_init(void*)`


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/mongo-cxx-driver/pull/1217

I missed that C++ driver 3.11.0 drops support (not just deprecates) of MongoDB 3.6 due to raising the required C driver to 1.28.0. C driver 1.28.0 dropped 3.6 as part of CDRIVER-4815.