### PR TITLE
CXX-3198 support `clang-format-all.sh` on macOS

### DIFF
--- a/etc/clang-format-all.sh
+++ b/etc/clang-format-all.sh
@@ -12,7 +12,8 @@
 set -o errexit
 set -o pipefail
 
-clang-format --version
+CLANG_FORMAT="${CLANG_FORMAT:-clang-format}"
+"$CLANG_FORMAT" --version
 
 source_dirs=(
   src
@@ -25,7 +26,7 @@ mapfile -t source_files < <(
 )
 
 if [[ -n "${DRYRUN:-}" ]]; then
-  clang-format --dry-run -Werror "${source_files[@]:?}"
+  "$CLANG_FORMAT" --dry-run -Werror "${source_files[@]:?}"
 else
-  clang-format --verbose -i "${source_files[@]:?}"
+  "$CLANG_FORMAT" --verbose -i "${source_files[@]:?}"
 fi

--- a/etc/clang-format-all.sh
+++ b/etc/clang-format-all.sh
@@ -12,8 +12,8 @@
 set -o errexit
 set -o pipefail
 
-CLANG_FORMAT="${CLANG_FORMAT:-clang-format}"
-"$CLANG_FORMAT" --version
+clang_format_binary="${CLANG_FORMAT_BINARY:-clang-format}"
+"${clang_format_binary:?}" --version
 
 source_dirs=(
   src
@@ -26,7 +26,7 @@ mapfile -t source_files < <(
 )
 
 if [[ -n "${DRYRUN:-}" ]]; then
-  "$CLANG_FORMAT" --dry-run -Werror "${source_files[@]:?}"
+  "$clang_format_binary" --dry-run -Werror "${source_files[@]:?}"
 else
-  "$CLANG_FORMAT" --verbose -i "${source_files[@]:?}"
+  "$clang_format_binary" --verbose -i "${source_files[@]:?}"
 fi

--- a/etc/clang-format-all.sh
+++ b/etc/clang-format-all.sh
@@ -21,7 +21,7 @@ source_dirs=(
 )
 
 mapfile -t source_files < <(
-  find "${source_dirs[@]:?}" -regextype posix-egrep -regex '.*\.(hpp|hh|cpp)'
+  find "${source_dirs[@]:?}" | grep -E '.*\.(hpp|hh|cpp)$'
 )
 
 if [[ -n "${DRYRUN:-}" ]]; then


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/mongo-cxx-driver/pull/1299. Verified with this [patch build](https://spruce.mongodb.com/version/6772fc401713a80007c98ce4).

Use `grep` instead of `-regextype` to fix observed error running `etc/clang-format-all.sh` on macOS:
```
find: -regextype: unknown primary or operator
```

Also allow overriding the used `clang-format`. This is intended to ease my current set-up and can be reverted if desired. I installed LLVM 1.19 with `brew install llvm`, and it is not on a system path to avoid interfering with AppleClang.


