### PR TITLE
CXX-3195 avoid deleting custom 404 page

### DIFF
--- a/etc/deploy-to-ghpages.pl
+++ b/etc/deploy-to-ghpages.pl
@@ -36,6 +36,7 @@ sub _hugo_rsync {
         'CNAME',
         '/sitemap.xml',
         '/sitemap_index.xml',
+        '/404.html',
     );
     _try_run( qw{rsync -Cavz --delete}, ( map { ; '--exclude' => $_ } @exclude ), qw{build/hugo/}, $tmpdir );
 }


### PR DESCRIPTION
Companion PR to https://github.com/mongodb/mongo-cxx-driver/pull/1302 which adds the new `404.html` file to the list of rsync exclude filters so it is not deleted by the script during deployment.