### PR TITLE
doxygen: fix return type for array concatenate()

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/concatenate.hpp
@@ -110,7 +110,7 @@ inline concatenate_doc concatenate(document::view_or_value doc) {
 ///
 /// @param array The array to concatenate.
 ///
-/// @return concatenate_doc A concatenating struct.
+/// @return concatenate_array A concatenating struct.
 ///
 /// @see
 /// - @ref bsoncxx::v_noabi::builder::concatenate_array


### PR DESCRIPTION
A small fix to https://github.com/mongodb/mongo-cxx-driver/pull/1185 which made a copy-paste error in the return type documentation of the array overload of `concatenate()`.