### PR TITLE
CXX-3155 Remove undocumented using-directives and using-declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
   - `b_utf8` in `bsoncxx::v_noabi::types`. Use `b_string` instead.
   - `get_utf8` in `bsoncxx::v_noabi::document::element`, `bsoncxx::v_noabi::array::element`, and `bsoncxx::v_noabi::types::bson_value::view`. Use `get_string` instead.
   - `k_cannot_append_utf8` and `k_need_element_type_k_utf8` in `bsoncxx::v_noabi::exception::error_code`. Use `k_cannot_append_string` and `k_need_element_type_k_string` instead.
+- Undocumented using-directives and using-declarations.
+  - `bsoncxx::builder::types` in `<bsoncxx/builder/list.hpp>`. Use `bsoncxx::types` in `<bsoncxx/types.hpp>` instead.
+  - `bsoncxx::builder::stream::concatenate` in `<bsoncxx/builder/stream/helpers.hpp>`. Use `bsoncxx::builder::concatenate` in `<bsoncxx/builder/concatenate.hpp>` instead.
+  - `mongocxx::events::read_preference` in `<mongocxx/events/topology_description.hpp>`. Use `mongocxx::read_preference` in `<mongocxx/read_preference.hpp>` instead.
 
 ## 3.11.0
 

--- a/examples/bsoncxx/builder_list.cpp
+++ b/examples/bsoncxx/builder_list.cpp
@@ -67,7 +67,7 @@ int EXAMPLES_CDECL main() {
            "BSON 32-bit signed integer value", -123,
            "BSON date value", std::chrono::milliseconds(123456789),
            "BSON Decimal128 value", decimal128{100, 200},
-           "BSON regex value with options", bson_value::value("regex", "imsx" /* opts */)};
+           "BSON regex value with options", types::bson_value::value("regex", "imsx" /* opts */)};
     // clang-format on
 
     //
@@ -95,7 +95,7 @@ int EXAMPLES_CDECL main() {
            -123,
            std::chrono::milliseconds(123456789),
            decimal128{100, 200},
-           bson_value::value("regex", "imsx" /* opts */)};
+           types::bson_value::value("regex", "imsx" /* opts */)};
 
     //
     // The list builder will create a BSON document, if possible. Otherwise, it will create a BSON

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/list.hpp
@@ -30,16 +30,6 @@ namespace bsoncxx {
 namespace v_noabi {
 namespace builder {
 
-using namespace ::bsoncxx::v_noabi::types;  // Deprecated. Deliberately undocumented.
-
-}  // namespace builder
-}  // namespace v_noabi
-}  // namespace bsoncxx
-
-namespace bsoncxx {
-namespace v_noabi {
-namespace builder {
-
 ///
 /// A JSON-like builder for creating documents and arrays.
 ///
@@ -94,7 +84,7 @@ class list {
     /// @see
     /// - @ref bsoncxx::v_noabi::types::bson_value::view.
     ///
-    operator bson_value::view() {
+    operator types::bson_value::view() {
         return view();
     }
 
@@ -104,12 +94,12 @@ class list {
     /// @see
     /// - @ref bsoncxx::v_noabi::types::bson_value::view.
     ///
-    bson_value::view view() {
+    types::bson_value::view view() {
         return val.view();
     }
 
    private:
-    bson_value::value val;
+    types::bson_value::value val;
 
     friend ::bsoncxx::v_noabi::builder::document;
     friend ::bsoncxx::v_noabi::builder::array;
@@ -141,12 +131,12 @@ class list {
                 _core.key_owned(std::string((begin(init) + i)->val.view().get_string().value));
                 _core.append((begin(init) + i + 1)->val);
             }
-            val = bson_value::value(_core.extract_document());
+            val = types::bson_value::value(_core.extract_document());
         } else if (type_deduction || is_array) {
             core _core{true};
             for (auto&& ele : init)
                 _core.append(ele.val);
-            val = bson_value::value(_core.extract_array());
+            val = types::bson_value::value(_core.extract_array());
         } else {
             throw bsoncxx::v_noabi::exception{error_code::k_unmatched_key_in_builder,
                                               err_msg.str()};
@@ -205,14 +195,6 @@ class array : public list {
 };
 }  // namespace builder
 }  // namespace v_noabi
-}  // namespace bsoncxx
-
-namespace bsoncxx {
-namespace builder {
-
-using namespace ::bsoncxx::v_noabi::types;  // Deprecated. Deliberately undocumented.
-
-}  // namespace builder
 }  // namespace bsoncxx
 
 #include <bsoncxx/config/postlude.hpp>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/helpers.hpp
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <bsoncxx/builder/concatenate.hpp>
 #include <bsoncxx/document/view_or_value.hpp>
 
 #include <bsoncxx/config/prelude.hpp>
@@ -23,8 +22,6 @@ namespace bsoncxx {
 namespace v_noabi {
 namespace builder {
 namespace stream {
-
-using ::bsoncxx::v_noabi::builder::concatenate;  // Deprecated. Deliberately undocumented.
 
 ///
 /// The type of a stream manipulator to open a subdocument.
@@ -98,8 +95,6 @@ constexpr finalize_type finalize;
 namespace bsoncxx {
 namespace builder {
 namespace stream {
-
-using ::bsoncxx::v_noabi::builder::stream::concatenate;  // Deprecated. Deliberately undocumented.
 
 using ::bsoncxx::v_noabi::builder::stream::close_array;
 using ::bsoncxx::v_noabi::builder::stream::close_document;

--- a/src/bsoncxx/test/bson_builder.cpp
+++ b/src/bsoncxx/test/bson_builder.cpp
@@ -583,7 +583,8 @@ TEST_CASE("builder appends concatenate", "[bsoncxx::builder::stream]") {
 
         {
             using namespace builder::stream;
-            b << "foo" << open_document << concatenate(child_builder.view()) << close_document;
+            b << "foo" << open_document << builder::concatenate(child_builder.view())
+              << close_document;
         }
 
         bson_eq_stream(&expected, b);
@@ -602,7 +603,8 @@ TEST_CASE("builder appends concatenate", "[bsoncxx::builder::stream]") {
 
         {
             using namespace builder::stream;
-            b << "foo" << open_array << "bar" << concatenate(child_builder.view()) << close_array;
+            b << "foo" << open_array << "bar" << builder::concatenate(child_builder.view())
+              << close_array;
         }
 
         bson_eq_stream(&expected, b);
@@ -1120,7 +1122,7 @@ TEST_CASE("basic document builder works with concat", "[bsoncxx::builder::basic]
     builder::stream::document stream;
     builder::basic::document basic;
 
-    stream << builder::stream::concatenate(subdoc.view());
+    stream << builder::concatenate(subdoc.view());
 
     SECTION("single insert works") {
         basic.append(builder::basic::concatenate(subdoc.view()));
@@ -1129,7 +1131,7 @@ TEST_CASE("basic document builder works with concat", "[bsoncxx::builder::basic]
     }
 
     SECTION("variadic works") {
-        stream << builder::stream::concatenate(subdoc.view());
+        stream << builder::concatenate(subdoc.view());
 
         basic.append(builder::basic::concatenate(subdoc.view()),
                      builder::basic::concatenate(subdoc.view()));
@@ -1147,7 +1149,7 @@ TEST_CASE("basic array builder works with concat", "[bsoncxx::builder::basic]") 
     builder::stream::array stream;
     builder::basic::array basic;
 
-    stream << builder::stream::concatenate(array_view);
+    stream << builder::concatenate(array_view);
 
     SECTION("single insert works") {
         basic.append(builder::basic::concatenate(array_view));
@@ -1156,7 +1158,7 @@ TEST_CASE("basic array builder works with concat", "[bsoncxx::builder::basic]") 
     }
 
     SECTION("variadic works") {
-        stream << builder::stream::concatenate(array_view);
+        stream << builder::concatenate(array_view);
 
         basic.append(builder::basic::concatenate(array_view),
                      builder::basic::concatenate(array_view));

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description.hpp
@@ -29,8 +29,6 @@ namespace mongocxx {
 namespace v_noabi {
 namespace events {
 
-using mongocxx::v_noabi::read_preference;  // Deprecated. Deliberately undocumented.
-
 ///
 /// Class representing what the driver knows about a topology of MongoDB servers: either a
 /// standalone, a replica set, or a sharded cluster.
@@ -165,14 +163,6 @@ class topology_description {
 
 }  // namespace events
 }  // namespace v_noabi
-}  // namespace mongocxx
-
-namespace mongocxx {
-namespace events {
-
-using ::mongocxx::v_noabi::events::read_preference;  // Deprecated. Deliberately undocumented.
-
-}  // namespace events
 }  // namespace mongocxx
 
 #include <mongocxx/config/postlude.hpp>


### PR DESCRIPTION
Resolves CXX-3155. Verified by [this patch](https://spruce.mongodb.com/version/6728f94aa8204a0007a8f82f). (Task failures appear to be unrelated.)