### PR TITLE
CXX-3179 Set ENABLE_TESTS=OFF by default

### DIFF
--- a/.evergreen/config_generator/components/atlas_search_indexes.py
+++ b/.evergreen/config_generator/components/atlas_search_indexes.py
@@ -55,7 +55,7 @@ def tasks():
             run_on=distro.name,
             commands=[
                 InstallCDriver.call(),
-                Compile.call(build_type='Debug'),
+                Compile.call(build_type='Debug', vars={'ENABLE_TESTS': 'ON'}),
                 TestSearchIndexHelpers.call(),
             ],
         )

--- a/.evergreen/config_generator/components/compile_only.py
+++ b/.evergreen/config_generator/components/compile_only.py
@@ -69,7 +69,6 @@ def generate_tasks():
                             build_type=build_type,
                             compiler=compiler,
                             polyfill=polyfill,
-                            vars={'ENABLE_TESTS': 'OFF'}
                         )
                     ],
                 )

--- a/.evergreen/config_generator/components/integration.py
+++ b/.evergreen/config_generator/components/integration.py
@@ -105,9 +105,15 @@ def tasks():
             distro = find_large_distro(distro_name)
 
             updates = []
-            icd_vars = {'BSON_EXTRA_ALIGNMENT': 1} if with_extra_align else {}
-            compile_vars = {'BSON_EXTRA_ALIGNMENT': 1} if with_extra_align else {'RUN_DISTCHECK': 1}
+            icd_vars = {}
+            compile_vars = {'ENABLE_TESTS': 'ON'}
             test_vars = {'MONGOCXX_TEST_TOPOLOGY': topology}
+
+            if with_extra_align:
+                icd_vars |= {'BSON_EXTRA_ALIGNMENT': 1}
+                compile_vars |= {'BSON_EXTRA_ALIGNMENT': 1}
+            else:
+                compile_vars |= {'RUN_DISTCHECK': 1}
 
             updates += [KeyValueParam(key='build_type', value=build_type)]
             updates += [KeyValueParam(key=key, value=value) for key, value in compiler_to_vars(compiler).items()]

--- a/.evergreen/config_generator/components/mongohouse.py
+++ b/.evergreen/config_generator/components/mongohouse.py
@@ -72,7 +72,7 @@ def tasks():
             commands=[
                 Setup.call(),
                 FetchCDriverSource.call(),
-                Compile.call(build_type='Release'),
+                Compile.call(build_type='Release', vars={'ENABLE_TESTS': 'ON'}),
                 BuildMongohouse.call(),
                 RunMongohouse.call(),
                 TestMongohouse.call(),

--- a/.evergreen/config_generator/components/sanitizers.py
+++ b/.evergreen/config_generator/components/sanitizers.py
@@ -62,7 +62,7 @@ def tasks():
             updates += [KeyValueParam(key=key, value=value) for key, value in compiler_to_vars(compiler).items()]
 
             icd_vars = {'SKIP_INSTALL_LIBMONGOCRYPT': 1}
-            compile_vars = {}
+            compile_vars = {'ENABLE_TESTS': 'ON'}
             test_vars = {
                 'MONGOCXX_TEST_TOPOLOGY': topology,
                 'example_projects_cc': 'clang',

--- a/.evergreen/config_generator/components/uninstall_check.py
+++ b/.evergreen/config_generator/components/uninstall_check.py
@@ -68,7 +68,6 @@ def tasks():
                         Compile.call(
                             build_type=build_type,
                             compiler=compiler,
-                            vars={'ENABLE_TESTS': 'OFF'},
                         ),
                         UninstallCheck.call(),
                     ],

--- a/.evergreen/config_generator/components/valgrind.py
+++ b/.evergreen/config_generator/components/valgrind.py
@@ -55,7 +55,7 @@ def tasks():
 
             updates = [KeyValueParam(key='build_type', value='Debug')]
             icd_vars = {'SKIP_INSTALL_LIBMONGOCRYPT': 1}
-            compile_vars = {}
+            compile_vars = {'ENABLE_TESTS': 'ON'}
             test_vars = {
                 'MONGOCXX_TEST_TOPOLOGY': topology,
                 'TEST_WITH_VALGRIND': 'ON',

--- a/.evergreen/config_generator/components/versioned_api.py
+++ b/.evergreen/config_generator/components/versioned_api.py
@@ -63,7 +63,7 @@ def tasks():
                 tags.append(polyfill)
 
             mongod_vars |= {'AUTH': 'noauth'}  # Versioned API + auth is tested by the C Driver.
-            compile_vars = {}
+            compile_vars = {'ENABLE_TESTS': 'ON'}
             test_vars |= {'MONGOCXX_TEST_TOPOLOGY': 'single'}
 
             match distro.os_type:

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -21,6 +21,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           build_type: Debug
       - func: test-search-index-helpers
   - name: atlas-search-indexes-8.0
@@ -30,6 +31,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           build_type: Debug
       - func: test-search-index-helpers
   - name: benchmarks
@@ -65,7 +67,6 @@ tasks:
       - func: compile
         vars:
           BSONCXX_POLYFILL: impls
-          ENABLE_TESTS: "OFF"
           build_type: Release
   - name: compile-only-rhel81-power8-release-shared
     run_on: rhel81-power8-large
@@ -76,7 +77,6 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
-          ENABLE_TESTS: "OFF"
           build_type: Release
   - name: compile-only-rhel83-zseries-release-shared
     run_on: rhel83-zseries-large
@@ -87,7 +87,6 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
-          ENABLE_TESTS: "OFF"
           build_type: Release
   - name: compile-only-ubuntu2004-clang-debug-shared
     run_on: ubuntu2004-large
@@ -97,7 +96,6 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
-          ENABLE_TESTS: "OFF"
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
@@ -109,7 +107,6 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
-          ENABLE_TESTS: "OFF"
           build_type: Debug
   - name: compile-only-ubuntu2004-gcc-debug-shared
     run_on: ubuntu2004-large
@@ -119,7 +116,6 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
-          ENABLE_TESTS: "OFF"
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
@@ -131,7 +127,6 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
-          ENABLE_TESTS: "OFF"
           build_type: Debug
           generator: Visual Studio 14 2015
           platform: x64
@@ -143,7 +138,6 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
-          ENABLE_TESTS: "OFF"
           build_type: Release
           generator: Visual Studio 14 2015
           platform: x64
@@ -175,6 +169,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -197,6 +192,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -218,6 +214,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -243,6 +240,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -263,6 +261,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_STATIC_LIBS: 1
       - func: fetch-det
@@ -290,6 +289,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           USE_STATIC_LIBS: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -313,6 +313,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -335,6 +336,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -356,6 +358,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -377,6 +380,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           REQUIRED_CXX_STANDARD: 20
           RUN_DISTCHECK: 1
       - func: fetch-det
@@ -405,6 +409,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           REQUIRED_CXX_STANDARD: 20
       - func: fetch-det
       - func: run_kms_servers
@@ -432,6 +437,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -452,6 +458,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_STATIC_LIBS: 1
       - func: fetch-det
@@ -479,6 +486,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           USE_STATIC_LIBS: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -502,6 +510,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -524,6 +533,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -549,6 +559,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           REQUIRED_CXX_STANDARD: 20
       - func: fetch-det
       - func: run_kms_servers
@@ -572,6 +583,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           REQUIRED_CXX_STANDARD: 20
           RUN_DISTCHECK: 1
       - func: fetch-det
@@ -600,6 +612,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -620,6 +633,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -645,6 +659,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           USE_STATIC_LIBS: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -667,6 +682,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_STATIC_LIBS: 1
       - func: fetch-det
@@ -691,6 +707,7 @@ tasks:
       - func: compile
         vars:
           BSONCXX_POLYFILL: boost
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -717,6 +734,7 @@ tasks:
         vars:
           BSONCXX_POLYFILL: boost
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -742,6 +760,7 @@ tasks:
         vars:
           BSONCXX_POLYFILL: boost
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -763,6 +782,7 @@ tasks:
       - func: compile
         vars:
           BSONCXX_POLYFILL: boost
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -785,6 +805,7 @@ tasks:
       - func: compile
         vars:
           BSONCXX_POLYFILL: boost
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_STATIC_LIBS: 1
       - func: fetch-det
@@ -813,6 +834,7 @@ tasks:
         vars:
           BSONCXX_POLYFILL: boost
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           USE_STATIC_LIBS: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -840,6 +862,7 @@ tasks:
         vars:
           BSONCXX_POLYFILL: boost
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           USE_STATIC_LIBS: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -863,6 +886,7 @@ tasks:
       - func: compile
         vars:
           BSONCXX_POLYFILL: boost
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_STATIC_LIBS: 1
       - func: fetch-det
@@ -887,6 +911,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -914,6 +939,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -940,6 +966,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -962,6 +989,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -985,6 +1013,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_STATIC_LIBS: 1
       - func: fetch-det
@@ -1014,6 +1043,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           USE_STATIC_LIBS: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1042,6 +1072,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           USE_STATIC_LIBS: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1066,6 +1097,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_STATIC_LIBS: 1
       - func: fetch-det
@@ -1091,6 +1123,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1114,6 +1147,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1141,6 +1175,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -1167,6 +1202,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -1193,6 +1229,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -1215,6 +1252,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1238,6 +1276,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_STATIC_LIBS: 1
       - func: fetch-det
@@ -1263,6 +1302,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_STATIC_LIBS: 1
       - func: fetch-det
@@ -1292,6 +1332,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           USE_STATIC_LIBS: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1320,6 +1361,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           USE_STATIC_LIBS: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1348,6 +1390,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           USE_STATIC_LIBS: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1372,6 +1415,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_STATIC_LIBS: 1
       - func: fetch-det
@@ -1397,6 +1441,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1420,6 +1465,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1446,6 +1492,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           REQUIRED_CXX_STANDARD: 20
       - func: fetch-det
       - func: run_kms_servers
@@ -1470,6 +1517,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           REQUIRED_CXX_STANDARD: 20
           RUN_DISTCHECK: 1
       - func: fetch-det
@@ -1499,6 +1547,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -1520,6 +1569,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1546,6 +1596,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           USE_STATIC_LIBS: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1569,6 +1620,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_STATIC_LIBS: 1
       - func: fetch-det
@@ -1594,6 +1646,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1617,6 +1670,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1643,6 +1697,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           REQUIRED_CXX_STANDARD: 20
       - func: fetch-det
       - func: run_kms_servers
@@ -1667,6 +1722,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           REQUIRED_CXX_STANDARD: 20
           RUN_DISTCHECK: 1
       - func: fetch-det
@@ -1696,6 +1752,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -1717,6 +1774,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1743,6 +1801,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           USE_STATIC_LIBS: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1766,6 +1825,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_STATIC_LIBS: 1
       - func: fetch-det
@@ -1790,6 +1850,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1815,6 +1876,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -1835,6 +1897,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_STATIC_LIBS: 1
       - func: fetch-det
@@ -1862,6 +1925,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           USE_STATIC_LIBS: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1884,6 +1948,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1905,6 +1970,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1926,6 +1992,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1947,6 +2014,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1968,6 +2036,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -1990,6 +2059,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2012,6 +2082,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2034,6 +2105,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2056,6 +2128,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2079,6 +2152,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2101,6 +2175,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2124,6 +2199,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2146,6 +2222,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2169,6 +2246,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2191,6 +2269,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2214,6 +2293,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2236,6 +2316,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2259,6 +2340,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2281,6 +2363,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2304,6 +2387,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2326,6 +2410,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2351,6 +2436,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -2375,6 +2461,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -2399,6 +2486,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -2423,6 +2511,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -2447,6 +2536,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -2468,6 +2558,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2490,6 +2581,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2515,6 +2607,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -2535,6 +2628,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2560,6 +2654,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           USE_STATIC_LIBS: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2582,6 +2677,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_STATIC_LIBS: 1
       - func: fetch-det
@@ -2605,6 +2701,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2626,6 +2723,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2648,6 +2746,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2670,6 +2769,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2692,6 +2792,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2714,6 +2815,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2736,6 +2838,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2758,6 +2861,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2781,6 +2885,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2803,6 +2908,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2829,6 +2935,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -2853,6 +2960,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -2877,6 +2985,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -2897,6 +3006,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2919,6 +3029,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2941,6 +3052,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2962,6 +3074,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -2984,6 +3097,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -3006,6 +3120,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -3028,6 +3143,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -3050,6 +3166,7 @@ tasks:
       - func: install_c_driver
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -3075,6 +3192,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -3099,6 +3217,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -3119,6 +3238,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -3140,6 +3260,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_STATIC_LIBS: 1
       - func: fetch-det
@@ -3167,6 +3288,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           USE_STATIC_LIBS: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -3193,6 +3315,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           USE_STATIC_LIBS: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -3215,6 +3338,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_STATIC_LIBS: 1
       - func: fetch-det
@@ -3240,6 +3364,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -3264,6 +3389,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -3288,6 +3414,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -3312,6 +3439,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -3336,6 +3464,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -3360,6 +3489,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -3384,6 +3514,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -3412,6 +3543,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -3439,6 +3571,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -3466,6 +3599,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -3493,6 +3627,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -3520,6 +3655,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -3547,6 +3683,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -3574,6 +3711,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -3601,6 +3739,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -3624,6 +3763,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -3708,6 +3848,7 @@ tasks:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_SANITIZER_ASAN: "ON"
       - func: fetch-det
@@ -3741,6 +3882,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           USE_SANITIZER_ASAN: "ON"
       - func: fetch-det
       - func: run_kms_servers
@@ -3772,6 +3914,7 @@ tasks:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_SANITIZER_ASAN: "ON"
       - func: fetch-det
@@ -3806,6 +3949,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           USE_SANITIZER_ASAN: "ON"
       - func: fetch-det
       - func: run_kms_servers
@@ -3836,6 +3980,7 @@ tasks:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_SANITIZER_ASAN: "ON"
       - func: fetch-det
@@ -3869,6 +4014,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           USE_SANITIZER_ASAN: "ON"
       - func: fetch-det
       - func: run_kms_servers
@@ -3900,6 +4046,7 @@ tasks:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_SANITIZER_ASAN: "ON"
       - func: fetch-det
@@ -3934,6 +4081,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           USE_SANITIZER_ASAN: "ON"
       - func: fetch-det
       - func: run_kms_servers
@@ -3965,6 +4113,7 @@ tasks:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_SANITIZER_UBSAN: "ON"
       - func: fetch-det
@@ -3997,6 +4146,7 @@ tasks:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
           USE_SANITIZER_UBSAN: "ON"
       - func: fetch-det
@@ -4131,6 +4281,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           build_type: Release
       - func: build_mongohouse
       - func: run_mongohouse
@@ -4143,7 +4294,6 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
-          ENABLE_TESTS: "OFF"
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
@@ -4156,7 +4306,6 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
-          ENABLE_TESTS: "OFF"
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
@@ -4169,7 +4318,6 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
-          ENABLE_TESTS: "OFF"
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
@@ -4182,7 +4330,6 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
-          ENABLE_TESTS: "OFF"
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
@@ -4195,7 +4342,6 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
-          ENABLE_TESTS: "OFF"
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
@@ -4208,7 +4354,6 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
-          ENABLE_TESTS: "OFF"
           build_type: Debug
           generator: Visual Studio 14 2015
           platform: x64
@@ -4221,7 +4366,6 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
-          ENABLE_TESTS: "OFF"
           build_type: Release
           generator: Visual Studio 14 2015
           platform: x64
@@ -4243,6 +4387,7 @@ tasks:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -4271,6 +4416,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -4297,6 +4443,7 @@ tasks:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -4326,6 +4473,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -4353,6 +4501,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -4378,6 +4527,7 @@ tasks:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -4407,6 +4557,7 @@ tasks:
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
       - func: fetch-det
       - func: run_kms_servers
       - func: test
@@ -4433,6 +4584,7 @@ tasks:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -4456,6 +4608,7 @@ tasks:
       - func: compile
         vars:
           BSONCXX_POLYFILL: boost
+          ENABLE_TESTS: "ON"
           build_type: Release
       - func: fetch-det
       - func: run_kms_servers
@@ -4477,6 +4630,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           build_type: Debug
       - func: fetch-det
       - func: run_kms_servers
@@ -4498,6 +4652,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           build_type: Debug
           generator: Visual Studio 16 2019
           platform: x64
@@ -4525,6 +4680,7 @@ tasks:
       - func: compile
         vars:
           BSONCXX_POLYFILL: boost
+          ENABLE_TESTS: "ON"
           build_type: Release
       - func: fetch-det
       - func: run_kms_servers
@@ -4545,6 +4701,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           build_type: Debug
       - func: fetch-det
       - func: run_kms_servers
@@ -4565,6 +4722,7 @@ tasks:
       - func: fetch_c_driver_source
       - func: compile
         vars:
+          ENABLE_TESTS: "ON"
           build_type: Debug
           generator: Visual Studio 16 2019
           platform: x64

--- a/.evergreen/scripts/build_snapshot_rpm.sh
+++ b/.evergreen/scripts/build_snapshot_rpm.sh
@@ -105,7 +105,7 @@ sudo mock -r ${config} --use-bootstrap-image --isolation=simple --copyout "/tmp/
 sudo mock -r ${config} --use-bootstrap-image --isolation=simple --cwd "/tmp/${build_dir}" --chroot -- /bin/sh -c "(
   [ -d build ] || mkdir build ;
   cd build ;
-  /usr/bin/cmake -DCMAKE_BUILD_TYPE=Release -DBSONCXX_POLY_USE_BOOST=1 -DENABLE_UNINSTALL=OFF -DENABLE_TESTS=OFF .. ;
+  /usr/bin/cmake -DCMAKE_BUILD_TYPE=Release -DBSONCXX_POLY_USE_BOOST=1 -DENABLE_UNINSTALL=OFF .. ;
   make -j 8 dist
   )"
 

--- a/.evergreen/scripts/compile-scan-build.sh
+++ b/.evergreen/scripts/compile-scan-build.sh
@@ -56,7 +56,6 @@ cmake_flags=(
   "-DCMAKE_BUILD_TYPE=Debug"
   "-DCMAKE_CXX_STANDARD=${CXX_STANDARD:?}"
   "-DCMAKE_CXX_STANDARD_REQUIRED=ON"
-  "-DENABLE_TESTS=OFF"
 )
 
 scan_build_flags=(

--- a/.evergreen/scripts/compile.sh
+++ b/.evergreen/scripts/compile.sh
@@ -73,7 +73,6 @@ if [[ -f "${mongoc_prefix:?}/.evergreen/scripts/find-ccache.sh" ]]; then
   find_ccache_and_export_vars "$(pwd)" || true
 fi
 
-
 build_targets=()
 cmake_build_opts=()
 case "${OSTYPE:?}" in
@@ -99,7 +98,6 @@ cd build
 cmake_flags=(
   "-DCMAKE_BUILD_TYPE=${build_type:?}"
   "-DCMAKE_PREFIX_PATH=${mongoc_prefix:?}"
-  -DBUILD_TESTING=ON
   -DMONGOCXX_ENABLE_SLOW_TESTS=ON
   -DCMAKE_INSTALL_PREFIX=install
   -DENABLE_UNINSTALL=ON
@@ -229,8 +227,11 @@ if [ "${USE_STATIC_LIBS:-}" ]; then
   cmake_flags+=("-DBUILD_SHARED_LIBS=OFF")
 fi
 
-if [ "${ENABLE_TESTS:-}" = "OFF" ]; then
-  cmake_flags+=("-DENABLE_TESTS=OFF")
+if [ "${ENABLE_TESTS:-}" = "ON" ]; then
+  cmake_flags+=(
+    "-DENABLE_TESTS=ON"
+    "-DBUILD_TESTING=ON"
+  )
 fi
 
 if [[ -n "${REQUIRED_CXX_STANDARD:-}" ]]; then

--- a/.evergreen/scripts/install-c-driver.sh
+++ b/.evergreen/scripts/install-c-driver.sh
@@ -104,7 +104,6 @@ declare -a configure_flags=(
   "-DENABLE_EXAMPLES=OFF"
   "-DENABLE_SHM_COUNTERS=OFF"
   "-DENABLE_STATIC=ON"
-  "-DENABLE_TESTS=OFF"
 )
 
 if [[ "${SKIP_INSTALL_LIBMONGOCRYPT:-}" != "1" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ## 4.0.0 [Unreleased]
 
+## Changed
+
+- CMake option `ENABLE_TESTS` is now `OFF` by default.
+  - Set `ENABLE_TEST=ON` to re-enable building test targets.
+  - Set `BUILD_TESTING=ON` to include test targets in the "all" target when `ENABLE_TESTS=ON` (since 3.9.0, `OFF` by default).
+
 ## Removed
 
 - Support for CMake option `MONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set(CMAKE_MODULE_PATH
     ${PROJECT_SOURCE_DIR}/cmake/make_dist
 )
 
-option(BUILD_TESTING "Include test targets in the \"all\" target")
+option(BUILD_TESTING "When ENABLE_TESTS=ON, include test targets in the \"all\" target")
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.8.2")
@@ -327,8 +327,12 @@ add_custom_target(docs
 set(THIRD_PARTY_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party)
 set(DATA_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data)
 
-option(ENABLE_TESTS "Build MongoDB C++ Driver tests." ON)
-option(ENABLE_MACRO_GUARD_TESTS "Enable targets for macro guard compile tests." OFF)
+option(ENABLE_TESTS "Enable building test targets." OFF)
+option(ENABLE_MACRO_GUARD_TESTS "When ENABLE_TESTS=ON, enable macro guard test targets." OFF)
+
+if(BUILD_TESTING AND NOT ENABLE_TESTS)
+    message(WARNING "BUILD_TESTING is enabled without also setting ENABLE_TESTS. Set ENABLE_TESTS=ON to building test targets.")
+endif()
 
 if(ENABLE_TESTS)
     enable_testing()


### PR DESCRIPTION
Resolves CXX-3179. Verified by [this patch](https://spruce.mongodb.com/version/673283e445a9270007fcea3c).

Changes the default value of `ENABLE_TESTS` from `ON` to `OFF`.

Tweaked descriptions of CMake options to better document how they are conditioned on `ENABLE_TESTS=ON` (e.g. `BUILD_TESTING=ON` alone does _not_ enable test targets). In particular, the difference between `BUILD_TESTING` (add test targets to "all") and `ENABLE_TESTS` (enable the test targets which may be added to "all") is clarified by the addition of a warning when `BUILD_TESTING=ON` + `ENABLE_TESTS=OFF` (which suggests a conflict of intent).

All instances of `ENABLE_TESTS=OFF` in Evergreen scripts (except in `spec.patch`) are removed in favor of using off-by-default behavior. All EVG tasks which require test targets or their corresponding build artifacts now explicitly set `ENABLE_TESTS=ON` (which atm always implies `BUILD_TESTING=ON`). In short, building test targets is now explicitly opt-in both in CMake configuration and in Evergreen scripts.