### PR TITLE
CXX-3003 Remove documentation of bsoncxx/util directory

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/fwd.hpp
@@ -349,13 +349,6 @@
 ///
 
 ///
-/// @dir bsoncxx/v_noabi/bsoncxx/util
-/// Headers provided by this directory are deprecated.
-///
-/// @deprecated To be removed in an upcoming major release.
-///
-
-///
 /// @namespace bsoncxx::v_noabi
 /// Declares entities whose ABI stability is NOT guaranteed.
 ///


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1251 which forgot to remove Doxygen documentation of the `bsoncxx/util` directory.