### PR TITLE
Make the `aws cp scan` command step for "upload scan build" optional

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -678,6 +678,7 @@ functions:
       - command: subprocess.exec
         params:
           silent: true
+          optional: true
           working_dir: mongo-cxx-driver
           binary: bash
           env:


### PR DESCRIPTION
Attempt to resolve [scan-build matrix task failures](https://spruce.mongodb.com/version/mongo_cxx_driver_latest_release_e3665ae00d1293df85bd8f3185bb9d55410fd212/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&variant=%5Escan-build-matrix%24) in the EVG release branch project. Assumption is that `aws cp scan` fails due to absence of any files to upload within the `scan` directory when no bugs are found.