### PR TITLE
doxygen: address unresolved reference warnings in range.hpp

### DIFF
--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/range.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/range.hpp
@@ -33,11 +33,11 @@ namespace options {
 /// @brief `RangeOpts` specifies index options for a Queryable Encryption field supporting
 /// "range" queries.
 ///
-/// @note @ref min, @ref max, @ref trimFactor, @ref sparsity, and @ref precision must match the
-/// values set in the encryptedFields of the destination collection.
+/// @note `min`, `max`, `trimFactor`, `sparsity`, and `precision` must match the values set in the
+/// encryptedFields of the destination collection.
 ///
-/// @note For double and decimal128, @ref min, @ref max, and @ref precision must all be set, or all
-/// be unset.
+/// @note For double and decimal128, `min`, `max`, and `precision` must all be set, or all be
+/// unset.
 ///
 class range {
    public:


### PR DESCRIPTION
A small followup to https://github.com/mongodb/mongo-cxx-driver/commit/0f990cab33d9b9d4a2ddeb8038ba9221db4fcdc2 to address the following Doxygen warning:

```
src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/range.hpp:36: warning: unable to resolve reference to 'trimFactor' for \ref command
```

Demotes mentions of encryptedFields members to inline monospace text rather than ambiguous or non-existent references to Doxygen entities. (Note: the valid references happen to link to the getter overload for each member function.)

Before:

![image](https://github.com/user-attachments/assets/03f910f8-e351-4028-bd07-f65826bb11b7)

After:

![image](https://github.com/user-attachments/assets/f65f6c2d-75d4-4d81-a660-077c8620d37e)
