### PR TITLE
Migrate ABI stability tasks to rhel95 distro (Clang 18)

### DIFF
--- a/.evergreen/config_generator/components/abi_stability.py
+++ b/.evergreen/config_generator/components/abi_stability.py
@@ -147,7 +147,7 @@ def generate_tasks():
         if func is Abidiff:
             distro_name = 'ubuntu2204'  # Clang 12, libabigail is not available on RHEL distros.
         else:
-            distro_name = 'rhel9-latest'  # Clang 17.
+            distro_name = 'rhel95'  # Clang 18.
 
         distro = find_large_distro(distro_name)
 

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -81,11 +81,11 @@ RHEL_DISTROS = [
     Distro(name='rhel87-small', os='rhel', os_type='linux', os_ver='8.7', size='small'),
     Distro(name='rhel90-large', os='rhel', os_type='linux', os_ver='9.0', size='large'),
     Distro(name='rhel90-small', os='rhel', os_type='linux', os_ver='9.0', size='small'),
+    Distro(name='rhel95-large', os='rhel', os_type='linux', os_ver='9.5', size='large'),
+    Distro(name='rhel95-small', os='rhel', os_type='linux', os_ver='9.5', size='small'),
 
     Distro(name='rhel8-latest-large', os='rhel', os_type='linux', os_ver='latest', size='large'),
     Distro(name='rhel8-latest-small', os='rhel', os_type='linux', os_ver='latest', size='small'),
-    Distro(name='rhel9-latest-large', os='rhel', os_type='linux', os_ver='latest', size='large'),
-    Distro(name='rhel9-latest-small', os='rhel', os_type='linux', os_ver='latest', size='small'),
 ]
 
 RHEL_ARM64_DISTROS = [

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -1,79 +1,79 @@
 tasks:
   - name: abi-compliance-check-impls-cxx11
-    run_on: rhel9-latest-large
-    tags: [abi-stability, rhel9-latest, abi-compliance-check, impls, cxx11]
+    run_on: rhel95-large
+    tags: [abi-stability, rhel95, abi-compliance-check, impls, cxx11]
     commands:
       - func: abi-compliance-check
         vars:
           cxx_standard: "11"
           polyfill: impls
   - name: abi-compliance-check-impls-cxx17
-    run_on: rhel9-latest-large
-    tags: [abi-stability, rhel9-latest, abi-compliance-check, impls, cxx17]
+    run_on: rhel95-large
+    tags: [abi-stability, rhel95, abi-compliance-check, impls, cxx17]
     commands:
       - func: abi-compliance-check
         vars:
           cxx_standard: "17"
           polyfill: impls
   - name: abi-compliance-check-stdlib-cxx17
-    run_on: rhel9-latest-large
-    tags: [abi-stability, rhel9-latest, abi-compliance-check, stdlib, cxx17]
+    run_on: rhel95-large
+    tags: [abi-stability, rhel95, abi-compliance-check, stdlib, cxx17]
     commands:
       - func: abi-compliance-check
         vars:
           cxx_standard: "17"
           polyfill: stdlib
   - name: abi-compliance-check-stdlib-cxx20
-    run_on: rhel9-latest-large
-    tags: [abi-stability, rhel9-latest, abi-compliance-check, stdlib, cxx20]
+    run_on: rhel95-large
+    tags: [abi-stability, rhel95, abi-compliance-check, stdlib, cxx20]
     commands:
       - func: abi-compliance-check
         vars:
           cxx_standard: "20"
           polyfill: stdlib
   - name: abi-compliance-check-stdlib-cxx23
-    run_on: rhel9-latest-large
-    tags: [abi-stability, rhel9-latest, abi-compliance-check, stdlib, cxx23]
+    run_on: rhel95-large
+    tags: [abi-stability, rhel95, abi-compliance-check, stdlib, cxx23]
     commands:
       - func: abi-compliance-check
         vars:
           cxx_standard: "23"
           polyfill: stdlib
   - name: abi-prohibited-symbols-impls-cxx11
-    run_on: rhel9-latest-large
-    tags: [abi-stability, rhel9-latest, abi-prohibited-symbols, impls, cxx11]
+    run_on: rhel95-large
+    tags: [abi-stability, rhel95, abi-prohibited-symbols, impls, cxx11]
     commands:
       - func: abi-prohibited-symbols
         vars:
           cxx_standard: "11"
           polyfill: impls
   - name: abi-prohibited-symbols-impls-cxx17
-    run_on: rhel9-latest-large
-    tags: [abi-stability, rhel9-latest, abi-prohibited-symbols, impls, cxx17]
+    run_on: rhel95-large
+    tags: [abi-stability, rhel95, abi-prohibited-symbols, impls, cxx17]
     commands:
       - func: abi-prohibited-symbols
         vars:
           cxx_standard: "17"
           polyfill: impls
   - name: abi-prohibited-symbols-stdlib-cxx17
-    run_on: rhel9-latest-large
-    tags: [abi-stability, rhel9-latest, abi-prohibited-symbols, stdlib, cxx17]
+    run_on: rhel95-large
+    tags: [abi-stability, rhel95, abi-prohibited-symbols, stdlib, cxx17]
     commands:
       - func: abi-prohibited-symbols
         vars:
           cxx_standard: "17"
           polyfill: stdlib
   - name: abi-prohibited-symbols-stdlib-cxx20
-    run_on: rhel9-latest-large
-    tags: [abi-stability, rhel9-latest, abi-prohibited-symbols, stdlib, cxx20]
+    run_on: rhel95-large
+    tags: [abi-stability, rhel95, abi-prohibited-symbols, stdlib, cxx20]
     commands:
       - func: abi-prohibited-symbols
         vars:
           cxx_standard: "20"
           polyfill: stdlib
   - name: abi-prohibited-symbols-stdlib-cxx23
-    run_on: rhel9-latest-large
-    tags: [abi-stability, rhel9-latest, abi-prohibited-symbols, stdlib, cxx23]
+    run_on: rhel95-large
+    tags: [abi-stability, rhel95, abi-prohibited-symbols, stdlib, cxx23]
     commands:
       - func: abi-prohibited-symbols
         vars:

--- a/.evergreen/scripts/abi-stability-setup.sh
+++ b/.evergreen/scripts/abi-stability-setup.sh
@@ -109,7 +109,7 @@ git -C mongo-cxx-driver reset --hard "${base:?}"
 
 # Install old (base) to install/old.
 echo "Building old libraries..."
-{
+(
   "${cmake_binary:?}" \
     -S mongo-cxx-driver \
     -B build/old \
@@ -118,7 +118,7 @@ echo "Building old libraries..."
     "${configure_flags[@]:?}" || exit
   "${cmake_binary:?}" --build build/old || exit
   "${cmake_binary:?}" --install build/old || exit
-} &>old.log || {
+) &>old.log || {
   cat old.log 1>&2
   exit 1
 }
@@ -130,7 +130,7 @@ git -C mongo-cxx-driver stash pop -q || true # Only patch builds have stashed ch
 
 # Install new (current) to install/new.
 echo "Building new libraries..."
-{
+(
   "${cmake_binary:?}" \
     -S mongo-cxx-driver \
     -B build/new \
@@ -139,7 +139,7 @@ echo "Building new libraries..."
     "${configure_flags[@]:?}" || exit
   "${cmake_binary:?}" --build build/new || exit
   "${cmake_binary:?}" --install build/new || exit
-} &>new.log || {
+) &>new.log || {
   cat new.log 1>&2
   exit 1
 }

--- a/.evergreen/scripts/abi-stability-setup.sh
+++ b/.evergreen/scripts/abi-stability-setup.sh
@@ -68,8 +68,8 @@ mkdir -p "${working_dir}/install"
 export CC CXX
 case "${distro_id:?}" in
 rhel9*)
-  CC="clang-17"
-  CXX="clang++-17"
+  CC="clang-18"
+  CXX="clang++-18"
   ;;
 ubuntu22*)
   CC="clang-12"

--- a/.evergreen/scripts/abi-stability-setup.sh
+++ b/.evergreen/scripts/abi-stability-setup.sh
@@ -115,9 +115,9 @@ echo "Building old libraries..."
     -B build/old \
     -DCMAKE_INSTALL_PREFIX=install/old \
     -DBUILD_VERSION="${old_ver:?}-base" \
-    "${configure_flags[@]:?}"
-  "${cmake_binary:?}" --build build/old
-  "${cmake_binary:?}" --install build/old
+    "${configure_flags[@]:?}" || exit
+  "${cmake_binary:?}" --build build/old || exit
+  "${cmake_binary:?}" --install build/old || exit
 } &>old.log || {
   cat old.log 1>&2
   exit 1
@@ -136,9 +136,9 @@ echo "Building new libraries..."
     -B build/new \
     -DCMAKE_INSTALL_PREFIX=install/new \
     -DBUILD_VERSION="${new_ver:?}-current" \
-    "${configure_flags[@]:?}"
-  "${cmake_binary:?}" --build build/new
-  "${cmake_binary:?}" --install build/new
+    "${configure_flags[@]:?}" || exit
+  "${cmake_binary:?}" --build build/new || exit
+  "${cmake_binary:?}" --install build/new || exit
 } &>new.log || {
   cat new.log 1>&2
   exit 1


### PR DESCRIPTION
EVG task failures due to a distro image misconfiguration revealed that Clang 18 is available on the newly-available rhel95 distro. Addresses task failures by migrating to the rhel95 distro with Clang 18 for improved C++23 compilation coverage.

Additionally added some missing early return handlers to correctly report failures during setup.