### PR TITLE
Fix polyfill selection for compile tasks + use large distros

### DIFF
--- a/.evergreen/compile.sh
+++ b/.evergreen/compile.sh
@@ -15,6 +15,7 @@ set -o pipefail
 : "${build_type:?}"
 : "${distro_id:?}" # Required by find-cmake-latest.sh.
 
+: "${BSONCXX_POLYFILL:-}"
 : "${COMPILE_MACRO_GUARD_TESTS:-}"
 : "${ENABLE_CODE_COVERAGE:-}"
 : "${ENABLE_TESTS:-}"
@@ -22,7 +23,6 @@ set -o pipefail
 : "${platform:-}"
 : "${REQUIRED_CXX_STANDARD:-}"
 : "${RUN_DISTCHECK:-}"
-: "${USE_POLYFILL_BOOST:-}"
 : "${USE_SANITIZER_ASAN:-}"
 : "${USE_SANITIZER_UBSAN:-}"
 : "${USE_STATIC_LIBS:-}"
@@ -130,9 +130,13 @@ esac
 export CMAKE_GENERATOR="${generator:?}"
 export CMAKE_GENERATOR_PLATFORM="${platform:-}"
 
-if [[ "${USE_POLYFILL_BOOST:-}" == "ON" ]]; then
-  cmake_flags+=("-DBSONCXX_POLY_USE_BOOST=ON")
-fi
+case "${BSONCXX_POLYFILL:-}" in
+mnmlstc) cmake_flags+=(-D "BSONCXX_POLY_USE_MNMLSTC=ON") ;;
+boost) cmake_flags+=(-D "BSONCXX_POLY_USE_BOOST=ON") ;;
+impls) cmake_flags+=(-D "BSONCXX_POLY_USE_IMPLS=ON") ;;
+std) cmake_flags+=(-D "BSONCXX_POLY_USE_STD=ON") ;;
+*) ;;
+esac
 
 cc_flags_init=(-Wall -Wextra -Wno-attributes -Werror -Wno-missing-field-initializers)
 cxx_flags_init=(-Wall -Wextra -Wconversion -Wnarrowing -pedantic -Werror)

--- a/.mci.yml
+++ b/.mci.yml
@@ -462,6 +462,7 @@ functions:
               include_expansions_in_env:
                   - branch_name
                   - build_type
+                  - BSONCXX_POLYFILL
                   - COMPILE_MACRO_GUARD_TESTS
                   - distro_id
                   - ENABLE_CODE_COVERAGE
@@ -470,7 +471,6 @@ functions:
                   - platform
                   - REQUIRED_CXX_STANDARD
                   - RUN_DISTCHECK
-                  - USE_POLYFILL_BOOST
                   - USE_SANITIZER_ASAN
                   - USE_SANITIZER_UBSAN
                   - USE_STATIC_LIBS
@@ -2181,7 +2181,7 @@ buildvariants:
       display_name: "MacOS 11.0 Release (Boost) (MongoDB Latest)"
       expansions:
           build_type: "Release"
-          USE_POLYFILL_BOOST: ON
+          BSONCXX_POLYFILL: "boost"
           mongodb_version: "latest"
       run_on:
           - macos-1100
@@ -2195,7 +2195,7 @@ buildvariants:
       display_name: "MacOS 11.0 Release (Boost) (MongoDB 5.0)"
       expansions:
           build_type: "Release"
-          USE_POLYFILL_BOOST: ON
+          BSONCXX_POLYFILL: "boost"
           mongodb_version: "5.0"
       run_on:
           - macos-1100
@@ -2209,7 +2209,7 @@ buildvariants:
       display_name: "MacOS 11.0 Release Versioned API"
       expansions:
           build_type: "Release"
-          USE_POLYFILL_BOOST: ON
+          BSONCXX_POLYFILL: "boost"
           mongodb_version: "latest"
       run_on:
           - macos-1100

--- a/.mci.yml
+++ b/.mci.yml
@@ -2029,7 +2029,7 @@ buildvariants:
         cc_compiler: gcc
         cxx_compiler: g++
       run_on:
-        - ubuntu2004-small
+        - ubuntu2004-large
       tasks:
         - name: compile_without_tests
         - name: compile_macro_guard_tests
@@ -2042,7 +2042,7 @@ buildvariants:
         cc_compiler: clang
         cxx_compiler: clang++
       run_on:
-        - ubuntu2004-small
+        - ubuntu2004-large
       tasks:
         - name: clang-tidy
         - name: compile_without_tests
@@ -2066,7 +2066,7 @@ buildvariants:
           cmake: "cmake"
           lib_dir: "lib64"
       run_on:
-          - rhel83-zseries-small
+          - rhel83-zseries-large
       tasks:
           - name: compile_with_shared_libs
           - name: compile_and_test_with_shared_libs
@@ -2084,7 +2084,7 @@ buildvariants:
           cmake: "cmake"
           lib_dir: "lib64"
       run_on:
-          - rhel83-zseries-small
+          - rhel83-zseries-large
       tasks:
           - name: compile_with_shared_libs
           - name: compile_and_test_with_shared_libs
@@ -2102,7 +2102,7 @@ buildvariants:
           cmake: "cmake"
           lib_dir: "lib64"
       run_on:
-          - rhel83-zseries-small
+          - rhel83-zseries-large
       tasks:
           - name: compile_with_shared_libs
           - name: compile_and_test_with_shared_libs
@@ -2283,6 +2283,6 @@ buildvariants:
           build_type: "Release"
           BSONCXX_POLYFILL: impls
       run_on:
-          - rhel79-small
+          - rhel79-large
       tasks:
           - name: compile_without_tests

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/optional.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/optional.hpp
@@ -506,7 +506,7 @@ struct optional_assign_base<T, movable> : optional_construct_base<T> {
 
     // Allow move-assignment.
 
-    bsoncxx_cxx14_constexpr optional_assign_base& operator=(optional_assign_base&& other) = default;
+    bsoncxx_cxx14_constexpr optional_assign_base& operator=(optional_assign_base&&) = default;
 };
 
 template <typename T>
@@ -529,7 +529,7 @@ struct optional_construct_base<T, movable> : optional_destruct_base<T> {
     optional_construct_base() = default;
 
     optional_construct_base(const optional_construct_base&) = delete;
-    optional_construct_base(optional_construct_base&& other) = default;
+    optional_construct_base(optional_construct_base&&) = default;
     optional_construct_base& operator=(const optional_construct_base&) = default;
     optional_construct_base& operator=(optional_construct_base&&) = default;
 };


### PR DESCRIPTION
Verified by [this patch](https://spruce.mongodb.com/version/6720f2c1b48a5c00078003e1).

https://github.com/mongodb/mongo-cxx-driver/pull/1194 added the RHEL 7.9 distro to test against GCC 4.8.5 and the bsoncxx polyfill impls via `BSONCXX_POLYFILL: impls`. However, the `"compile"` EVG function doesn't know about this env var, as it is only used by the scan-build tasks. Therefore, the task has actually been [compiling against mnmlstc/core instead](https://parsley.mongodb.com/evergreen/mongo_cxx_driver_rhel79_compile_compile_without_tests_761aeb891d96dd7317258a72ed79873b5d2c7ac0_24_10_23_14_08_44/0/task?bookmarks=0,1779&shareLine=192).

This PR extends the `BSONCXX_POLYFILL` pattern to the `"compile"` EVG function and `compile.sh` script for consistency, replacing the `USE_POLYFILL_BOOST` env var. The task now [compiles with bsoncxx impls](https://parsley.mongodb.com/evergreen/mongo_cxx_driver_rhel79_compile_compile_without_tests_patch_761aeb891d96dd7317258a72ed79873b5d2c7ac0_6720f2c1b48a5c00078003e1_24_10_29_14_35_46/0/task?bookmarks=0,1703&shareLine=96) as intended. This revealed some compilation errors due to unused named parameters in `optional.hpp`, which this PR also addresses.

As a drive-by improvement, this PR also moves all compile/build/etc. tasks to large distro variants to reduce task execution times.