### PR TITLE
CXX-3195 add 404 page with automatic redirection

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+    <link rel="shortcut icon" href="https://mongocxx.org/img/favicon.png">
+
+    <title>Page Not Found</title>
+
+    <link rel="stylesheet" href="https://mongocxx.org/lib/bootstrap.css" type="text/css" />
+    <link rel="stylesheet" href="https://mongocxx.org/lib/font-awesome/css/font-awesome.min.css" type="text/css" />
+    <link rel="stylesheet" href="https://mongocxx.org/css/mongodb-docs.css" type="text/css" />
+    <link rel="stylesheet" href="https://mongocxx.org/css/overrides.css" type="text/css" />
+    <link rel="stylesheet" href="https://mongocxx.org/lib/highlight/styles/idea.css" />
+
+    <link rel="canonical" href="https://mongocxx.org/404.html" />
+    <script type="text/javascript">
+        var milliseconds = 5000;
+
+        function redirect() {
+            if (window.location.pathname.startsWith("/api/")) {
+                // Redirect to current API homepage.
+                window.location.assign(window.location.href.split('/api/')[0] + '/api/current')
+            } else {
+                // Redirect to website homepage.
+                window.location.assign(window.location.origin)
+            }
+        }
+
+        setTimeout(redirect, milliseconds);
+    </script>
+</head>
+
+<body>
+    <p>This page could not be found. Automatically redirecting in a few seconds...</p>
+
+    <p><a href="https://mongocxx.org/">Click here</a> if automatic redirection fails.</p>
+
+    <script type="text/javascript" src="https://mongocxx.org/js/jquery.js"></script>
+    <script type="text/javascript" src="https://mongocxx.org/lib/bootstrap.js"></script>
+    <script type="text/javascript" src="https://mongocxx.org/js/navbar.js"></script>
+    <script type="text/javascript" src="https://mongocxx.org/lib/highlight/highlight.pack.js"></script>
+    <script type="text/javascript" src="https://mongocxx.org/js/scripts.js"></script>
+
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-JQHP" height="0" width="0"
+            style="display:none;visibility:hidden"></iframe></noscript>
+    <script>(function (w, d, s, l, i) {
+            w[l] = w[l] || []; w[l].push(
+                { 'gtm.start': new Date().getTime(), event: 'gtm.js' }
+            ); var f = d.getElementsByTagName(s)[0],
+                j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
+                    '//www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
+        })(window, document, 'script', 'dataLayer', 'GTM-JQHP');</script>
+    <script type="text/javascript">
+        var _elqQ = _elqQ || [];
+        _elqQ.push(['elqSetSiteId', '413370795']);
+        _elqQ.push(['elqTrackPageView']);
+        (function () {
+            function async_load() { var s = document.createElement('script'); s.type = 'text/javascript'; s.async = true; s.src = '//img03.en25.com/i/elqCfg.min.js'; var x = document.getElementsByTagName('script')[0]; x.parentNode.insertBefore(s, x); }
+            if (window.addEventListener) window.addEventListener('DOMContentLoaded', async_load, false);
+            else if (window.attachEvent) window.attachEvent('onload', async_load);
+        })();
+    </script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-56KD6L3MDX"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+        gtag('config', 'G-56KD6L3MDX');
+    </script>
+    <script type="text/javascript">
+        !function (e, t, r, n, a) { if (!e[a]) { for (var i = e[a] = [], s = 0; s < r.length; s++) { var c = r[s]; i[c] = i[c] || function (e) { return function () { var t = Array.prototype.slice.call(arguments); i.push([e, t]) } }(c) } i.SNIPPET_VERSION = "1.0.1"; var o = t.createElement("script"); o.type = "text/javascript", o.async = !0, o.src = "https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/" + n + "/" + a + ".js"; var l = t.getElementsByTagName("script")[0]; l.parentNode.insertBefore(o, l) } }(window, document, ["survey", "reset", "config", "init", "set", "get", "event", "identify", "track", "page", "screen", "group", "alias"], "Dk30CC86ba0nATlK", "delighted");
+        delighted.survey();
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
Resolves CXX-3195. Precursor changes to CXX-2745 to gracefully handle API doc pages which are no longer present in the latest API documentation, such as in https://github.com/mongodb/mongo-cxx-driver/pull/1301.

Implemented according to [GitHub Pages Docs](https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-custom-404-page-for-your-github-pages-site) using a Hugo-generated custom 404 homepage as a template which was stripped down to its current state with site-wide contents preserved (e.g. content security policy, stylesheets, site visit tracker, etc.).

404 and redirection behavior has not yet been tested with GitHub Pages deployment. Behavior will be tested and validated after deployment with followup PRs if necessary.

GitHub Pages supports using a custom 404 error page located at `/404.html` relative to the root directory. This PR proposes a 404 page which waits 5 seconds before redirecting users (with page history preservation, unlike `/api/current` page redirects) to _either_ the current API docs homepage for URLs under `/api`, or to the website homepage for all other URLs. It is possible this behavior does not work as intended with GitHub Pages depending on how it implements the 404 error page (does it "redirect" to `/404.html`, thus `window.location` is always the 404 page, not the original link? does it "substitute" the contents of `/404.html` using the original link?). Regardless, the proposed 404 error page is expected to automatically redirect the user instead of the current status quo of GitHub Pages' default 404 page with no redirection.