### PR TITLE
Improve documentation briefs and misc. details

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value.hpp
@@ -29,9 +29,10 @@ namespace v_noabi {
 namespace array {
 
 ///
-/// A read-only BSON array that owns its underlying buffer. When a array::value goes
-/// out of scope, the underlying buffer is freed. Generally this class should be used
-/// sparingly; array::view should be used instead wherever possible.
+/// A read-only BSON array that owns its underlying buffer.
+///
+/// When a array::value goes out of scope, the underlying buffer is freed. Generally this class
+/// should be used sparingly; array::view should be used instead wherever possible.
 ///
 class value {
    public:

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_array.hpp
@@ -35,8 +35,11 @@ void value_append(core* core, T&& t);
 } // namespace impl
 
 ///
-/// An internal class of builder::basic.
-/// Users should almost always construct a builder::basic::array instead.
+/// Represents an array element being constructed during an append operation.
+///
+/// @see
+/// - @ref bsoncxx::v_noabi::builder::basic::array
+/// - @ref bsoncxx::v_noabi::builder::basic::document
 ///
 class sub_array {
    public:

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/basic/sub_document.hpp
@@ -37,8 +37,11 @@ void value_append(core* core, T&& t);
 } // namespace impl
 
 ///
-/// An internal class of builder::basic.
-/// Users should almost always construct a builder::basic::document instead.
+/// Represents a document element being constructed during an append operation.
+///
+/// @see
+/// - @ref bsoncxx::v_noabi::builder::basic::array
+/// - @ref bsoncxx::v_noabi::builder::basic::document
 ///
 class sub_document {
    public:

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/closed_context.hpp
@@ -25,11 +25,11 @@ namespace builder {
 namespace stream {
 
 ///
-/// The closed_context, when used as a template parameter for array_context,
-/// value_context or key_context, indicates that the document cannot be closed
-/// further. This could indicate that the document is the root, or that the type
-/// stack has been intentionally erased, as is the case when using callbacks in
-/// the stream api.
+/// Indicates the document being constructed cannot be closed further.
+///
+/// Used as a template parameter for array_context, value_context or key_context. This could
+/// indicate that the document is the root, or that the type stack has been intentionally erased, as
+/// is the case when using callbacks in the stream api.
 ///
 struct closed_context {
     closed_context(core*) {}

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/key_context.hpp
@@ -30,8 +30,9 @@ namespace builder {
 namespace stream {
 
 ///
-/// A stream context which expects a key, which can later be followed by
-/// value, then more key/value pairs.
+/// A stream context which expects a key.
+///
+/// This can later be followed by value, then more key/value pairs.
 ///
 /// The template argument can be used to hold additional information about
 /// containing documents or arrays. I.e. value_context<> implies that this

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/builder/stream/value_context.hpp
@@ -30,8 +30,9 @@ namespace builder {
 namespace stream {
 
 ///
-/// A stream context which expects a value, which can later be followed by
-/// more key/value pairs.
+/// A stream context which expects a value.
+///
+/// This can later be followed by more key/value pairs.
 ///
 /// The template argument can be used to hold additional information about
 /// containing documents or arrays. I.e. value_context<> implies that this

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
@@ -27,7 +27,7 @@ namespace bsoncxx {
 namespace v_noabi {
 
 ///
-/// Represents an IEEE 754-2008 BSON Decimal128 value in a platform-independent way.
+/// Represents an IEEE 754-2008 BSON Decimal128 value.
 ///
 class decimal128 {
    public:

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
@@ -29,6 +29,9 @@ namespace v_noabi {
 ///
 /// Represents an IEEE 754-2008 BSON Decimal128 value.
 ///
+/// @see
+/// - [BSON Types (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/bson-types/)
+///
 class decimal128 {
    public:
     ///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
@@ -27,7 +27,7 @@ namespace bsoncxx {
 namespace v_noabi {
 
 ///
-/// Represents a MongoDB BSON Decimal128 value.
+/// Represents a MongoDB BSON Decimal128.
 ///
 /// This type implements the Decimal Arithmetic Encodings (IEEE 754-2008) specification, _with certain
 /// exceptions_ around value integrity and the coefficient encoding. When a value cannot be represented exactly, the

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/decimal128.hpp
@@ -27,10 +27,15 @@ namespace bsoncxx {
 namespace v_noabi {
 
 ///
-/// Represents an IEEE 754-2008 BSON Decimal128 value.
+/// Represents a MongoDB BSON Decimal128 value.
+///
+/// This type implements the Decimal Arithmetic Encodings (IEEE 754-2008) specification, _with certain
+/// exceptions_ around value integrity and the coefficient encoding. When a value cannot be represented exactly, the
+/// value will be rejected.
 ///
 /// @see
 /// - [BSON Types (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/bson-types/)
+/// - [BSON Decimal128 (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/bson-decimal128/decimal128/)
 ///
 class decimal128 {
    public:

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
@@ -31,9 +31,10 @@ namespace v_noabi {
 namespace document {
 
 ///
-/// A read-only BSON document that owns its underlying buffer. When a document::value goes
-/// out of scope, the underlying buffer is freed. Generally this class should be used
-/// sparingly; document::view should be used instead wherever possible.
+/// A read-only BSON document that owns its underlying buffer.
+///
+/// When a document::value goes out of scope, the underlying buffer is freed. Generally this class
+/// should be used sparingly; document::view should be used instead wherever possible.
 ///
 class value {
    public:

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/exception/exception.hpp
@@ -28,8 +28,7 @@ BSONCXX_DISABLE_WARNING(MSVC(4251));
 BSONCXX_DISABLE_WARNING(MSVC(4275));
 
 ///
-/// Class representing any exceptions emitted from the bsoncxx library or
-/// its underlying implementation.
+/// Base class for all exceptions thrown by the bsoncxx library unless otherwise specified.
 ///
 class exception : public std::system_error {
    public:

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
@@ -30,14 +30,8 @@ namespace v_noabi {
 ///
 /// Represents a MongoDB ObjectId.
 ///
-/// As this BSON type is used within the MongoDB server as a primary key for each document, it is
-/// useful for representing a 'pointer' to another document.
-///
-/// @note we use 'oid' to refer to this concrete class. We use 'ObjectId' to refer
-/// to the BSON type.
-///
 /// @see
-/// - https://www.mongodb.com/docs/manual/reference/object-id/
+/// - [BSON Types (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/bson-types/)
 ///
 class oid {
    public:

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
@@ -28,9 +28,10 @@ namespace bsoncxx {
 namespace v_noabi {
 
 ///
-/// Represents a MongoDB ObjectId. As this BSON type is used within the MongoDB server
-/// as a primary key for each document, it is useful for representing a 'pointer'
-/// to another document.
+/// Represents a MongoDB ObjectId.
+///
+/// As this BSON type is used within the MongoDB server as a primary key for each document, it is
+/// useful for representing a 'pointer' to another document.
 ///
 /// @note we use 'oid' to refer to this concrete class. We use 'ObjectId' to refer
 /// to the BSON type.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/oid.hpp
@@ -28,7 +28,7 @@ namespace bsoncxx {
 namespace v_noabi {
 
 ///
-/// Represents a MongoDB ObjectId.
+/// Represents a MongoDB BSON ObjectId.
 ///
 /// @see
 /// - [BSON Types (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/bson-types/)

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/string/view_or_value.hpp
@@ -28,7 +28,7 @@ namespace v_noabi {
 namespace string {
 
 ///
-/// Class representing a view-or-value variant type for strings.
+/// A view-or-value variant type for strings.
 ///
 /// @par Derived From
 /// - @ref bsoncxx::v_noabi::view_or_value<stdx::string_view, std::string>

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hpp
@@ -34,9 +34,10 @@ namespace types {
 namespace bson_value {
 
 ///
-/// A variant owning type that represents any BSON type. Owns its underlying
-/// buffer. When a bson_value::value goes out of scope, its underlying
-/// buffer is freed.
+/// An owning variant type that represents any BSON type.
+///
+/// Owns its underlying buffer. When a bson_value::value goes out of scope, its underlying buffer is
+/// freed.
 ///
 /// For accessors into this type and to extract the various BSON types out,
 /// please use bson_value::view.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/types/bson_value/view.hpp
@@ -44,8 +44,9 @@ namespace bsoncxx {
 namespace v_noabi {
 namespace types {
 namespace bson_value {
+
 ///
-/// A view-only variant that can contain any BSON type.
+/// A non-owning variant that can contain any BSON type.
 ///
 /// @warning
 ///   Calling the wrong get_<type> method will cause an exception

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/validate.hpp
@@ -72,8 +72,7 @@ validate(
     std::size_t* invalid_offset = nullptr);
 
 ///
-/// A validator is used to enable or disable specific checks that can be
-/// performed during BSON validation.
+/// Used to toggle checks which may be performed during BSON validation.
 ///
 class validator {
    public:

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/view_or_value.hpp
@@ -26,7 +26,7 @@ namespace bsoncxx {
 namespace v_noabi {
 
 ///
-/// Class representing a view-or-value variant type.
+/// A view-or-value variant type.
 ///
 template <typename View, typename Value>
 class view_or_value {
@@ -35,12 +35,12 @@ class view_or_value {
     using value_type = Value;
 
     ///
-    /// Class View must be constructible from an instance of class Value.
+    /// View must be constructible from an instance of class Value.
     ///
     static_assert(std::is_constructible<View, Value>::value, "View type must be constructible from a Value");
 
     ///
-    /// Class View must be default constructible.
+    /// View must be default constructible.
     ///
     static_assert(std::is_default_constructible<View>::value, "View type must be default constructible");
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/bulk_write.hpp
@@ -28,7 +28,7 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing a batch of write operations that can be sent to the server as a group.
+/// A batch of write operations that can be sent to the server as a group.
 ///
 /// If you have a lot of write operations to execute, it can be more efficient to send them as
 /// part of a bulk_write in order to avoid unnecessary network-level round trips between the driver

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/change_stream.hpp
@@ -30,7 +30,7 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing a MongoDB change stream.
+/// A MongoDB change stream.
 ///
 class change_stream {
    public:
@@ -124,7 +124,7 @@ class change_stream {
 };
 
 ///
-/// Class representing a MongoDB change stream iterator.
+/// A MongoDB change stream iterator.
 ///
 class change_stream::iterator {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
@@ -41,7 +41,7 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing a client connection to MongoDB.
+/// A client connection to a MongoDB server.
 ///
 /// Acts as a logical gateway for working with databases contained within a MongoDB server.
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
@@ -37,7 +37,7 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class supporting operations for MongoDB Client-Side Field Level Encryption.
+/// Supports MongoDB Client-Side Field Level Encryption operations.
 ///
 class client_encryption {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_session.hpp
@@ -36,6 +36,8 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
+/// Supports MongoDB client session operations.
+///
 /// Use a session for a sequence of operations, optionally with either causal consistency
 /// or snapshots.
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
@@ -71,7 +71,7 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing server side document groupings within a MongoDB database.
+/// A MongoDB collection.
 ///
 /// Collections do not require or enforce a schema and documents inside of a collection can have
 /// different fields. While not a requirement, typically documents in a collection have a similar

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/cursor.hpp
@@ -33,7 +33,7 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing a pointer to the result set of a query on a MongoDB server.
+/// A cursor over the documents returned by a query to a MongoDB server.
 ///
 /// Clients can iterate through a cursor::iterator to retrieve results.
 ///
@@ -104,7 +104,7 @@ class cursor {
 };
 
 ///
-/// Class representing an input iterator of documents in a MongoDB cursor
+/// An input iterator of documents in a MongoDB cursor
 /// result set.
 ///
 /// All non-end iterators derived from the same mongocxx::v_noabi::cursor move in

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
@@ -38,7 +38,7 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing a MongoDB database.
+/// A MongoDB database.
 ///
 /// Acts as a gateway for accessing collections that are contained within a database. It inherits
 /// all of its default settings from the client that creates it.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_failed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_failed_event.hpp
@@ -29,10 +29,10 @@ namespace v_noabi {
 namespace events {
 
 ///
-/// An event notification sent when the driver fails to execute a MongoDB command.
+/// The failed execution of a MongoDB command.
 ///
 /// @see
-/// - "CommandFailedEvent" in https://github.com/mongodb/specifications/blob/master/source/command-logging-and-monitoring/command-logging-and-monitoring.md
+/// - [Command Logging and Monitoring (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/command-logging-and-monitoring/command-logging-and-monitoring/)
 ///
 class command_failed_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_started_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_started_event.hpp
@@ -29,10 +29,10 @@ namespace v_noabi {
 namespace events {
 
 ///
-/// An event notification sent when the driver begins executing a MongoDB command.
+/// The start of the execution of a MongoDB command.
 ///
 /// @see
-/// - "CommandStartedEvent" in https://github.com/mongodb/specifications/blob/master/source/command-logging-and-monitoring/command-logging-and-monitoring.md
+/// - [Command Logging and Monitoring (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/command-logging-and-monitoring/command-logging-and-monitoring/)
 ///
 class command_started_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_succeeded_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/command_succeeded_event.hpp
@@ -29,10 +29,10 @@ namespace v_noabi {
 namespace events {
 
 ///
-/// An event notification sent when the driver successfully executes a MongoDB command.
+/// The successful execution of a MongoDB command.
 ///
 /// @see
-/// - "CommandSucceededEvent" in https://github.com/mongodb/specifications/blob/master/source/command-logging-and-monitoring/command-logging-and-monitoring.md
+/// - [Command Logging and Monitoring (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/command-logging-and-monitoring/command-logging-and-monitoring/)
 ///
 class command_succeeded_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_failed_event.hpp
@@ -28,11 +28,10 @@ namespace v_noabi {
 namespace events {
 
 ///
-/// An event notification sent when the driver failed to send an "hello" command to check the
-/// status of a server.
+/// The failed execution of a heartbeat ("hello") command.
 ///
 /// @see
-/// - "ServerHeartbeatFailedEvent" in https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md
+/// - [SDAM Logging and Monitoring Specification (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring/)
 ///
 class heartbeat_failed_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_started_event.hpp
@@ -27,11 +27,10 @@ namespace v_noabi {
 namespace events {
 
 ///
-/// An event notification sent when the driver begins executing a "hello" command to check the
-/// status of a server.
+/// The start of the execution of a heartbeat ("hello") command.
 ///
 /// @see
-/// - "ServerHeartbeatStartedEvent" in https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md
+/// - [SDAM Logging and Monitoring Specification (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring/)
 ///
 class heartbeat_started_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event.hpp
@@ -26,11 +26,10 @@ namespace v_noabi {
 namespace events {
 
 ///
-/// An event notification sent when the driver completes a "hello" command to check the status
-/// of a server.
+/// The successful execution of a heartbeat ("hello") command.
 ///
 /// @see
-/// - "ServerHeartbeatSucceededEvent" in https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md
+/// - [SDAM Logging and Monitoring Specification (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring/)
 ///
 class heartbeat_succeeded_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_changed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_changed_event.hpp
@@ -28,11 +28,10 @@ namespace v_noabi {
 namespace events {
 
 ///
-/// An event notification sent when the driver observes a change in the status of a server it is
-/// connected to.
+/// A change in the description of a connected MongoDB server.
 ///
 /// @see
-/// - "ServerDescriptionChangedEvent" in https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md
+/// - [SDAM Logging and Monitoring Specification (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring/)
 ///
 class server_changed_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_closed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_closed_event.hpp
@@ -28,11 +28,12 @@ namespace v_noabi {
 namespace events {
 
 ///
-/// An event notification sent when the driver stops monitoring a MongoDB server and removes it
-/// from the topology description.
+/// The closing of a connection to a shutdown MongoDB server.
+///
+/// The server is removed from the topology description and no longer monitored.
 ///
 /// @see
-/// - "ServerClosedEvent" in https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md
+/// - [SDAM Logging and Monitoring Specification (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring/)
 ///
 class server_closed_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_description.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_description.hpp
@@ -26,7 +26,10 @@ namespace v_noabi {
 namespace events {
 
 ///
-/// Class representing what the driver knows about a MongoDB server.
+/// The description of a connected MongoDB server.
+///
+/// @see
+/// - @ref mongocxx::v_noabi::events::topology_description
 ///
 class server_description {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_opening_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/server_opening_event.hpp
@@ -27,11 +27,10 @@ namespace v_noabi {
 namespace events {
 
 ///
-/// An event notification sent when the driver adds a MongoDB server to the topology description
-/// and begins monitoring it.
+/// The addition of a new MongoDB server to the topology description.
 ///
 /// @see
-/// - "ServerOpeningEvent" in https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md
+/// - [SDAM Logging and Monitoring Specification (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring/)
 ///
 class server_opening_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_changed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_changed_event.hpp
@@ -27,11 +27,10 @@ namespace v_noabi {
 namespace events {
 
 ///
-/// An event notification sent when the driver observes a change in any of the servers it is
-/// connected to or a change in the overall server topology.
+/// A change in the topology description (including its server descriptions).
 ///
 /// @see
-/// - "TopologyDescriptionChangedEvent" in https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md
+/// - [SDAM Logging and Monitoring Specification (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring/)
 ///
 class topology_changed_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_closed_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_closed_event.hpp
@@ -25,11 +25,10 @@ namespace v_noabi {
 namespace events {
 
 ///
-/// An event notification sent when the driver stops monitoring a server topology and destroys its
-/// description.
+/// The closing of connections to a topology of shutdown MongoDB servers.
 ///
 /// @see
-/// - "TopologyClosedEvent" in https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md
+/// - [SDAM Logging and Monitoring Specification (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring/)
 ///
 class topology_closed_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_description.hpp
@@ -30,8 +30,10 @@ namespace v_noabi {
 namespace events {
 
 ///
-/// Class representing what the driver knows about a topology of MongoDB servers: either a
-/// standalone, a replica set, or a sharded cluster.
+/// A description of the topology of one or more connected MongoDB servers.
+///
+/// @see
+/// - mongocxx::v_noabi::events::topology_changed_event
 ///
 class topology_description {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_opening_event.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/events/topology_opening_event.hpp
@@ -27,10 +27,10 @@ namespace v_noabi {
 namespace events {
 
 ///
-/// An event notification sent when the driver initializes a server topology.
+/// A new connection to a topology of MongoDB servers.
 ///
 /// @see
-/// - "TopologyOpeningEvent" in https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md
+/// - [SDAM Logging and Monitoring Specification (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring/)
 ///
 class topology_opening_event {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/authentication_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/authentication_exception.hpp
@@ -26,12 +26,11 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing an exception during authentication.
+/// Unused. To be removed in an upcoming major release.
 ///
-/// @see
-/// - @ref mongocxx::v_noabi::operation_exception
+/// @deprecated To be removed in an upcoming major release.
 ///
-class authentication_exception : public operation_exception {
+class MONGOCXX_DEPRECATED authentication_exception : public operation_exception {
    public:
     ~authentication_exception() override;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/bulk_write_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/bulk_write_exception.hpp
@@ -26,7 +26,7 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing an exception during a bulk write operation.
+/// An exception thrown during a bulk write operation.
 ///
 /// @see
 /// - @ref mongocxx::v_noabi::operation_exception

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/error_code.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/error_code.hpp
@@ -25,7 +25,7 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Enum representing the various error types that can occur during driver usage.
+/// Errors which may occur during mongocxx library usage.
 ///
 /// @note `std::is_error_code_enum` is specialized for this type.
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/exception.hpp
@@ -31,7 +31,7 @@ BSONCXX_DISABLE_WARNING(MSVC(4251));
 BSONCXX_DISABLE_WARNING(MSVC(4275));
 
 ///
-/// A class to be used as the base class for all mongocxx exceptions.
+/// Base class for all exceptions thrown by the mongocxx library unless otherwise specified.
 ///
 class exception : public std::system_error {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/gridfs_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/gridfs_exception.hpp
@@ -24,8 +24,7 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing an error encountered when attempting to perform the requested GridFS
-/// operation.
+/// An exception thrown during a GridFS operation.
 ///
 /// @see
 /// - @ref mongocxx::v_noabi::exception

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/logic_error.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/logic_error.hpp
@@ -24,7 +24,7 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing an exception caused by using the mongocxx API improperly.
+/// An exception thrown due to incorrect use of mongocxx interfaces.
 ///
 /// @see
 /// - @ref mongocxx::v_noabi::exception

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/operation_exception.hpp
@@ -35,8 +35,7 @@ BSONCXX_DISABLE_WARNING(MSVC(4251));
 BSONCXX_DISABLE_WARNING(MSVC(4275));
 
 ///
-/// Class representing an exception received from a MongoDB server.  It includes the server-provided
-/// error code, if one was available.
+/// An exception thrown during a MongoDB server operation.
 ///
 /// @see
 /// - @ref mongocxx::v_noabi::exception

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/query_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/query_exception.hpp
@@ -24,7 +24,7 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing an exception during a query operation.
+/// An exception thrown during a query operation.
 ///
 /// @see
 /// - @ref mongocxx::v_noabi::operation_exception

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/server_error_code.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/server_error_code.hpp
@@ -25,10 +25,10 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Enum representing the various errors types that can be returned from the server.
+/// Errors which may be returned by the server.
 ///
-/// As this list changes over time, this is just a placeholder for an Int32 error code value from
-/// the server.
+/// This type is used to represent Int32 server error codeswithout defining the error codes
+/// themselves.
 ///
 /// @note `std::is_error_code_enum` is specialized for this type.
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/write_exception.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/exception/write_exception.hpp
@@ -24,7 +24,7 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing an exception during a write operation.
+/// An exception thrown during a write operation.
 ///
 /// @see
 /// - @ref mongocxx::v_noabi::operation_exception

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/bucket.hpp
@@ -41,7 +41,7 @@ namespace v_noabi {
 namespace gridfs {
 
 ///
-/// Class representing a GridFS bucket.
+/// A GridFS bucket.
 ///
 /// A GridFS bucket is used to store files that may be too large to store in a single document due
 /// to the 16 MB limit. The bucket comprises of two collections, `<bucketname>.files` and

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/downloader.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/downloader.hpp
@@ -35,7 +35,7 @@ namespace v_noabi {
 namespace gridfs {
 
 ///
-/// Class used to specify the offset from which to start reading the chunks of the file.
+/// Used to specify the offset from which to start reading the chunks of the file.
 ///
 struct chunks_and_bytes_offset {
     std::int32_t chunks_offset = 0;
@@ -43,7 +43,7 @@ struct chunks_and_bytes_offset {
 };
 
 ///
-/// Class used to download a GridFS file.
+/// Used to download a GridFS file.
 ///
 class downloader {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/uploader.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/gridfs/uploader.hpp
@@ -38,7 +38,7 @@ namespace v_noabi {
 namespace gridfs {
 
 ///
-/// Class used to upload a GridFS file.
+/// Used to upload a GridFS file.
 ///
 class uploader {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/hint.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/hint.hpp
@@ -30,7 +30,7 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing a hint to be passed to a database operation.
+/// The index to "hint" or force a MongoDB server to use when performing a query.
 ///
 class hint {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_model.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_model.hpp
@@ -27,7 +27,7 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing an index on a MongoDB server.
+/// Used by @ref mongocxx::v_noabi::index_view.
 ///
 class index_model {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/index_view.hpp
@@ -34,7 +34,10 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing a MongoDB index view.
+/// A MongoDB index.
+///
+/// @note Not to be confused with a MongoDB Atlas Search Index (@ref
+/// mongocxx::v_noabi::search_index_view).
 ///
 class index_view {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/instance.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/instance.hpp
@@ -25,7 +25,7 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing an instance of the MongoDB driver.
+/// An instance of the MongoDB driver.
 ///
 /// The constructor and destructor initialize and shut down the driver, respectively. Therefore, an
 /// instance must be created before using the driver and must remain alive until all other mongocxx

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger.hpp
@@ -26,7 +26,7 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// The log level of a message passed to a mongocxx::v_noabi::logger.
+/// The log level of a log message.
 ///
 enum class log_level {
     k_error,    ///< Log Level Error.
@@ -49,7 +49,10 @@ enum class log_level {
 MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v_noabi::stdx::string_view) to_string(log_level level);
 
 ///
-/// The interface that all user-defined loggers must implement.
+/// The interface which user-defined loggers must implement.
+///
+/// @see
+/// - @ref mongocxx::v_noabi::instance
 ///
 class logger {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_many.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_many.hpp
@@ -28,7 +28,7 @@ namespace v_noabi {
 namespace model {
 
 ///
-/// Class representing a MongoDB delete operation that removes multiple documents.
+/// A MongoDB delete operation that removes multiple documents.
 ///
 class delete_many {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/delete_one.hpp
@@ -28,7 +28,7 @@ namespace v_noabi {
 namespace model {
 
 ///
-/// Class representing a MongoDB delete operation that removes a single document.
+/// A MongoDB delete operation that removes a single document.
 ///
 class delete_one {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/insert_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/insert_one.hpp
@@ -25,7 +25,7 @@ namespace v_noabi {
 namespace model {
 
 ///
-/// Class representing a MongoDB insert operation that creates a single document.
+/// A MongoDB insert operation that creates a single document.
 ///
 class insert_one {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/replace_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/replace_one.hpp
@@ -28,7 +28,7 @@ namespace v_noabi {
 namespace model {
 
 ///
-/// Class representing a MongoDB update operation that replaces a single document.
+/// A MongoDB update operation that replaces a single document.
 ///
 class replace_one {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_many.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_many.hpp
@@ -30,7 +30,7 @@ namespace v_noabi {
 namespace model {
 
 ///
-/// Class representing a MongoDB update operation that modifies multiple documents.
+/// A MongoDB update operation that modifies multiple documents.
 ///
 class update_many {
     //

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/update_one.hpp
@@ -30,7 +30,7 @@ namespace v_noabi {
 namespace model {
 
 ///
-/// Class representing a MongoDB update operation that modifies a single document.
+/// A MongoDB update operation that modifies a single document.
 ///
 class update_one {
     //

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/model/write.hpp
@@ -35,7 +35,7 @@ namespace v_noabi {
 namespace model {
 
 ///
-/// Models a single write operation within a mongocxx::v_noabi::bulk_write.
+/// A single write operation for use with @ref mongocxx::v_noabi::bulk_write.
 ///
 class write {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/aggregate.hpp
@@ -38,7 +38,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing the optional arguments to a MongoDB aggregation operation.
+/// Used by MongoDB aggregation operations.
 ///
 class aggregate {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/apm.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/apm.hpp
@@ -38,7 +38,11 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing MongoDB application performance monitoring.
+/// Used by @ref mongocxx::v_noabi::options::client::apm_opts.
+///
+/// @see
+/// - [Command Logging and Monitoring (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/command-logging-and-monitoring/command-logging-and-monitoring/)
+/// - [SDAM Logging and Monitoring Specification (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring/#events-api_1)
 ///
 class apm {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/auto_encryption.hpp
@@ -30,7 +30,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing options for automatic client-side encryption.
+/// Used by @ref mongocxx::v_noabi::options::client::auto_encryption_opts.
 ///
 class auto_encryption {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/bulk_write.hpp
@@ -29,7 +29,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing the optional arguments to a MongoDB bulk write
+/// Used by @ref mongocxx::v_noabi::collection.
 ///
 class bulk_write {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/change_stream.hpp
@@ -33,7 +33,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing MongoDB change stream options.
+/// Used by change streams.
 ///
 class change_stream {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client.hpp
@@ -31,10 +31,8 @@ namespace mongocxx {
 namespace v_noabi {
 namespace options {
 
-// NOTE: client options interface still evolving
-
 ///
-/// Class representing the optional arguments to a MongoDB driver client object.
+/// Used by clients.
 ///
 class client {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_encryption.hpp
@@ -30,7 +30,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing options for the object managing explicit client-side encryption.
+/// Used by @ref mongocxx::v_noabi::client_encryption.
 ///
 class client_encryption {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/client_session.hpp
@@ -28,7 +28,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing the optional arguments to mongocxx::v_noabi::client::start_session.
+/// Used by client sessions.
 ///
 class client_session {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count.hpp
@@ -34,7 +34,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing the optional arguments to mongocxx::v_noabi::collection::count_documents
+/// Used by @ref mongocxx::v_noabi::collection::count_documents.
 ///
 class count {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
@@ -30,7 +30,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// used by @ref mongocxx::v_noabi::client_encryption::create_data_key.
+/// Used by @ref mongocxx::v_noabi::client_encryption::create_data_key.
 ///
 class data_key {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/data_key.hpp
@@ -30,7 +30,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing options for data key generation for encryption.
+/// used by @ref mongocxx::v_noabi::client_encryption::create_data_key.
 ///
 class data_key {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/delete.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/delete.hpp
@@ -30,7 +30,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing the optional arguments to a MongoDB delete operation
+/// Used by MongoDB delete operations.
 ///
 class delete_options {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct.hpp
@@ -33,7 +33,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing the optional arguments to a MongoDB distinct command.
+/// Used by @ref mongocxx::v_noabi::collection.
 ///
 class distinct {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt.hpp
@@ -32,7 +32,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing options for explicit client-side encryption.
+/// Used by @ref mongocxx::v_noabi::client_encryption.
 ///
 class encrypt {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/estimated_document_count.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/estimated_document_count.hpp
@@ -30,8 +30,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing the optional arguments to
-/// mongocxx::v_noabi::collection::estimated_document_count
+/// Used by @ref mongocxx::v_noabi::collection::estimated_document_count.
 ///
 class estimated_document_count {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find.hpp
@@ -35,7 +35,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing the optional arguments to a MongoDB query.
+/// Used by MongoDB find operations.
 ///
 class find {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.hpp
@@ -33,7 +33,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing the optional arguments to a MongoDB find_and_modify delete operation
+/// Used by @ref mongocxx::v_noabi::collection.
 ///
 class find_one_and_delete {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.hpp
@@ -34,7 +34,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing the optional arguments to a MongoDB find_and_modify replace operation
+/// Used by @ref mongocxx::v_noabi::collection.
 ///
 class find_one_and_replace {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update.hpp
@@ -35,7 +35,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing the optional arguments to a MongoDB find_and_modify update operation.
+/// Used by @ref mongocxx::v_noabi::collection.
 ///
 class find_one_and_update {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_common_options.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_common_options.hpp
@@ -23,8 +23,8 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Enum representing whether to return the old or new version of a document modified by a
-/// `findOneAndModify` operation.
+/// Indicates whether a `findOneAndModify` operation should return the old or new version of the
+/// modified document.
 ///
 enum class return_document {
     /// Return the version of the document before the modification takes place.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/bucket.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/bucket.hpp
@@ -32,7 +32,7 @@ namespace options {
 namespace gridfs {
 
 ///
-/// Class representing the optional arguments to a MongoDB GridFS bucket creation operation.
+/// Used by @ref mongocxx::v_noabi::gridfs::bucket.
 ///
 class bucket {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/upload.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/gridfs/upload.hpp
@@ -27,7 +27,7 @@ namespace options {
 namespace gridfs {
 
 ///
-/// Class representing the optional arguments to a MongoDB GridFS upload operation.
+/// Used by @ref mongocxx::v_noabi::gridfs::bucket.
 ///
 class upload {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index.hpp
@@ -35,7 +35,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing the optional arguments to a MongoDB create index operation.
+/// Used by MongoDB index creation operations.
 ///
 /// @see
 /// - https://www.mongodb.com/docs/manual/reference/command/createIndexes
@@ -67,7 +67,7 @@ class index {
     };
 
     ///
-    /// Class representing the optional WiredTiger storage engine options for indexes.
+    /// The optional WiredTiger storage engine options for indexes.
     ///
     class MONGOCXX_ABI_EXPORT wiredtiger_storage_options final : public base_storage_options {
        public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view.hpp
@@ -30,7 +30,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing optional arguments to IndexView operations
+/// Used by MongoDB index view operations.
 ///
 class index_view {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert.hpp
@@ -29,7 +29,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing the optional arguments to a MongoDB insert operation
+/// Used by @ref mongocxx::v_noabi::collection.
 ///
 class insert {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/pool.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/pool.hpp
@@ -25,8 +25,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing the optional arguments to a MongoDB driver pool object. Pool options
-/// logically extend client options.
+/// Used by @ref mongocxx::v_noabi::pool.
 ///
 class pool {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/range.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/range.hpp
@@ -28,8 +28,10 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// @brief `RangeOpts` specifies index options for a Queryable Encryption field supporting
-/// "range" queries.
+/// Used by @ref mongocxx::v_noabi::options::encrypt::range_opts.
+///
+/// Specifies index options (`RangeOpts`) for a Queryable Encryption field supporting "range"
+/// queries.
 ///
 /// @note `min`, `max`, `trimFactor`, `sparsity`, and `precision` must match the values set in the
 /// encryptedFields of the destination collection.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace.hpp
@@ -31,7 +31,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing the optional arguments to a MongoDB replace operation.
+/// Used by @ref mongocxx::v_noabi::collection.
 ///
 class replace {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/rewrap_many_datakey.hpp
@@ -29,7 +29,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing options for a rewrap many datakey operation.
+/// Used by @ref mongocxx::v_noabi::client_encryption::rewrap_many_datakey.
 ///
 class rewrap_many_datakey {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/server_api.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/server_api.hpp
@@ -30,7 +30,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing options for server API.
+/// Used by @ref mongocxx::v_noabi::options::client::server_api_opts.
 ///
 /// @see
 /// - [Stable API (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/stable-api/)

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/ssl.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/ssl.hpp
@@ -25,7 +25,9 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// @copydoc mongocxx::v_noabi::options::tls
+/// Equivalent to @ref mongocxx::v_noabi::options::tls.
+///
+/// To be removed in an upcoming major release.
 ///
 /// @deprecated Use @ref mongocxx::v_noabi::options::tls instead.
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/tls.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/tls.hpp
@@ -28,7 +28,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing the optional arguments to a MongoDB driver client (TLS)
+/// Used by @ref mongocxx::v_noabi::options::client::tls_opts.
 ///
 class tls {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/transaction.hpp
@@ -32,7 +32,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing the optional arguments for a transaction.
+/// Used by MongoDB transaction operations.
 ///
 class transaction {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/update.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/update.hpp
@@ -31,7 +31,7 @@ namespace v_noabi {
 namespace options {
 
 ///
-/// Class representing the optional arguments to a MongoDB update operation.
+/// Used by @ref mongocxx::v_noabi::collection.
 ///
 class update {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline.hpp
@@ -34,7 +34,7 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing a MongoDB aggregation pipeline.
+/// A MongoDB aggregation pipeline.
 ///
 class pipeline {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pool.hpp
@@ -33,7 +33,10 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// A pool of @c client objects associated with a MongoDB deployment.
+/// A pool of reusable client objects connected to the same MongoDB topology.
+///
+/// @important This class does NOT implement [Connection Monitoring and Pooling (MongoDB
+/// Specifications)](https://specifications.readthedocs.io/en/latest/connection-monitoring-and-pooling/connection-monitoring-and-pooling/).
 ///
 /// For interoperability with other MongoDB drivers, the minimum and maximum number of connections
 /// in the pool is configured using the 'minPoolSize' and 'maxPoolSize' connection string options.
@@ -77,8 +80,9 @@ class pool {
     pool& operator=(pool const&) = delete;
 
     ///
-    /// An entry is a handle on a @c client object acquired via the pool. Similar to
-    /// std::unique_ptr.
+    /// An owning handle to a client obtained from a pool.
+    ///
+    /// Returns the client back to its original pool on destruction.
     ///
     /// @note The lifetime of any entry object must be a subset of the pool object
     ///  from which it was acquired.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_concern.hpp
@@ -35,21 +35,12 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// A class to represent the read concern. Read concern can be set at the client, database, or
-/// collection level. The read concern can also be provided via connection string, and will be
-/// parsed and set on the client constructed for the URI.
+/// Controls the consistency and isolation properties of data read from replica sets and sharded
+/// clusters.
 ///
-/// For the WiredTiger storage engine, MongoDB 3.2 introduced the readConcern option for replica
-/// sets and replica set shards. The readConcern option allows clients to choose a level of
-/// isolation for their reads. You can specify a readConcern of "majority" to read data that has
-/// been written to a majority of nodes and thus cannot be rolled back. By default, MongoDB uses a
-/// readConcern of "local" which does not guarantee that the read data would not be rolled back.
-///
-/// MongoDB 3.4 introduces a read concern level of "linearizable" to read data that has been written
-/// to a majority of nodes (i.e. cannot be rolled back) @b and is not stale. Linearizable read
-/// concern is available for all MongoDB supported storage engines and applies to read operations on
-/// a single document. Note that writes must be made with majority write concern in order for reads
-/// to be linearizable.
+/// Read concern can be set at the client, database, or collection level. The read concern can also
+/// be provided via connection string, and will be parsed and set on the client constructed for the
+/// URI.
 ///
 /// @see
 /// - [Read Concern (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/read-concern/)

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
@@ -40,26 +40,11 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing a preference for how the driver routes read operations to members of a
-/// replica set or to a sharded cluster.
-///
-/// By default read operations are directed to the primary member in a replica set. Reading from the
-/// primary guarantees that read operations reflect the latest version of a document. However, by
-/// distributing some or all reads to secondary members of the replica set, you can improve read
-/// throughput or reduce latency for an application that does not require fully up-to-date data.
-///
-/// Read preference can be broadly specified by setting a mode. It is also possible to
-/// set tags in the read preference for more granular control, and to target specific members of a
-/// replica set via attributes other than their current state as a primary or secondary node.
-/// Furthermore, it is also possible to set a staleness threshold, such that the read is limited to
-/// targeting secondaries whose staleness is less than or equal to the given threshold.
-///
-/// Read preferences are ignored for direct connections to a single mongod instance. However,
-/// in order to perform read operations on a direct connection to a secondary member of a replica
-/// set, you must set a read preference that allows reading from secondaries.
+/// Describes how MongoDB clients route read operations to the members of a replica set or sharded
+/// cluster.
 ///
 /// @see
-/// - https://www.mongodb.com/docs/manual/core/read-preference/
+/// - [Read Preference (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/read-preference/)
 ///
 class read_preference {
    public:
@@ -107,7 +92,9 @@ class read_preference {
     ///
     MONGOCXX_ABI_EXPORT_CDECL() read_preference();
 
+    // @cond DOXYGEN_DISABLE
     struct deprecated_tag {};
+    // @endcond
 
     ///
     /// Constructs a new read_preference.
@@ -115,11 +102,13 @@ class read_preference {
     /// @param mode
     ///   Specifies the read_mode.
     ///
-    /// @deprecated The constructor with no arguments and the method mode() should be used.
+    /// @deprecated Use @ref mode instead.
     ///
     MONGOCXX_DEPRECATED MONGOCXX_ABI_EXPORT_CDECL() read_preference(read_mode mode);
 
+    // @cond DOXYGEN_DISABLE
     MONGOCXX_ABI_EXPORT_CDECL() read_preference(read_mode mode, deprecated_tag);
+    // @endcond
 
     ///
     /// Constructs a new read_preference with tags.
@@ -132,14 +121,16 @@ class read_preference {
     /// @see
     /// - https://www.mongodb.com/docs/manual/core/read-preference/#tag-sets
     ///
-    /// @deprecated The tags() method should be used instead.
+    /// @deprecated Use @ref tags instead.
     ///
     MONGOCXX_DEPRECATED MONGOCXX_ABI_EXPORT_CDECL() read_preference(
         read_mode mode,
         bsoncxx::v_noabi::document::view_or_value tags);
 
+    // @cond DOXYGEN_DISABLE
     MONGOCXX_ABI_EXPORT_CDECL()
     read_preference(read_mode mode, bsoncxx::v_noabi::document::view_or_value tags, deprecated_tag);
+    // @endcond
 
     ///
     /// Copy constructs a read_preference.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/bulk_write.hpp
@@ -31,7 +31,7 @@ namespace v_noabi {
 namespace result {
 
 ///
-/// Class representing the result of a MongoDB bulk write operation.
+/// The result of a MongoDB bulk write operation.
 ///
 class bulk_write {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/delete.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/delete.hpp
@@ -27,7 +27,7 @@ namespace v_noabi {
 namespace result {
 
 ///
-/// Class representing the result of a MongoDB delete operation.
+/// The result of a MongoDB delete operation.
 ///
 class delete_result {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/gridfs/upload.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/gridfs/upload.hpp
@@ -26,7 +26,7 @@ namespace v_noabi {
 namespace result {
 namespace gridfs {
 
-/// Class representing the result of a GridFS upload operation.
+/// The result of a GridFS upload operation.
 class upload {
    public:
     MONGOCXX_ABI_EXPORT_CDECL() upload(bsoncxx::v_noabi::types::bson_value::view id);

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_many.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_many.hpp
@@ -32,8 +32,7 @@ namespace v_noabi {
 namespace result {
 
 ///
-/// Class representing the result of a MongoDB insert many operation
-/// (executed as a bulk write).
+/// The result of a MongoDB insert many operation.
 ///
 class insert_many {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/insert_one.hpp
@@ -28,7 +28,9 @@ namespace mongocxx {
 namespace v_noabi {
 namespace result {
 
-/// Class representing the result of a MongoDB insert operation.
+///
+/// The result of a MongoDB insert operation.
+///
 class insert_one {
    public:
     // This constructor is public for testing purposes only

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/replace_one.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/replace_one.hpp
@@ -29,7 +29,9 @@ namespace mongocxx {
 namespace v_noabi {
 namespace result {
 
-/// Class representing the result of a MongoDB replace_one operation.
+///
+/// The result of a MongoDB replaceOne operation.
+///
 class replace_one {
    public:
     // This constructor is public for testing purposes only

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/rewrap_many_datakey.hpp
@@ -27,7 +27,9 @@ namespace mongocxx {
 namespace v_noabi {
 namespace result {
 
-/// Class representing the result of a MongoDB rewrap_many_datakey operation.
+///
+/// The result of a MongoDB rewrapManyDatakey operation.
+///
 class rewrap_many_datakey {
    public:
     rewrap_many_datakey() = default;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/update.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/update.hpp
@@ -29,7 +29,9 @@ namespace mongocxx {
 namespace v_noabi {
 namespace result {
 
-/// Class representing the result of a MongoDB update operation.
+///
+/// The result of a MongoDB update operation.
+///
 class update {
    public:
     // This constructor is public for testing purposes only

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_model.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_model.hpp
@@ -15,7 +15,7 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing a search index on a MongoDB server.
+/// Used by @ref mongocxx::v_noabi::search_index_view.
 ///
 class search_index_model {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/search_index_view.hpp
@@ -19,7 +19,9 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing a MongoDB search index view.
+/// A MongoDB Atlas Search Index.
+///
+/// @note Not to be confused with a MongoDB index (@ref mongocxx::v_noabi::index_view).
 ///
 class search_index_view {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
@@ -35,18 +35,20 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing a MongoDB connection string URI.
+/// A MongoDB connection string URI.
 ///
 /// @see
-/// - https://www.mongodb.com/docs/manual/reference/connection-string/
+/// - [Connection Strings (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/connection-string/)
 ///
 class uri {
    public:
+    ///
     /// A host.
+    ///
     struct host {
-        std::string name;
-        std::uint16_t port;
-        std::int32_t family;
+        std::string name;    ///< The host name.
+        std::uint16_t port;  ///< The port number.
+        std::int32_t family; ///< The address family.
     };
 
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/validation_criteria.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/validation_criteria.hpp
@@ -25,10 +25,13 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing criteria for document validation, to be applied to a collection.
+/// Supports creating validation rules for fields.
+///
+/// @deprecated To be removed in an upcoming major release. Set schema validation options as fields of a BSON
+/// document passed as an options argument to a MongoDB command instead.
 ///
 /// @see
-/// - https://www.mongodb.com/docs/manual/core/document-validation/
+/// - [Schema Validation](https://www.mongodb.com/docs/manual/core/schema-validation/)
 ///
 class validation_criteria {
    public:

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_concern.hpp
@@ -40,19 +40,7 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Class representing the server-side requirement for reporting the success of a write
-/// operation. The strength of the write concern setting determines the level of guarantees
-/// that you will receive from MongoDB regarding write durability.
-///
-/// Weaker requirements that provide fewer guarantees report on success quickly while stronger
-/// requirements that provide greater guarantees will take longer (or potentially forever, if
-/// the write_concern's requirements are not satisfied and no timeout is set).
-///
-/// MongoDB drivers allow for different levels of write concern to better address the specific
-/// needs of applications. Clients may adjust write concern to ensure that the most important
-/// operations persist successfully to an entire MongoDB deployment. However, for other less
-/// critical operations, clients can adjust the write concern to ensure better performance
-/// rather than persistence to the entire deployment.
+/// The level of acknowledgment requested for write operations to a MongoDB server.
 ///
 /// @see
 /// - [Write Concern (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/write-concern/)

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_type.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/write_type.hpp
@@ -22,7 +22,7 @@ namespace mongocxx {
 namespace v_noabi {
 
 ///
-/// Enum representing the the types of write operations that can be performed.
+/// Used by @ref mongocxx::v_noabi::model::write.
 ///
 enum class write_type {
     /// Inserting a single document into a collection.


### PR DESCRIPTION
Miscellaneous improvements to API documentation following https://github.com/mongodb/mongo-cxx-driver/pull/1309. Primarily targets cleanup of the brief descriptions displayed on the "Class List" page.

> [!NOTE]
> Doxygen seems to fail to generate a class description for a member of a using-declared class. Filed https://github.com/doxygen/doxygen/issues/11326.

The current brief descriptions on the Class List page are not consistently "brief", often unnecessarily including parts of what should be a detailed description instead:

![image](https://github.com/user-attachments/assets/e8214305-3050-4249-bb19-d6d2a17fc79b)

![image](https://github.com/user-attachments/assets/08efaa4b-aa86-496f-9984-c0bf70ca9fa5)

The changes in this PR update all brief descriptions to be more consistent in their format and be properly "brief" in their length:

![image](https://github.com/user-attachments/assets/96ca2e61-ccd8-40a9-b2c2-e461cdbbca85)

![image](https://github.com/user-attachments/assets/885b7714-b8db-4770-b87d-2ca1b54a8252)

When able, brief descriptions of auxiliary class types (e.g. "options") simply refer to their primary interface with which they are meant to be used to avoid redundancy and verbosity (e.g. "Used by X"). Redundant leads (e.g. "Class representing...", "Class used to...", etc.) are omitted to improve brevity of descriptions.

Some notable changes that go beyond brief description updates include:

- Adding or updating references to the MongoDB Manual, C++ Driver Manual, and the [MongoDB (Drivers) Specification](https://specifications.readthedocs.io/en/latest/) (note: ReadTheDocs; can revert to GitHub file references instead if preferable).
- Add `MONGOCXX_DEPRECATED` + `@deprecated` to `authentication_exception`, which is not used anywhere.
- Notes disambiguating interfaces pertaining to MongoDB server indexes vs. Atlas Search Indexes.
- Add `@important` to `mongocxx::v_noabi::pool` documenting it does not conform to the CMAP specification.
- Deferred bulk of read/write concern descriptions (mostly outdated references to pre-3.6 behavior) to the MongoDB Manual.
- Add `@deprecated` to `mongocxx::v_noabi::validation_criteria` given there is mostly unused + its primary interfaces (conversion to BSON) are already deprecated as well.