### PR TITLE
CXX-3031 add 8.0 test tasks

### DIFF
--- a/.mci.yml
+++ b/.mci.yml
@@ -2001,7 +2001,23 @@ buildvariants:
       tasks:
         - name: compile_without_tests
         - name: compile_macro_guard_tests
+
+    - name: atlas-search-indexes-7.0
+      display_name: "Atlas Search Indexes (7.0)"
+      expansions:
+        build_type: "Debug"
+      run_on:
+        - ubuntu2004-build
+      tasks:
         - name: test_atlas_task_group_search_indexes
+
+    - name: atlas-search-indexes-8.0
+      display_name: "Atlas Search Indexes (8.0)"
+      expansions:
+        build_type: "Debug"
+      run_on:
+        - ubuntu2004-build
+      tasks:
         - name: test_atlas_task_group_search_indexes_8.0
 
     - name: ubuntu2004-debug-gcc

--- a/.mci.yml
+++ b/.mci.yml
@@ -1292,7 +1292,7 @@ task_groups:
           binary: bash
           args: [-c, rm -rf *]
 
-  - name: test_atlas_task_group_search_indexes
+  - name: test_atlas_task_group_search_indexes_7.0
     setup_group:
       - func: "setup"
       - func: "clone_drivers-evergreen-tools"
@@ -2009,7 +2009,7 @@ buildvariants:
       run_on:
         - ubuntu2004-build
       tasks:
-        - name: test_atlas_task_group_search_indexes
+        - name: test_atlas_task_group_search_indexes_7.0
 
     - name: atlas-search-indexes-8.0
       display_name: "Atlas Search Indexes (8.0)"

--- a/.mci.yml
+++ b/.mci.yml
@@ -1320,6 +1320,34 @@ task_groups:
     tasks:
       - test_search_index_helpers
 
+  - name: test_atlas_task_group_search_indexes_8.0
+    setup_group:
+      - func: "setup"
+      - func: "clone_drivers-evergreen-tools"
+      - command: subprocess.exec
+        params:
+          working_dir: mongo-cxx-driver
+          binary: bash
+          add_expansions_to_env: true
+          env:
+            MONGODB_VERSION: '8.0'
+          args: [-c, "${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh"]
+      - command: expansions.update
+        # Expected to set MONGODB_URI expansion.
+        params:
+          file: mongo-cxx-driver/atlas-expansion.yml
+    teardown_group:
+      - command: subprocess.exec
+        params:
+          working_dir: mongo-cxx-driver
+          binary: bash
+          add_expansions_to_env: true
+          args: [-c, "${DRIVERS_TOOLS}/.evergreen/atlas/teardown-atlas-cluster.sh"]
+    setup_group_can_fail_task: true
+    setup_group_timeout_secs: 1800
+    tasks:
+      - test_search_index_helpers
+
 
 #######################################
 #           Buildvariants             #
@@ -1357,6 +1385,14 @@ buildvariants:
       run_on: ubuntu2004-large
       expansions:
           mongodb_version: "latest"
+          <<: *integration_matrix_expansions_linux
+      <<: *integration_matrix_tasks_single
+
+    - name: integration-ubuntu2004-8.0-single
+      display_name: "Ubuntu 20.04 Debug (MongoDB 8.0)"
+      run_on: ubuntu2004-large
+      expansions:
+          mongodb_version: "8.0"
           <<: *integration_matrix_expansions_linux
       <<: *integration_matrix_tasks_single
 
@@ -1416,6 +1452,14 @@ buildvariants:
           <<: *integration_matrix_expansions_windows_vs2019
       <<: *integration_matrix_tasks_single
 
+    - name: integration-vs2019-8.0-single
+      display_name: "Windows (VS 2019) Debug (MongoDB 8.0)"
+      run_on: windows-vsCurrent-large
+      expansions:
+          mongodb_version: "8.0"
+          <<: *integration_matrix_expansions_windows_vs2019
+      <<: *integration_matrix_tasks_single
+
     - name: integration-vs2019-7.0-single
       display_name: "Windows (VS 2019) Debug (MongoDB 7.0)"
       run_on: windows-vsCurrent-large
@@ -1472,6 +1516,14 @@ buildvariants:
           <<: *integration_matrix_expansions_linux
       <<: *integration_matrix_tasks_replica
 
+    - name: integration-ubuntu2004-8.0-replica
+      display_name: "Ubuntu 20.04 Debug replica set (MongoDB 8.0)"
+      run_on: ubuntu2004-large
+      expansions:
+          mongodb_version: "8.0"
+          <<: *integration_matrix_expansions_linux
+      <<: *integration_matrix_tasks_replica
+
     - name: integration-ubuntu2004-7.0-replica
       display_name: "Ubuntu 20.04 Debug replica set (MongoDB 7.0)"
       run_on: ubuntu2004-large
@@ -1525,6 +1577,14 @@ buildvariants:
       run_on: ubuntu2004-large
       expansions:
           mongodb_version: "latest"
+          <<: *integration_matrix_expansions_linux
+      <<: *integration_matrix_tasks_sharded
+
+    - name: integration-ubuntu2004-8.0-sharded
+      display_name: "Ubuntu 20.04 Debug sharded cluster (MongoDB 8.0)"
+      run_on: ubuntu2004-large
+      expansions:
+          mongodb_version: "8.0"
           <<: *integration_matrix_expansions_linux
       <<: *integration_matrix_tasks_sharded
 
@@ -1942,6 +2002,7 @@ buildvariants:
         - name: compile_without_tests
         - name: compile_macro_guard_tests
         - name: test_atlas_task_group_search_indexes
+        - name: test_atlas_task_group_search_indexes_8.0
 
     - name: ubuntu2004-debug-gcc
       display_name: "Ubuntu 20.04 Debug (GCC)"


### PR DESCRIPTION
Copy 7.0 server tasks to test 8.0. Verified with this [patch build](https://spruce.mongodb.com/version/670e809a5c60a20007e96a37).

Atlas search index task groups are scheduled on separate build variants to avoid duplicate tasks on one variant:

```
invalid patched config syntax: task 'test_search_index_helpers' in 'ubuntu2004-debug' is listed more than once, likely through a task group
```
