### PR TITLE
CXX-3194 Migrate from macos-1100 to macos-11-arm64

### DIFF
--- a/.evergreen/config_generator/components/integration.py
+++ b/.evergreen/config_generator/components/integration.py
@@ -34,7 +34,7 @@ MATRIX = [
     ('debian12', None, ['Release'], ['shared',         ], [      20], [None], ['plain',        ], [False, True], ['latest'], ['single',                     ]),
     ('debian12', None, ['Release'], ['shared',         ], [None,   ], [None], [         'csfle'], [False,     ], ['latest'], [          'replica', 'sharded']),
 
-    ('macos-1100', None, ['Release'], ['shared', 'static'], [None], [None], ['plain'], [False, True], ['latest'], ['single']),
+    ('macos-11-arm64', None, ['Release'], ['shared', 'static'], [None], [None], ['plain'], [False, True], ['latest'], ['single']),
 
     ('macos-14',       None, ['Release'], ['shared', 'static'], [None], [None], ['plain'], [False, True], ['5.0',         ], ['single']),
     ('macos-14-arm64', None, ['Release'], ['shared', 'static'], [None], [None], ['plain'], [False, True], [       'latest'], ['single']),

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -797,9 +797,9 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
           USE_STATIC_LIBS: 1
-  - name: integration-macos-1100-release-shared-extra_alignment-latest-single
-    run_on: macos-1100
-    tags: [integration, macos-1100, release, shared, extra_alignment, latest, single]
+  - name: integration-macos-11-arm64-release-shared-extra_alignment-latest-single
+    run_on: macos-11-arm64
+    tags: [integration, macos-11-arm64, release, shared, extra_alignment, latest, single]
     commands:
       - command: expansions.update
         params:
@@ -822,9 +822,9 @@ tasks:
       - func: test
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
-  - name: integration-macos-1100-release-shared-latest-single
-    run_on: macos-1100
-    tags: [integration, macos-1100, release, shared, latest, single]
+  - name: integration-macos-11-arm64-release-shared-latest-single
+    run_on: macos-11-arm64
+    tags: [integration, macos-11-arm64, release, shared, latest, single]
     commands:
       - command: expansions.update
         params:
@@ -844,9 +844,9 @@ tasks:
       - func: test
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
-  - name: integration-macos-1100-release-static-extra_alignment-latest-single
-    run_on: macos-1100
-    tags: [integration, macos-1100, release, static, extra_alignment, latest, single]
+  - name: integration-macos-11-arm64-release-static-extra_alignment-latest-single
+    run_on: macos-11-arm64
+    tags: [integration, macos-11-arm64, release, static, extra_alignment, latest, single]
     commands:
       - command: expansions.update
         params:
@@ -871,9 +871,9 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
           USE_STATIC_LIBS: 1
-  - name: integration-macos-1100-release-static-latest-single
-    run_on: macos-1100
-    tags: [integration, macos-1100, release, static, latest, single]
+  - name: integration-macos-11-arm64-release-static-latest-single
+    run_on: macos-11-arm64
+    tags: [integration, macos-11-arm64, release, static, latest, single]
     commands:
       - command: expansions.update
         params:


### PR DESCRIPTION
Resolves CXX-3194. Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1293. Verified by [this patch](https://spruce.mongodb.com/version/675230629678270007e78266/).

[DEVPROD-13222](https://jira.mongodb.org/browse/DEVPROD-13222) may have been a fluke or misdiagnosis, as reattempting the migration appears to succeed without notable changes to the implementation.