### PR TITLE
CXX-3194 Migrate from macos-1100 to macos-14-arm64

### DIFF
--- a/.evergreen/config_generator/components/integration.py
+++ b/.evergreen/config_generator/components/integration.py
@@ -34,7 +34,7 @@ MATRIX = [
     ('debian12', None, ['Release'], ['shared',         ], [      20], [None], ['plain',        ], [False, True], ['latest'], ['single',                     ]),
     ('debian12', None, ['Release'], ['shared',         ], [None,   ], [None], [         'csfle'], [False,     ], ['latest'], [          'replica', 'sharded']),
 
-    ('macos-11', None, ['Release'], ['shared', 'static'], [None], [None], ['plain'], [False, True], ['latest'], ['single']),
+    ('macos-1100', None, ['Release'], ['shared', 'static'], [None], [None], ['plain'], [False, True], ['latest'], ['single']),
 
     ('macos-14',       None, ['Release'], ['shared', 'static'], [None], [None], ['plain'], [False, True], ['5.0',         ], ['single']),
     ('macos-14-arm64', None, ['Release'], ['shared', 'static'], [None], [None], ['plain'], [False, True], [       'latest'], ['single']),

--- a/.evergreen/config_generator/components/integration.py
+++ b/.evergreen/config_generator/components/integration.py
@@ -34,6 +34,8 @@ MATRIX = [
     ('debian12', None, ['Release'], ['shared',         ], [      20], [None], ['plain',        ], [False, True], ['latest'], ['single',                     ]),
     ('debian12', None, ['Release'], ['shared',         ], [None,   ], [None], [         'csfle'], [False,     ], ['latest'], [          'replica', 'sharded']),
 
+    ('macos-11', None, ['Release'], ['shared', 'static'], [None], [None], ['plain'], [False, True], ['latest'], ['single']),
+
     ('macos-14',       None, ['Release'], ['shared', 'static'], [None], [None], ['plain'], [False, True], ['5.0',         ], ['single']),
     ('macos-14-arm64', None, ['Release'], ['shared', 'static'], [None], [None], ['plain'], [False, True], [       'latest'], ['single']),
 

--- a/.evergreen/config_generator/components/integration.py
+++ b/.evergreen/config_generator/components/integration.py
@@ -34,7 +34,8 @@ MATRIX = [
     ('debian12', None, ['Release'], ['shared',         ], [      20], [None], ['plain',        ], [False, True], ['latest'], ['single',                     ]),
     ('debian12', None, ['Release'], ['shared',         ], [None,   ], [None], [         'csfle'], [False,     ], ['latest'], [          'replica', 'sharded']),
 
-    ('macos-1100', None, ['Release'], ['shared', 'static'], [None], [None], ['plain'], [False, True], ['5.0', 'latest'], ['single']),
+    ('macos-14',       None, ['Release'], ['shared', 'static'], [None], [None], ['plain'], [False, True], ['5.0',         ], ['single']),
+    ('macos-14-arm64', None, ['Release'], ['shared', 'static'], [None], [None], ['plain'], [False, True], [       'latest'], ['single']),
 
     ('rhel81-power8',  None, ['Release'], ['shared', 'static'], [None], [None], ['plain'], [False, True], ['5.0',        'latest'], ['single']),
     ('rhel83-zseries', None, ['Release'], ['shared', 'static'], [None], [None], ['plain'], [False, True], ['5.0', '6.0', 'latest'], ['single']),

--- a/.evergreen/config_generator/components/versioned_api.py
+++ b/.evergreen/config_generator/components/versioned_api.py
@@ -20,7 +20,7 @@ TAG = 'versioned-api'
 # pylint: disable=line-too-long
 # fmt: off
 MATRIX = [
-    ('macos-1100',        None,        ['Release'], ['shared'], [None]),
+    ('macos-14-arm64',    None,        ['Release'], ['shared'], [None]),
     ('ubuntu2004',        None,        ['Debug'  ], ['shared'], [None]),
     ('windows-vsCurrent', 'vs2019x64', ['Debug'  ], ['shared'], [None]),
 ]

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -57,10 +57,12 @@ DEBIAN_DISTROS = [
 ]
 
 MACOS_DISTROS = [
+    Distro(name='macos-11', os='macos', os_type='macos', os_ver='11'),
     Distro(name='macos-14', os='macos', os_type='macos', os_ver='14'),
 ]
 
 MACOS_ARM64_DISTROS = [
+    Distro(name='macos-11-arm64', os='macos', os_type='macos', os_ver='11', arch='arm64'),
     Distro(name='macos-14-arm64', os='macos', os_type='macos', os_ver='14', arch='arm64'),
 ]
 

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -57,7 +57,7 @@ DEBIAN_DISTROS = [
 ]
 
 MACOS_DISTROS = [
-    Distro(name='macos-11', os='macos', os_type='macos', os_ver='11'),
+    Distro(name='macos-1100', os='macos', os_type='macos', os_ver='11.00'),
     Distro(name='macos-14', os='macos', os_type='macos', os_ver='14'),
 ]
 

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -57,11 +57,11 @@ DEBIAN_DISTROS = [
 ]
 
 MACOS_DISTROS = [
-    Distro(name='macos-1100', os='macos', os_type='macos', os_ver='11.00'),
+    Distro(name='macos-14', os='macos', os_type='macos', os_ver='14'),
 ]
 
 MACOS_ARM64_DISTROS = [
-    Distro(name='macos-1100-arm64', os='macos', os_type='macos', os_ver='11.00', arch='arm64'),
+    Distro(name='macos-14-arm64', os='macos', os_type='macos', os_ver='14', arch='arm64'),
 ]
 
 RHEL_DISTROS = [

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -692,9 +692,9 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
           USE_STATIC_LIBS: 1
-  - name: integration-macos-11-release-shared-extra_alignment-latest-single
-    run_on: macos-11
-    tags: [integration, macos-11, release, shared, extra_alignment, latest, single]
+  - name: integration-macos-1100-release-shared-extra_alignment-latest-single
+    run_on: macos-1100
+    tags: [integration, macos-1100, release, shared, extra_alignment, latest, single]
     commands:
       - command: expansions.update
         params:
@@ -717,9 +717,9 @@ tasks:
       - func: test
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
-  - name: integration-macos-11-release-shared-latest-single
-    run_on: macos-11
-    tags: [integration, macos-11, release, shared, latest, single]
+  - name: integration-macos-1100-release-shared-latest-single
+    run_on: macos-1100
+    tags: [integration, macos-1100, release, shared, latest, single]
     commands:
       - command: expansions.update
         params:
@@ -739,9 +739,9 @@ tasks:
       - func: test
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
-  - name: integration-macos-11-release-static-extra_alignment-latest-single
-    run_on: macos-11
-    tags: [integration, macos-11, release, static, extra_alignment, latest, single]
+  - name: integration-macos-1100-release-static-extra_alignment-latest-single
+    run_on: macos-1100
+    tags: [integration, macos-1100, release, static, extra_alignment, latest, single]
     commands:
       - command: expansions.update
         params:
@@ -766,9 +766,9 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
           USE_STATIC_LIBS: 1
-  - name: integration-macos-11-release-static-latest-single
-    run_on: macos-11
-    tags: [integration, macos-11, release, static, latest, single]
+  - name: integration-macos-1100-release-static-latest-single
+    run_on: macos-1100
+    tags: [integration, macos-1100, release, static, latest, single]
     commands:
       - command: expansions.update
         params:

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -692,6 +692,104 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
           USE_STATIC_LIBS: 1
+  - name: integration-macos-11-release-shared-extra_alignment-latest-single
+    run_on: macos-11
+    tags: [integration, macos-11, release, shared, extra_alignment, latest, single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Release }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: latest
+      - func: install_c_driver
+        vars:
+          BSON_EXTRA_ALIGNMENT: 1
+          SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: compile
+        vars:
+          BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+  - name: integration-macos-11-release-shared-latest-single
+    run_on: macos-11
+    tags: [integration, macos-11, release, shared, latest, single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Release }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: latest
+      - func: fetch_c_driver_source
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+  - name: integration-macos-11-release-static-extra_alignment-latest-single
+    run_on: macos-11
+    tags: [integration, macos-11, release, static, extra_alignment, latest, single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Release }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: latest
+      - func: install_c_driver
+        vars:
+          BSON_EXTRA_ALIGNMENT: 1
+          SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: compile
+        vars:
+          BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          USE_STATIC_LIBS: 1
+  - name: integration-macos-11-release-static-latest-single
+    run_on: macos-11
+    tags: [integration, macos-11, release, static, latest, single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Release }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: latest
+      - func: fetch_c_driver_source
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          USE_STATIC_LIBS: 1
   - name: integration-macos-14-arm64-release-shared-extra_alignment-latest-single
     run_on: macos-14-arm64
     tags: [integration, macos-14-arm64, release, shared, extra_alignment, latest, single]

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -692,56 +692,9 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
           USE_STATIC_LIBS: 1
-  - name: integration-macos-1100-release-shared-5.0-single
-    run_on: macos-1100
-    tags: [integration, macos-1100, release, shared, "5.0", single]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-      - func: setup
-      - func: start_mongod
-        vars:
-          mongodb_version: "5.0"
-      - func: fetch_c_driver_source
-      - func: compile
-        vars:
-          ENABLE_TESTS: "ON"
-          RUN_DISTCHECK: 1
-      - func: fetch-det
-      - func: run_kms_servers
-      - func: test
-        vars:
-          MONGOCXX_TEST_TOPOLOGY: single
-  - name: integration-macos-1100-release-shared-extra_alignment-5.0-single
-    run_on: macos-1100
-    tags: [integration, macos-1100, release, shared, extra_alignment, "5.0", single]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-      - func: setup
-      - func: start_mongod
-        vars:
-          mongodb_version: "5.0"
-      - func: install_c_driver
-        vars:
-          BSON_EXTRA_ALIGNMENT: 1
-          SKIP_INSTALL_LIBMONGOCRYPT: 1
-      - func: compile
-        vars:
-          BSON_EXTRA_ALIGNMENT: 1
-          ENABLE_TESTS: "ON"
-      - func: fetch-det
-      - func: run_kms_servers
-      - func: test
-        vars:
-          MONGOCXX_TEST_TOPOLOGY: single
-  - name: integration-macos-1100-release-shared-extra_alignment-latest-single
-    run_on: macos-1100
-    tags: [integration, macos-1100, release, shared, extra_alignment, latest, single]
+  - name: integration-macos-14-arm64-release-shared-extra_alignment-latest-single
+    run_on: macos-14-arm64
+    tags: [integration, macos-14-arm64, release, shared, extra_alignment, latest, single]
     commands:
       - command: expansions.update
         params:
@@ -764,9 +717,9 @@ tasks:
       - func: test
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
-  - name: integration-macos-1100-release-shared-latest-single
-    run_on: macos-1100
-    tags: [integration, macos-1100, release, shared, latest, single]
+  - name: integration-macos-14-arm64-release-shared-latest-single
+    run_on: macos-14-arm64
+    tags: [integration, macos-14-arm64, release, shared, latest, single]
     commands:
       - command: expansions.update
         params:
@@ -786,60 +739,9 @@ tasks:
       - func: test
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
-  - name: integration-macos-1100-release-static-5.0-single
-    run_on: macos-1100
-    tags: [integration, macos-1100, release, static, "5.0", single]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-      - func: setup
-      - func: start_mongod
-        vars:
-          mongodb_version: "5.0"
-      - func: fetch_c_driver_source
-      - func: compile
-        vars:
-          ENABLE_TESTS: "ON"
-          RUN_DISTCHECK: 1
-          USE_STATIC_LIBS: 1
-      - func: fetch-det
-      - func: run_kms_servers
-      - func: test
-        vars:
-          MONGOCXX_TEST_TOPOLOGY: single
-          USE_STATIC_LIBS: 1
-  - name: integration-macos-1100-release-static-extra_alignment-5.0-single
-    run_on: macos-1100
-    tags: [integration, macos-1100, release, static, extra_alignment, "5.0", single]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-      - func: setup
-      - func: start_mongod
-        vars:
-          mongodb_version: "5.0"
-      - func: install_c_driver
-        vars:
-          BSON_EXTRA_ALIGNMENT: 1
-          SKIP_INSTALL_LIBMONGOCRYPT: 1
-      - func: compile
-        vars:
-          BSON_EXTRA_ALIGNMENT: 1
-          ENABLE_TESTS: "ON"
-          USE_STATIC_LIBS: 1
-      - func: fetch-det
-      - func: run_kms_servers
-      - func: test
-        vars:
-          MONGOCXX_TEST_TOPOLOGY: single
-          USE_STATIC_LIBS: 1
-  - name: integration-macos-1100-release-static-extra_alignment-latest-single
-    run_on: macos-1100
-    tags: [integration, macos-1100, release, static, extra_alignment, latest, single]
+  - name: integration-macos-14-arm64-release-static-extra_alignment-latest-single
+    run_on: macos-14-arm64
+    tags: [integration, macos-14-arm64, release, static, extra_alignment, latest, single]
     commands:
       - command: expansions.update
         params:
@@ -864,9 +766,9 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
           USE_STATIC_LIBS: 1
-  - name: integration-macos-1100-release-static-latest-single
-    run_on: macos-1100
-    tags: [integration, macos-1100, release, static, latest, single]
+  - name: integration-macos-14-arm64-release-static-latest-single
+    run_on: macos-14-arm64
+    tags: [integration, macos-14-arm64, release, static, latest, single]
     commands:
       - command: expansions.update
         params:
@@ -881,6 +783,104 @@ tasks:
         vars:
           ENABLE_TESTS: "ON"
           RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          USE_STATIC_LIBS: 1
+  - name: integration-macos-14-release-shared-5.0-single
+    run_on: macos-14
+    tags: [integration, macos-14, release, shared, "5.0", single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Release }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "5.0"
+      - func: fetch_c_driver_source
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+  - name: integration-macos-14-release-shared-extra_alignment-5.0-single
+    run_on: macos-14
+    tags: [integration, macos-14, release, shared, extra_alignment, "5.0", single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Release }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "5.0"
+      - func: install_c_driver
+        vars:
+          BSON_EXTRA_ALIGNMENT: 1
+          SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: compile
+        vars:
+          BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+  - name: integration-macos-14-release-static-5.0-single
+    run_on: macos-14
+    tags: [integration, macos-14, release, static, "5.0", single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Release }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "5.0"
+      - func: fetch_c_driver_source
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          USE_STATIC_LIBS: 1
+  - name: integration-macos-14-release-static-extra_alignment-5.0-single
+    run_on: macos-14
+    tags: [integration, macos-14, release, static, extra_alignment, "5.0", single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Release }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "5.0"
+      - func: install_c_driver
+        vars:
+          BSON_EXTRA_ALIGNMENT: 1
+          SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: compile
+        vars:
+          BSON_EXTRA_ALIGNMENT: 1
+          ENABLE_TESTS: "ON"
           USE_STATIC_LIBS: 1
       - func: fetch-det
       - func: run_kms_servers
@@ -4537,9 +4537,9 @@ tasks:
           TEST_WITH_VALGRIND: "ON"
           disable_slow_tests: 1
           use_mongocryptd: true
-  - name: versioned-api-one-required-macos-1100-release-shared
-    run_on: macos-1100
-    tags: [versioned-api, macos-1100, release, shared]
+  - name: versioned-api-one-required-macos-14-arm64-release-shared
+    run_on: macos-14-arm64
+    tags: [versioned-api, macos-14-arm64, release, shared]
     commands:
       - func: setup
       - func: start_mongod
@@ -4608,9 +4608,9 @@ tasks:
           example_projects_cxx_standard: 17
           generator: Visual Studio 16 2019
           platform: x64
-  - name: versioned-api-two-accepted-macos-1100-release-shared
-    run_on: macos-1100
-    tags: [versioned-api, macos-1100, release, shared]
+  - name: versioned-api-two-accepted-macos-14-arm64-release-shared
+    run_on: macos-14-arm64
+    tags: [versioned-api, macos-14-arm64, release, shared]
     commands:
       - func: setup
       - func: start_mongod

--- a/.evergreen/scripts/compile.sh
+++ b/.evergreen/scripts/compile.sh
@@ -145,7 +145,11 @@ cygwin)
   ;;
 darwin*)
   cc_flags+=("${cc_flags_init[@]}")
-  cxx_flags+=("${cxx_flags_init[@]}" -stdlib=libc++ -Wno-align-mismatch)
+  cxx_flags+=("${cxx_flags_init[@]}" -stdlib=libc++)
+
+  if [[ "${distro_id:?}" == macos-14* ]]; then
+    cxx_flags+=(-Wno-align-mismatch)
+  fi
   ;;
 linux*)
   cc_flags+=("${cc_flags_init[@]}")

--- a/.evergreen/scripts/compile.sh
+++ b/.evergreen/scripts/compile.sh
@@ -145,7 +145,7 @@ cygwin)
   ;;
 darwin*)
   cc_flags+=("${cc_flags_init[@]}")
-  cxx_flags+=("${cxx_flags_init[@]}" -stdlib=libc++)
+  cxx_flags+=("${cxx_flags_init[@]}" -stdlib=libc++ -Wno-align-mismatch)
   ;;
 linux*)
   cc_flags+=("${cc_flags_init[@]}")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ## 4.1.0 [Unreleased]
 
-<!-- Will contain entries for the next minor release. -->
+### Deprecated
+
+- Support for MacOS 11 (EOL since Nov 2020) and MacOS 12 (EOL since Oct 2021).
 
 ## 4.0.0
 


### PR DESCRIPTION
Similar to https://github.com/mongodb/mongo-c-driver/pull/1791, motivated by [DEVPROD-21](https://jira.mongodb.org/browse/DEVPROD-21). Verified by [this patch](https://spruce.mongodb.com/version/674f3b6232d276000785a7ce/).

MongoDB Server 5.0 tasks remain on `macos-14` (Intel) due to lack of availability on `macos-14-arm64`.

Also an attempt to avoid spurious Clang internal compiler errors as observed in [this patch](https://spruce.mongodb.com/task/mongo_cxx_driver_integration_matrix_integration_macos_1100_release_static_extra_alignment_latest_single_e55829024adbd437e48d8310bf959f644d67dc07_24_12_02_21_11_39/).

```
clang: error: unable to execute command: Segmentation fault: 11
clang: error: clang frontend command failed due to signal (use -v to see invocation)
Apple clang version 12.0.0 (clang-1200.0.32.29)
Target: x86_64-apple-darwin20.6.0
Thread model: posix
```

The addition of `-Wno-aligned-mismatch` was necessary to address compilation errors similar to those currently being silenced by `-Wno-aligned-new` for GCC (see "Extra Alignment" in PR description of https://github.com/mongodb/mongo-cxx-driver/pull/1244).