### PR TITLE
Exclude rhel79 from compile-only matrix in patch builds

### DIFF
--- a/.evergreen/config_generator/components/compile_only.py
+++ b/.evergreen/config_generator/components/compile_only.py
@@ -53,8 +53,15 @@ def generate_tasks():
                 name += f'-{polyfill}'
                 tags.append(polyfill)
 
+            patchable = None
+
             # PowerPC and zSeries are limited resources.
-            patchable = False if any(pattern in distro_name for pattern in ['power8', 'zseries']) else None
+            if any(pattern in distro_name for pattern in ['power8', 'zseries']):
+                patchable = False
+
+            # etc/calc_release_version.py: error: unknown option `--format=...'
+            if distro_name == 'rhel79':
+                patchable = False
 
             res.append(
                 EvgTask(

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -61,6 +61,7 @@ tasks:
   - name: compile-only-rhel79-release-shared-impls
     run_on: rhel79-large
     tags: [compile-only, rhel79, release, shared, impls]
+    patchable: false
     commands:
       - func: setup
       - func: fetch_c_driver_source


### PR DESCRIPTION
Excludes the rhel79 distro from the compile-only matrix to avoid the noisy git compatibility error when executing `calc_release_version.py` in patch builds (not on a branch -> use of an unsupported git flag due to git binary version).