### PR TITLE
Bump shrub.py to 3.6.0 and remove batchtime workarounds

### DIFF
--- a/.evergreen/config_generator/components/compile_only.py
+++ b/.evergreen/config_generator/components/compile_only.py
@@ -3,7 +3,6 @@ from config_generator.components.funcs.fetch_c_driver_source import FetchCDriver
 from config_generator.components.funcs.setup import Setup
 
 from config_generator.etc.distros import find_large_distro, make_distro_str
-from config_generator.etc.utils import TaskRef
 
 from shrub.v3.evg_build_variant import BuildVariant, DisplayTask
 from shrub.v3.evg_task import EvgTask, EvgTaskRef
@@ -105,8 +104,8 @@ def variants():
 
     # PowerPC and zSeries are limited resources.
     tasks = [
-        TaskRef(name=f'.{TAG} .rhel81-power8', batchtime=one_day),
-        TaskRef(name=f'.{TAG} .rhel83-zseries', batchtime=one_day),
+        EvgTaskRef(name=f'.{TAG} .rhel81-power8', batchtime=one_day),
+        EvgTaskRef(name=f'.{TAG} .rhel83-zseries', batchtime=one_day),
         EvgTaskRef(name=f'.{TAG} !.rhel81-power8 !.rhel83-zseries'),
     ]
 

--- a/.evergreen/config_generator/components/integration.py
+++ b/.evergreen/config_generator/components/integration.py
@@ -8,7 +8,6 @@ from config_generator.components.funcs.start_mongod import StartMongod
 from config_generator.components.funcs.test import Test
 
 from config_generator.etc.distros import compiler_to_vars, find_large_distro, make_distro_str
-from config_generator.etc.utils import TaskRef
 
 from shrub.v3.evg_build_variant import BuildVariant, DisplayTask
 from shrub.v3.evg_command import KeyValueParam, expansions_update
@@ -209,8 +208,8 @@ def variants():
 
     # PowerPC and zSeries are limited resources.
     tasks = [
-        TaskRef(name=f'.{TAG} .rhel81-power8', batchtime=one_day),
-        TaskRef(name=f'.{TAG} .rhel83-zseries', batchtime=one_day),
+        EvgTaskRef(name=f'.{TAG} .rhel81-power8', batchtime=one_day),
+        EvgTaskRef(name=f'.{TAG} .rhel83-zseries', batchtime=one_day),
         EvgTaskRef(name=f'.{TAG} !.rhel81-power8 !.rhel83-zseries'),
     ]
 

--- a/.evergreen/config_generator/etc/utils.py
+++ b/.evergreen/config_generator/etc/utils.py
@@ -16,17 +16,6 @@ from typing_extensions import get_args, get_origin, get_type_hints
 T = TypeVar('T')
 
 
-# Equivalent to EvgTaskRef but defines additional properties.
-class TaskRef(EvgTaskRef):
-    """
-    An evergreen task reference model that also includes additional properties.
-
-    (The shrub.py model is missing some properties)
-    """
-
-    batchtime: int | None = None
-
-
 # Automatically formats the provided script and invokes it in Bash.
 def bash_exec(
     script,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dev = [
     # .evergreen/config_generator/generate.py
     "packaging>=14.0",
     "pydantic>=2.7",
-    "shrub-py>=3.4.0",
+    "shrub-py>=3.6.0",
 
     # etc/make_release.py (requires python<3.12)
     "click>=6.0",

--- a/uv.lock
+++ b/uv.lock
@@ -282,7 +282,7 @@ dev = [
     { name = "packaging", specifier = ">=14.0" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pygithub", specifier = ">=2.0" },
-    { name = "shrub-py", specifier = ">=3.4.0" },
+    { name = "shrub-py", specifier = ">=3.6.0" },
 ]
 
 [[package]]
@@ -537,7 +537,7 @@ wheels = [
 
 [[package]]
 name = "shrub-py"
-version = "3.5.0"
+version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "croniter" },
@@ -545,9 +545,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/3b/17fae4e0ed7a858ccb5cee4e9c5bc8186737787e55f2ec67bd9afb1550ed/shrub_py-3.5.0.tar.gz", hash = "sha256:6081f283848f140cb203fc944c8de3dd883077b689437511aeed03119422936c", size = 33596 }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/be/1ac80b36382c6bccebd3e00ce7cf811ca6b01fb6d5b3c4dcbd877962526e/shrub_py-3.6.0.tar.gz", hash = "sha256:35bdb700b3a9b742f8b7b6447cf86134ffbf66b154679cda4b1520123aec024e", size = 33574 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/80/6a8fc118c6e6129ddbe7687a19383ec7efd63c3cf47ad74ef68a151ae4cf/shrub_py-3.5.0-py3-none-any.whl", hash = "sha256:57e83733108f20f36d2e55299976a21ebf6c4abd02cb911a2561addfd09bb51c", size = 40044 },
+    { url = "https://files.pythonhosted.org/packages/1e/7b/1caf1c1c8d88c548d044942fc6d02dcd5e3d63bbf0a86d1a493d6b4f3745/shrub_py-3.6.0-py3-none-any.whl", hash = "sha256:bd9bb5fbb2d644915cd20d5563130ad0a5a7c110f2d3b6bea9dfdf5b28b3dda4", size = 40054 },
 ]
 
 [[package]]


### PR DESCRIPTION
Followup to https://github.com/evergreen-ci/shrub.py/commit/3038539b2e411c6f9f2fae5b3eacffe5aaa97045 (which adds `batchtime` to `EvgTaskRef`) and https://github.com/evergreen-ci/shrub.py/commit/089d270db048c1999dbdb53b60eb8146501b9a26 (which addresses Python 3.12 compatibility and the `UserWarning: Valid config keys have changed in V2` pydantic warning).