### PR TITLE
Exclude the releases/stable tag from matching 'r*' tags in calc_releases_version.py

### DIFF
--- a/etc/calc_release_version.py
+++ b/etc/calc_release_version.py
@@ -151,6 +151,10 @@ def check_head_tag():  # type: () -> str | None
     # have git tell us if any tags that look like release tags point at HEAD;
     # based on our policy, a commit should never have more than one release tag
     tags = check_output(['git', 'tag', '--points-at', 'HEAD', '--list', 'r*']).split()
+
+    # exclude the releases/stable tag
+    tags = [tag for tag in tags if tag != 'releases/stable']
+
     tag = ''
     if len(tags) == 1:
         tag = tags[0]


### PR DESCRIPTION
Addresses EVG task failures due to the following error:

```
Exception: Expected 1 or 0 tags on HEAD, got: ['r4.0.0', 'releases/stable']
```

This appears to be due to `releases/stable` matching the `'r*'` tagname filter now that it is a tag rather than a branch. This PR adds a filter to remove the `releases/stable` tag from results. No other tags should start with `'r'`.