### PR TITLE
Use SKIP() in mongocxx::spec::run_tests_in_suite

### DIFF
--- a/src/mongocxx/test/spec/util.cpp
+++ b/src/mongocxx/test/spec/util.cpp
@@ -593,10 +593,10 @@ void run_tests_in_suite(std::string ev, test_runner cb, std::set<std::string> un
     while (std::getline(test_files, test_file)) {
         DYNAMIC_SECTION(test_file) {
             if (unsupported_tests.find(test_file) != unsupported_tests.end()) {
-                WARN("Skipping unsupported test file: " << test_file);
-            } else {
-                cb(path + "/" + test_file);
+                SKIP("Skipping unsupported test file: " << test_file);
             }
+
+            cb(path + "/" + test_file);
         }
     }
 }


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/issues/1206. Missed an instance of `WARN()` being used for skipping.