### PR TITLE
CXX-2770 Add missing postlude header include directives

### DIFF
--- a/cmake/MacroGuardTest.cmake
+++ b/cmake/MacroGuardTest.cmake
@@ -108,10 +108,6 @@ function(add_macro_guard_test)
             set(relheader "${header}")
         endif()
 
-        # CXX-2770: workaround missing postlude header includes.
-        string(TOUPPER "${PARSED_PROJECT_NAME}" project_name_upper)
-        string(APPEND MACRO_GUARD_TEST "#define ${project_name_upper}_TEST_MACRO_GUARDS_FIX_MISSING_POSTLUDE\n\n")
-
         # The include directive.
         string(APPEND MACRO_GUARD_TEST "#include <${relheader}>\n\n")
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
@@ -215,10 +215,7 @@ using namespace ::bsoncxx::v_noabi::types;  // Deprecated. Deliberately undocume
 }  // namespace builder
 }  // namespace bsoncxx
 
-// CXX-2770: missing include of postlude header.
-#if defined(BSONCXX_TEST_MACRO_GUARDS_FIX_MISSING_POSTLUDE)
 #include <bsoncxx/config/postlude.hpp>
-#endif
 
 ///
 /// @file

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/downloader.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/downloader.hpp
@@ -175,10 +175,7 @@ class downloader {
 }  // namespace v_noabi
 }  // namespace mongocxx
 
-// CXX-2770: missing include of postlude header.
-#if defined(MONGOCXX_TEST_MACRO_GUARDS_FIX_MISSING_POSTLUDE)
 #include <mongocxx/config/postlude.hpp>
-#endif
 
 ///
 /// @file

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/uploader.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/uploader.hpp
@@ -173,10 +173,7 @@ class uploader {
 }  // namespace v_noabi
 }  // namespace mongocxx
 
-// CXX-2770: missing include of postlude header.
-#if defined(MONGOCXX_TEST_MACRO_GUARDS_FIX_MISSING_POSTLUDE)
 #include <mongocxx/config/postlude.hpp>
-#endif
 
 ///
 /// @file

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
@@ -421,10 +421,7 @@ class auto_encryption {
 }  // namespace v_noabi
 }  // namespace mongocxx
 
-// CXX-2770: missing include of postlude header.
-#if defined(MONGOCXX_TEST_MACRO_GUARDS_FIX_MISSING_POSTLUDE)
 #include <mongocxx/config/postlude.hpp>
-#endif
 
 ///
 /// @file

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
@@ -177,10 +177,7 @@ class data_key {
 }  // namespace v_noabi
 }  // namespace mongocxx
 
-// CXX-2770: missing include of postlude header.
-#if defined(MONGOCXX_TEST_MACRO_GUARDS_FIX_MISSING_POSTLUDE)
 #include <mongocxx/config/postlude.hpp>
-#endif
 
 ///
 /// @file

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/range.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/range.hpp
@@ -93,10 +93,7 @@ class range {
 }  // namespace v_noabi
 }  // namespace mongocxx
 
-// CXX-2770: missing include of postlude header.
-#if defined(MONGOCXX_TEST_MACRO_GUARDS_FIX_MISSING_POSTLUDE)
 #include <mongocxx/config/postlude.hpp>
-#endif
 
 ///
 /// @file


### PR DESCRIPTION
Long-awaited followup to https://github.com/mongodb/mongo-cxx-driver/pull/1043. Verified by [this patch](https://spruce.mongodb.com/version/6725389950efee000716da7a). With these changes, all current public headers have proper one-to-one match of prelude and postlude header include directives.