### PR TITLE
Update SSDLC-related files and release instructions

### DIFF
--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -118,7 +118,7 @@ Triage any outstanding issues using the `Issues: By Snapshot | Outstanding Issue
 > [!NOTE]
 > The "Classification", "Action", and "MongoDB Final Status" fields should always be updated. The "Ext. Reference" field may refer to a JIRA ticket number or an external issue tracker as appropriate. Use the "Notes" field to document rationale for the "MongoDB Final Status" for issues with Medium severity or higher. Add any additional notes for future reference in the "Comments" field.
 
-Verify that all issues listed in the `Issues: By Snapshot | SSDLC Report (v2)` view have been triaged. All
+Verify that all issues listed in the `Issues: By Snapshot | SSDLC Report (v2)` view have been triaged.
 
 All issues with an Impact level of "High" or greater must have a "MongoDB Final Status" of "Fix Committed" and a corresponding JIRA ticket number in the "Ext. Reference" field.
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -113,7 +113,16 @@ See the comment accompanying `MONGOC_VERSION_MINIMUM` for a list of other source
 
 Ensure there are no new or unexpected issues with High severity or greater.
 
-Update the [SSDLC Report spreadsheet](https://docs.google.com/spreadsheets/d/1sp0bLjj29xO9T8BwDIxUk5IPJ493QkBVCJKIgptxEPc/edit?usp=sharing) with any updates to new or known issues.
+Triage any outstanding issues using the `Issues: By Snapshot | Outstanding Issues` view, create JIRA tickets if necessary, and update issue fields accordingly.
+
+> [!NOTE]
+> The "Classification", "Action", and "MongoDB Final Status" fields should always be updated. The "Ext. Reference" field may refer to a JIRA ticket number or an external issue tracker as appropriate. Use the "Notes" field to document rationale for the "MongoDB Final Status" for issues with Medium severity or higher. Add any additional notes for future reference in the "Comments" field.
+
+Verify that all issues listed in the `Issues: By Snapshot | SSDLC Report (v2)` view have been triaged. All
+
+All issues with an Impact level of "High" or greater must have a "MongoDB Final Status" of "Fix Committed" and a corresponding JIRA ticket number in the "Ext. Reference" field.
+
+All issues with an Impact level of "Medium" or greater which do not have a "MongoDB Final Status" of "Fix Committed" must document rationale for its current status in the "Notes" field.
 
 ### SBOM Lite
 
@@ -276,7 +285,7 @@ Commit the updates to `CHANGELOG.md`.
 git commit -m 'Update CHANGELOG for X.Y.Z'
 ```
 
-## Pre-Release Changes PR
+### Pre-Release Changes PR
 
 Push the `pre-release-changes` branch to a fork repository and create a PR to merge `pre-release-changes` onto `master`:
 
@@ -424,17 +433,13 @@ git reset --hard rX.Y.Z
 git push -f upstream releases/stable
 ```
 
+### Coverity Report
+
+Export the `Issues: By Snapshot | SSDLC Report (v2)` view as a CSV named `static_analysis-X.Y.Z.csv`.
+
 ### Upload SSDLC Reports
 
-Navigate to the [C++ Driver SSDLC Reports](https://drive.google.com/drive/folders/1q9RI55trFzHlh8McALSIAbT6ugyn8zlO) folder and update the master spreadsheet.
-
-Once complete, make two copies of the spreadsheet.
-
-Rename one copy to: "SSDLC Report: mongo-cxx-driver X.Y.Z". Leave this copy in this folder.
-
-Rename the other copy to: "static_analysis_report-X.Y.Z". Move this copy into the [SSDLC Compliance Files](https://drive.google.com/drive/folders/1_qwTwYyqPL7VjrZOiuyiDYi1y2NYiClS) folder and name it.
-
-Upload a copy of the `etc/ssdlc_compliance_report.md`, `etc/third_party_vulnerabilities.md`, and `etc/augmented.sbom.json` files. Rename the files with the version number `-X.Y.Z` suffix in their filenames as already done for other files in this folder.
+Upload a copy of the `static_analysis-X.Y.Z.csv`, `etc/ssdlc_compliance_report.md`, `etc/third_party_vulnerabilities.md`, and `etc/augmented.sbom.json` files. Rename the files with the version number `-X.Y.Z` suffix in their filenames as already done for other files in this folder.
 
 > [!WARNING]
 > Uploading a file into the SSDLC Compliance Files folder is an irreversible action! However, the files may still be renamed. If necessary, rename any accidentally uploaded files to "(Delete Me)" or similar.
@@ -442,10 +447,10 @@ Upload a copy of the `etc/ssdlc_compliance_report.md`, `etc/third_party_vulnerab
 Four new files should be present in the [SSDLC Compliance Files](https://drive.google.com/drive/folders/1_qwTwYyqPL7VjrZOiuyiDYi1y2NYiClS) folder following a release `X.Y.Z`:
 
 ```
-ssdlc_compliance_report-X.Y.Z.md
-third_party_vulnerabilities-X.Y.Z.md
-static_analysis-X.Y.Z
 augmented.sbom-X.Y.Z.json
+ssdlc_compliance_report-X.Y.Z.md
+static_analysis-X.Y.Z.csv
+third_party_vulnerabilities-X.Y.Z.md
 ```
 
 ## Post-Release Steps
@@ -810,6 +815,10 @@ Sincerely,
 
 The C++ Driver Team
 ```
+
+### Update the Release Info Spreadsheet
+
+Add an entry to the [C/C++ Release Info](https://docs.google.com/spreadsheets/d/1yHfGmDnbA5-Qt8FX4tKWC5xk9AhzYZx1SKF4AD36ecY) spreadsheet documenting the date, release version, author (of the release), and additional comments.
 
 ## Packaging
 

--- a/etc/ssdlc_compliance_report.md
+++ b/etc/ssdlc_compliance_report.md
@@ -11,17 +11,17 @@
 ## Tool used to track third party vulnerabilities
 
 - See [Silk](https://us1.app.silk.security/inventory/asset-group/mongodb____DedupedAssetGroup____60640b8853771efe3af5f78ea37af5d1cdd190df) (internal).
-- See [C++ Driver - SSDLC Reports](https://drive.google.com/drive/folders/1q9RI55trFzHlh8McALSIAbT6ugyn8zlO) for release-specific reports.
+- See [SSDLC Compliance Files: C++ Driver](https://drive.google.com/drive/folders/1_qwTwYyqPL7VjrZOiuyiDYi1y2NYiClS) (internal) for release-specific reports. Available as needed from the MongoDB C++ Driver team.
 
 ## Third-Party Dependency Information
 
 - See [etc/augmented.sbom.json](https://github.com/mongodb/mongo-cxx-driver/blob/master/etc/augmented.sbom.json) within the release tarball.
 - See [etc/third_party_vulnerabilities.md](https://github.com/mongodb/mongo-cxx-driver/blob/master/etc/third_party_vulnerabilities.md) within the release tarball.
-- See [C++ Driver - SSDLC Reports](https://drive.google.com/drive/folders/1q9RI55trFzHlh8McALSIAbT6ugyn8zlO) for release-specific reports.
+- See [SSDLC Compliance Files: C++ Driver](https://drive.google.com/drive/folders/1_qwTwYyqPL7VjrZOiuyiDYi1y2NYiClS) (internal) for release-specific reports. Available as needed from the MongoDB C++ Driver team.
 
 ## Static Analysis Findings
 
-- See [C++ Driver - SSDLC Reports](https://drive.google.com/drive/folders/1q9RI55trFzHlh8McALSIAbT6ugyn8zlO) for release-specific reports.
+- Available as needed from the MongoDB C++ Driver team.
 
 ## Security Testing Report
 
@@ -37,4 +37,4 @@
 
 ## Known Vulnerabilities
 
-- Any vulnerabilities that may be shown in the links referenced above have been reviewed and accepted by the appropriate approvers. For detailed information, see [C++ Driver - SSDLC Reports](https://drive.google.com/drive/folders/1q9RI55trFzHlh8McALSIAbT6ugyn8zlO) for release-specific reports.
+- Any vulnerabilities that may be shown in the links referenced above have been reviewed and accepted by the appropriate approvers. For more information, see [SSDLC Compliance Files: C++ Driver](https://drive.google.com/drive/folders/1_qwTwYyqPL7VjrZOiuyiDYi1y2NYiClS) (internal) for release-specific reports. Available as needed from the MongoDB C++ Driver team.


### PR DESCRIPTION
Updates SSDLC-related files and release instructions to better align with latest state of requirements.

Of note, completely transitions away from using the [SSDLC Report: mongo-cxx-driver](https://docs.google.com/spreadsheets/d/1sp0bLjj29xO9T8BwDIxUk5IPJ493QkBVCJKIgptxEPc/edit?usp=sharing) spreadsheet (primarily used to track static analysis issues) in favor of using the Coverity CSV export file for static analysis reports, which will be archived alongside other SSDLC compliance files in the [definitive SSDLC compliance files folder](https://drive.google.com/drive/folders/1_qwTwYyqPL7VjrZOiuyiDYi1y2NYiClS) rather than our project-specific folder. Triaging and handling of Coverity issues is, and will be, handled entirely within Coverity.

The SBOM Lite (`cyclonedx.sbom.json`) and Augmented SBOM (`augmented.sbom.json`) files which are committed to the repository automatically handle the necessary 3rd party vulnerability tracking and reporting requirements. The `etc/third_party_vulnerabilities.md` remains as our means to list any unresolved vulnerabilities for a given release and document corresponding rationale for its remediation status as needed.