### PR TITLE
Fix typo: ENABLE_TEST -> ENABLE_TESTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 - Bump the minimum required C Driver version to [1.29.0](https://github.com/mongodb/mongo-c-driver/releases/tag/1.29.0).
 - CMake option `ENABLE_TESTS` is now `OFF` by default.
-  - Set `ENABLE_TEST=ON` to re-enable building test targets.
+  - Set `ENABLE_TESTS=ON` to re-enable building test targets.
   - Set `BUILD_TESTING=ON` to include test targets in the "all" target when `ENABLE_TESTS=ON` (since 3.9.0, `OFF` by default).
 - Layout of `mongocxx::v_noabi::options::change_stream` to support the new optional `start_at_operation_time` accessor.
 


### PR DESCRIPTION
The [4.0.0 release notes](https://github.com/mongodb/mongo-cxx-driver/releases/tag/r4.0.0) have been updated accordingly.