### PR TITLE
CXX-3082 use from_json and make_array to simplify expectation expressions

### DIFF
--- a/examples/api/bsoncxx/examples/bson_documents/create_array/builder_append.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_array/builder_append.cpp
@@ -17,7 +17,6 @@
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/builder/basic/array.hpp>
-#include <bsoncxx/types.hpp>
 
 #include <examples/api/runner.hh>
 #include <examples/macros.hh>
@@ -30,12 +29,9 @@ void example() {
     builder.append(std::int32_t{1});
     builder.append(2.0);
     builder.append("three");
-    bsoncxx::array::value owner = builder.extract();
-    bsoncxx::array::view arr = owner.view();
+    bsoncxx::array::value arr = builder.extract();
 
-    EXPECT(arr[0].get_int32().value == 1);
-    EXPECT(arr[1].get_double().value == 2.0);
-    EXPECT(arr[2].get_string().value.compare("three") == 0);
+    EXPECT(arr.view() == bsoncxx::builder::basic::make_array(1, 2.0, "three"));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_array/builder_basic.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_array/builder_basic.cpp
@@ -17,7 +17,6 @@
 #include <bsoncxx/array/value.hpp>
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/builder/basic/array.hpp>
-#include <bsoncxx/types.hpp>
 
 #include <examples/api/runner.hh>
 #include <examples/macros.hh>
@@ -28,12 +27,9 @@ namespace {
 void example() {
     bsoncxx::builder::basic::array builder;
     builder.append(std::int32_t{1}, 2.0, "three");
-    bsoncxx::array::value owner = builder.extract();
-    bsoncxx::array::view arr = owner.view();
+    bsoncxx::array::value arr = builder.extract();
 
-    EXPECT(arr[0].get_int32().value == 1);
-    EXPECT(arr[1].get_double().value == 2.0);
-    EXPECT(arr[2].get_string().value.compare("three") == 0);
+    EXPECT(arr.view() == bsoncxx::builder::basic::make_array(1, 2.0, "three"));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_array/builder_bson_type.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_array/builder_bson_type.cpp
@@ -28,16 +28,9 @@ void example() {
     bsoncxx::types::b_double b{2.0};
     bsoncxx::types::b_string c{"three"};
 
-    bsoncxx::array::value owner = bsoncxx::builder::basic::make_array(a, b, c);
-    bsoncxx::array::view arr = owner.view();
+    bsoncxx::array::value arr = bsoncxx::builder::basic::make_array(a, b, c);
 
-    EXPECT(arr[0].type() == bsoncxx::type::k_int32);
-    EXPECT(arr[1].type() == bsoncxx::type::k_double);
-    EXPECT(arr[2].type() == bsoncxx::type::k_string);
-
-    EXPECT(arr[0].get_int32().value == 1);
-    EXPECT(arr[1].get_double().value == 2.0);
-    EXPECT(arr[2].get_string().value.compare("three") == 0);
+    EXPECT(arr.view() == bsoncxx::builder::basic::make_array(1, 2.0, "three"));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_array/builder_bson_value.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_array/builder_bson_value.cpp
@@ -18,7 +18,6 @@
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
-#include <bsoncxx/types.hpp>
 #include <bsoncxx/types/bson_value/value.hpp>
 
 #include <examples/api/runner.hh>
@@ -36,17 +35,10 @@ void example() {
         "three",
     };
 
-    bsoncxx::array::value owner =
+    bsoncxx::array::value arr =
         bsoncxx::builder::basic::make_array(values[0], values[1], values[2]);
-    bsoncxx::array::view arr = owner.view();
 
-    EXPECT(arr[0].type() == bsoncxx::type::k_int32);
-    EXPECT(arr[1].type() == bsoncxx::type::k_double);
-    EXPECT(arr[2].type() == bsoncxx::type::k_string);
-
-    EXPECT(arr[0].get_value() == values[0]);
-    EXPECT(arr[1].get_value() == values[1]);
-    EXPECT(arr[2].get_value() == values[2]);
+    EXPECT(arr.view() == bsoncxx::builder::basic::make_array(1, 2.0, "three"));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_array/builder_raw_value.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_array/builder_raw_value.cpp
@@ -20,7 +20,6 @@
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/document/value.hpp>
-#include <bsoncxx/types.hpp>
 
 #include <examples/api/runner.hh>
 #include <examples/macros.hh>
@@ -36,11 +35,9 @@ void example(const std::uint8_t* data, std::size_t length) {
     std::copy_n(data, length, raw);
 
     deleter_type deleter = [](std::uint8_t* data) { delete[] data; };
-    bsoncxx::array::value owner{raw, length, deleter};
-    bsoncxx::array::view arr = owner.view();
+    bsoncxx::array::value arr{raw, length, deleter};
 
-    EXPECT(arr[0].get_int32().value == 1);
-    EXPECT(arr[1].get_int32().value == 2);
+    EXPECT(arr.view() == bsoncxx::builder::basic::make_array(1, 2));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_array/builder_raw_view.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_array/builder_raw_view.cpp
@@ -18,7 +18,6 @@
 #include <bsoncxx/array/view.hpp>
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/document/value.hpp>
-#include <bsoncxx/types.hpp>
 
 #include <examples/api/runner.hh>
 #include <examples/macros.hh>
@@ -30,8 +29,7 @@ namespace {
 void example(const std::uint8_t* data, std::size_t length) {
     bsoncxx::array::view arr{data, length};
 
-    EXPECT(arr[0].get_int32().value == 1);
-    EXPECT(arr[1].get_int32().value == 2);
+    EXPECT(arr == bsoncxx::builder::basic::make_array(1, 2));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_array/builder_sub_array.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_array/builder_sub_array.cpp
@@ -27,14 +27,12 @@ namespace {
 void example() {
     using bsoncxx::builder::basic::make_array;
 
-    bsoncxx::array::value owner = make_array(make_array(std::int32_t{1}, std::int64_t{2}));
+    bsoncxx::array::value arr = make_array(1, 2.0, "three");
+
+    bsoncxx::array::value owner = make_array(arr.view());
     bsoncxx::array::view v = owner.view()[0].get_array().value;
 
-    EXPECT(v[0].type() == bsoncxx::type::k_int32);
-    EXPECT(v[1].type() == bsoncxx::type::k_int64);
-
-    EXPECT(v[0].get_int32().value == 1);
-    EXPECT(v[1].get_int64().value == 2);
+    EXPECT(v == arr.view());
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_array/builder_sub_array_append.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_array/builder_sub_array_append.cpp
@@ -25,19 +25,18 @@ namespace {
 
 // [Example]
 void example() {
+    using bsoncxx::builder::basic::make_array;
+
     std::int32_t values[] = {1, 2, 3};
 
-    bsoncxx::array::value owner =
-        bsoncxx::builder::basic::make_array([&](bsoncxx::builder::basic::sub_array arr) {
-            for (int i = 0; i < 3; ++i) {
-                arr.append(values[i]);
-            }
-        });
+    bsoncxx::array::value owner = make_array([&](bsoncxx::builder::basic::sub_array arr) {
+        for (int i = 0; i < 3; ++i) {
+            arr.append(values[i]);
+        }
+    });
     bsoncxx::array::view v = owner.view()[0].get_array().value;
 
-    EXPECT(v[0].get_int32().value == 1);
-    EXPECT(v[1].get_int32().value == 2);
-    EXPECT(v[2].get_int32().value == 3);
+    EXPECT(v == make_array(1, 2, 3));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_array/builder_sub_document.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_array/builder_sub_document.cpp
@@ -16,6 +16,8 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/document/view.hpp>
+#include <bsoncxx/json.hpp>
+#include <bsoncxx/types.hpp>
 
 #include <examples/api/runner.hh>
 #include <examples/macros.hh>
@@ -28,10 +30,12 @@ void example() {
     using bsoncxx::builder::basic::make_array;
     using bsoncxx::builder::basic::make_document;
 
-    bsoncxx::array::value owner = make_array(make_document(kvp("key", "value")));
+    bsoncxx::document::value subdoc = make_document(kvp("key", "value"));
+
+    bsoncxx::array::value owner = make_array(subdoc.view());
     bsoncxx::document::view v = owner.view()[0].get_document().value;
 
-    EXPECT(v["key"].get_string().value.compare("value") == 0);
+    EXPECT(v == subdoc.view());
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_array/builder_sub_document_append.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_array/builder_sub_document_append.cpp
@@ -19,6 +19,7 @@
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/builder/basic/sub_document.hpp>
 #include <bsoncxx/document/view.hpp>
+#include <bsoncxx/json.hpp>
 
 #include <examples/api/runner.hh>
 #include <examples/macros.hh>
@@ -40,9 +41,7 @@ void example() {
         });
     bsoncxx::document::view v = owner.view()[0].get_document().value;
 
-    EXPECT(v["a"].get_int32().value == 1);
-    EXPECT(v["b"].get_int32().value == 2);
-    EXPECT(v["c"].get_int32().value == 3);
+    EXPECT(v == bsoncxx::from_json(R"({"a": 1, "b": 2, "c": 3})"));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_array/json_sub_array.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_array/json_sub_array.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/array/view.hpp>
+#include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/types.hpp>
@@ -24,15 +25,14 @@ namespace {
 
 // [Example]
 void example() {
-    bsoncxx::document::value owner = bsoncxx::from_json(R"(
+    bsoncxx::document::value doc = bsoncxx::from_json(R"(
         [
-            [1, 2]
+            [1, 2.0, "three"]
         ]
     )");
-    bsoncxx::array::view sub = owner.view()["0"].get_array().value;
+    bsoncxx::array::view sub = doc.view()["0"].get_array().value;
 
-    EXPECT(sub[0].get_int32().value == 1);
-    EXPECT(sub[1].get_int32().value == 2);
+    EXPECT(sub == bsoncxx::builder::basic::make_array(1, 2.0, "three"));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_array/json_sub_document.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_array/json_sub_document.cpp
@@ -24,14 +24,14 @@ namespace {
 
 // [Example]
 void example() {
-    bsoncxx::document::value owner = bsoncxx::from_json(R"(
+    bsoncxx::document::value doc = bsoncxx::from_json(R"(
         [
             {"key": "value"}
         ]
     )");
-    bsoncxx::document::view v = owner.view()["0"].get_document().value;
+    bsoncxx::document::view v = doc.view()["0"].get_document().value;
 
-    EXPECT(v["key"].get_string().value.compare("value") == 0);
+    EXPECT(v == bsoncxx::from_json(R"({"key": "value"})"));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_append.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_append.cpp
@@ -17,8 +17,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/document/value.hpp>
-#include <bsoncxx/document/view.hpp>
-#include <bsoncxx/types.hpp>
+#include <bsoncxx/json.hpp>
 
 #include <examples/api/runner.hh>
 #include <examples/macros.hh>
@@ -33,12 +32,9 @@ void example() {
     builder.append(kvp("a", std::int32_t{1}));
     builder.append(kvp("b", 2.0));
     builder.append(kvp("c", "three"));
-    bsoncxx::document::value owner = builder.extract();
-    bsoncxx::document::view doc = owner.view();
+    bsoncxx::document::value doc = builder.extract();
 
-    EXPECT(doc["a"].get_int32().value == 1);
-    EXPECT(doc["b"].get_double().value == 2.0);
-    EXPECT(doc["c"].get_string().value.compare("three") == 0);
+    EXPECT(doc == bsoncxx::from_json(R"({"a": 1, "b": 2.0, "c": "three"})"));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_basic.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_basic.cpp
@@ -17,8 +17,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/document/value.hpp>
-#include <bsoncxx/document/view.hpp>
-#include <bsoncxx/types.hpp>
+#include <bsoncxx/json.hpp>
 
 #include <examples/api/runner.hh>
 #include <examples/macros.hh>
@@ -31,12 +30,9 @@ void example() {
 
     bsoncxx::builder::basic::document builder;
     builder.append(kvp("a", std::int32_t{1}), kvp("b", 2.0), kvp("c", "three"));
-    bsoncxx::document::value owner = builder.extract();
-    bsoncxx::document::view doc = owner.view();
+    bsoncxx::document::value doc = builder.extract();
 
-    EXPECT(doc["a"].get_int32().value == 1);
-    EXPECT(doc["b"].get_double().value == 2.0);
-    EXPECT(doc["c"].get_string().value.compare("three") == 0);
+    EXPECT(doc.view() == bsoncxx::from_json(R"({"a": 1, "b": 2.0, "c": "three"})"));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_bson_type.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_bson_type.cpp
@@ -17,7 +17,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/document/value.hpp>
-#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/json.hpp>
 #include <bsoncxx/types.hpp>
 
 #include <examples/api/runner.hh>
@@ -33,17 +33,10 @@ void example() {
     bsoncxx::types::b_double b{2.0};
     bsoncxx::types::b_string c{"three"};
 
-    bsoncxx::document::value owner =
+    bsoncxx::document::value doc =
         bsoncxx::builder::basic::make_document(kvp("a", a), kvp("b", b), kvp("c", c));
-    bsoncxx::document::view doc = owner.view();
 
-    EXPECT(doc["a"].type() == bsoncxx::type::k_int32);
-    EXPECT(doc["b"].type() == bsoncxx::type::k_double);
-    EXPECT(doc["c"].type() == bsoncxx::type::k_string);
-
-    EXPECT(doc["a"].get_int32() == a);
-    EXPECT(doc["b"].get_double() == b);
-    EXPECT(doc["c"].get_string() == c);
+    EXPECT(doc.view() == bsoncxx::from_json(R"({"a": 1, "b": 2.0, "c": "three"})"));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_bson_value.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_bson_value.cpp
@@ -17,8 +17,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/document/value.hpp>
-#include <bsoncxx/document/view.hpp>
-#include <bsoncxx/types.hpp>
+#include <bsoncxx/json.hpp>
 #include <bsoncxx/types/bson_value/value.hpp>
 
 #include <examples/api/runner.hh>
@@ -36,17 +35,10 @@ void example() {
         "three",
     };
 
-    bsoncxx::document::value owner = bsoncxx::builder::basic::make_document(
+    bsoncxx::document::value doc = bsoncxx::builder::basic::make_document(
         kvp("a", values[0]), kvp("b", values[1]), kvp("c", values[2]));
-    bsoncxx::document::view doc = owner.view();
 
-    EXPECT(doc["a"].type() == bsoncxx::type::k_int32);
-    EXPECT(doc["b"].type() == bsoncxx::type::k_double);
-    EXPECT(doc["c"].type() == bsoncxx::type::k_string);
-
-    EXPECT(doc["a"].get_value() == values[0]);
-    EXPECT(doc["b"].get_value() == values[1]);
-    EXPECT(doc["c"].get_value() == values[2]);
+    EXPECT(doc.view() == bsoncxx::from_json(R"({"a": 1, "b": 2.0, "c": "three"})"));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_make_document.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_make_document.cpp
@@ -17,8 +17,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/document/value.hpp>
-#include <bsoncxx/document/view.hpp>
-#include <bsoncxx/types.hpp>
+#include <bsoncxx/json.hpp>
 
 #include <examples/api/runner.hh>
 #include <examples/macros.hh>
@@ -29,13 +28,10 @@ namespace {
 void example() {
     using bsoncxx::builder::basic::kvp;
 
-    bsoncxx::document::value owner = bsoncxx::builder::basic::make_document(
+    bsoncxx::document::value doc = bsoncxx::builder::basic::make_document(
         kvp("a", std::int32_t{1}), kvp("b", 2.0), kvp("c", "three"));
-    bsoncxx::document::view doc = owner.view();
 
-    EXPECT(doc["a"].get_int32().value == 1);
-    EXPECT(doc["b"].get_double().value == 2.0);
-    EXPECT(doc["c"].get_string().value.compare("three") == 0);
+    EXPECT(doc.view() == bsoncxx::from_json(R"({"a": 1, "b": 2.0, "c": "three"})"));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_raw_value.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_raw_value.cpp
@@ -19,7 +19,6 @@
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/json.hpp>
-#include <bsoncxx/types.hpp>
 
 #include <examples/api/runner.hh>
 #include <examples/macros.hh>
@@ -35,10 +34,9 @@ void example(const std::uint8_t* data, std::size_t length) {
     std::copy_n(data, length, raw);
 
     deleter_type deleter = [](std::uint8_t* data) { delete[] data; };
-    bsoncxx::document::value owner{raw, length, deleter};
-    bsoncxx::document::view doc = owner.view();
+    bsoncxx::document::value doc{raw, length, deleter};
 
-    EXPECT(doc["key"].get_string().value.compare("value") == 0);
+    EXPECT(doc.view() == bsoncxx::from_json(R"({"key": "value"})"));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_raw_view.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_raw_view.cpp
@@ -18,7 +18,6 @@
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/json.hpp>
-#include <bsoncxx/types.hpp>
 
 #include <examples/api/runner.hh>
 #include <examples/macros.hh>
@@ -30,7 +29,7 @@ namespace {
 void example(const std::uint8_t* data, std::size_t length) {
     bsoncxx::document::view doc{data, length};
 
-    EXPECT(doc["key"].get_string().value.compare("value") == 0);
+    EXPECT(doc == bsoncxx::from_json(R"({"key": "value"})"));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_reset.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_reset.cpp
@@ -17,8 +17,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/document/value.hpp>
-#include <bsoncxx/document/view.hpp>
-#include <bsoncxx/types.hpp>
+#include <bsoncxx/json.hpp>
 
 #include <examples/api/runner.hh>
 #include <examples/macros.hh>
@@ -31,22 +30,16 @@ void example() {
 
     bsoncxx::builder::basic::document builder;
 
-    builder.append(kvp("v", std::int32_t{1}));
-    bsoncxx::document::value a_owner = builder.extract();
+    builder.append(kvp("a", 1));
+    bsoncxx::document::value a = builder.extract();
 
     builder.clear();
 
-    builder.append(kvp("v", std::int64_t{2}));
-    bsoncxx::document::value b_owner = builder.extract();
+    builder.append(kvp("b", 2));
+    bsoncxx::document::value b = builder.extract();
 
-    bsoncxx::document::view a = a_owner.view();
-    bsoncxx::document::view b = b_owner.view();
-
-    EXPECT(a["v"].type() == bsoncxx::type::k_int32);
-    EXPECT(b["v"].type() == bsoncxx::type::k_int64);
-
-    EXPECT(a["v"].get_int32().value == 1);
-    EXPECT(b["v"].get_int64().value == 2);
+    EXPECT(a.view() == bsoncxx::from_json(R"({"a": 1})"));
+    EXPECT(b.view() == bsoncxx::from_json(R"({"b": 2})"));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_sub_array.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_sub_array.cpp
@@ -19,6 +19,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/document/value.hpp>
+#include <bsoncxx/json.hpp>
 #include <bsoncxx/types.hpp>
 
 #include <examples/api/runner.hh>
@@ -32,15 +33,12 @@ void example() {
     using bsoncxx::builder::basic::make_array;
     using bsoncxx::builder::basic::make_document;
 
-    bsoncxx::document::value owner =
-        make_document(kvp("v", make_array(std::int32_t{1}, std::int64_t{2})));
+    bsoncxx::array::value subarr = make_array(1, 2.0, "three");
+
+    bsoncxx::document::value owner = make_document(kvp("v", subarr.view()));
     bsoncxx::array::view v = owner.view()["v"].get_array().value;
 
-    EXPECT(v[0].type() == bsoncxx::type::k_int32);
-    EXPECT(v[1].type() == bsoncxx::type::k_int64);
-
-    EXPECT(v[0].get_int32().value == 1);
-    EXPECT(v[1].get_int64().value == 2);
+    EXPECT(v == subarr.view());
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_sub_array_append.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_sub_array_append.cpp
@@ -15,6 +15,7 @@
 #include <cstdint>
 
 #include <bsoncxx/array/view.hpp>
+#include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/builder/basic/sub_array.hpp>
@@ -40,9 +41,7 @@ void example() {
         }));
     bsoncxx::array::view v = owner.view()["v"].get_array().value;
 
-    EXPECT(v[0].get_int32().value == 1);
-    EXPECT(v[1].get_int32().value == 2);
-    EXPECT(v[2].get_int32().value == 3);
+    EXPECT(v == bsoncxx::builder::basic::make_array(1, 2, 3));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_sub_document.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_sub_document.cpp
@@ -16,6 +16,7 @@
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
+#include <bsoncxx/json.hpp>
 #include <bsoncxx/types.hpp>
 
 #include <examples/api/runner.hh>
@@ -28,10 +29,12 @@ void example() {
     using bsoncxx::builder::basic::kvp;
     using bsoncxx::builder::basic::make_document;
 
-    bsoncxx::document::value owner = make_document(kvp("v", make_document(kvp("key", "value"))));
+    bsoncxx::document::value subdoc = make_document(kvp("key", "value"));
+
+    bsoncxx::document::value owner = make_document(kvp("v", subdoc.view()));
     bsoncxx::document::view v = owner.view()["v"].get_document().value;
 
-    EXPECT(v["key"].get_string().value.compare("value") == 0);
+    EXPECT(v == subdoc.view());
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_sub_document_append.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_sub_document_append.cpp
@@ -18,6 +18,7 @@
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/document/view.hpp>
+#include <bsoncxx/json.hpp>
 #include <bsoncxx/types.hpp>
 
 #include <examples/api/runner.hh>
@@ -40,9 +41,7 @@ void example() {
         }));
     bsoncxx::document::view v = owner.view()["v"].get_document().value;
 
-    EXPECT(v["a"].get_int32().value == 1);
-    EXPECT(v["b"].get_int32().value == 2);
-    EXPECT(v["c"].get_int32().value == 3);
+    EXPECT(v == bsoncxx::from_json(R"({"a": 1, "b": 2, "c": 3})"));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_value_type.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_doc/builder_value_type.cpp
@@ -17,8 +17,7 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/document/value.hpp>
-#include <bsoncxx/document/view.hpp>
-#include <bsoncxx/types.hpp>
+#include <bsoncxx/json.hpp>
 
 #include <examples/api/runner.hh>
 #include <examples/macros.hh>
@@ -29,17 +28,10 @@ namespace {
 void example() {
     using bsoncxx::builder::basic::kvp;
 
-    bsoncxx::document::value owner = bsoncxx::builder::basic::make_document(
+    bsoncxx::document::value doc = bsoncxx::builder::basic::make_document(
         kvp("a", std::int32_t{1}), kvp("b", 2.0), kvp("c", "three"));
-    bsoncxx::document::view doc = owner.view();
 
-    EXPECT(doc["a"].type() == bsoncxx::type::k_int32);
-    EXPECT(doc["b"].type() == bsoncxx::type::k_double);
-    EXPECT(doc["c"].type() == bsoncxx::type::k_string);
-
-    EXPECT(doc["a"].get_int32().value == 1);
-    EXPECT(doc["b"].get_double().value == 2.0);
-    EXPECT(doc["c"].get_string().value.compare("three") == 0);
+    EXPECT(doc == bsoncxx::from_json(R"({"a": 1, "b": 2.0, "c": "three"})"));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_doc/json_sub_array.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_doc/json_sub_array.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <bsoncxx/array/view.hpp>
+#include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/types.hpp>
@@ -31,8 +32,7 @@ void example() {
     )");
     bsoncxx::array::view sub = owner.view()["v"].get_array().value;
 
-    EXPECT(sub[0].get_int32().value == 1);
-    EXPECT(sub[1].get_int32().value == 2);
+    EXPECT(sub == bsoncxx::builder::basic::make_array(1, 2));
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_doc/json_sub_document.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_doc/json_sub_document.cpp
@@ -31,7 +31,7 @@ void example() {
     )");
     bsoncxx::document::view v = doc["v"].get_document().value;
 
-    EXPECT(v["key"].get_string().value.compare("value") == 0);
+    EXPECT(v == bsoncxx::from_json(R"({"key": "value"})"));
 }
 // [Example]
 


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1208.

Simplifies existing bsoncxx examples by using `bsoncxx::from_json()` and `bsoncxx::builder::basic::make_array()` in expectation expressions for final result values. These patterns help avoid the two-step "check valid element" -> "obtain element value" usually required for per-element value access.

The written-out JSON document is expected to be easier to read and understand by users than per-element access syntax. Examples of the form `from_json() == from_json()` (demonstrating its own behavior) is avoided. Some examples still use element access syntax (particularly array examples) in cases where it is more convenient (i.e. element type expectations).