### PR TITLE
Do not compile with system libmongoc during integration tests

### DIFF
--- a/.evergreen/scripts/compile.sh
+++ b/.evergreen/scripts/compile.sh
@@ -103,6 +103,11 @@ cmake_flags=(
   -DENABLE_UNINSTALL=ON
 )
 
+# System-installed libmongoc must not prevent fetch-and-build of libmongoc.
+if [[ -z "$(find "${mongoc_prefix:?}" -name 'bson-config.h')" ]]; then
+  cmake_flags+=("-DCMAKE_DISABLE_FIND_PACKAGE_mongoc-1.0=ON")
+fi
+
 _RUN_DISTCHECK=""
 case "${OSTYPE:?}" in
 cygwin)
@@ -271,7 +276,7 @@ if [[ -n "$(find "${mongoc_prefix:?}" -name 'bson-config.h')" ]]; then
       exit 1
     }
   fi
-else
+elif [[ -n "$(find install -name 'bson-config.h')" ]]; then
   if [[ "${BSON_EXTRA_ALIGNMENT:-}" == "1" ]]; then
     grep -R "#define BSON_EXTRA_ALIGN 1" install || {
       echo "BSON_EXTRA_ALIGN is not 1 despite BSON_EXTRA_ALIGNMENT=1" 1>&2
@@ -283,4 +288,7 @@ else
       exit 1
     }
   fi
+else
+  echo "unexpectedly compiled using a system libmongoc library" 1>&2
+  exit 1
 fi


### PR DESCRIPTION
Addresses recent Evergreen flaky test failures on MacOS distros due to unexpectedly compiling with a system-installed libmongoc (CMake reports version 1.29.1 despite `MONGOC_DOWNLOAD_VERSION` being 1.29.0). This leads to the libbson library having a `BSON_EXTRA_ALIGN` that is inconsistent with test expectations. Filed [DEVPROD-13793](https://jira.mongodb.org/browse/DEVPROD-13793).

This PR sets `CMAKE_DISABLE_FIND_PACKAGE_<PackageName>=ON` when a preinstalled C Driver is not detected (the presence of the `bson-config.h` header, as used by the extra alignment consistency checks). This forces CMake to "fail" to find an existing C Driver, thus ensuring it fetch-and-builds the C Driver as expected by integration tests.