### PR TITLE
Update the silk asset group being compared against to v3.11

### DIFF
--- a/.evergreen/check-augmented-sbom.sh
+++ b/.evergreen/check-augmented-sbom.sh
@@ -23,7 +23,7 @@ silkbomb_download_flags=(
   --no-update-sbom-version
   --no-update-timestamp
 
-  --silk-asset-group mongo-cxx-driver
+  --silk-asset-group mongo-cxx-driver-3.11
   -o /pwd/etc/augmented.sbom.json.new
 )
 


### PR DESCRIPTION
Addresses check-silk-augmented-sbom task failure on the new EVG project waterfall for v3.