### PR TITLE
CXX-2797 Set ENABLE_BSONCXX_POLY_USE_IMPLS=ON by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ## 3.12.0 [Unreleased]
 
-<!-- Will contain entries for the next minor release. -->
+> [!WARNING]
+> Set CMake option `ENABLE_BSONCXX_POLY_USE_IMPLS=OFF` to preserve API backward compatibility!
+
+### Changed
+
+- The CMake option `ENABLE_BSONCXX_POLY_USE_IMPLS` is set to `ON` by default.
+  - This is a potential API breaking change for users who depend on deprecated default polyfill library selection behavior to select mnmlstc/core or Boost as the polyfill library.
+  - This is not an API breaking change for users who already explicitly set `ENABLE_BSONCXX_POLY_USE_IMPL` or one of the `BSONCXX_POLY_USE_*` options.
+  - Set `ENABLE_BSONCXX_POLY_USE_IMPLS=OFF` to preserve API backward compatibility.
 
 ## 3.11.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ option(BUILD_SHARED_LIBS_WITH_STATIC_MONGOC
 )
 
 # Allow the user to opt into using bsoncxx implementations for C++17 polyfills by default.
-option(ENABLE_BSONCXX_POLY_USE_IMPLS "Enable using bsoncxx implementations of C++17 polyfills for pre-C++17 configurations by default" OFF)
+option(ENABLE_BSONCXX_POLY_USE_IMPLS "Enable using bsoncxx implementations of C++17 polyfills for pre-C++17 configurations by default" ON)
 
 if(DEFINED CACHE{ENABLE_ABI_TAG_IN_LIBRARY_FILENAMES} AND NOT MSVC)
     message(WARNING "ENABLE_ABI_TAG_IN_LIBRARY_FILENAMES is an MSVC-only option and will be ignored by the current configuration")


### PR DESCRIPTION
## Summary

Resolves CXX-2797. Verified by [this patch](https://spruce.mongodb.com/version/6723d94569fce60007e11100/).

> [!IMPORTANT]
> Refusing the proposed changing in this PR is _entirely acceptable_ (see "Motivation and Risk" below). If so, this PR will be closed without merging the proposed changes.

> [!WARNING]
> This PR changes CMake configuration behavior such that API breaking changes _**MAY**_ occur without user intervention. API compatibility is preserved by explicitly setting `ENABLE_BSONCXX_POLYFILL_USE_IMPLS=OFF` during CMake configuration.

This is likely the biggest build system breaking change to date since the 3.0 release. This release is an _**API breaking change**_ for users who _**do not**_ explicitly set `ENABLE_BSONCXX_POLYFILL_USE_IMPLS=OFF` due to default polyfill library selection selecting bsoncxx polyfill implementations instead of mnmlstc/core or Boost.

Users _**MUST**_ explicitly set `ENABLE_BSONCXX_POLYFILL_USE_IMPLS=OFF` to prevent this release from causing API breaking changes if they do not already explicitly set `ENABLE_BSONCXX_POLYFILL_USE_IMPLS` or one of the `BSONCXX_POLY_USE_*` options. Warnings and repetition are used to communicate this change as loudly and clearly as possible in both the changelog and this PR description.

## Potential API Breaking Changes

This change may lead to API breaking changes due to default polyfill library selection behavior selecting a different polyfill library (bsoncxx impls) in 3.12.0 than in 3.11.0 (mnmlstc/core or Boost). Selecting a different polyfill library changes the definition of `bsoncxx::stdx::string_view` and `bsoncxx::stdx::optional<T>`. Code which expects these types to match one of the external polyfill library definitions will be incompatible with the new polyfill library definition.

For example, users may expect `bsoncxx::stdx::string_view` to be equivalent to `boost::string_view`:

```cpp
// OK: `bsoncxx::stdx::string_view` is an alias for `boost::string_view`.
boost::string_view sv = bsoncxx::stdx::string_view("example");
```

Without user intervention, new default polyfill library selection behavior in 3.12.0 will use bsoncxx implementations instead of Boost:

```cpp
// error: no viable conversion from 'bsoncxx::stdx::string_view' to 'boost::string_view'
boost::string_view sv = bsoncxx::stdx::string_view("example");
```

Users may also expect `<bsoncxx/stdx/string_view.hpp>` to transitively include `<boost/utility/string_view.hpp>`, thus behave as an equivalent substitute for `<boost/utility/string_view.hpp>`.

If users only use `bsoncxx::stdx` interfaces with bsoncxx (or mongocxx) library interfaces without making assumptions regarding its "underlying" type as an external library type (e.g. referring to `bsoncxx::stdx::string_view` only ever as `bsoncxx::stdx::string_view`, deducing its type with `auto` or as templates, or avoiding its use with external library interfaces), this change in default polyfill library selection behavior should not cause API breaking changes. However, we cannot expect this to be the case for all users of the C++ Driver.

## Motivation and Risk

This change could be considered an unnecessary prerequisite for the upcoming 4.0 release.

The rationale motivating the implementation of this change is to actively alert downstream users to the upcoming "hard" API breaking changes in 4.0, before a fallback mechanism (i.e. `ENABLE_BSONCXX_POLYFILL_USE_IMPLS=OFF`) is no longer be available, by first implementing a "soft" API breaking change. The [3.10.0 release](https://github.com/mongodb/mongo-cxx-driver/releases/tag/r3.10.0) provided the `ENABLE_BSONCXX_POLYFILL_USE_IMPLS` option as an _opt-in_ opportunity to incrementally migrate prior to feature removal (with corresponding deprecation messages). The changes in this PR convert this _opt-in_ opportunity into an _opt-out_ opportunity.

However, this change will test the limits of our [API compatibility policy](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/api-abi-versioning/abi-versioning/), which deliberately excludes the build system from our definition of the "API" being tracked by SemVer to support this scenario, to an extent which may not be compatible with, or expected by, downstream users. This could lead to a negative user experience and criticism of our API versioning policy. If we want to avoid taking this risk, we can decide to omit this change from our major release process.

## Evergreen Tasks

This change also affects all Evergreen tasks which do not explicitly select a polyfill library via `BSONCXX_POLYFILL`. Given the currently proposed changes in this PR, the only tasks which use the mnmlstc/core library are:

- `debian-package-build-mnmlstc`
- `scan-build-ubuntu2204-std11-mnmlstc`

and the only tasks which use the Boost library are:

- `scan-build-ubuntu2204-std11-boost`
- `compile_and_test_with_shared_libs` (on macos-1100 with 5.0 and latest)
- `compile_and_test_with_shared_libs_extra_alignment` (on macos-1100 with 5.0 and latest)
- `compile_and_test_with_static_libs` (on macos-1100 with 5.0 and latest)
- `compile_and_test_with_static_libs_extra_alignment` (on macos-1100 with 5.0 and latest)
- `test_versioned_api` (on macos-1100 with latest)
- `test_versioned_api_accept_version_two` (on macos-1100 with latest)

All other tasks either use the bsoncxx impls (pre-C++17) or the standard library (C++17). The results of the [verifying patch](https://spruce.mongodb.com/version/6723d94569fce60007e11100/) indicate the bsoncxx impls polyfill is in a healthy state across most of our current test coverage.