### PR TITLE
Fix indentation level of CHANGELOG entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ## 4.0.0
 
-## Added
+### Added
 
 - Getter for the `start_at_operation_time` option in `mongocxx::v_noabi::options::change_stream`.
 
-## Changed
+### Changed
 
 - Bump the minimum required C Driver version to [1.29.0](https://github.com/mongodb/mongo-c-driver/releases/tag/1.29.0).
 - CMake option `ENABLE_TESTS` is now `OFF` by default.
@@ -21,12 +21,12 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
   - Set `BUILD_TESTING=ON` to include test targets in the "all" target when `ENABLE_TESTS=ON` (since 3.9.0, `OFF` by default).
 - Layout of `mongocxx::v_noabi::options::change_stream` to support the new optional `start_at_operation_time` accessor.
 
-## Deprecated
+### Deprecated
 
 - Support for MongoDB Server 4.0.
   - See: [MongoDB Software Lifecycle Schedules](https://www.mongodb.com/legal/support-policy/lifecycles).
 
-## Removed
+### Removed
 
 - Support for external polyfill libraries.
   - `ENABLE_BSONCXX_POLY_USE_IMPLS=ON` is now implicit behavior.

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -411,9 +411,9 @@ Run the release script with the git tag created above as an argument and
 
 ```bash
 make_release_args=(
+    -r upstream
     --jira-creds-file ~/.secrets/jira-creds.txt
     --github-token-file ~/.secrets/github-token.txt
-    -r upstream # Only if mongodb/mongo-cxx-driver is not "origin".
 )
 python ./etc/make_release.py "${make_release_args[@]:?}" --dry-run rX.Y.Z
 ```
@@ -431,6 +431,7 @@ follows:
   distribution tarball.
 - If the script succeeded at creating the distribution tarball, pass it directly
   with `--dist-file ./build/mongo-cxx-driver-rX.Y.Z.tar.gz`.
+- If the only open JIRA ticket is the ticket tracking the release itself, pass `--allow-open-issues`.
 
 If all goes well, run the command again without `--dry-run`. This should update Jira and create a draft release on GitHub.
 


### PR DESCRIPTION
Unintentionally(?) detected by the `etc/make_release.py` script:

```
Error: Failed to find changelog contents for 4.0.0
```