### PR TITLE
Avoid running packaging tasks during GitHub operations

### DIFF
--- a/.evergreen/config_generator/components/packaging.py
+++ b/.evergreen/config_generator/components/packaging.py
@@ -2,11 +2,11 @@ from config_generator.components.funcs.setup import Setup
 
 from config_generator.etc.distros import find_large_distro
 from config_generator.etc.function import Function, merge_defns
-from config_generator.etc.utils import bash_exec
+from config_generator.etc.utils import Task, bash_exec
 
 from shrub.v3.evg_build_variant import BuildVariant
 from shrub.v3.evg_command import EvgCommandType, s3_put
-from shrub.v3.evg_task import EvgTask, EvgTaskRef
+from shrub.v3.evg_task import EvgTaskRef
 
 
 TAG = 'packaging'
@@ -78,10 +78,19 @@ def functions():
 
 def tasks():
     return [
-        EvgTask(
+        Task(
             name=f'{TAG}-{fn.desc}',
             tags=[TAG, distro_name],
             run_on=find_large_distro(distro_name).name,
+            allowed_requesters=[
+                'ad_hoc',
+                'commit',
+                # 'github_merge_queue'
+                # 'github_pr',
+                # 'github_tag',
+                'patch',
+                'trigger',
+            ],
             commands=[
                 Setup.call(),
                 fn.call(),

--- a/.evergreen/config_generator/etc/utils.py
+++ b/.evergreen/config_generator/etc/utils.py
@@ -3,17 +3,22 @@ from importlib import import_module
 from inspect import isclass
 from pathlib import Path
 from textwrap import dedent
-from typing import (Any, Iterable, Literal, Mapping, Type, TypeVar,
+from typing import (Any, Iterable, List, Literal, Mapping, Optional, Type, TypeVar,
                     Union, cast)
 
 import yaml
 from shrub.v3.evg_command import EvgCommandType, KeyValueParam, subprocess_exec
 from shrub.v3.evg_project import EvgProject
 from shrub.v3.shrub_service import ConfigDumper
-from shrub.v3.evg_task import EvgTaskRef
+from shrub.v3.evg_task import EvgTask
 from typing_extensions import get_args, get_origin, get_type_hints
 
 T = TypeVar('T')
+
+
+# Equivalent to EvgTaskRef but defines additional properties.
+class Task(EvgTask):
+    allowed_requesters: Optional[List[str]] = None
 
 
 # Automatically formats the provided script and invokes it in Bash.

--- a/.evergreen/config_generator/etc/utils.py
+++ b/.evergreen/config_generator/etc/utils.py
@@ -16,7 +16,7 @@ from typing_extensions import get_args, get_origin, get_type_hints
 T = TypeVar('T')
 
 
-# Equivalent to EvgTaskRef but defines additional properties.
+# Equivalent to EvgTask but defines additional properties.
 class Task(EvgTask):
     allowed_requesters: Optional[List[str]] = None
 

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -4010,12 +4010,22 @@ tasks:
   - name: packaging-debian
     run_on: debian12-latest-large
     tags: [packaging, debian12-latest]
+    allowed_requesters:
+      - ad_hoc
+      - commit
+      - patch
+      - trigger
     commands:
       - func: setup
       - func: build-package-debian
   - name: packaging-rpm
     run_on: rhel92-arm64-large
     tags: [packaging, rhel92-arm64]
+    allowed_requesters:
+      - ad_hoc
+      - commit
+      - patch
+      - trigger
     commands:
       - func: setup
       - func: build-package-rpm


### PR DESCRIPTION
Adds the `allowed_requesters` field to packaging tasks such that they are not scheduled by GitHub operations. The "trigger" and "ad_hoc" requesters are left in their default enabled state (despite AFAIK also being unused; they can also be disabled if preferable). This effectively limits the requesters which may schedule the packaging tasks to commit builds (EVG waterfall) and manually requested patch builds.

~~The proposed config does not apply to this PR's own patch build.~~ Disregard, it _does_ apply. 😄 