### PR TITLE
Remove display task for compile-only matrix (DEVPROD-13331)

### DIFF
--- a/.evergreen/config_generator/components/compile_only.py
+++ b/.evergreen/config_generator/components/compile_only.py
@@ -114,11 +114,5 @@ def variants():
             name=f'{TAG}-matrix',
             display_name=f'{TAG}-matrix',
             tasks=tasks,
-            display_tasks=[
-                DisplayTask(
-                    name=f'{TAG}-matrix',
-                    execution_tasks=[f'.{TAG}'],
-                )
-            ],
         ),
     ]

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -30,10 +30,6 @@ buildvariants:
       - name: .clang-tidy
   - name: compile-only-matrix
     display_name: compile-only-matrix
-    display_tasks:
-      - name: compile-only-matrix
-        execution_tasks:
-          - .compile-only
     tasks:
       - name: .compile-only .rhel81-power8
         batchtime: 1440


### PR DESCRIPTION
Address Evergreen finalization errors for patch builds (causing the "Evergreen error" on GitHub PRs) due to [DEVPROD-13331](https://jira.mongodb.org/browse/DEVPROD-13331), which appears to be caused by display tasks interacting poorly with `patchable: false`. Resolve the issue by removing the display task.