### PR TITLE
CXX-2813 document KMIP "delegated" option

### DIFF
--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
@@ -81,7 +81,9 @@ class data_key {
     ///     keyId: Optional<String>, // keyId is the KMIP Unique Identifier to a 96 byte KMIP Secret
     ///                              // Data managed object.If keyId is omitted, the driver creates
     ///                              // a random 96 byte KMIP Secret Data managed object.
-    ///     endpoint: Optional<String> // Host with optional port.
+    ///     endpoint: Optional<String>, // Host with optional port.
+    ///     delegated: Optional<Boolean> // If true, this key should be decrypted by the KMIP
+    ///                                  // server.
     /// }
     /// ```
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
@@ -44,7 +44,8 @@ class data_key {
     ///    region: String,
     ///    key: String, // The Amazon Resource Name (ARN) to the AWS customer master key (CMK).
     ///    endpoint: Optional<String> // An alternate host identifier to send KMS requests to. May
-    ///    include port number. Defaults to "kms.<region>.amazonaws.com"
+    ///                               // include port number. Defaults to
+    ///                               // "kms.<region>.amazonaws.com"
     /// }
     /// ```
     ///
@@ -55,7 +56,7 @@ class data_key {
     ///    keyVaultEndpoint: String, // Host with optional port. Example: "example.vault.azure.net".
     ///    keyName: String,
     ///    keyVersion: Optional<String> // A specific version of the named key, defaults to using
-    ///    the key's primary version.
+    ///                                 // the key's primary version.
     /// }
     /// ```
     ///
@@ -68,9 +69,9 @@ class data_key {
     ///    keyRing: String,
     ///    keyName: String,
     ///    keyVersion: Optional<String>, // A specific version of the named key, defaults to using
-    ///    the key's primary version.
+    ///                                  // the key's primary version.
     ///    endpoint: Optional<String> // Host with optional port. Defaults to
-    ///    "cloudkms.googleapis.com".
+    ///                               // "cloudkms.googleapis.com".
     /// }
     /// ```
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
@@ -71,10 +71,10 @@ class data_key {
     /// If the KMS provider is "kmip" the masterKey is required and has the following fields:
     ///
     /// {
-    //     keyId: Optional<String>, // keyId is the KMIP Unique Identifier to a 96 byte KMIP Secret
-    //                              // Data managed object.If keyId is omitted, the driver creates a
-    //                              // random 96 byte KMIP Secret Data managed object.
-    //     endpoint: Optional<String> // Host with optional port.
+    ///     keyId: Optional<String>, // keyId is the KMIP Unique Identifier to a 96 byte KMIP Secret
+    ///                              // Data managed object.If keyId is omitted, the driver creates
+    ///                              // a random 96 byte KMIP Secret Data managed object.
+    ///     endpoint: Optional<String> // Host with optional port.
     /// }
     ///
     /// If the KMS provider is "local" the masterKey is not applicable.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
@@ -39,24 +39,29 @@ class data_key {
     ///
     /// If the KMS provider is "aws" the masterKey is required and has the following fields:
     ///
+    /// ```
     /// {
     ///    region: String,
     ///    key: String, // The Amazon Resource Name (ARN) to the AWS customer master key (CMK).
     ///    endpoint: Optional<String> // An alternate host identifier to send KMS requests to. May
     ///    include port number. Defaults to "kms.<region>.amazonaws.com"
     /// }
+    /// ```
     ///
     /// If the KMS provider is "azure" the masterKey is required and has the following fields:
     ///
+    /// ```
     /// {
     ///    keyVaultEndpoint: String, // Host with optional port. Example: "example.vault.azure.net".
     ///    keyName: String,
     ///    keyVersion: Optional<String> // A specific version of the named key, defaults to using
     ///    the key's primary version.
     /// }
+    /// ```
     ///
     /// If the KMS provider is "gcp" the masterKey is required and has the following fields:
     ///
+    /// ```
     /// {
     ///    projectId: String,
     ///    location: String,
@@ -67,15 +72,18 @@ class data_key {
     ///    endpoint: Optional<String> // Host with optional port. Defaults to
     ///    "cloudkms.googleapis.com".
     /// }
+    /// ```
     ///
     /// If the KMS provider is "kmip" the masterKey is required and has the following fields:
     ///
+    /// ```
     /// {
     ///     keyId: Optional<String>, // keyId is the KMIP Unique Identifier to a 96 byte KMIP Secret
     ///                              // Data managed object.If keyId is omitted, the driver creates
     ///                              // a random 96 byte KMIP Secret Data managed object.
     ///     endpoint: Optional<String> // Host with optional port.
     /// }
+    /// ```
     ///
     /// If the KMS provider is "local" the masterKey is not applicable.
     ///


### PR DESCRIPTION
Document the KMIP "delegated" masterKey option. Fix rendering of documentation for `data_key::master_key`:

Before:
![Before changes](https://github.com/user-attachments/assets/13886f82-a3a2-4209-8c6f-5a7724adce09)

After:
![After changes](https://github.com/user-attachments/assets/c13b6f06-7064-4046-a986-2ef42245c587)

