### PR TITLE
CXX-2797 Update Augmented SBOM with mnmlstc/core removal

### DIFF
--- a/.evergreen/config_generator/components/silk.py
+++ b/.evergreen/config_generator/components/silk.py
@@ -68,7 +68,7 @@ def tasks():
 
     return [
         EvgTask(
-            name=TAG,
+            name='silk-check-augmented-sbom',
             tags=[TAG, distro_name],
             run_on=distro.name,
             commands=[

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -4208,7 +4208,7 @@ tasks:
           BSONCXX_POLYFILL: impls
           CXX_STANDARD: 17
       - func: upload scan artifacts
-  - name: silk
+  - name: silk-check-augmented-sbom
     run_on: rhel8-latest-small
     tags: [silk, rhel8-latest]
     commands:

--- a/etc/augmented.sbom.json
+++ b/etc/augmented.sbom.json
@@ -1,32 +1,6 @@
 {
   "components": [
     {
-      "bom-ref": "pkg:github/mnmlstc/core@v1.1.0",
-      "copyright": "Copyright \u00a9 2013 - 2014 MNMLSTC",
-      "externalReferences": [
-        {
-          "type": "distribution",
-          "url": "https://github.com/mnmlstc/core/archive/refs/tags/v1.1.0.tar.gz"
-        },
-        {
-          "type": "website",
-          "url": "https://github.com/mnmlstc/core/tree/v1.1.0"
-        }
-      ],
-      "group": "mnmlstc",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
-      "name": "core",
-      "purl": "pkg:github/mnmlstc/core@v1.1.0",
-      "type": "library",
-      "version": "v1.1.0"
-    },
-    {
       "bom-ref": "pkg:github/mongodb/mongo-c-driver@v1.28.0",
       "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
@@ -55,14 +29,11 @@
   ],
   "dependencies": [
     {
-      "ref": "pkg:github/mnmlstc/core@v1.1.0"
-    },
-    {
       "ref": "pkg:github/mongodb/mongo-c-driver@v1.28.0"
     }
   ],
   "metadata": {
-    "timestamp": "2024-09-30T15:53:24.743787+00:00",
+    "timestamp": "2024-11-04T17:45:42.970888+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -106,7 +77,7 @@
     ]
   },
   "serialNumber": "urn:uuid:dd68fbb0-f77c-4bb9-90cd-606dd854f301",
-  "version": 3,
+  "version": 4,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1257. Verified by [this patch](https://spruce.mongodb.com/version/67366c3ac323860007b53810).

https://github.com/mongodb/mongo-cxx-driver/pull/1257 updated the `purls.txt` and SBOM Lite files. There was a delay until the Augmented SBOM observed the updates to SBOM Lite file. The [silk-check-augmented-sbom](https://spruce.mongodb.com/task/mongo_cxx_driver_silk_silk_e6e2696826a5c64e87c76bf31673dcf16aefc83f_24_11_13_17_48_46/logs?execution=1) task failure indicated the Augmented SBOM was finally updated accordingly.

This PR also restores the name of the `silk-check-augmented-sbom` task (changed in https://github.com/mongodb/mongo-cxx-driver/pull/1244) for consistency with [release instructions](https://github.com/mongodb/mongo-cxx-driver/blob/e6e2696826a5c64e87c76bf31673dcf16aefc83f/etc/releasing.md#augmented-sbom).