### PR TITLE
CXX-2778 document a warning against catching with_transaction_cb errors

### DIFF
--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
@@ -185,10 +185,18 @@ class client_session {
     /// the transaction, the entire sequence may be retried, and the callback
     /// may be run multiple times.
     ///
-    /// If the user callback calls driver methods that run operations against the
-    /// server that can throw an operation_exception (ex: collection::insert_one),
-    /// the user callback should allow those exceptions to propagate up the stack
-    /// so they can be caught and processed by the with_transaction helper.
+    /// This method has an internal non-adjustable time limit of 120 seconds,
+    /// including all retries.
+    ///
+    /// If the user callback invokes driver methods that run operations against the
+    /// server which could throw an operation_exception, the user callback MUST allow
+    /// those exceptions to propagate up the stack so they can be caught and processed
+    /// by the with_transaction() helper.
+    ///
+    /// For example, a callback that invokes collection::insert_one may encounter a
+    /// "DuplicateKey" error with accompanying server-side transaction abort. If this
+    /// error were not seen by the with_transaction() helper, the entire transaction
+    /// would retry repeatedly until the overall time limit expires.
     ///
     /// @param cb
     ///   The callback to run inside of a transaction.


### PR DESCRIPTION
This strengthens with_transaction()'s warning against catching operational errors, upgrading the language to "MUST" and adding an explanation.

Corresponding specification change:
https://github.com/mongodb/specifications/commit/13117d601fb6ea177e485880175b5be1651a7e46