### PR TITLE
add release instruction for webhook

### DIFF
--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -331,6 +331,16 @@ Commit the updates to `CHANGELOG.md`.
 git commit -m 'Update CHANGELOG for X.Y.Z'
 ```
 
+### Update GitHub Webhook
+
+For a non-patch release, update the [Github Webhook](https://wiki.corp.mongodb.com/display/INTX/Githook) to include the new branch.
+
+Navigate to the [Webhook Settings](https://github.com/mongodb/mongo-cxx-driver/settings/hooks)
+
+Click `Edit` on the hook for `https://githook.mongodb.com/`.
+
+Add the branch to the `Payload URL`.
+
 ### Pre-Release Changes PR
 
 Push the `pre-release-changes` branch to a fork repository and create a PR to merge `pre-release-changes` onto `master`:

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -331,16 +331,6 @@ Commit the updates to `CHANGELOG.md`.
 git commit -m 'Update CHANGELOG for X.Y.Z'
 ```
 
-### Update GitHub Webhook
-
-For a non-patch release, update the [Github Webhook](https://wiki.corp.mongodb.com/display/INTX/Githook) to include the new branch.
-
-Navigate to the [Webhook Settings](https://github.com/mongodb/mongo-cxx-driver/settings/hooks)
-
-Click `Edit` on the hook for `https://githook.mongodb.com/`.
-
-Add the new release branch to the `Payload URL`. Remove unmaintained release branches.
-
 ### Pre-Release Changes PR
 
 Push the `pre-release-changes` branch to a fork repository and create a PR to merge `pre-release-changes` onto `master`:
@@ -472,6 +462,16 @@ Navigate to the
 [fixVersions page on Jira](https://jira.mongodb.com/plugins/servlet/project-config/CXX/versions?status=unreleased).
 
 Click the "..." next to the relevant version and select "Release".
+
+### Update GitHub Webhook
+
+For a non-patch release, update the [Github Webhook](https://wiki.corp.mongodb.com/display/INTX/Githook) to include the new branch.
+
+Navigate to the [Webhook Settings](https://github.com/mongodb/mongo-cxx-driver/settings/hooks)
+
+Click `Edit` on the hook for `https://githook.mongodb.com/`.
+
+Add the new release branch to the `Payload URL`. Remove unmaintained release branches.
 
 ### Update releases/stable
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -339,7 +339,7 @@ Navigate to the [Webhook Settings](https://github.com/mongodb/mongo-cxx-driver/s
 
 Click `Edit` on the hook for `https://githook.mongodb.com/`.
 
-Add the branch to the `Payload URL`.
+Add the new release branch to the `Payload URL`. Remove unmaintained release branches.
 
 ### Pre-Release Changes PR
 


### PR DESCRIPTION
To avoid excessive e-mails when updating the `debian/unstable` branch, the GitHub Webhook is updated to limit posting to selected branches. As a consequence, this requires updating the settings on each minor release.

Quoting https://wiki.corp.mongodb.com/display/INTX/Githook:

> The default behavior of this webhook is to post commit to all branches in a repo to JIRA.  If you want to limit the commit activity to a specific repository or set of repositories, you must do the following:
> - https://githook.mongodb.com/?branches=master --> Master only
> - https://githook.mongodb.com/?branches=master..legacy..someotherbranch --> Master, Legacy and Someotherbranch.  The syntax is strange (.. not &)