### PR TITLE
Add 4.0.1 changelog section and update Silk asset group

### DIFF
--- a/.evergreen/scripts/check-augmented-sbom.sh
+++ b/.evergreen/scripts/check-augmented-sbom.sh
@@ -23,7 +23,7 @@ silkbomb_download_flags=(
   --no-update-sbom-version
   --no-update-timestamp
 
-  --silk-asset-group mongo-cxx-driver
+  --silk-asset-group mongo-cxx-driver-4.0
   -o /pwd/etc/augmented.sbom.json.new
 )
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changes prior to 3.9.0 are documented as [release notes on GitHub](https://github.com/mongodb/mongo-cxx-driver/releases).
 
+## 4.0.1 [Unreleased]
+
+<!-- Will contain entries for the next patch release. -->
+
 ## 4.0.0
 
 ### Added


### PR DESCRIPTION
To trigger a commit build for the v4.0 EVG project + update Silk asset group to track the `releases/v4.0` branch.