### PR TITLE
CXX-3170 Remove MONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ## Removed
 
+- Support for CMake option `MONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX`.
+  - `MONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX=OFF` is now implicit behavior.
 - Redeclarations of `bsoncxx::stdx` interfaces in the `mongocxx::stdx` namespace.
   - Use `bsoncxx::stdx::optional<T>` instead of `mongocxx::stdx::optional<T>`.
   - Use `bsoncxx::stdx::string_view` instead of `mongocxx::stdx::string_view`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,18 +188,6 @@ To build static libraries only, set both BUILD_SHARED_LIBS and BUILD_SHARED_AND_
     set(MONGOCXX_LINK_WITH_STATIC_MONGOC ON CACHE INTERNAL "")
 endif()
 
-option(MONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX "If enabled, mongocxx will set a default CMAKE_INSTALL_PREFIX if one is not already defined" TRUE)
-
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND MONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX)
-    message(WARNING
-        "mongocxx: The default CMAKE_INSTALL_PREFIX is being overridden to the "
-        "build directory. This behavior will not be the default in a future "
-        "release. Build with 'MONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX=OFF' to opt "
-        "into what will be the default behavior in a future release. Setting install "
-        "path to: ${CMAKE_BINARY_DIR}/install")
-    set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "default install path" FORCE)
-endif()
-
 include(GNUInstallDirs)
 include(ParseVersion)
 


### PR DESCRIPTION
Resolves CXX-3170. Verified by [this patch](https://spruce.mongodb.com/version/672d008e1a72ee000787bbbf).

Followup to https://github.com/mongodb/mongo-cxx-driver/pull/994 and https://github.com/mongodb/mongo-cxx-driver/pull/1012 which added a CMake option to opt out of legacy implicit install prefix override behavior. This PR removes the legacy behavior and this opt-out option in favor of full consistency with CMake's default behavior instead (explicit `CMAKE_PREFIX_PATH` for custom install prefix specification, default install paths otherwise).