### PR TITLE
CXX-3101 Remove workarounds for core::string_view

### DIFF
--- a/examples/api/bsoncxx/examples/bson_documents/access_array/algorithms.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/access_array/algorithms.cpp
@@ -34,12 +34,12 @@ void example(bsoncxx::array::view arr) {
 
     std::copy_if(
         arr.begin(), arr.end(), std::back_inserter(elements), [](const bsoncxx::array::element& e) {
-            return e.key().compare("0") == 0 || e.type() == bsoncxx::type::k_string;
+            return e.key() == "0" || e.type() == bsoncxx::type::k_string;
         });
 
     EXPECT(elements.size() == 2u);
-    EXPECT(elements[0].key().compare("0") == 0);
-    EXPECT(elements[1].key().compare("2") == 0);
+    EXPECT(elements[0].key() == "0");
+    EXPECT(elements[1].key() == "2");
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/access_array/basic.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/access_array/basic.cpp
@@ -28,16 +28,16 @@ void example(bsoncxx::array::view arr) {
     for (bsoncxx::array::element e : arr) {
         switch (e.type()) {
             case bsoncxx::type::k_int32:
-                EXPECT(e.key().compare("0") == 0);
+                EXPECT(e.key() == "0");
                 EXPECT(e.get_int32().value == 1);
                 break;
             case bsoncxx::type::k_double:
-                EXPECT(e.key().compare("1") == 0);
+                EXPECT(e.key() == "1");
                 EXPECT(e.get_double().value == 2.0);
                 break;
             case bsoncxx::type::k_string:
-                EXPECT(e.key().compare("2") == 0);
-                EXPECT(e.get_string().value.compare("three") == 0);
+                EXPECT(e.key() == "2");
+                EXPECT(e.get_string().value == "three");
                 break;
         }
     }

--- a/examples/api/bsoncxx/examples/bson_documents/access_array/find.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/access_array/find.cpp
@@ -30,7 +30,7 @@ void example(bsoncxx::array::view arr) {
         auto iter = arr.find(1);
 
         EXPECT(iter != arr.end());
-        EXPECT(iter->key().compare("1") == 0);
+        EXPECT(iter->key() == "1");
         EXPECT(iter->get_int32().value == 2);
     }
 

--- a/examples/api/bsoncxx/examples/bson_documents/access_array/iterators.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/access_array/iterators.cpp
@@ -33,20 +33,20 @@ void example(bsoncxx::array::view arr) {
     {
         bsoncxx::array::element e = *iter;
 
-        EXPECT(e.key().compare("0") == 0);
+        EXPECT(e.key() == "0");
         EXPECT(e.get_int32().value == 1);
     }
 
     ++iter;
 
-    EXPECT(iter->key().compare("1") == 0);
+    EXPECT(iter->key() == "1");
     EXPECT(iter->get_int32().value == 2);
 
     {
         auto iter_copy = iter++;
 
         EXPECT(iter_copy != iter);
-        EXPECT(iter_copy->key().compare("1") == 0);
+        EXPECT(iter_copy->key() == "1");
         EXPECT(iter_copy->get_int32() == 2);
     }
 

--- a/examples/api/bsoncxx/examples/bson_documents/access_array/subscript.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/access_array/subscript.cpp
@@ -30,7 +30,7 @@ void example(bsoncxx::array::view arr) {
     {
         bsoncxx::array::element e = arr[1];
 
-        EXPECT(e.key().compare("1") == 0);
+        EXPECT(e.key() == "1");
         EXPECT(e.get_int32().value == 2);
     }
 

--- a/examples/api/bsoncxx/examples/bson_documents/access_doc/algorithms.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/access_doc/algorithms.cpp
@@ -37,12 +37,12 @@ void example(bsoncxx::document::view doc) {
                  doc.end(),
                  std::back_inserter(elements),
                  [](const bsoncxx::document::element& e) {
-                     return e.key().compare("a") == 0 || e.type() == bsoncxx::type::k_string;
+                     return e.key() == "a" || e.type() == bsoncxx::type::k_string;
                  });
 
     EXPECT(elements.size() == 2u);
-    EXPECT(elements[0].key().compare("a") == 0);
-    EXPECT(elements[1].key().compare("c") == 0);
+    EXPECT(elements[0].key() == "a");
+    EXPECT(elements[1].key() == "c");
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/access_doc/basic.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/access_doc/basic.cpp
@@ -28,16 +28,16 @@ void example(bsoncxx::document::view doc) {
     for (bsoncxx::document::element e : doc) {
         switch (e.type()) {
             case bsoncxx::type::k_int32:
-                EXPECT(e.key().compare("a") == 0);
+                EXPECT(e.key() == "a");
                 EXPECT(e.get_int32().value == 1);
                 break;
             case bsoncxx::type::k_double:
-                EXPECT(e.key().compare("b") == 0);
+                EXPECT(e.key() == "b");
                 EXPECT(e.get_double().value == 2.0);
                 break;
             case bsoncxx::type::k_string:
-                EXPECT(e.key().compare("c") == 0);
-                EXPECT(e.get_string().value.compare("three") == 0);
+                EXPECT(e.key() == "c");
+                EXPECT(e.get_string().value == "three");
                 break;
         }
     }

--- a/examples/api/bsoncxx/examples/bson_documents/access_doc/find.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/access_doc/find.cpp
@@ -30,7 +30,7 @@ void example(bsoncxx::document::view doc) {
         auto iter = doc.find("b");
 
         EXPECT(iter != doc.end());
-        EXPECT(iter->key().compare("b") == 0);
+        EXPECT(iter->key() == "b");
         EXPECT(iter->get_int32().value == 2);
     }
 

--- a/examples/api/bsoncxx/examples/bson_documents/access_doc/iterators.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/access_doc/iterators.cpp
@@ -33,20 +33,20 @@ void example(bsoncxx::document::view doc) {
     {
         bsoncxx::document::element e = *iter;
 
-        EXPECT(e.key().compare("a") == 0);
+        EXPECT(e.key() == "a");
         EXPECT(e.get_int32().value == 1);
     }
 
     ++iter;
 
-    EXPECT(iter->key().compare("b") == 0);
+    EXPECT(iter->key() == "b");
     EXPECT(iter->get_int32().value == 2);
 
     {
         auto iter_copy = iter++;
 
         EXPECT(iter_copy != iter);
-        EXPECT(iter_copy->key().compare("b") == 0);
+        EXPECT(iter_copy->key() == "b");
         EXPECT(iter_copy->get_int32() == 2);
     }
 

--- a/examples/api/bsoncxx/examples/bson_documents/access_doc/subscript.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/access_doc/subscript.cpp
@@ -30,7 +30,7 @@ void example(bsoncxx::document::view doc) {
     {
         bsoncxx::document::element e = doc["b"];
 
-        EXPECT(e.key().compare("b") == 0);
+        EXPECT(e.key() == "b");
         EXPECT(e.get_int32().value == 2);
     }
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_array/builder_make_document.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_array/builder_make_document.cpp
@@ -32,7 +32,7 @@ void example() {
 
     EXPECT(arr[0].get_int32().value == 1);
     EXPECT(arr[1].get_double().value == 2.0);
-    EXPECT(arr[2].get_string().value.compare("three") == 0);
+    EXPECT(arr[2].get_string().value == "three");
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_array/builder_value_type.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_array/builder_value_type.cpp
@@ -36,7 +36,7 @@ void example() {
 
     EXPECT(arr[0].get_int32().value == 1);
     EXPECT(arr[1].get_double().value == 2.0);
-    EXPECT(arr[2].get_string().value.compare("three") == 0);
+    EXPECT(arr[2].get_string().value == "three");
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_array/json_basic.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_array/json_basic.cpp
@@ -31,7 +31,7 @@ void example() {
 
     EXPECT(doc["0"].get_int32().value == 1);
     EXPECT(doc["1"].get_double().value == 2.0);
-    EXPECT(doc["2"].get_string().value.compare("three") == 0);
+    EXPECT(doc["2"].get_string().value == "three");
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/create_doc/json_basic.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/create_doc/json_basic.cpp
@@ -35,7 +35,7 @@ void example() {
 
     EXPECT(doc["a"].get_int32().value == 1);
     EXPECT(doc["b"].get_double().value == 2.0);
-    EXPECT(doc["c"].get_string().value.compare("three") == 0);
+    EXPECT(doc["c"].get_string().value == "three");
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/elements/arr_multi.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/elements/arr_multi.cpp
@@ -26,7 +26,7 @@ namespace {
 void example(bsoncxx::array::element e) {
     switch (e.type()) {
         case bsoncxx::type::k_int32: {
-            EXPECT(e.key().compare("0") == 0);
+            EXPECT(e.key() == "0");
 
             bsoncxx::types::b_int32 v = e.get_int32();
 
@@ -36,7 +36,7 @@ void example(bsoncxx::array::element e) {
             break;
         }
         case bsoncxx::type::k_double: {
-            EXPECT(e.key().compare("1") == 0);
+            EXPECT(e.key() == "1");
 
             bsoncxx::types::b_double v = e.get_double();
 
@@ -46,12 +46,12 @@ void example(bsoncxx::array::element e) {
             break;
         }
         case bsoncxx::type::k_string: {
-            EXPECT(e.key().compare("2") == 0);
+            EXPECT(e.key() == "2");
 
             bsoncxx::types::b_string v = e.get_string();
 
             EXPECT(v.type_id == bsoncxx::type::k_string);
-            EXPECT(v.value.compare("three") == 0);
+            EXPECT(v.value == "three");
 
             break;
         }

--- a/examples/api/bsoncxx/examples/bson_documents/elements/arr_single.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/elements/arr_single.cpp
@@ -25,14 +25,14 @@ namespace {
 // [1, 2.0, "three"]
 void example(bsoncxx::array::element e) {
     if (e.type() == bsoncxx::type::k_int32) {
-        EXPECT(e.key().compare("0") == 0);
+        EXPECT(e.key() == "0");
 
         bsoncxx::types::b_int32 v = e.get_int32();
 
         EXPECT(v.type_id == bsoncxx::type::k_int32);
         EXPECT(v.value == 1);
     } else {
-        EXPECT(e.key().compare("0") != 0);
+        EXPECT(e.key() != "0");
     }
 }
 // [Example]

--- a/examples/api/bsoncxx/examples/bson_documents/elements/cmp_bson_value.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/elements/cmp_bson_value.cpp
@@ -29,18 +29,18 @@ void example(bsoncxx::document::element e) {
     bsoncxx::types::b_int64 b{2};
 
     if (e.get_value() == a) {
-        EXPECT(e.key().compare("a") == 0);
+        EXPECT(e.key() == "a");
     } else if (e.get_value() == b) {
-        EXPECT(e.key().compare("b") == 0);
+        EXPECT(e.key() == "b");
     }
 
     bsoncxx::types::bson_value::view va{a};
     bsoncxx::types::bson_value::view vb{b};
 
     if (e == va) {
-        EXPECT(e.key().compare("a") == 0);
+        EXPECT(e.key() == "a");
     } else if (e == vb) {
-        EXPECT(e.key().compare("b") == 0);
+        EXPECT(e.key() == "b");
     }
 }
 // [Example]

--- a/examples/api/bsoncxx/examples/bson_documents/elements/cmp_type.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/elements/cmp_type.cpp
@@ -30,10 +30,10 @@ void example(bsoncxx::document::element e) {
     std::int64_t b{2};
 
     if (e.type() == bsoncxx::type::k_int32) {
-        EXPECT(e.key().compare("a") == 0);
+        EXPECT(e.key() == "a");
         EXPECT(e.get_int32().value == a);
     } else if (e.type() == bsoncxx::type::k_int64) {
-        EXPECT(e.key().compare("b") == 0);
+        EXPECT(e.key() == "b");
         EXPECT(e.get_int64().value == b);
     }
 }

--- a/examples/api/bsoncxx/examples/bson_documents/elements/doc_multi.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/elements/doc_multi.cpp
@@ -26,7 +26,7 @@ namespace {
 void example(bsoncxx::document::element e) {
     switch (e.type()) {
         case bsoncxx::type::k_int32: {
-            EXPECT(e.key().compare("a") == 0);
+            EXPECT(e.key() == "a");
 
             bsoncxx::types::b_int32 v = e.get_int32();
 
@@ -36,7 +36,7 @@ void example(bsoncxx::document::element e) {
             break;
         }
         case bsoncxx::type::k_double: {
-            EXPECT(e.key().compare("b") == 0);
+            EXPECT(e.key() == "b");
 
             bsoncxx::types::b_double v = e.get_double();
 
@@ -46,12 +46,12 @@ void example(bsoncxx::document::element e) {
             break;
         }
         case bsoncxx::type::k_string: {
-            EXPECT(e.key().compare("c") == 0);
+            EXPECT(e.key() == "c");
 
             bsoncxx::types::b_string v = e.get_string();
 
             EXPECT(v.type_id == bsoncxx::type::k_string);
-            EXPECT(v.value.compare("three") == 0);
+            EXPECT(v.value == "three");
 
             break;
         }

--- a/examples/api/bsoncxx/examples/bson_documents/elements/doc_single.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/elements/doc_single.cpp
@@ -25,14 +25,14 @@ namespace {
 // {"a": 1, "b": 2.0, "c": "three"}
 void example(bsoncxx::document::element e) {
     if (e.type() == bsoncxx::type::k_int32) {
-        EXPECT(e.key().compare("a") == 0);
+        EXPECT(e.key() == "a");
 
         bsoncxx::types::b_int32 v = e.get_int32();
 
         EXPECT(v.type_id == bsoncxx::type::k_int32);
         EXPECT(v.value == 1);
     } else {
-        EXPECT(e.key().compare("a") != 0);
+        EXPECT(e.key() != "a");
     }
 }
 // [Example]

--- a/examples/api/bsoncxx/examples/bson_documents/values/arr_value.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/values/arr_value.cpp
@@ -37,7 +37,7 @@ void example() {
     v = v.view().get_array().value[0].get_string();  // Copy: no dangling.
 
     EXPECT(v.view().type() == bsoncxx::type::k_string);
-    EXPECT(v.view().get_string().value.compare("value") == 0);
+    EXPECT(v.view().get_string().value == "value");
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/values/arr_view.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/values/arr_view.cpp
@@ -30,15 +30,15 @@ void example(bsoncxx::array::element e) {
 
     switch (v.type()) {
         case bsoncxx::type::k_int32:
-            EXPECT(e.key().compare("0") == 0);
+            EXPECT(e.key() == "0");
             EXPECT(v.get_int32() == e.get_int32());
             break;
         case bsoncxx::type::k_double:
-            EXPECT(e.key().compare("1") == 0);
+            EXPECT(e.key() == "1");
             EXPECT(v.get_double() == e.get_double());
             break;
         case bsoncxx::type::k_string:
-            EXPECT(e.key().compare("2") == 0);
+            EXPECT(e.key() == "2");
             EXPECT(v.get_string() == e.get_string());
             break;
     }

--- a/examples/api/bsoncxx/examples/bson_documents/values/bson_type_value.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/values/bson_type_value.cpp
@@ -37,7 +37,7 @@ void example() {
 
     v = bsoncxx::types::b_string{"three"};
     EXPECT(v.view().type() == bsoncxx::type::k_string);
-    EXPECT(v.view().get_string().value.compare("three") == 0);
+    EXPECT(v.view().get_string().value == "three");
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/values/doc_value.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/values/doc_value.cpp
@@ -37,7 +37,7 @@ void example() {
     v = v.view().get_document().value["key"].get_string();  // Copy: no dangling.
 
     EXPECT(v.view().type() == bsoncxx::type::k_string);
-    EXPECT(v.view().get_string().value.compare("value") == 0);
+    EXPECT(v.view().get_string().value == "value");
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_documents/values/doc_view.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/values/doc_view.cpp
@@ -30,15 +30,15 @@ void example(bsoncxx::document::element e) {
 
     switch (v.type()) {
         case bsoncxx::type::k_int32:
-            EXPECT(e.key().compare("a") == 0);
+            EXPECT(e.key() == "a");
             EXPECT(v.get_int32() == e.get_int32());
             break;
         case bsoncxx::type::k_double:
-            EXPECT(e.key().compare("b") == 0);
+            EXPECT(e.key() == "b");
             EXPECT(v.get_double() == e.get_double());
             break;
         case bsoncxx::type::k_string:
-            EXPECT(e.key().compare("c") == 0);
+            EXPECT(e.key() == "c");
             EXPECT(v.get_string() == e.get_string());
             break;
     }

--- a/examples/api/bsoncxx/examples/bson_documents/values/make_value.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/values/make_value.cpp
@@ -50,7 +50,7 @@ void example() {
         view_type v = owner.view();
 
         EXPECT(v.type() == bsoncxx::type::k_string);
-        EXPECT(v.get_string().value.compare("three") == 0);
+        EXPECT(v.get_string().value == "three");
     }
 }
 // [Example]

--- a/examples/api/bsoncxx/examples/bson_documents/values/value_type.cpp
+++ b/examples/api/bsoncxx/examples/bson_documents/values/value_type.cpp
@@ -42,7 +42,7 @@ void example() {
     v = std::string("three");
 
     EXPECT(v.view().type() == bsoncxx::type::k_string);
-    EXPECT(v.view().get_string().value.compare("three") == 0);
+    EXPECT(v.view().get_string().value == "three");
 }
 // [Example]
 

--- a/examples/api/bsoncxx/examples/bson_errors/query_element_arr_invalid_type.cpp
+++ b/examples/api/bsoncxx/examples/bson_errors/query_element_arr_invalid_type.cpp
@@ -26,7 +26,7 @@ namespace {
 // [Example]
 // [1]
 void example(bsoncxx::array::element e) {
-    EXPECT(e.key().compare("0") == 0);
+    EXPECT(e.key() == "0");
     EXPECT(e.type() == bsoncxx::type::k_int32);
     EXPECT(e.get_int32().value == 1);
 

--- a/examples/api/bsoncxx/examples/bson_errors/query_element_doc_invalid_type.cpp
+++ b/examples/api/bsoncxx/examples/bson_errors/query_element_doc_invalid_type.cpp
@@ -26,7 +26,7 @@ namespace {
 // [Example]
 // {"x": 1}
 void example(bsoncxx::document::element e) {
-    EXPECT(e.key().compare("x") == 0);
+    EXPECT(e.key() == "x");
     EXPECT(e.type() == bsoncxx::type::k_int32);
     EXPECT(e.get_int32().value == 1);
 

--- a/examples/api/mongocxx/examples/change_streams/basic.cpp
+++ b/examples/api/mongocxx/examples/change_streams/basic.cpp
@@ -48,7 +48,7 @@ void example(mongocxx::database db) {
             ++count;
 
             EXPECT(change["operationType"]);
-            EXPECT(change["operationType"].get_string().value.compare("insert") == 0);
+            EXPECT(change["operationType"].get_string().value == "insert");
 
             EXPECT(change["ns"]);
             EXPECT(change["ns"]["db"].get_string().value == db.name());

--- a/examples/api/mongocxx/examples/clients/use/list_databases.cpp
+++ b/examples/api/mongocxx/examples/clients/use/list_databases.cpp
@@ -34,7 +34,7 @@ void example(mongocxx::client client) {
         EXPECT(doc["sizeOnDisk"]);
         EXPECT(doc["empty"]);
 
-        if (doc["name"].get_string().value.compare("admin") == 0) {
+        if (doc["name"].get_string().value == "admin") {
             ++count;
         }
     }

--- a/examples/api/mongocxx/examples/clients/use/list_databases_with_options.cpp
+++ b/examples/api/mongocxx/examples/clients/use/list_databases_with_options.cpp
@@ -39,7 +39,7 @@ void example(mongocxx::client client) {
         EXPECT(!doc["sizeOnDisk"]);
         EXPECT(!doc["empty"]);
 
-        if (doc["name"].get_string().value.compare("admin") == 0) {
+        if (doc["name"].get_string().value == "admin") {
             ++count;
         }
     }

--- a/examples/api/mongocxx/examples/collections/create_index.cpp
+++ b/examples/api/mongocxx/examples/collections/create_index.cpp
@@ -35,7 +35,7 @@ void example(mongocxx::collection coll) {
     bsoncxx::document::value result = coll.create_index(bsoncxx::from_json(R"({"key": 1})"));
 
     EXPECT(result["name"]);
-    EXPECT(result["name"].get_string().value.compare("key_1") == 0);
+    EXPECT(result["name"].get_string().value == "key_1");
 }
 // [Example]
 

--- a/examples/api/mongocxx/examples/collections/create_index_with_options.cpp
+++ b/examples/api/mongocxx/examples/collections/create_index_with_options.cpp
@@ -44,7 +44,7 @@ void example(mongocxx::collection coll) {
             coll.create_index(bsoncxx::from_json(R"({"key_a": 1})"), opts.view());
 
         EXPECT(result["name"]);
-        EXPECT(result["name"].get_string().value.compare("custom_name") == 0);
+        EXPECT(result["name"].get_string().value == "custom_name");
     }
 
     // Create index options.
@@ -59,7 +59,7 @@ void example(mongocxx::collection coll) {
             coll.create_index(bsoncxx::from_json(R"({"key_b": 1})"), opts.view());
 
         EXPECT(result["name"]);
-        EXPECT(result["name"].get_string().value.compare("key_b_1") == 0);
+        EXPECT(result["name"].get_string().value == "key_b_1");
     }
 }
 // [Example]
@@ -79,7 +79,7 @@ RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
         for (auto doc : db["coll"].list_indexes()) {
             EXPECT(doc["name"]);
 
-            if (doc["name"].get_string().value.compare("custom_name") == 0) {
+            if (doc["name"].get_string().value == "custom_name") {
                 EXPECT(doc["unique"]);
                 EXPECT(doc["unique"].get_bool().value == true);
             }

--- a/examples/api/mongocxx/examples/collections/index_views/create_with_options.cpp
+++ b/examples/api/mongocxx/examples/collections/index_views/create_with_options.cpp
@@ -90,7 +90,7 @@ RUNNER_REGISTER_COMPONENT_FOR_SINGLE() {
         for (auto doc : coll.indexes().list()) {
             EXPECT(doc["name"]);
 
-            if (doc["name"].get_string().value.compare("custom_name") == 0) {
+            if (doc["name"].get_string().value == "custom_name") {
                 EXPECT(doc["unique"]);
                 EXPECT(doc["unique"].get_bool().value == true);
             }

--- a/examples/api/mongocxx/examples/collections/obtain.cpp
+++ b/examples/api/mongocxx/examples/collections/obtain.cpp
@@ -27,9 +27,9 @@ void example(mongocxx::database db) {
     mongocxx::collection coll = db["coll"];
 
     EXPECT(coll);
-    EXPECT(coll.name().compare("coll") == 0);
+    EXPECT(coll.name() == "coll");
 
-    EXPECT(db.collection("coll").name().compare("coll") == 0);
+    EXPECT(db.collection("coll").name() == "coll");
 }
 // [Example]
 

--- a/examples/api/mongocxx/examples/collections/rename.cpp
+++ b/examples/api/mongocxx/examples/collections/rename.cpp
@@ -31,11 +31,11 @@ void example(mongocxx::database db) {
     EXPECT(db.has_collection("old"));
     EXPECT(!db.has_collection("new"));
 
-    EXPECT(coll.name().compare("old") == 0);
+    EXPECT(coll.name() == "old");
 
     coll.rename("new");
 
-    EXPECT(coll.name().compare("new") == 0);
+    EXPECT(coll.name() == "new");
 
     EXPECT(!db.has_collection("old"));
     EXPECT(db.has_collection("new"));

--- a/examples/api/mongocxx/examples/databases/obtain.cpp
+++ b/examples/api/mongocxx/examples/databases/obtain.cpp
@@ -26,9 +26,9 @@ void example(mongocxx::client client) {
     mongocxx::database db = client["db"];
 
     EXPECT(db);
-    EXPECT(db.name().compare("db") == 0);
+    EXPECT(db.name() == "db");
 
-    EXPECT(client.database("db").name().compare("db") == 0);
+    EXPECT(client.database("db").name() == "db");
 }
 // [Example]
 

--- a/examples/api/mongocxx/examples/logger/basic_usage.cpp
+++ b/examples/api/mongocxx/examples/logger/basic_usage.cpp
@@ -36,8 +36,8 @@ class example_logger : public mongocxx::logger {
                     bsoncxx::stdx::string_view domain,
                     bsoncxx::stdx::string_view message) noexcept override {
         EXPECT(level == mongocxx::log_level::k_info);
-        EXPECT(domain.compare("mongocxx") == 0);
-        EXPECT(message.compare("libmongoc logging callback enabled") == 0);
+        EXPECT(domain == "mongocxx");
+        EXPECT(message == "libmongoc logging callback enabled");
 
         *counter_ptr += 1;
     }

--- a/examples/api/mongocxx/examples/logger/to_string.cpp
+++ b/examples/api/mongocxx/examples/logger/to_string.cpp
@@ -34,13 +34,13 @@ void example() {
     bsoncxx::stdx::string_view debug = mongocxx::to_string(mongocxx::log_level::k_debug);
     bsoncxx::stdx::string_view trace = mongocxx::to_string(mongocxx::log_level::k_trace);
 
-    EXPECT(error.compare("error") == 0);
-    EXPECT(critical.compare("critical") == 0);
-    EXPECT(warning.compare("warning") == 0);
-    EXPECT(message.compare("message") == 0);
-    EXPECT(info.compare("info") == 0);
-    EXPECT(debug.compare("debug") == 0);
-    EXPECT(trace.compare("trace") == 0);
+    EXPECT(error == "error");
+    EXPECT(critical == "critical");
+    EXPECT(warning == "warning");
+    EXPECT(message == "message");
+    EXPECT(info == "info");
+    EXPECT(debug == "debug");
+    EXPECT(trace == "trace");
 }
 // [Example]
 

--- a/examples/api/mongocxx/examples/operation_exceptions/operation.cpp
+++ b/examples/api/mongocxx/examples/operation_exceptions/operation.cpp
@@ -31,7 +31,7 @@ namespace {
 
 // [Example]
 void example(mongocxx::database db) {
-    EXPECT(db.name().compare("db") == 0);
+    EXPECT(db.name() == "db");
 
     // The `getParameter` command can only be run in the `admin` database.
     auto cmd = bsoncxx::from_json(R"({"getParameter": "*"})");

--- a/examples/api/mongocxx/examples/operation_exceptions/regular.cpp
+++ b/examples/api/mongocxx/examples/operation_exceptions/regular.cpp
@@ -29,7 +29,7 @@ namespace {
 
 // [Example]
 void example(mongocxx::database db) {
-    EXPECT(db.name().compare("db") == 0);
+    EXPECT(db.name() == "db");
 
     // The `getParameter` command can only be run in the `admin` database.
     auto cmd = bsoncxx::from_json(R"({"getParameter": "*"})");

--- a/examples/api/mongocxx/examples/uri/all_options.cpp
+++ b/examples/api/mongocxx/examples/uri/all_options.cpp
@@ -32,7 +32,7 @@ void example() {
     bsoncxx::document::view options = uri.options();
 
     EXPECT(options["appname"]);
-    EXPECT(options["appname"].get_string().value.compare("example") == 0);
+    EXPECT(options["appname"].get_string().value == "example");
 
     EXPECT(options["tls"]);
     EXPECT(options["tls"].get_bool().value == true);

--- a/examples/api/mongocxx/examples/uri/basic_usage.cpp
+++ b/examples/api/mongocxx/examples/uri/basic_usage.cpp
@@ -27,7 +27,7 @@ void example() {
 
     EXPECT(uri.to_string() == uri_str);
 
-    EXPECT(uri.username().compare("bob") == 0);
+    EXPECT(uri.username() == "bob");
     EXPECT(uri.password() == "pwd123");
     EXPECT(uri.tls() == true);
 }

--- a/examples/api/mongocxx/examples/uri/optional.cpp
+++ b/examples/api/mongocxx/examples/uri/optional.cpp
@@ -43,7 +43,7 @@ void example() {
         mongocxx::uri uri{"mongodb://localhost:27017/dbName?appName=example&retryReads=true"};
 
         auto database = uri.database();
-        EXPECT(database.compare("dbName") == 0);
+        EXPECT(database == "dbName");
 
         auto retry_reads_opt = uri.retry_reads();
         EXPECT(retry_reads_opt);

--- a/examples/api/mongocxx/examples/uri/userpass.cpp
+++ b/examples/api/mongocxx/examples/uri/userpass.cpp
@@ -35,7 +35,7 @@ void example() {
     {
         mongocxx::uri uri{"mongodb://bob:pwd123@localhost:27017/?tls=true"};
 
-        EXPECT(uri.username().compare("bob") == 0);
+        EXPECT(uri.username() == "bob");
         EXPECT(uri.password() == "pwd123");
 
         EXPECT(uri.tls() == true);

--- a/examples/bsoncxx/getting_values.cpp
+++ b/examples/bsoncxx/getting_values.cpp
@@ -90,7 +90,7 @@ int EXAMPLES_CDECL main() {
 
     // Make all variables used.
     return (awards && first_award_year && second_award_year && last_name && id_i32 == 1 &&
-            0 == first_name_str.compare("John"))
+            first_name_str == "John")
                ? EXIT_SUCCESS
                : EXIT_FAILURE;
 }

--- a/examples/mongocxx/mongodb.com/documentation_examples.cpp
+++ b/examples/mongocxx/mongodb.com/documentation_examples.cpp
@@ -121,7 +121,7 @@ mongocxx::options::client add_test_server_api(mongocxx::options::client opts = {
     const auto api_version_sv = bsoncxx::stdx::string_view(api_version);
 
     if (!api_version_sv.empty()) {
-        if (api_version_sv.compare("1") == 0) {
+        if (api_version_sv == "1") {
             opts.server_api_opts(
                 mongocxx::options::server_api(mongocxx::options::server_api::version::k_version_1));
         } else {

--- a/examples/mongocxx/tutorial.cpp
+++ b/examples/mongocxx/tutorial.cpp
@@ -54,7 +54,7 @@ int EXAMPLES_CDECL main() {
         auto element = doc_view["name"];
         assert(element.type() == bsoncxx::type::k_string);
         auto name = element.get_string().value;  // For C++ driver version < 3.7.0, use get_utf8()
-        assert(0 == name.compare("MongoDB"));
+        assert(name == "MongoDB");
     }
 
     // Insert One Document: { "i": 0 }

--- a/src/bsoncxx/test/json.cpp
+++ b/src/bsoncxx/test/json.cpp
@@ -55,14 +55,14 @@ TEST_CASE("valid json is converted to equivalent BSON") {
 
 TEST_CASE("empty document is converted correctly to json string") {
     using namespace bsoncxx;
-    REQUIRE(0 == to_json(make_document().view()).compare("{ }"));
+    REQUIRE(to_json(make_document().view()) == "{ }");
 }
 
 TEST_CASE("empty array is converted correctly to json string") {
     using bsoncxx::to_json;
 
     auto doc = make_document(kvp("array", make_array()));
-    REQUIRE(0 == to_json(doc.view()).compare(R"({ "array" : [  ] })"));
+    REQUIRE(to_json(doc.view()) == R"({ "array" : [  ] })");
 }
 
 TEST_CASE("CXX-941 is resolved") {

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/server_api.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/server_api.cpp
@@ -38,7 +38,7 @@ std::string server_api::version_to_string(server_api::version version) {
 }
 
 server_api::version server_api::version_from_string(bsoncxx::v_noabi::stdx::string_view version) {
-    if (!version.compare("1")) {
+    if (version != "1") {
         return server_api::version::k_version_1;
     }
     throw mongocxx::v_noabi::logic_error{mongocxx::v_noabi::error_code::k_invalid_parameter,

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/server_api.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/server_api.cpp
@@ -38,7 +38,7 @@ std::string server_api::version_to_string(server_api::version version) {
 }
 
 server_api::version server_api::version_from_string(bsoncxx::v_noabi::stdx::string_view version) {
-    if (version != "1") {
+    if (version == "1") {
         return server_api::version::k_version_1;
     }
     throw mongocxx::v_noabi::logic_error{mongocxx::v_noabi::error_code::k_invalid_parameter,

--- a/src/mongocxx/test/change_streams.cpp
+++ b/src/mongocxx/test/change_streams.cpp
@@ -469,7 +469,7 @@ TEST_CASE("Documentation Examples", "[min36]") {
         }
         bsoncxx::document::view next = *it;
         // End Changestream Example 1
-        REQUIRE(0 == next["operationType"].get_string().value.compare("insert"));
+        REQUIRE(next["operationType"].get_string().value == "insert");
     }
 
     SECTION("Example 2") {
@@ -484,7 +484,7 @@ TEST_CASE("Documentation Examples", "[min36]") {
         }
         bsoncxx::document::view next = *it;
         // End Changestream Example 2
-        REQUIRE(0 == next["operationType"].get_string().value.compare("insert"));
+        REQUIRE(next["operationType"].get_string().value == "insert");
     }
 
     SECTION("Example 3") {
@@ -510,7 +510,7 @@ TEST_CASE("Documentation Examples", "[min36]") {
             it = stream.begin();
         }
         // End Changestream Example 3
-        REQUIRE(0 == (*it)["operationType"].get_string().value.compare("insert"));
+        REQUIRE((*it)["operationType"].get_string().value == "insert");
     }
 
     SECTION("Example 4") {
@@ -531,7 +531,7 @@ TEST_CASE("Documentation Examples", "[min36]") {
             it = stream.begin();
         }
         // End Changestream Example 4
-        REQUIRE(0 == (*it)["operationType"].get_string().value.compare("insert"));
+        REQUIRE((*it)["operationType"].get_string().value == "insert");
     }
 
     insert_thread_done = true;

--- a/src/mongocxx/test/client_helpers.cpp
+++ b/src/mongocxx/test/client_helpers.cpp
@@ -300,7 +300,7 @@ static bool is_sharded_cluster(document::view reply) {
         return false;
     }
 
-    return msg.get_string().value.compare("isdbgrid") == 0;
+    return msg.get_string().value == "isdbgrid";
 }
 
 bool is_sharded_cluster(const client& client) {
@@ -369,9 +369,9 @@ bool is_numeric(types::bson_value::view value) {
 static bsoncxx::stdx::optional<type> is_type_operator(types::bson_value::view value) {
     if (value.type() == type::k_document && value.get_document().value["$$type"]) {
         auto t = value.get_document().value["$$type"].get_string().value;
-        if (t.compare("binData") == 0) {
+        if (t == "binData") {
             return {type::k_binary};
-        } else if (t.compare("long") == 0) {
+        } else if (t == "long") {
             return {type::k_int64};
         }
         throw std::logic_error{"unsupported type for $$type"};
@@ -402,7 +402,7 @@ bool matches(types::bson_value::view main,
 
     if (main.type() == type::k_document) {
         // the value '42' acts as placeholders for "any value"
-        if (pattern.type() == type::k_string && 0 == pattern.get_string().value.compare("42")) {
+        if (pattern.type() == type::k_string && pattern.get_string().value == "42") {
             return true;
         }
 
@@ -426,14 +426,14 @@ bool matches(types::bson_value::view main,
             }
 
             // For write errors, only check for existence.
-            if (el.key().compare("writeErrors") == 0) {
+            if (el.key() == "writeErrors") {
                 if (main_view.find(el.key()) == main_view.end()) {
                     return false;
                 }
                 continue;
             }
             // The C++ driver does not include insertedIds as part of the bulk write result.
-            if (el.key().compare("insertedIds") == 0) {
+            if (el.key() == "insertedIds") {
                 if (main_view.find(el.key()) == main_view.end()) {
                     return false;
                 }

--- a/src/mongocxx/test/client_session.cpp
+++ b/src/mongocxx/test/client_session.cpp
@@ -320,8 +320,8 @@ class session_test {
             // Ignore auth commands like "saslStart", and handshakes with "hello" (and the legacy
             // "hello" command).
             std::string sasl{"sasl"};
-            if (event.command_name().substr(0, sasl.size()).compare(sasl) == 0 ||
-                command_name.compare("hello") == 0 || command_name.compare("isMaster") == 0) {
+            if (event.command_name().substr(0, sasl.size()) == sasl || command_name == "hello" ||
+                command_name == "isMaster") {
                 return;
             }
 

--- a/src/mongocxx/test/client_side_encryption.cpp
+++ b/src/mongocxx/test/client_side_encryption.cpp
@@ -650,7 +650,7 @@ TEST_CASE("BSON size limits and batch splitting", "[client_side_encryption]") {
     int n_inserts = 0;
     options::apm apm_opts;
     apm_opts.on_command_started([&](const events::command_started_event& event) {
-        if (event.command_name().compare("insert") == 0) {
+        if (event.command_name() == "insert") {
             n_inserts++;
         }
     });

--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -2670,7 +2670,7 @@ TEST_CASE("expose writeErrors[].errInfo", "[collection]") {
                                       const mongocxx::events::command_succeeded_event& ev) {
         BSONCXX_TEST_EXCEPTION_GUARD_BEGIN(eguard);
 
-        if (0 != ev.command_name().compare("insert")) {
+        if (ev.command_name() != "insert") {
             return;
         }
 

--- a/src/mongocxx/test/spec/command_monitoring.cpp
+++ b/src/mongocxx/test/spec/command_monitoring.cpp
@@ -90,7 +90,7 @@ void run_command_monitoring_tests_in_file(std::string test_path) {
         apm_opts.on_command_started([&](const events::command_started_event& event) {
             BSONCXX_TEST_EXCEPTION_GUARD_BEGIN(eguard);
 
-            if (event.command_name().compare("endSessions") == 0) {
+            if (event.command_name() == "endSessions") {
                 return;
             }
 
@@ -101,13 +101,13 @@ void run_command_monitoring_tests_in_file(std::string test_path) {
                 bsoncxx::stdx::string_view field{ele.key()};
                 types::bson_value::view value{ele.get_value()};
 
-                if (field.compare("command_name") == 0) {
+                if (field == "command_name") {
                     REQUIRE(event.command_name() == value.get_string().value);
-                } else if (field.compare("command") == 0) {
+                } else if (field == "command") {
                     document::view expected_command = value.get_document().value;
                     document::view command = event.command();
                     REQUIRE_BSON_MATCHES(command, expected_command);
-                } else if (field.compare("database_name") == 0) {
+                } else if (field == "database_name") {
                     REQUIRE(event.database_name() == value.get_string().value);
                 } else {
                     FAIL("Should not reach this point.");
@@ -128,7 +128,7 @@ void run_command_monitoring_tests_in_file(std::string test_path) {
                 bsoncxx::stdx::string_view field{ele.key()};
                 types::bson_value::view value{ele.get_value()};
 
-                if (field.compare("command_name") == 0) {
+                if (field == "command_name") {
                     REQUIRE(event.command_name() == value.get_string().value);
                 } else {
                     FAIL("Should not reach this point.");
@@ -142,7 +142,7 @@ void run_command_monitoring_tests_in_file(std::string test_path) {
         apm_opts.on_command_succeeded([&](const events::command_succeeded_event& event) {
             BSONCXX_TEST_EXCEPTION_GUARD_BEGIN(eguard);
 
-            if (event.command_name().compare("endSessions") == 0) {
+            if (event.command_name() == "endSessions") {
                 return;
             }
 
@@ -153,9 +153,9 @@ void run_command_monitoring_tests_in_file(std::string test_path) {
                 bsoncxx::stdx::string_view field{ele.key()};
                 types::bson_value::view value{ele.get_value()};
 
-                if (field.compare("command_name") == 0) {
+                if (field == "command_name") {
                     REQUIRE(event.command_name() == value.get_string().value);
-                } else if (field.compare("reply") == 0) {
+                } else if (field == "reply") {
                     document::view expected_reply = value.get_document().value;
                     document::view reply = event.reply();
                     REQUIRE_BSON_MATCHES(reply, expected_reply);

--- a/src/mongocxx/test/spec/initial_dns_seedlist_discovery.cpp
+++ b/src/mongocxx/test/spec/initial_dns_seedlist_discovery.cpp
@@ -40,20 +40,20 @@ struct initial_dns_seedlist_test {
 
         for (auto el : test_doc) {
             const auto key = el.key();
-            if (0 == key.compare("uri")) {
+            if (key == "uri") {
                 test.uri = el.get_string().value;
-            } else if (0 == key.compare("seeds") || 0 == key.compare("numSeeds")) {
+            } else if (key == "seeds" || key == "numSeeds") {
                 // The 'seeds' and 'numSeeds' assertions are explicitly skipped. The C++ driver does
                 // not have access to the initial seedlist populated in the C driver.
-            } else if (0 == key.compare("hosts")) {
+            } else if (key == "hosts") {
                 test.hosts = el.get_array().value;
-            } else if (0 == key.compare("options")) {
+            } else if (key == "options") {
                 test.options = el.get_document().value;
-            } else if (0 == key.compare("error")) {
+            } else if (key == "error") {
                 test.error = el.get_bool().value;
-            } else if (0 == key.compare("comment")) {
+            } else if (key == "comment") {
                 // Ignore comment.
-            } else if (0 == key.compare("ping")) {
+            } else if (key == "ping") {
                 test.ping = el.get_bool().value;
             } else {
                 FAIL("unexpected initial_dns_seedlist_test option: " << el.key());

--- a/src/mongocxx/test/spec/mongohouse.cpp
+++ b/src/mongocxx/test/spec/mongohouse.cpp
@@ -120,7 +120,7 @@ void test_kill_cursors() {
             cmd_ns += ".";
             cmd_ns += std::string(coll);
 
-            if (cmd_ns.compare(cursor_ns) != 0) {
+            if (cmd_ns != cursor_ns) {
                 continue;
             }
 

--- a/src/mongocxx/test/spec/operation.cpp
+++ b/src/mongocxx/test/spec/operation.cpp
@@ -87,11 +87,11 @@ bsoncxx::stdx::optional<write_concern> lookup_write_concern(document::view doc) 
         document::element w = doc["writeConcern"]["w"];
         if (w.type() == bsoncxx::type::k_string) {
             std::string level = string::to_string(w.get_string().value);
-            if (level.compare("majority") == 0) {
+            if (level == "majority") {
                 wc.acknowledge_level(write_concern::level::k_majority);
-            } else if (level.compare("acknowledged") == 0) {
+            } else if (level == "acknowledged") {
                 wc.acknowledge_level(write_concern::level::k_acknowledged);
-            } else if (level.compare("unacknowledged") == 0) {
+            } else if (level == "unacknowledged") {
                 wc.acknowledge_level(write_concern::level::k_unacknowledged);
             }
         } else if (w.type() == bsoncxx::type::k_int32) {
@@ -107,15 +107,15 @@ bsoncxx::stdx::optional<read_preference> lookup_read_preference(document::view d
     if (doc["readPreference"] && doc["readPreference"]["mode"]) {
         read_preference rp;
         std::string mode = string::to_string(doc["readPreference"]["mode"].get_string().value);
-        if (mode.compare("Primary") == 0) {
+        if (mode == "Primary") {
             rp.mode(read_preference::read_mode::k_primary);
-        } else if (mode.compare("PrimaryPreferred") == 0) {
+        } else if (mode == "PrimaryPreferred") {
             rp.mode(read_preference::read_mode::k_primary_preferred);
-        } else if (mode.compare("Secondary") == 0) {
+        } else if (mode == "Secondary") {
             rp.mode(read_preference::read_mode::k_secondary);
-        } else if (mode.compare("SecondaryPreferred") == 0) {
+        } else if (mode == "SecondaryPreferred") {
             rp.mode(read_preference::read_mode::k_secondary_preferred);
-        } else if (mode.compare("Nearest") == 0) {
+        } else if (mode == "Nearest") {
             rp.mode(read_preference::read_mode::k_nearest);
         }
         return rp;
@@ -125,11 +125,11 @@ bsoncxx::stdx::optional<read_preference> lookup_read_preference(document::view d
 }
 
 client_session* operation_runner::_lookup_session(bsoncxx::stdx::string_view key) {
-    if (key.compare("session0") == 0) {
+    if (key == "session0") {
         return _session0;
     }
 
-    if (key.compare("session1") == 0) {
+    if (key == "session1") {
         return _session1;
     }
 
@@ -1081,7 +1081,7 @@ document::value operation_runner::_run_bulk_write(document::view operation) {
         auto request_arguments = request["arguments"].get_document().value;
         auto operation_name = request["name"].get_string().value;
 
-        if (operation_name.compare("updateOne") == 0) {
+        if (operation_name == "updateOne") {
             auto update_one = _build_update_model<model::update_one>(request_arguments);
 
             if (request_arguments["hint"]) {
@@ -1104,7 +1104,7 @@ document::value operation_runner::_run_bulk_write(document::view operation) {
             }
 
             writes.emplace_back(update_one);
-        } else if (operation_name.compare("updateMany") == 0) {
+        } else if (operation_name == "updateMany") {
             auto update_many = _build_update_model<model::update_many>(request_arguments);
 
             if (request_arguments["hint"]) {
@@ -1127,7 +1127,7 @@ document::value operation_runner::_run_bulk_write(document::view operation) {
             }
 
             writes.emplace_back(update_many);
-        } else if (operation_name.compare("replaceOne") == 0) {
+        } else if (operation_name == "replaceOne") {
             document::view filter = request_arguments["filter"].get_document().value;
             document::view replacement = request_arguments["replacement"].get_document().value;
             model::replace_one replace_one(filter, replacement);
@@ -1147,11 +1147,11 @@ document::value operation_runner::_run_bulk_write(document::view operation) {
             }
 
             writes.emplace_back(replace_one);
-        } else if (operation_name.compare("insertOne") == 0) {
+        } else if (operation_name == "insertOne") {
             document::view document = request_arguments["document"].get_document().value;
             model::insert_one insert_one(document);
             writes.emplace_back(insert_one);
-        } else if (operation_name.compare("deleteOne") == 0) {
+        } else if (operation_name == "deleteOne") {
             document::view filter = request_arguments["filter"].get_document().value;
             model::delete_one delete_one(filter);
             if (request_arguments["hint"]) {
@@ -1166,7 +1166,7 @@ document::value operation_runner::_run_bulk_write(document::view operation) {
             }
 
             writes.emplace_back(delete_one);
-        } else if (operation_name.compare("deleteMany") == 0) {
+        } else if (operation_name == "deleteMany") {
             document::view filter = request_arguments["filter"].get_document().value;
             model::delete_many delete_many(filter);
             if (request_arguments["hint"]) {
@@ -1409,63 +1409,63 @@ document::value operation_runner::run(document::view operation) {
         object = operation["object"].get_string().value;
     }
 
-    if (key.compare("aggregate") == 0) {
+    if (key == "aggregate") {
         return _run_aggregate(operation);
-    } else if (key.compare("count") == 0) {
+    } else if (key == "count") {
         throw std::logic_error{"count command not supported"};
-    } else if (key.compare("countDocuments") == 0) {
+    } else if (key == "countDocuments") {
         return _run_count_documents(operation);
-    } else if (key.compare("estimatedDocumentCount") == 0) {
+    } else if (key == "estimatedDocumentCount") {
         return _run_estimated_document_count(operation);
-    } else if (key.compare("distinct") == 0) {
+    } else if (key == "distinct") {
         return _run_distinct(operation);
-    } else if (key.compare("find") == 0) {
+    } else if (key == "find") {
         return _run_find(operation);
-    } else if (key.compare("deleteMany") == 0) {
+    } else if (key == "deleteMany") {
         return _run_delete_many(operation);
-    } else if (key.compare("deleteOne") == 0) {
+    } else if (key == "deleteOne") {
         return _run_delete_one(operation);
-    } else if (key.compare("findOne") == 0) {
+    } else if (key == "findOne") {
         return _run_find_one(operation);
-    } else if (key.compare("findOneAndDelete") == 0) {
+    } else if (key == "findOneAndDelete") {
         return _run_find_one_and_delete(operation);
-    } else if (key.compare("findOneAndReplace") == 0) {
+    } else if (key == "findOneAndReplace") {
         return _run_find_one_and_replace(operation);
-    } else if (key.compare("findOneAndUpdate") == 0) {
+    } else if (key == "findOneAndUpdate") {
         return _run_find_one_and_update(operation);
-    } else if (key.compare("insertMany") == 0) {
+    } else if (key == "insertMany") {
         return _run_insert_many(operation);
-    } else if (key.compare("insertOne") == 0) {
+    } else if (key == "insertOne") {
         return _run_insert_one(operation);
-    } else if (key.compare("replaceOne") == 0) {
+    } else if (key == "replaceOne") {
         return _run_replace_one(operation);
-    } else if (key.compare("updateMany") == 0) {
+    } else if (key == "updateMany") {
         return _run_update_many(operation);
-    } else if (key.compare("updateOne") == 0) {
+    } else if (key == "updateOne") {
         return _run_update_one(operation);
-    } else if (key.compare("bulkWrite") == 0) {
+    } else if (key == "bulkWrite") {
         return _run_bulk_write(operation);
-    } else if (key.compare("startTransaction") == 0) {
+    } else if (key == "startTransaction") {
         return _run_start_transaction(operation);
-    } else if (key.compare("commitTransaction") == 0) {
+    } else if (key == "commitTransaction") {
         return _run_commit_transaction(operation);
-    } else if (key.compare("abortTransaction") == 0) {
+    } else if (key == "abortTransaction") {
         return _run_abort_transaction(operation);
-    } else if (key.compare("runCommand") == 0) {
+    } else if (key == "runCommand") {
         return _run_run_command(operation);
-    } else if (key.compare("assertSessionPinned") == 0) {
+    } else if (key == "assertSessionPinned") {
         const client_session* session =
             _lookup_session(operation["arguments"].get_document().value);
         REQUIRE(session);
         REQUIRE(session->server_id() != 0);
         return empty_document;
-    } else if (key.compare("assertSessionUnpinned") == 0) {
+    } else if (key == "assertSessionUnpinned") {
         const client_session* session =
             _lookup_session(operation["arguments"].get_document().value);
         REQUIRE(session);
         REQUIRE(session->server_id() == 0);
         return empty_document;
-    } else if (key.compare("assertSessionTransactionState") == 0) {
+    } else if (key == "assertSessionTransactionState") {
         const auto arguments = operation["arguments"].get_document().value;
         const client_session* session = _lookup_session(arguments);
         REQUIRE(session);
@@ -1488,63 +1488,63 @@ document::value operation_runner::run(document::view operation) {
                 break;
         }
         return empty_document;
-    } else if (key.compare("watch") == 0) {
-        if (object.compare("collection") == 0) {
+    } else if (key == "watch") {
+        if (object == "collection") {
             _coll->watch();
-        } else if (object.compare("database") == 0) {
+        } else if (object == "database") {
             _db->watch();
-        } else if (object.compare("client") == 0) {
+        } else if (object == "client") {
             _client->watch();
         } else {
             throw std::logic_error{"unsupported operation object: " + string::to_string(object)};
         }
         return empty_document;
-    } else if (key.compare("rename") == 0) {
+    } else if (key == "rename") {
         _coll->rename(operation["arguments"]["to"].get_string().value);
         return empty_document;
-    } else if (key.compare("drop") == 0) {
+    } else if (key == "drop") {
         _coll->drop();
         return empty_document;
-    } else if (key.compare("dropCollection") == 0) {
+    } else if (key == "dropCollection") {
         return _run_drop_collection(operation);
-    } else if (key.compare("listCollectionNames") == 0) {
+    } else if (key == "listCollectionNames") {
         _db->list_collection_names();
         return empty_document;
-    } else if (key.compare("listCollectionObjects") == 0) {
+    } else if (key == "listCollectionObjects") {
         throw std::logic_error("listCollectionObjects is not implemented in mongocxx");
-    } else if (key.compare("listCollections") == 0) {
+    } else if (key == "listCollections") {
         _db->list_collections();
         return empty_document;
-    } else if (key.compare("listDatabases") == 0) {
+    } else if (key == "listDatabases") {
         _client->list_databases().begin(); /* calling begin() iterates the cursor */
         return empty_document;
-    } else if (key.compare("listDatabaseNames") == 0) {
+    } else if (key == "listDatabaseNames") {
         _client->list_database_names();
         return empty_document;
-    } else if (key.compare("listIndexes") == 0) {
+    } else if (key == "listIndexes") {
         _coll->list_indexes().begin(); /* calling begin() iterates the cursor */
         return empty_document;
-    } else if (key.compare("download") == 0) {
+    } else if (key == "download") {
         std::ostream null_stream(nullptr); /* no need to store output */
         auto bucket = _db->gridfs_bucket();
         bucket.download_to_stream(operation["arguments"]["id"].get_value(), &null_stream);
 
         return empty_document;
-    } else if (key.compare("createCollection") == 0) {
+    } else if (key == "createCollection") {
         return _run_create_collection(operation);
-    } else if (key.compare("assertCollectionNotExists") == 0) {
+    } else if (key == "assertCollectionNotExists") {
         auto collection_name = operation["arguments"]["collection"].get_string().value;
         client client{uri{}};
         REQUIRE_FALSE(client[_db->name()].has_collection(collection_name));
         return empty_document;
-    } else if (key.compare("assertCollectionExists") == 0) {
+    } else if (key == "assertCollectionExists") {
         auto collection_name = operation["arguments"]["collection"].get_string().value;
         client client{uri{}};
         REQUIRE(client[_db->name()].has_collection(collection_name));
         return empty_document;
-    } else if (key.compare("createIndex") == 0) {
+    } else if (key == "createIndex") {
         return _create_index(operation);
-    } else if (key.compare("assertIndexNotExists") == 0) {
+    } else if (key == "assertIndexNotExists") {
         client client{uri{}};
         auto cursor = client[_db->name()][_coll->name()].list_indexes();
 
@@ -1555,7 +1555,7 @@ document::value operation_runner::run(document::view operation) {
             }));
 
         return empty_document;
-    } else if (key.compare("assertIndexExists") == 0) {
+    } else if (key == "assertIndexExists") {
         client client{uri{}};
         auto db = operation["arguments"]["database"].get_string().value;
         auto collection = operation["arguments"]["collection"].get_string().value;
@@ -1568,7 +1568,7 @@ document::value operation_runner::run(document::view operation) {
             }));
 
         return empty_document;
-    } else if (key.compare("targetedFailPoint") == 0) {
+    } else if (key == "targetedFailPoint") {
         REQUIRE(object == bsoncxx::stdx::string_view("testRunner"));
 
         const auto arguments = operation["arguments"].get_document().value;

--- a/src/mongocxx/test/spec/unified_tests/operations.cpp
+++ b/src/mongocxx/test/spec/unified_tests/operations.cpp
@@ -368,7 +368,7 @@ document::value run_bulk_write(collection& coll, client_session* session, docume
         auto request_arguments = request_element[operation_name].get_document().value;
         CAPTURE(to_json(request_arguments), operation_name);
 
-        if (operation_name.compare("updateOne") == 0) {
+        if (operation_name == "updateOne") {
             auto update_one = _build_update_model<model::update_one>(request_arguments);
 
             add_hint_to_model(update_one, request_arguments);
@@ -390,7 +390,7 @@ document::value run_bulk_write(collection& coll, client_session* session, docume
             }
 
             writes.emplace_back(update_one);
-        } else if (operation_name.compare("updateMany") == 0) {
+        } else if (operation_name == "updateMany") {
             auto update_many = _build_update_model<model::update_many>(request_arguments);
 
             add_hint_to_model(update_many, request_arguments);
@@ -412,7 +412,7 @@ document::value run_bulk_write(collection& coll, client_session* session, docume
             }
 
             writes.emplace_back(update_many);
-        } else if (operation_name.compare("replaceOne") == 0) {
+        } else if (operation_name == "replaceOne") {
             document::view filter = request_arguments["filter"].get_document().value;
             document::view replacement = request_arguments["replacement"].get_document().value;
             model::replace_one replace_one(filter, replacement);
@@ -432,11 +432,11 @@ document::value run_bulk_write(collection& coll, client_session* session, docume
             }
 
             writes.emplace_back(replace_one);
-        } else if (operation_name.compare("insertOne") == 0) {
+        } else if (operation_name == "insertOne") {
             document::view document = request_arguments["document"].get_document().value;
             model::insert_one insert_one(document);
             writes.emplace_back(insert_one);
-        } else if (operation_name.compare("deleteOne") == 0) {
+        } else if (operation_name == "deleteOne") {
             document::view filter = request_arguments["filter"].get_document().value;
             model::delete_one delete_one(filter);
             add_hint_to_model(delete_one, request_arguments);
@@ -450,7 +450,7 @@ document::value run_bulk_write(collection& coll, client_session* session, docume
             }
 
             writes.emplace_back(delete_one);
-        } else if (operation_name.compare("deleteMany") == 0) {
+        } else if (operation_name == "deleteMany") {
             document::view filter = request_arguments["filter"].get_document().value;
             model::delete_many delete_many(filter);
             add_hint_to_model(delete_many, request_arguments);

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -505,7 +505,7 @@ read_preference get_read_preference(const document::element& opts) {
 
     const auto mode = read_pref["mode"].get_string().value;
 
-    if (mode.compare("secondaryPreferred") == 0) {
+    if (mode == "secondaryPreferred") {
         rp.mode(read_preference::read_mode::k_secondary_preferred);
     } else {
         FAIL("unhandled readPreference mode: " << mode);
@@ -519,7 +519,7 @@ write_concern get_write_concern(const document::element& opts) {
     if (auto w = opts["writeConcern"]["w"]) {
         if (w.type() == type::k_string) {
             const auto strval = w.get_string().value;
-            if (0 == strval.compare("majority")) {
+            if (strval == "majority") {
                 wc.acknowledge_level(mongocxx::write_concern::level::k_majority);
             } else {
                 FAIL("Unsupported write concern string " << strval);

--- a/src/mongocxx/test/spec/uri_options.cpp
+++ b/src/mongocxx/test/spec/uri_options.cpp
@@ -34,17 +34,17 @@ struct URIOptionsTest {
         URIOptionsTest test;
 
         for (auto el : test_doc) {
-            if (0 == el.key().compare("description")) {
+            if (el.key() == "description") {
                 test.description = el.get_string().value;
-            } else if (0 == el.key().compare("uri")) {
+            } else if (el.key() == "uri") {
                 test.uri = el.get_string().value;
-            } else if (0 == el.key().compare("valid")) {
+            } else if (el.key() == "valid") {
                 test.valid = el.get_bool().value;
-            } else if (0 == el.key().compare("warning")) {
+            } else if (el.key() == "warning") {
                 test.warning = el.get_bool().value;
-            } else if (0 == el.key().compare("options")) {
+            } else if (el.key() == "options") {
                 test.options = el.get_document().value;
-            } else if ((0 == el.key().compare("hosts")) || ((0 == el.key().compare("auth")))) {
+            } else if (el.key() == "hosts" || el.key() == "auth") {
                 // hosts and auth will always be null are to be skipped as per the spec test
                 // description
             } else {

--- a/src/mongocxx/test/spec/util.cpp
+++ b/src/mongocxx/test/spec/util.cpp
@@ -66,27 +66,27 @@ using bsoncxx::stdx::string_view;
 static const int kMaxHelloFailCommands = 7;
 
 uint32_t error_code_from_name(string_view name) {
-    if (name.compare("CannotSatisfyWriteConcern") == 0) {
+    if (name == "CannotSatisfyWriteConcern") {
         return 100;
-    } else if (name.compare("DuplicateKey") == 0) {
+    } else if (name == "DuplicateKey") {
         return 11000;
-    } else if (name.compare("NoSuchTransaction") == 0) {
+    } else if (name == "NoSuchTransaction") {
         return 251;
-    } else if (name.compare("WriteConflict") == 0) {
+    } else if (name == "WriteConflict") {
         return 112;
-    } else if (name.compare("Interrupted") == 0) {
+    } else if (name == "Interrupted") {
         return 11601;
-    } else if (name.compare("MaxTimeMSExpired") == 0) {
+    } else if (name == "MaxTimeMSExpired") {
         return 50;
-    } else if (name.compare("UnknownReplWriteConcern") == 0) {
+    } else if (name == "UnknownReplWriteConcern") {
         return 79;
-    } else if (name.compare("UnsatisfiableWriteConcern") == 0) {
+    } else if (name == "UnsatisfiableWriteConcern") {
         return 100;
-    } else if (name.compare("OperationNotSupportedInTransaction") == 0) {
+    } else if (name == "OperationNotSupportedInTransaction") {
         return 263;
-    } else if (name.compare("APIStrictError") == 0) {
+    } else if (name == "APIStrictError") {
         return 323;
-    } else if (name.compare("ChangeStreamFatalError") == 0) {
+    } else if (name == "ChangeStreamFatalError") {
         return 280;
     }
 
@@ -684,14 +684,14 @@ static void run_transaction_operations(
         const auto operation = op.get_document().value;
 
         // Handle with_transaction separately.
-        if (operation["name"].get_string().value.compare("withTransaction") == 0) {
+        if (operation["name"].get_string().value == "withTransaction") {
             const auto session = [&]() -> mongocxx::client_session* {
                 const auto object = operation["object"].get_string().value;
-                if (object.compare("session0") == 0) {
+                if (object == "session0") {
                     return session0;
                 }
 
-                if (object.compare("session1") == 0) {
+                if (object == "session1") {
                     return session1;
                 }
 
@@ -974,12 +974,12 @@ void run_transactions_tests_in_file(const std::string& test_path) {
                     [&](bsoncxx::stdx::string_view key,
                         bsoncxx::stdx::optional<bsoncxx::types::bson_value::view> main,
                         bsoncxx::types::bson_value::view pattern) {
-                        if (key.compare("lsid") == 0) {
+                        if (key == "lsid") {
                             REQUIRE(pattern.type() == type::k_string);
                             REQUIRE(main);
                             REQUIRE(main->type() == type::k_document);
                             auto session_name = pattern.get_string().value;
-                            if (session_name.compare("session0") == 0) {
+                            if (session_name == "session0") {
                                 REQUIRE(
                                     test_util::matches(session_lsid0, main->get_document().value));
                             } else {
@@ -992,7 +992,7 @@ void run_transactions_tests_in_file(const std::string& test_path) {
                                 return test_util::match_action::k_not_equal;
                             }
                             return test_util::match_action::k_skip;
-                        } else if (key.compare("upsert") == 0 || key.compare("multi") == 0) {
+                        } else if (key == "upsert" || key == "multi") {
                             // libmongoc includes `multi: false` and `upsert: false`.
                             // Some tests do not include `multi: false` and `upsert: false`
                             // in expectations. See DRIVERS-2271 and DRIVERS-976.


### PR DESCRIPTION
Resolves CXX-3101. Verified by ~[this patch](https://spruce.mongodb.com/version/6733aa7a2bad8f00071e910d)~ [this patch](https://spruce.mongodb.com/version/6733aef318af6a000732e375).

Following https://github.com/mongodb/mongo-cxx-driver/pull/1257, workarounds that were required for mnmlstc/core `string_view` compatibility are no longer necessary.

These former workarounds primarily consist of the lack of equality comparison operators against string literals (fixed in https://github.com/mnmlstc/core/commit/776eb3e5340d4fa06e81e06252c3ca1a26163b5b but never released) and broken hash algorithm (fixed in https://github.com/mnmlstc/core/commit/42a34a9b6168733d60f1334d875247d67cc364fc but never released). The changes in this PR address workarounds for the equality comparison operators only. We've opted to completely avoid hashing of `string_view` up to this point (e.g. see https://github.com/mongodb/mongo-cxx-driver/pull/935#discussion_r1145409717). Refactoring existing workarounds to use `string_view` instead is not as straightforward (due to lifetime/dangling concerns) and thus deferred.