### PR TITLE
CXX-1201 remove extra cmake config

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -122,19 +122,6 @@ file(GLOB_RECURSE examples_headers
     "*.hh"
 )
 
-foreach(source ${api_examples_sources})
-    add_examples_executable(${source} LIBRARIES mongocxx_target)
-
-    # Silence warnings for common patterns in API examples.
-    set_property (SOURCE ${source} APPEND PROPERTY COMPILE_OPTIONS
-        # Allow unused variables.
-        $<$<CXX_COMPILER_ID:AppleClang,Clang,GNU>:-Wno-unused>
-        $<$<CXX_COMPILER_ID:MSVC>:/wd4189>
-
-        # Allow simpler switch statements.
-        $<$<CXX_COMPILER_ID:AppleClang,Clang,GNU>:-Wno-switch>
-    )
-endforeach()
 
 foreach(source ${bsoncxx_examples_sources})
     add_examples_executable(${source} LIBRARIES bsoncxx_target)


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/mongo-cxx-driver/pull/1190 to remove an extra unused block in `examples/CMakeLists.txt`.
