### PR TITLE
CXX-2769 Remove out-of-place BSONCXX_ENUM macro guards

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/postlude.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/postlude.hpp
@@ -63,12 +63,6 @@
 #pragma pop_macro("bsoncxx_cxx14_constexpr")
 #pragma pop_macro("BSONCXX_RETURNS")
 
-// CXX-2769: out-of-place, but remains for backward compatibility.
-#ifdef BSONCXX_ENUM
-static_assert(false, "BSONCXX_ENUM must be undef'ed");
-#endif
-#pragma pop_macro("BSONCXX_ENUM")
-
 // util.hpp
 #pragma pop_macro("BSONCXX_PUSH_WARNINGS")
 #pragma pop_macro("BSONCXX_POP_WARNINGS")

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/prelude.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/config/prelude.hpp
@@ -121,10 +121,6 @@
 #undef BSONCXX_UNREACHABLE
 #define BSONCXX_UNREACHABLE std::abort()
 
-// CXX-2769: out-of-place, but remains for backward compatibility.
-#pragma push_macro("BSONCXX_ENUM")
-#undef BSONCXX_ENUM
-
 ///
 /// @file
 /// The bsoncxx macro guard prelude header.


### PR DESCRIPTION
Resolves CXX-2769. Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1043 which postponed this change as a possible API breaking change for users who may be depending on this out-of-place macro guard.