### PR TITLE
Post-release augmented SBOM updates

### DIFF
--- a/etc/augmented.sbom.json
+++ b/etc/augmented.sbom.json
@@ -27,16 +27,16 @@
       "version": "v1.1.0"
     },
     {
-      "bom-ref": "pkg:github/mongodb/mongo-c-driver@v1.25.0",
+      "bom-ref": "pkg:github/mongodb/mongo-c-driver@v1.28.0",
       "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/v1.25.0.tar.gz"
+          "url": "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/v1.28.0.tar.gz"
         },
         {
           "type": "website",
-          "url": "https://github.com/mongodb/mongo-c-driver/tree/v1.25.0"
+          "url": "https://github.com/mongodb/mongo-c-driver/tree/v1.28.0"
         }
       ],
       "group": "mongodb",
@@ -48,9 +48,9 @@
         }
       ],
       "name": "mongo-c-driver",
-      "purl": "pkg:github/mongodb/mongo-c-driver@v1.25.0",
+      "purl": "pkg:github/mongodb/mongo-c-driver@v1.28.0",
       "type": "library",
-      "version": "v1.25.0"
+      "version": "v1.28.0"
     }
   ],
   "dependencies": [
@@ -58,11 +58,11 @@
       "ref": "pkg:github/mnmlstc/core@v1.1.0"
     },
     {
-      "ref": "pkg:github/mongodb/mongo-c-driver@v1.25.0"
+      "ref": "pkg:github/mongodb/mongo-c-driver@v1.28.0"
     }
   ],
   "metadata": {
-    "timestamp": "2024-06-05T21:16:58.419485+00:00",
+    "timestamp": "2024-09-30T15:53:24.743787+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -106,7 +106,7 @@
     ]
   },
   "serialNumber": "urn:uuid:dd68fbb0-f77c-4bb9-90cd-606dd854f301",
-  "version": 1,
+  "version": 3,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",


### PR DESCRIPTION
Detected by the silk task after the pre-release CHANGELOG updates. Updates to release instructions to account for this step incoming in a followup PR.