### PR TITLE
CXX-1110 add CHECK_THROWS_WITH_CODE

### DIFF
--- a/src/bsoncxx/test/catch.cpp
+++ b/src/bsoncxx/test/catch.cpp
@@ -12,10 +12,231 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <bsoncxx/test/catch.hh>
+
+//
+
+#include <system_error>
+
 #include <bsoncxx/config/prelude.hpp>
 
 #include <catch2/catch_session.hpp>
 
 int BSONCXX_ABI_CDECL main(int argc, char* argv[]) {
     return Catch::Session().run(argc, argv);
+}
+
+TEST_CASE("THROWS_WITH_CODE", "[bsoncxx][test]") {
+    SECTION("basic") {
+        CHECK_THROWS_WITH_CODE(
+            throw std::system_error(std::make_error_code(std::errc::invalid_argument)),
+            std::errc::invalid_argument);
+    }
+
+    // TEST_CHECK is evaluated when a `std::system_error` exception is thrown as expected and is
+    // used to evaluate the error code comparison check.
+    int checked = 0;
+
+    // TEST_CHECK_THROWS_AS is evaluated when an unexpected exception type is thrown and is used to
+    // trigger Catch test failure (always fails).
+    int checked_throws_as = 0;
+
+    SECTION("Catch::TestFailureException") {
+#define TEST_CHECK(expr)                                   \
+    if (1) {                                               \
+        ++checked;                                         \
+        FAIL("Catch::TestFailureException did not throw"); \
+    } else                                                 \
+        ((void)0)
+
+#define TEST_CHECK_THROWS_AS(expr, type)                    \
+    if (1) {                                                \
+        ++checked_throws_as;                                \
+        CHECK_THROWS_AS(expr, Catch::TestFailureException); \
+    } else                                                  \
+        ((void)0)
+
+        try {
+            THROWS_WITH_CODE_IMPL(
+                TEST_CHECK, throw Catch::TestFailureException(), std::errc::invalid_argument);
+        } catch (const Catch::TestFailureException&) {
+            SUCCEED("Catch::TestFailureException was propagated");
+        } catch (...) {
+            FAIL("unexpected exception was thrown");
+        }
+
+#undef TEST_CHECK
+#undef TEST_CHECK_THROWS_AS
+
+        CHECK(checked == 0);
+        CHECK(checked_throws_as == 0);
+    }
+
+    SECTION("Catch::TestSkipException") {
+#define TEST_CHECK(expr)                                \
+    if (1) {                                            \
+        ++checked;                                      \
+        FAIL("Catch::TestSkipException did not throw"); \
+    } else                                              \
+        ((void)0)
+
+#define TEST_CHECK_THROWS_AS(expr, type)                 \
+    if (1) {                                             \
+        ++checked_throws_as;                             \
+        CHECK_THROWS_AS(expr, Catch::TestSkipException); \
+    } else                                               \
+        ((void)0)
+
+        try {
+            THROWS_WITH_CODE_IMPL(
+                TEST_CHECK, throw Catch::TestSkipException(), std::errc::invalid_argument);
+        } catch (const Catch::TestSkipException&) {
+            SUCCEED("Catch::TestSkipException was propagated");
+        } catch (...) {
+            FAIL("unexpected exception was thrown");
+        }
+
+#undef TEST_CHECK
+#undef TEST_CHECK_THROWS_AS
+
+        CHECK(checked == 0);
+        CHECK(checked_throws_as == 0);
+    }
+
+    SECTION("unrelated") {
+        struct unrelated {};
+
+#define TEST_CHECK(expr)                           \
+    if (1) {                                       \
+        ++checked;                                 \
+        FAIL("unrelated exception did not throw"); \
+    } else                                         \
+        ((void)0)
+
+#define TEST_CHECK_THROWS_AS(expr, type)  \
+    if (1) {                              \
+        ++checked_throws_as;              \
+        CHECK_THROWS_AS(expr, unrelated); \
+    } else                                \
+        ((void)0)
+
+        THROWS_WITH_CODE_IMPL(TEST_CHECK, throw unrelated(), std::errc::invalid_argument);
+
+#undef TEST_CHECK
+#undef TEST_CHECK_THROWS_AS
+
+        CHECK(checked == 0);
+        CHECK(checked_throws_as == 1);
+    }
+
+    SECTION("std::system_error") {
+#define TEST_CHECK(expr) \
+    if (1) {             \
+        ++checked;       \
+        CHECK(expr);     \
+    } else               \
+        ((void)0)
+
+#define TEST_CHECK_THROWS_AS(expr, type)          \
+    if (1) {                                      \
+        ++checked_throws_as;                      \
+        CHECK_THROWS_AS(expr, std::system_error); \
+    } else                                        \
+        ((void)0)
+
+        THROWS_WITH_CODE_IMPL(
+            TEST_CHECK,
+            throw std::system_error(std::make_error_code(std::errc::invalid_argument)),
+            std::make_error_code(std::errc::invalid_argument));
+
+#undef TEST_CHECK
+#undef TEST_CHECK_THROWS_AS
+
+        CHECK(checked == 1);
+        CHECK(checked_throws_as == 0);
+    }
+
+    SECTION("derived") {
+        struct derived : std::system_error {
+            using std::system_error::system_error;
+        };
+
+#define TEST_CHECK(expr) \
+    if (1) {             \
+        ++checked;       \
+        CHECK(expr);     \
+    } else               \
+        ((void)0)
+
+#define TEST_CHECK_THROWS_AS(expr, type)          \
+    if (1) {                                      \
+        ++checked_throws_as;                      \
+        CHECK_THROWS_AS(expr, std::system_error); \
+    } else                                        \
+        ((void)0)
+
+        THROWS_WITH_CODE_IMPL(TEST_CHECK,
+                              throw derived(std::make_error_code(std::errc::invalid_argument)),
+                              std::errc::invalid_argument);
+
+#undef TEST_CHECK
+#undef TEST_CHECK_THROWS_AS
+
+        CHECK(checked == 1);
+        CHECK(checked_throws_as == 0);
+    }
+
+    SECTION("error code") {
+#define TEST_CHECK(expr)                                           \
+    if (1) {                                                       \
+        ++checked;                                                 \
+        CHECK_FALSE(expr); /* invalid_argument != not_supported */ \
+    } else                                                         \
+        ((void)0)
+
+#define TEST_CHECK_THROWS_AS(expr, type)          \
+    if (1) {                                      \
+        ++checked_throws_as;                      \
+        CHECK_THROWS_AS(expr, std::system_error); \
+    } else                                        \
+        ((void)0)
+
+        THROWS_WITH_CODE_IMPL(
+            TEST_CHECK,
+            throw std::system_error(std::make_error_code(std::errc::invalid_argument)),
+            std::errc::not_supported);
+
+#undef TEST_CHECK
+#undef TEST_CHECK_THROWS_AS
+
+        CHECK(checked == 1);
+        CHECK(checked_throws_as == 0);
+    }
+
+    SECTION("error condition") {
+#define TEST_CHECK(expr) \
+    if (1) {             \
+        ++checked;       \
+        CHECK(expr);     \
+    } else               \
+        ((void)0)
+
+#define TEST_CHECK_THROWS_AS(expr, type)          \
+    if (1) {                                      \
+        ++checked_throws_as;                      \
+        CHECK_THROWS_AS(expr, std::system_error); \
+    } else                                        \
+        ((void)0)
+
+        THROWS_WITH_CODE_IMPL(
+            TEST_CHECK,
+            throw std::system_error(std::make_error_code(std::errc::invalid_argument)),
+            std::make_error_condition(std::errc::invalid_argument));
+
+#undef TEST_CHECK
+#undef TEST_CHECK_THROWS_AS
+
+        CHECK(checked == 1);
+        CHECK(checked_throws_as == 0);
+    }
 }

--- a/src/bsoncxx/test/catch.hh
+++ b/src/bsoncxx/test/catch.hh
@@ -27,9 +27,43 @@
 #include <catch2/catch_test_macros.hpp>  // TEST_CASE, SECTION, CHECK, etc.
 #include <catch2/catch_tostring.hpp>     // Catch::StringMaker
 
+#define THROWS_WITH_CODE_IMPL(_assertion, _expr, _code)                       \
+    if (1) {                                                                  \
+        try {                                                                 \
+            (void)(_expr);                                                    \
+            INFO("expected an exception to be thrown: " #_expr);              \
+            _assertion(false);                                                \
+        } catch (const Catch::TestFailureException&) {                        \
+            throw; /* Propagate Catch exceptions. */                          \
+        } catch (const Catch::TestSkipException&) {                           \
+            throw; /* Propagate Catch exceptions. */                          \
+        } catch (const std::system_error& ex) {                               \
+            using std::make_error_code;                                       \
+            (void)ex; /* Avoid unused variable warnings. */                   \
+            _assertion(ex.code() == (_code));                                 \
+        } catch (...) {                                                       \
+            BSONCXX_CONCAT(_assertion, _THROWS_AS)(throw, std::system_error); \
+        }                                                                     \
+    } else                                                                    \
+        ((void)0)
+
+#define CHECK_THROWS_WITH_CODE(_expr, _code) THROWS_WITH_CODE_IMPL(CHECK, _expr, _code)
+#define REQUIRE_THROWS_WITH_CODE(_expr, _code) THROWS_WITH_CODE_IMPL(REQUIRE, _expr, _code)
+
 namespace Catch {
 
-// Catch2 must be able to stringify documents, optionals, etc. if they're used in Catch2 macros.
+template <>
+struct StringMaker<std::error_condition> {
+    static std::string convert(const std::error_condition& value) {
+        std::string res;
+
+        res += value.category().name();
+        res += ':';
+        res += Catch::StringMaker<int>::convert(value.value());
+
+        return res;
+    }
+};
 
 template <>
 struct StringMaker<bsoncxx::oid> {

--- a/src/bsoncxx/test/catch.hh
+++ b/src/bsoncxx/test/catch.hh
@@ -27,25 +27,25 @@
 #include <catch2/catch_test_macros.hpp>  // TEST_CASE, SECTION, CHECK, etc.
 #include <catch2/catch_tostring.hpp>     // Catch::StringMaker
 
-#define THROWS_WITH_CODE_IMPL(_assertion, _expr, _code)                          \
-    if (1) {                                                                     \
-        try {                                                                    \
-            (void)(_expr);                                                       \
-            INFO("expected an exception to be thrown: " #_expr);                 \
-            _assertion(false);                                                   \
-        } catch (const Catch::TestFailureException&) {                           \
-            throw; /* Propagate Catch exceptions. */                             \
-        } catch (const Catch::TestSkipException&) {                              \
-            throw; /* Propagate Catch exceptions. */                             \
-        } catch (const std::system_error& ex) {                                  \
-            using std::make_error_code;                                          \
-            (void)ex; /* Avoid unused variable warnings. */                      \
-            _assertion(ex.code() == (_code));                                    \
-        } catch (...) {                                                          \
-            /* Reuse `*_THROWS_AS` to describe the unexpected exception type. */ \
-            BSONCXX_CONCAT(_assertion, _THROWS_AS)(throw, std::system_error);    \
-        }                                                                        \
-    } else                                                                       \
+#define THROWS_WITH_CODE_IMPL(_assertion, _expr, _code)                        \
+    if (1) {                                                                   \
+        try {                                                                  \
+            (void)(_expr);                                                     \
+            INFO("expected an exception to be thrown: " #_expr);               \
+            _assertion(false);                                                 \
+        } catch (const Catch::TestFailureException&) {                         \
+            throw; /* Propagate Catch exceptions. */                           \
+        } catch (const Catch::TestSkipException&) {                            \
+            throw; /* Propagate Catch exceptions. */                           \
+        } catch (const std::system_error& ex) {                                \
+            using std::make_error_code;                                        \
+            (void)ex; /* Avoid unused variable warnings. */                    \
+            _assertion(ex.code() == (_code));                                  \
+        } catch (...) {                                                        \
+            /* Reuse `*_THROWS_AS` to handle the unexpected exception type. */ \
+            BSONCXX_CONCAT(_assertion, _THROWS_AS)(throw, std::system_error);  \
+        }                                                                      \
+    } else                                                                     \
         ((void)0)
 
 #define CHECK_THROWS_WITH_CODE(_expr, _code) THROWS_WITH_CODE_IMPL(CHECK, _expr, _code)

--- a/src/bsoncxx/test/catch.hh
+++ b/src/bsoncxx/test/catch.hh
@@ -27,24 +27,25 @@
 #include <catch2/catch_test_macros.hpp>  // TEST_CASE, SECTION, CHECK, etc.
 #include <catch2/catch_tostring.hpp>     // Catch::StringMaker
 
-#define THROWS_WITH_CODE_IMPL(_assertion, _expr, _code)                       \
-    if (1) {                                                                  \
-        try {                                                                 \
-            (void)(_expr);                                                    \
-            INFO("expected an exception to be thrown: " #_expr);              \
-            _assertion(false);                                                \
-        } catch (const Catch::TestFailureException&) {                        \
-            throw; /* Propagate Catch exceptions. */                          \
-        } catch (const Catch::TestSkipException&) {                           \
-            throw; /* Propagate Catch exceptions. */                          \
-        } catch (const std::system_error& ex) {                               \
-            using std::make_error_code;                                       \
-            (void)ex; /* Avoid unused variable warnings. */                   \
-            _assertion(ex.code() == (_code));                                 \
-        } catch (...) {                                                       \
-            BSONCXX_CONCAT(_assertion, _THROWS_AS)(throw, std::system_error); \
-        }                                                                     \
-    } else                                                                    \
+#define THROWS_WITH_CODE_IMPL(_assertion, _expr, _code)                          \
+    if (1) {                                                                     \
+        try {                                                                    \
+            (void)(_expr);                                                       \
+            INFO("expected an exception to be thrown: " #_expr);                 \
+            _assertion(false);                                                   \
+        } catch (const Catch::TestFailureException&) {                           \
+            throw; /* Propagate Catch exceptions. */                             \
+        } catch (const Catch::TestSkipException&) {                              \
+            throw; /* Propagate Catch exceptions. */                             \
+        } catch (const std::system_error& ex) {                                  \
+            using std::make_error_code;                                          \
+            (void)ex; /* Avoid unused variable warnings. */                      \
+            _assertion(ex.code() == (_code));                                    \
+        } catch (...) {                                                          \
+            /* Reuse `*_THROWS_AS` to describe the unexpected exception type. */ \
+            BSONCXX_CONCAT(_assertion, _THROWS_AS)(throw, std::system_error);    \
+        }                                                                        \
+    } else                                                                       \
         ((void)0)
 
 #define CHECK_THROWS_WITH_CODE(_expr, _code) THROWS_WITH_CODE_IMPL(CHECK, _expr, _code)


### PR DESCRIPTION
Resolves CXX-1110. Verified by [this patch](https://spruce.mongodb.com/version/675877e0c945f10007c344e2/) (containing the proposed changes in https://github.com/mongodb/mongo-cxx-driver/pull/1298).

Precursor changes to faciliate the improvement and addition of tests for bsoncxx and mongocxx error codes and error categories as part of CXX-834 and CXX-2745.

The two new macros `(CHECK|REQUIRE)_THROWS_WITH_CODE` mirror the existing Catch2 exception assertion macros `(CHECK|REQUIRE)_THROWS_WITH`. It is expected to be used as follows:

```cpp
CHECK_THROWS_WITH_CODE(throwing-expr, error-code-enumerator);
CHECK_THROWS_WITH_CODE(throwing-expr, error-code);
CHECK_THROWS_WITH_CODE(throwing-expr, error-condition);
```

The exception type must be or derive from `std::system_error` which provides the error code (via `.code()`) to be compared against. Otherwise, the test assertion fails via an always-false `*_THROWS_WITH(throw, std::system_error)` to reuse Catch's exception type-match error messages.

The option to define and use a custom Catch matcher for use with `*_THROWS_WITH` was rejected due to not correctly supporting Catch test exception propagation and not fully supporting customization of the resulting error messages due to unavoidable internal exception handler routines being executed within Catch. It was also comparatively unwieldy to write due to having to construct the custom matcher as an argument (its omission would just lead to the same `*_THROWS_WITH_CODE` interface as proposed by this PR):

```cpp
CHECK_THROWS_WITH(throwing-expr, Code(error-code));
```

Although Catch seems to support string-making a `std::error_code` (e.g. `std::errc::invalid_argument` -> `generic:22`), it doesn't seem to support `std::error_condition`, so a specialization is also added which uses the same format as error codes. This produces assertion messages like the following:

```cpp
// path/to/file:line: PASSED:
//   CHECK( ex.code() == (std::errc::invalid_argument)) )
// with expansion:
//   generic:22 == 22
CHECK_THROWS_WITH_CODE(..., std::errc::invalid_argument);

// path/to/file:line: PASSED:
//   CHECK( ex.code() == (std::make_error_code(std::errc::invalid_argument)) )
// with expansion:
//   generic:22 == generic:22
CHECK_THROWS_WITH_CODE(..., std::make_error_code(std::errc::invalid_argument));

// path/to/file:line: PASSED:
//   CHECK( ex.code() == (std::make_error_condition(std::errc::invalid_argument)) )
// with expansion:
//   generic:22 == generic:22
CHECK_THROWS_WITH_CODE(..., std::make_error_condition(std::errc::invalid_argument));
```

and in the event of an unexpected exception whose type does not provide `ex.code() -> std::error_code`:

```
// file:line: FAILED:
//   CHECK_THROWS_AS( throw, std::system_error )
// due to unexpected exception with message:
//   foo
CHECK_THROWS_WITH_CODE(throw std::runtime_error("foo"), std::errc::invalid_argument);
```