### PR TITLE
Migrate most windows-64-vs2015 tasks to windows-vsCurrent distro

### DIFF
--- a/.evergreen/config_generator/components/atlas_search_indexes.py
+++ b/.evergreen/config_generator/components/atlas_search_indexes.py
@@ -1,6 +1,7 @@
 from config_generator.components.funcs.compile import Compile
 from config_generator.components.funcs.fetch_det import FetchDET
 from config_generator.components.funcs.install_c_driver import InstallCDriver
+from config_generator.components.funcs.install_uv import InstallUV
 from config_generator.components.funcs.setup import Setup
 
 from config_generator.etc.distros import find_large_distro
@@ -55,6 +56,7 @@ def tasks():
             run_on=distro.name,
             commands=[
                 InstallCDriver.call(),
+                InstallUV.call(),
                 Compile.call(build_type='Debug', vars={'ENABLE_TESTS': 'ON'}),
                 TestSearchIndexHelpers.call(),
             ],

--- a/.evergreen/config_generator/components/compile_only.py
+++ b/.evergreen/config_generator/components/compile_only.py
@@ -1,10 +1,11 @@
 from config_generator.components.funcs.compile import Compile
+from config_generator.components.funcs.install_uv import InstallUV
 from config_generator.components.funcs.fetch_c_driver_source import FetchCDriverSource
 from config_generator.components.funcs.setup import Setup
 
 from config_generator.etc.distros import find_large_distro, make_distro_str
 
-from shrub.v3.evg_build_variant import BuildVariant, DisplayTask
+from shrub.v3.evg_build_variant import BuildVariant
 from shrub.v3.evg_task import EvgTask, EvgTaskRef
 
 from itertools import product
@@ -71,6 +72,7 @@ def generate_tasks():
                     commands=[
                         Setup.call(),
                         FetchCDriverSource.call(),
+                        InstallUV.call(),
                         Compile.call(
                             build_type=build_type,
                             compiler=compiler,

--- a/.evergreen/config_generator/components/compile_only.py
+++ b/.evergreen/config_generator/components/compile_only.py
@@ -26,8 +26,10 @@ MATRIX = [
     ('ubuntu2004', 'gcc',   ['Debug'], ['shared'],  [None]),
     ('ubuntu2004', 'clang', ['Debug'], ['shared'],  [None]),
 
-    ('windows-64-vs2015', 'vs2015x64', ['Debug'], ['shared'],  [None]),
-    ('windows-64-vs2015', 'vs2015x64', ['Release'], ['shared'],  [None]),
+    ('windows-64-vs2015', 'vs2015x64', ['Debug', 'Release'], ['shared'],  [None]),
+    ('windows-vsCurrent', 'vs2017x64', ['Debug', 'Release'], ['shared'],  [None]),
+    ('windows-vsCurrent', 'vs2019x64', ['Debug', 'Release'], ['shared'],  [None]),
+    ('windows-vsCurrent', 'vs2022x64', ['Debug', 'Release'], ['shared'],  [None]),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/funcs/compile.py
+++ b/.evergreen/config_generator/components/funcs/compile.py
@@ -31,6 +31,7 @@ class Compile(Function):
             'USE_SANITIZER_ASAN',
             'USE_SANITIZER_UBSAN',
             'USE_STATIC_LIBS',
+            'UV_INSTALL_DIR',
         ],
         working_dir='mongo-cxx-driver',
         script='.evergreen/scripts/compile.sh',

--- a/.evergreen/config_generator/components/funcs/install_uv.py
+++ b/.evergreen/config_generator/components/funcs/install_uv.py
@@ -1,3 +1,5 @@
+from config_generator.components.funcs.set_cache_dir import SetCacheDir
+
 from config_generator.etc.function import Function
 from config_generator.etc.utils import bash_exec
 
@@ -6,7 +8,7 @@ from shrub.v3.evg_command import EvgCommandType, expansions_update
 
 class InstallUV(Function):
     name = 'install-uv'
-    commands = [
+    commands = SetCacheDir.commands + [
         bash_exec(
             command_type=EvgCommandType.SETUP,
             script='''\
@@ -18,15 +20,19 @@ class InstallUV(Function):
                     exit 1
                 fi
 
-                uv_install_dir="${MONGO_CXX_DRIVER_CACHE_DIR}/uv-0.5.9"
+                uv_install_dir="${MONGO_CXX_DRIVER_CACHE_DIR}/uv-0.5.14"
                 mkdir -p "$uv_install_dir"
 
-                if ! command -V "$uv_install_dir/uv" 2>/dev/null; then
+                if ! command -v "$uv_install_dir/uv" 2>/dev/null; then
                     env \\
                         UV_INSTALL_DIR="$uv_install_dir" \\
-                        UV_NO_MODIFY_PATH=1 \\
-                        mongo-cxx-driver/.evergreen/scripts/uv-installer.sh
+                        UV_UNMANAGED_INSTALL=1 \\
+                        INSTALLER_PRINT_VERBOSE=1 \\
+                        mongo-cxx-driver/.evergreen/scripts/uv-installer.sh --verbose
                 fi
+
+                PATH="$uv_install_dir:$PATH" command -V uv
+                PATH="$uv_install_dir:$PATH" uv --version
 
                 printf "UV_INSTALL_DIR: %s\\n" "$uv_install_dir" >|expansions.uv.yml
             ''',

--- a/.evergreen/config_generator/components/funcs/install_uv.py
+++ b/.evergreen/config_generator/components/funcs/install_uv.py
@@ -28,7 +28,7 @@ class InstallUV(Function):
                         UV_INSTALL_DIR="$uv_install_dir" \\
                         UV_UNMANAGED_INSTALL=1 \\
                         INSTALLER_PRINT_VERBOSE=1 \\
-                        mongo-cxx-driver/.evergreen/scripts/uv-installer.sh --verbose
+                        mongo-cxx-driver/.evergreen/scripts/uv-installer.sh
                 fi
 
                 PATH="$uv_install_dir:$PATH" command -V uv

--- a/.evergreen/config_generator/components/funcs/run_kms_servers.py
+++ b/.evergreen/config_generator/components/funcs/run_kms_servers.py
@@ -12,11 +12,6 @@ class RunKMSServers(Function):
             script='''\
                 set -o errexit
                 echo "Preparing CSFLE venv environment..."
-                if [[ "${distro_id}" =~ windows-64-vs2015-* ]]; then
-                    # Python: ImportError: DLL load failed while importing _rust: The specified procedure could not be found.
-                    echo "Preparing CSFLE venv environment... skipped."
-                    exit 0
-                fi
                 cd ./drivers-evergreen-tools/.evergreen/csfle
                 # This function ensures future invocations of activate-kmstlsvenv.sh conducted in
                 # parallel do not race to setup a venv environment; it has already been prepared.
@@ -32,11 +27,6 @@ class RunKMSServers(Function):
             script='''\
                 set -o errexit
                 echo "Starting mock KMS servers..."
-                if [[ "${distro_id}" =~ windows-64-vs2015-* ]]; then
-                    # Python: ImportError: DLL load failed while importing _rust: The specified procedure could not be found.
-                    echo "Starting mock KMS servers... skipped."
-                    exit 0
-                fi
                 cd ./drivers-evergreen-tools/.evergreen/csfle
                 . ./activate-kmstlsvenv.sh
                 python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --port 8999 &

--- a/.evergreen/config_generator/components/integration.py
+++ b/.evergreen/config_generator/components/integration.py
@@ -2,6 +2,7 @@ from config_generator.components.funcs.compile import Compile
 from config_generator.components.funcs.fetch_c_driver_source import FetchCDriverSource
 from config_generator.components.funcs.fetch_det import FetchDET
 from config_generator.components.funcs.install_c_driver import InstallCDriver
+from config_generator.components.funcs.install_uv import InstallUV
 from config_generator.components.funcs.run_kms_servers import RunKMSServers
 from config_generator.components.funcs.setup import Setup
 from config_generator.components.funcs.start_mongod import StartMongod
@@ -149,6 +150,7 @@ def tasks():
                             Setup.call(),
                             StartMongod.call(mongodb_version=mongodb_version, topology=topology),
                             InstallCDriver.call(vars=icd_vars | {'SKIP_INSTALL_LIBMONGOCRYPT': 1}),
+                            InstallUV.call(),
                             Compile.call(polyfill=polyfill, vars=compile_vars),
                             FetchDET.call(),
                             RunKMSServers.call(),
@@ -159,6 +161,7 @@ def tasks():
                             Setup.call(),
                             StartMongod.call(mongodb_version=mongodb_version, topology=topology),
                             FetchCDriverSource.call(),
+                            InstallUV.call(),
                             Compile.call(polyfill=polyfill, vars=compile_vars),
                             FetchDET.call(),
                             RunKMSServers.call(),
@@ -169,6 +172,7 @@ def tasks():
                         Setup.call(),
                         StartMongod.call(mongodb_version=mongodb_version, topology=topology),
                         InstallCDriver.call(vars=icd_vars),
+                        InstallUV.call(),
                         Compile.call(polyfill=polyfill, vars=compile_vars),
                         FetchDET.call(),
                         RunKMSServers.call(),
@@ -179,6 +183,7 @@ def tasks():
                         Setup.call(),
                         StartMongod.call(mongodb_version=mongodb_version, topology=topology),
                         InstallCDriver.call(vars=icd_vars),
+                        InstallUV.call(),
                         Compile.call(polyfill=polyfill, vars=compile_vars),
                         FetchDET.call(),
                         RunKMSServers.call(),

--- a/.evergreen/config_generator/components/lint.py
+++ b/.evergreen/config_generator/components/lint.py
@@ -1,5 +1,4 @@
 from config_generator.components.funcs.install_uv import InstallUV
-from config_generator.components.funcs.set_cache_dir import SetCacheDir
 from config_generator.components.funcs.setup import Setup
 
 from config_generator.etc.distros import find_small_distro
@@ -45,7 +44,6 @@ def tasks():
             run_on=[distro.name for distro in distros],
             commands=[
                 Setup.call(),
-                SetCacheDir.call(),
                 InstallUV.call(),
                 Lint.call(),
             ],

--- a/.evergreen/config_generator/components/macro_guards.py
+++ b/.evergreen/config_generator/components/macro_guards.py
@@ -1,5 +1,6 @@
 from config_generator.components.funcs.compile import Compile
 from config_generator.components.funcs.fetch_c_driver_source import FetchCDriverSource
+from config_generator.components.funcs.install_uv import InstallUV
 from config_generator.components.funcs.setup import Setup
 
 from config_generator.etc.distros import find_large_distro, make_distro_str
@@ -42,6 +43,7 @@ def tasks():
                 commands=[
                     Setup.call(),
                     FetchCDriverSource.call(),
+                    InstallUV.call(),
                     Compile.call(
                         build_type='Debug',
                         compiler=compiler,

--- a/.evergreen/config_generator/components/mongohouse.py
+++ b/.evergreen/config_generator/components/mongohouse.py
@@ -1,5 +1,6 @@
 from config_generator.components.funcs.compile import Compile
 from config_generator.components.funcs.fetch_c_driver_source import FetchCDriverSource
+from config_generator.components.funcs.install_uv import InstallUV
 from config_generator.components.funcs.setup import Setup
 
 from config_generator.etc.distros import find_large_distro
@@ -72,6 +73,7 @@ def tasks():
             commands=[
                 Setup.call(),
                 FetchCDriverSource.call(),
+                InstallUV.call(),
                 Compile.call(build_type='Release', vars={'ENABLE_TESTS': 'ON'}),
                 BuildMongohouse.call(),
                 RunMongohouse.call(),

--- a/.evergreen/config_generator/components/sanitizers.py
+++ b/.evergreen/config_generator/components/sanitizers.py
@@ -1,6 +1,7 @@
 from config_generator.components.funcs.compile import Compile
 from config_generator.components.funcs.fetch_det import FetchDET
 from config_generator.components.funcs.install_c_driver import InstallCDriver
+from config_generator.components.funcs.install_uv import InstallUV
 from config_generator.components.funcs.run_kms_servers import RunKMSServers
 from config_generator.components.funcs.setup import Setup
 from config_generator.components.funcs.start_mongod import StartMongod
@@ -107,6 +108,7 @@ def tasks():
                 Setup.call(),
                 StartMongod.call(mongodb_version=mongodb_version, topology=topology),
                 InstallCDriver.call(vars=icd_vars),
+                InstallUV.call(),
                 Compile.call(vars=compile_vars),
                 FetchDET.call(),
                 RunKMSServers.call(),

--- a/.evergreen/config_generator/components/uninstall_check.py
+++ b/.evergreen/config_generator/components/uninstall_check.py
@@ -1,5 +1,6 @@
 from config_generator.components.funcs.compile import Compile
 from config_generator.components.funcs.fetch_c_driver_source import FetchCDriverSource
+from config_generator.components.funcs.install_uv import InstallUV
 from config_generator.components.funcs.setup import Setup
 
 from config_generator.etc.distros import find_large_distro, make_distro_str
@@ -65,6 +66,7 @@ def tasks():
                     commands=[
                         Setup.call(),
                         FetchCDriverSource.call(),
+                        InstallUV.call(),
                         Compile.call(
                             build_type=build_type,
                             compiler=compiler,

--- a/.evergreen/config_generator/components/uninstall_check.py
+++ b/.evergreen/config_generator/components/uninstall_check.py
@@ -23,7 +23,7 @@ MATRIX = [
     ('debian10',          'gcc',       [         'Release'], ['shared']),
     ('debian11',          'gcc',       [         'Release'], ['shared']),
     ('debian12',          'gcc',       [         'Release'], ['shared']),
-    ('windows-64-vs2015', 'vs2015x64', ['Debug', 'Release'], ['shared']),
+    ('windows-vsCurrent', 'vs2017x64', ['Debug', 'Release'], ['shared']),
     ('ubuntu1804',        'gcc',       [         'Release'], ['shared']),
     ('ubuntu2004',        'gcc',       [         'Release'], ['shared']),
 ]

--- a/.evergreen/config_generator/components/valgrind.py
+++ b/.evergreen/config_generator/components/valgrind.py
@@ -1,6 +1,7 @@
 from config_generator.components.funcs.compile import Compile
 from config_generator.components.funcs.fetch_det import FetchDET
 from config_generator.components.funcs.install_c_driver import InstallCDriver
+from config_generator.components.funcs.install_uv import InstallUV
 from config_generator.components.funcs.run_kms_servers import RunKMSServers
 from config_generator.components.funcs.setup import Setup
 from config_generator.components.funcs.start_mongod import StartMongod
@@ -78,6 +79,7 @@ def tasks():
                 Setup.call(),
                 StartMongod.call(mongodb_version=mongodb_version, topology=topology),
                 InstallCDriver.call(vars=icd_vars),
+                InstallUV.call(),
                 Compile.call(compiler=compiler, vars=compile_vars),
                 FetchDET.call(),
                 RunKMSServers.call(),

--- a/.evergreen/config_generator/components/versioned_api.py
+++ b/.evergreen/config_generator/components/versioned_api.py
@@ -1,6 +1,7 @@
 from config_generator.components.funcs.compile import Compile
 from config_generator.components.funcs.fetch_c_driver_source import FetchCDriverSource
 from config_generator.components.funcs.fetch_det import FetchDET
+from config_generator.components.funcs.install_uv import InstallUV
 from config_generator.components.funcs.run_kms_servers import RunKMSServers
 from config_generator.components.funcs.setup import Setup
 from config_generator.components.funcs.start_mongod import StartMongod
@@ -78,6 +79,7 @@ def tasks():
                         Setup.call(),
                         StartMongod.call(mongodb_version='latest', topology='single', vars=mongod_vars),
                         FetchCDriverSource.call(),
+                        InstallUV.call(),
                         Compile.call(build_type=build_type, compiler=compiler, vars=compile_vars),
                         FetchDET.call(),
                         RunKMSServers.call(),

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -415,11 +415,6 @@ functions:
           - |
             set -o errexit
             echo "Preparing CSFLE venv environment..."
-            if [[ "${distro_id}" =~ windows-64-vs2015-* ]]; then
-                # Python: ImportError: DLL load failed while importing _rust: The specified procedure could not be found.
-                echo "Preparing CSFLE venv environment... skipped."
-                exit 0
-            fi
             cd ./drivers-evergreen-tools/.evergreen/csfle
             # This function ensures future invocations of activate-kmstlsvenv.sh conducted in
             # parallel do not race to setup a venv environment; it has already been prepared.
@@ -437,11 +432,6 @@ functions:
           - |
             set -o errexit
             echo "Starting mock KMS servers..."
-            if [[ "${distro_id}" =~ windows-64-vs2015-* ]]; then
-                # Python: ImportError: DLL load failed while importing _rust: The specified procedure could not be found.
-                echo "Starting mock KMS servers... skipped."
-                exit 0
-            fi
             cd ./drivers-evergreen-tools/.evergreen/csfle
             . ./activate-kmstlsvenv.sh
             python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --port 8999 &

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -310,6 +310,37 @@ functions:
         args:
           - -c
           - |
+            if [[ -n "$XDG_CACHE_DIR" ]]; then
+                cache_dir="$XDG_CACHE_DIR" # XDG Base Directory specification.
+            elif [[ -n "$LOCALAPPDATA" ]]; then
+                cache_dir="$LOCALAPPDATA" # Windows.
+            elif [[ -n "$USERPROFILE" ]]; then
+                cache_dir="$USERPROFILE/.cache" # Windows (fallback).
+            elif [[ -d "$HOME/Library/Caches" ]]; then
+                cache_dir="$HOME/Library/Caches" # MacOS.
+            elif [[ -n "$HOME" ]]; then
+                cache_dir="$HOME/.cache" # Linux-like.
+            elif [[ -d ~/.cache ]]; then
+                cache_dir="~/.cache" # Linux-like (fallback).
+            else
+                cache_dir="$(pwd)/.cache" # EVG task directory (fallback).
+            fi
+
+            mkdir -p "$cache_dir/mongo-cxx-driver" || exit
+            cache_dir="$(cd "$cache_dir/mongo-cxx-driver" && pwd)" || exit
+
+            printf "MONGO_CXX_DRIVER_CACHE_DIR: %s\n" "$cache_dir" >|expansions.set-cache-dir.yml
+    - command: expansions.update
+      type: setup
+      params:
+        file: expansions.set-cache-dir.yml
+    - command: subprocess.exec
+      type: setup
+      params:
+        binary: bash
+        args:
+          - -c
+          - |
             set -o errexit
             set -o pipefail
 
@@ -318,15 +349,19 @@ functions:
                 exit 1
             fi
 
-            uv_install_dir="${MONGO_CXX_DRIVER_CACHE_DIR}/uv-0.5.9"
+            uv_install_dir="${MONGO_CXX_DRIVER_CACHE_DIR}/uv-0.5.14"
             mkdir -p "$uv_install_dir"
 
-            if ! command -V "$uv_install_dir/uv" 2>/dev/null; then
+            if ! command -v "$uv_install_dir/uv" 2>/dev/null; then
                 env \
                     UV_INSTALL_DIR="$uv_install_dir" \
-                    UV_NO_MODIFY_PATH=1 \
-                    mongo-cxx-driver/.evergreen/scripts/uv-installer.sh
+                    UV_UNMANAGED_INSTALL=1 \
+                    INSTALLER_PRINT_VERBOSE=1 \
+                    mongo-cxx-driver/.evergreen/scripts/uv-installer.sh --verbose
             fi
+
+            PATH="$uv_install_dir:$PATH" command -V uv
+            PATH="$uv_install_dir:$PATH" uv --version
 
             printf "UV_INSTALL_DIR: %s\n" "$uv_install_dir" >|expansions.uv.yml
     - command: expansions.update

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -358,7 +358,7 @@ functions:
                     UV_INSTALL_DIR="$uv_install_dir" \
                     UV_UNMANAGED_INSTALL=1 \
                     INSTALLER_PRINT_VERBOSE=1 \
-                    mongo-cxx-driver/.evergreen/scripts/uv-installer.sh --verbose
+                    mongo-cxx-driver/.evergreen/scripts/uv-installer.sh
             fi
 
             PATH="$uv_install_dir:$PATH" command -V uv

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -254,6 +254,7 @@ functions:
         - USE_SANITIZER_ASAN
         - USE_SANITIZER_UBSAN
         - USE_STATIC_LIBS
+        - UV_INSTALL_DIR
       args:
         - -c
         - .evergreen/scripts/compile.sh

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -4759,9 +4759,9 @@ tasks:
           cc_compiler: gcc
           cxx_compiler: g++
       - func: uninstall-check
-  - name: uninstall-check-vs2015-x64-debug-shared
-    run_on: windows-64-vs2015-large
-    tags: [uninstall-check, windows-64-vs2015, vs2015x64, debug, shared]
+  - name: uninstall-check-windows-2019-vs2017-x64-debug-shared
+    run_on: windows-vsCurrent-large
+    tags: [uninstall-check, windows-vsCurrent, vs2017x64, debug, shared]
     commands:
       - func: setup
       - func: fetch_c_driver_source
@@ -4769,12 +4769,12 @@ tasks:
       - func: compile
         vars:
           build_type: Debug
-          generator: Visual Studio 14 2015
+          generator: Visual Studio 15 2017
           platform: x64
       - func: uninstall-check
-  - name: uninstall-check-vs2015-x64-release-shared
-    run_on: windows-64-vs2015-large
-    tags: [uninstall-check, windows-64-vs2015, vs2015x64, release, shared]
+  - name: uninstall-check-windows-2019-vs2017-x64-release-shared
+    run_on: windows-vsCurrent-large
+    tags: [uninstall-check, windows-vsCurrent, vs2017x64, release, shared]
     commands:
       - func: setup
       - func: fetch_c_driver_source
@@ -4782,7 +4782,7 @@ tasks:
       - func: compile
         vars:
           build_type: Release
-          generator: Visual Studio 14 2015
+          generator: Visual Studio 15 2017
           platform: x64
       - func: uninstall-check
   - name: valgrind-ubuntu1804-shared-5.0-single

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -3977,7 +3977,6 @@ tasks:
     tags: [lint]
     commands:
       - func: setup
-      - func: set-cache-dir
       - func: install-uv
       - func: lint
   - name: macro-guards-ubuntu2004

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -124,6 +124,7 @@ tasks:
     tags: [atlas-search-indexes, ubuntu2004]
     commands:
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -134,6 +135,7 @@ tasks:
     tags: [atlas-search-indexes, ubuntu2004]
     commands:
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -170,6 +172,7 @@ tasks:
     commands:
       - func: setup
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           BSONCXX_POLYFILL: impls
@@ -181,6 +184,7 @@ tasks:
     commands:
       - func: setup
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           build_type: Release
@@ -191,6 +195,7 @@ tasks:
     commands:
       - func: setup
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           build_type: Release
@@ -200,6 +205,7 @@ tasks:
     commands:
       - func: setup
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           build_type: Debug
@@ -211,6 +217,7 @@ tasks:
     commands:
       - func: setup
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           build_type: Debug
@@ -220,6 +227,7 @@ tasks:
     commands:
       - func: setup
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           build_type: Debug
@@ -231,6 +239,7 @@ tasks:
     commands:
       - func: setup
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           build_type: Debug
@@ -242,6 +251,7 @@ tasks:
     commands:
       - func: setup
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           build_type: Release
@@ -273,6 +283,7 @@ tasks:
           TOPOLOGY: replica_set
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -296,6 +307,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -318,6 +330,7 @@ tasks:
         vars:
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -343,6 +356,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -365,6 +379,7 @@ tasks:
         vars:
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -392,6 +407,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -417,6 +433,7 @@ tasks:
           TOPOLOGY: replica_set
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -440,6 +457,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -462,6 +480,7 @@ tasks:
         vars:
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -484,6 +503,7 @@ tasks:
         vars:
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -512,6 +532,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -540,6 +561,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -562,6 +584,7 @@ tasks:
         vars:
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -589,6 +612,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -614,6 +638,7 @@ tasks:
           TOPOLOGY: replica_set
           mongodb_version: latest
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -637,6 +662,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           mongodb_version: latest
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -662,6 +688,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -687,6 +714,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -715,6 +743,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -737,6 +766,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -762,6 +792,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -786,6 +817,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -813,6 +845,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -835,6 +868,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -860,6 +894,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -884,6 +919,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -911,6 +947,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -933,6 +970,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -958,6 +996,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -982,6 +1021,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1006,6 +1046,7 @@ tasks:
         vars:
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1031,6 +1072,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -1053,6 +1095,7 @@ tasks:
         vars:
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1080,6 +1123,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -1105,6 +1149,7 @@ tasks:
         vars:
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1132,6 +1177,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -1159,6 +1205,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -1183,6 +1230,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1207,6 +1255,7 @@ tasks:
         vars:
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1236,6 +1285,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -1265,6 +1315,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -1291,6 +1342,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1317,6 +1369,7 @@ tasks:
         vars:
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1341,6 +1394,7 @@ tasks:
         vars:
           mongodb_version: "6.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1368,6 +1422,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -1395,6 +1450,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -1422,6 +1478,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -1446,6 +1503,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1470,6 +1528,7 @@ tasks:
         vars:
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1496,6 +1555,7 @@ tasks:
         vars:
           mongodb_version: "6.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1525,6 +1585,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -1554,6 +1615,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -1583,6 +1645,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -1609,6 +1672,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1635,6 +1699,7 @@ tasks:
           TOPOLOGY: replica_set
           mongodb_version: latest
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1659,6 +1724,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           mongodb_version: latest
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1685,6 +1751,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -1711,6 +1778,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1740,6 +1808,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -1763,6 +1832,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1789,6 +1859,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -1814,6 +1885,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1840,6 +1912,7 @@ tasks:
           TOPOLOGY: replica_set
           mongodb_version: latest
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1864,6 +1937,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           mongodb_version: latest
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1890,6 +1964,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -1916,6 +1991,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1945,6 +2021,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -1968,6 +2045,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -1994,6 +2072,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -2019,6 +2098,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2044,6 +2124,7 @@ tasks:
         vars:
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2069,6 +2150,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -2091,6 +2173,7 @@ tasks:
         vars:
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2118,6 +2201,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -2142,6 +2226,7 @@ tasks:
         vars:
           mongodb_version: "4.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2164,6 +2249,7 @@ tasks:
         vars:
           mongodb_version: "4.2"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2186,6 +2272,7 @@ tasks:
         vars:
           mongodb_version: "4.4"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2208,6 +2295,7 @@ tasks:
         vars:
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2230,6 +2318,7 @@ tasks:
         vars:
           mongodb_version: "6.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2253,6 +2342,7 @@ tasks:
           TOPOLOGY: replica_set
           mongodb_version: "4.0"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2276,6 +2366,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           mongodb_version: "4.0"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2299,6 +2390,7 @@ tasks:
           TOPOLOGY: replica_set
           mongodb_version: "4.2"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2322,6 +2414,7 @@ tasks:
           TOPOLOGY: replica_set
           mongodb_version: "4.2"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2346,6 +2439,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           mongodb_version: "4.2"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2369,6 +2463,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           mongodb_version: "4.2"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2393,6 +2488,7 @@ tasks:
           TOPOLOGY: replica_set
           mongodb_version: "4.4"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2416,6 +2512,7 @@ tasks:
           TOPOLOGY: replica_set
           mongodb_version: "4.4"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2440,6 +2537,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           mongodb_version: "4.4"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2463,6 +2561,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           mongodb_version: "4.4"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2487,6 +2586,7 @@ tasks:
           TOPOLOGY: replica_set
           mongodb_version: "5.0"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2510,6 +2610,7 @@ tasks:
           TOPOLOGY: replica_set
           mongodb_version: "5.0"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2534,6 +2635,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           mongodb_version: "5.0"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2557,6 +2659,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           mongodb_version: "5.0"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2581,6 +2684,7 @@ tasks:
           TOPOLOGY: replica_set
           mongodb_version: "6.0"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2604,6 +2708,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           mongodb_version: "6.0"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2629,6 +2734,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -2654,6 +2760,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -2679,6 +2786,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -2704,6 +2812,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -2729,6 +2838,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -2752,6 +2862,7 @@ tasks:
           TOPOLOGY: replica_set
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2775,6 +2886,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2800,6 +2912,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -2822,6 +2935,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2847,6 +2961,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -2871,6 +2986,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2895,6 +3011,7 @@ tasks:
         vars:
           mongodb_version: "7.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2917,6 +3034,7 @@ tasks:
         vars:
           mongodb_version: "8.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2940,6 +3058,7 @@ tasks:
           TOPOLOGY: replica_set
           mongodb_version: "7.0"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2963,6 +3082,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           mongodb_version: "7.0"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -2986,6 +3106,7 @@ tasks:
           TOPOLOGY: replica_set
           mongodb_version: "8.0"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3009,6 +3130,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           mongodb_version: "8.0"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3032,6 +3154,7 @@ tasks:
           TOPOLOGY: replica_set
           mongodb_version: latest
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3055,6 +3178,7 @@ tasks:
           TOPOLOGY: replica_set
           mongodb_version: latest
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3079,6 +3203,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           mongodb_version: latest
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3102,6 +3227,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           mongodb_version: latest
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3128,6 +3254,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -3153,6 +3280,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -3178,6 +3306,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -3200,6 +3329,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3223,6 +3353,7 @@ tasks:
           TOPOLOGY: replica_set
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3246,6 +3377,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3268,6 +3400,7 @@ tasks:
         vars:
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3291,6 +3424,7 @@ tasks:
           TOPOLOGY: replica_set
           mongodb_version: "5.0"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3314,6 +3448,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           mongodb_version: "5.0"
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3337,6 +3472,7 @@ tasks:
           TOPOLOGY: replica_set
           mongodb_version: latest
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3360,6 +3496,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           mongodb_version: latest
       - func: install_c_driver
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3385,6 +3522,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -3410,6 +3548,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -3432,6 +3571,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3454,6 +3594,7 @@ tasks:
         vars:
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3481,6 +3622,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -3508,6 +3650,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -3532,6 +3675,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3558,6 +3702,7 @@ tasks:
         vars:
           mongodb_version: "4.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3583,6 +3728,7 @@ tasks:
         vars:
           mongodb_version: "4.2"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3608,6 +3754,7 @@ tasks:
         vars:
           mongodb_version: "4.4"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3633,6 +3780,7 @@ tasks:
         vars:
           mongodb_version: "5.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3658,6 +3806,7 @@ tasks:
         vars:
           mongodb_version: "6.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3683,6 +3832,7 @@ tasks:
         vars:
           mongodb_version: "7.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3708,6 +3858,7 @@ tasks:
         vars:
           mongodb_version: "8.0"
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3736,6 +3887,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -3764,6 +3916,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -3792,6 +3945,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -3820,6 +3974,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -3848,6 +4003,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -3876,6 +4032,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -3904,6 +4061,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -3932,6 +4090,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -3957,6 +4116,7 @@ tasks:
         vars:
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -3985,6 +4145,7 @@ tasks:
     commands:
       - func: setup
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           COMPILE_MACRO_GUARD_TESTS: "ON"
@@ -3995,6 +4156,7 @@ tasks:
     commands:
       - func: setup
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           COMPILE_MACRO_GUARD_TESTS: "ON"
@@ -4007,6 +4169,7 @@ tasks:
     commands:
       - func: setup
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           COMPILE_MACRO_GUARD_TESTS: "ON"
@@ -4052,6 +4215,7 @@ tasks:
       - func: install_c_driver
         vars:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -4085,6 +4249,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -4118,6 +4283,7 @@ tasks:
       - func: install_c_driver
         vars:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -4152,6 +4318,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -4184,6 +4351,7 @@ tasks:
       - func: install_c_driver
         vars:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -4217,6 +4385,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -4250,6 +4419,7 @@ tasks:
       - func: install_c_driver
         vars:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -4284,6 +4454,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -4317,6 +4488,7 @@ tasks:
       - func: install_c_driver
         vars:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -4350,6 +4522,7 @@ tasks:
       - func: install_c_driver
         vars:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -4441,6 +4614,7 @@ tasks:
     commands:
       - func: setup
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -4454,6 +4628,7 @@ tasks:
     commands:
       - func: setup
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           build_type: Release
@@ -4466,6 +4641,7 @@ tasks:
     commands:
       - func: setup
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           build_type: Release
@@ -4478,6 +4654,7 @@ tasks:
     commands:
       - func: setup
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           build_type: Release
@@ -4490,6 +4667,7 @@ tasks:
     commands:
       - func: setup
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           build_type: Release
@@ -4502,6 +4680,7 @@ tasks:
     commands:
       - func: setup
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           build_type: Release
@@ -4514,6 +4693,7 @@ tasks:
     commands:
       - func: setup
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           build_type: Debug
@@ -4526,6 +4706,7 @@ tasks:
     commands:
       - func: setup
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           build_type: Release
@@ -4547,6 +4728,7 @@ tasks:
       - func: install_c_driver
         vars:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -4575,6 +4757,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -4603,6 +4786,7 @@ tasks:
       - func: install_c_driver
         vars:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -4632,6 +4816,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -4660,6 +4845,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -4687,6 +4873,7 @@ tasks:
       - func: install_c_driver
         vars:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -4716,6 +4903,7 @@ tasks:
         vars:
           BSON_EXTRA_ALIGNMENT: 1
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           BSON_EXTRA_ALIGNMENT: 1
@@ -4744,6 +4932,7 @@ tasks:
       - func: install_c_driver
         vars:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -4767,6 +4956,7 @@ tasks:
           REQUIRE_API_VERSION: true
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -4789,6 +4979,7 @@ tasks:
           REQUIRE_API_VERSION: true
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -4811,6 +5002,7 @@ tasks:
           REQUIRE_API_VERSION: true
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -4838,6 +5030,7 @@ tasks:
           ORCHESTRATION_FILE: versioned-api-testing.json
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -4859,6 +5052,7 @@ tasks:
           ORCHESTRATION_FILE: versioned-api-testing.json
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"
@@ -4880,6 +5074,7 @@ tasks:
           ORCHESTRATION_FILE: versioned-api-testing.json
           mongodb_version: latest
       - func: fetch_c_driver_source
+      - func: install-uv
       - func: compile
         vars:
           ENABLE_TESTS: "ON"

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -257,6 +257,78 @@ tasks:
           build_type: Release
           generator: Visual Studio 14 2015
           platform: x64
+  - name: compile-only-windows-2019-vs2017-x64-debug-shared
+    run_on: windows-vsCurrent-large
+    tags: [compile-only, windows-vsCurrent, vs2017x64, debug, shared]
+    commands:
+      - func: setup
+      - func: fetch_c_driver_source
+      - func: install-uv
+      - func: compile
+        vars:
+          build_type: Debug
+          generator: Visual Studio 15 2017
+          platform: x64
+  - name: compile-only-windows-2019-vs2017-x64-release-shared
+    run_on: windows-vsCurrent-large
+    tags: [compile-only, windows-vsCurrent, vs2017x64, release, shared]
+    commands:
+      - func: setup
+      - func: fetch_c_driver_source
+      - func: install-uv
+      - func: compile
+        vars:
+          build_type: Release
+          generator: Visual Studio 15 2017
+          platform: x64
+  - name: compile-only-windows-2019-vs2019-x64-debug-shared
+    run_on: windows-vsCurrent-large
+    tags: [compile-only, windows-vsCurrent, vs2019x64, debug, shared]
+    commands:
+      - func: setup
+      - func: fetch_c_driver_source
+      - func: install-uv
+      - func: compile
+        vars:
+          build_type: Debug
+          generator: Visual Studio 16 2019
+          platform: x64
+  - name: compile-only-windows-2019-vs2019-x64-release-shared
+    run_on: windows-vsCurrent-large
+    tags: [compile-only, windows-vsCurrent, vs2019x64, release, shared]
+    commands:
+      - func: setup
+      - func: fetch_c_driver_source
+      - func: install-uv
+      - func: compile
+        vars:
+          build_type: Release
+          generator: Visual Studio 16 2019
+          platform: x64
+  - name: compile-only-windows-2019-vs2022-x64-debug-shared
+    run_on: windows-vsCurrent-large
+    tags: [compile-only, windows-vsCurrent, vs2022x64, debug, shared]
+    commands:
+      - func: setup
+      - func: fetch_c_driver_source
+      - func: install-uv
+      - func: compile
+        vars:
+          build_type: Debug
+          generator: Visual Studio 17 2022
+          platform: x64
+  - name: compile-only-windows-2019-vs2022-x64-release-shared
+    run_on: windows-vsCurrent-large
+    tags: [compile-only, windows-vsCurrent, vs2022x64, release, shared]
+    commands:
+      - func: setup
+      - func: fetch_c_driver_source
+      - func: install-uv
+      - func: compile
+        vars:
+          build_type: Release
+          generator: Visual Studio 17 2022
+          platform: x64
   - name: docker-build-ubuntu2204
     run_on: ubuntu2204-large
     tags: [docker-build, ubuntu2204]

--- a/.evergreen/scripts/test.sh
+++ b/.evergreen/scripts/test.sh
@@ -107,9 +107,6 @@ export MONGOCXX_TEST_TLS_CA_FILE="${DRIVERS_TOOLS:?}/.evergreen/x509gen/ca.pem"
 
 if [ "$(uname -m)" == "ppc64le" ]; then
   echo "Skipping CSFLE test setup (CDRIVER-4246/CXX-2423)"
-elif [[ "${distro_id:?}" =~ windows-64-vs2015-* ]]; then
-  # Python: ImportError: DLL load failed while importing _rust: The specified procedure could not be found.
-  echo "Skipping CSFLE test setup (CXX-2628)"
 else
   # export environment variables for encryption tests
   set +o errexit

--- a/.evergreen/scripts/uv-installer.sh
+++ b/.evergreen/scripts/uv-installer.sh
@@ -17,7 +17,7 @@ fi
 set -u
 
 APP_NAME="uv"
-APP_VERSION="0.5.9"
+APP_VERSION="0.5.14"
 # Look for GitHub Enterprise-style base URL first
 if [ -n "${UV_INSTALLER_GHE_BASE_URL:-}" ]; then
     INSTALLER_BASE_URL="$UV_INSTALLER_GHE_BASE_URL"
@@ -27,7 +27,7 @@ fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
 else
-    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/astral-sh/uv/releases/download/0.5.9"
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/astral-sh/uv/releases/download/0.5.14"
 fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
@@ -48,19 +48,19 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"0.25.2-prerelease.3"},"source":{"app_name":"uv","name":"uv","owner":"astral-sh","release_type":"github"},"version":"0.5.9"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"0.27.0"},"source":{"app_name":"uv","name":"uv","owner":"astral-sh","release_type":"github"},"version":"0.5.14"}
 EORECEIPT
-RECEIPT_HOME="${HOME}/.config/uv"
+RECEIPT_HOME="${XDG_CONFIG_HOME:-$HOME/.config}/uv"
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
     cat <<EOF
 uv-installer.sh
 
-The installer for uv 0.5.9
+The installer for uv 0.5.14
 
 This script detects what platform you're on and fetches an appropriate archive from
-https://github.com/astral-sh/uv/releases/download/0.5.9
+https://github.com/astral-sh/uv/releases/download/0.5.14
 then unpacks the binaries and installs them to the first of the following locations
 
     \$XDG_BIN_HOME
@@ -169,7 +169,7 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="uv uvx"
             _bins_js_array='"uv","uvx"'
-            _checksum_value="66d352728d0efe9ecc65f7e9ee419fce139e3ab99addc08527e8cebbb405d382"
+            _checksum_value="d548dffc256014c4c8c693e148140a3a21bcc2bf066a35e1d5f0d24c91d32112"
             _libs=""
             _libs_js_array=""
             _staticlibs=""
@@ -182,7 +182,7 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="uv uvx"
             _bins_js_array='"uv","uvx"'
-            _checksum_value="376d5d52a4b3a9875d66898261e2ce2d31d36c095a1d81cb88d953f5bf7273eb"
+            _checksum_value="1c9cdb265b0c24ce2e74b7795a00842dc6d487c11ba49aa6c9ca1c784b82755a"
             _libs=""
             _libs_js_array=""
             _staticlibs=""
@@ -195,7 +195,7 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="uv uvx"
             _bins_js_array='"uv","uvx"'
-            _checksum_value="ec5598ae9daba48f7a12b2f12533c6aa683049e6a822835794cea136f63abd31"
+            _checksum_value="64c5321f5141db39e04209d170db34fcef5c8de3f561346dc0c1d132801c4f88"
             _libs=""
             _libs_js_array=""
             _staticlibs=""
@@ -208,7 +208,7 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="uv uvx"
             _bins_js_array='"uv","uvx"'
-            _checksum_value="4ca86619f26c0879f81e26760b529a548ba96b33141d24075b71137cf9dfa639"
+            _checksum_value="903f87c609479099c87c229429f2a25f451689d862ee19170f6d87ab656815a0"
             _libs=""
             _libs_js_array=""
             _staticlibs=""
@@ -221,7 +221,7 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="uv uvx"
             _bins_js_array='"uv","uvx"'
-            _checksum_value="412d249f2c9a3dd7c070a219fc658fe9a36c6e9c50bef53b536efd54446eeae9"
+            _checksum_value="c33a4caa441c770ca720d301059eeb6af5473ceb22b69adf08b99043c3e4a854"
             _libs=""
             _libs_js_array=""
             _staticlibs=""
@@ -234,7 +234,7 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="uv uvx"
             _bins_js_array='"uv","uvx"'
-            _checksum_value="4097f1b45627212aa8936c973d9c7dcfaf1512ed08cfe958cf9dc68d0cc5d02f"
+            _checksum_value="c3b1bbe0d70e916abdd557092bf94c4830f98c471fe7d45b23d4dec8546251f3"
             _libs=""
             _libs_js_array=""
             _staticlibs=""
@@ -247,7 +247,7 @@ download_binary_and_run_installer() {
             _zip_ext=".zip"
             _bins="uv.exe uvx.exe"
             _bins_js_array='"uv.exe","uvx.exe"'
-            _checksum_value="73ac9d7aab6bafe1d8da36b7d4cb2bd969ca1d9c675b7a021afec3c913fe223f"
+            _checksum_value="2ea709cf816b70661c6aa43d6aff7526faebafc2d45f7167d3192c5b9bb0a28f"
             _libs=""
             _libs_js_array=""
             _staticlibs=""
@@ -260,7 +260,7 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="uv uvx"
             _bins_js_array='"uv","uvx"'
-            _checksum_value="7236440874031e47a2ff3b4df93c7c2833c0bbe428716e491b8e87c8539a6651"
+            _checksum_value="74fd05a1e04bb8c591cb4531d517848d1e2cdc05762ccd291429c165e2a19aa1"
             _libs=""
             _libs_js_array=""
             _staticlibs=""
@@ -273,7 +273,7 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="uv uvx"
             _bins_js_array='"uv","uvx"'
-            _checksum_value="64e588a32f12dac948733eb8ad57f7344bffd30023150a4b9b2b9b2a47ba2c9b"
+            _checksum_value="a616553164336a57fc154a424d44cd75eb06104bc4e69f3d757e3da90a90d31f"
             _libs=""
             _libs_js_array=""
             _staticlibs=""
@@ -286,7 +286,7 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="uv uvx"
             _bins_js_array='"uv","uvx"'
-            _checksum_value="56d62d87a42f05f49f29fda674ec2576b811838029c048ed776cdbbaa690da57"
+            _checksum_value="4b675ac963f4d90034f8b8de8b03e0691b7e48eb8ce7bf5449ea65774750dfd4"
             _libs=""
             _libs_js_array=""
             _staticlibs=""
@@ -299,7 +299,7 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="uv uvx"
             _bins_js_array='"uv","uvx"'
-            _checksum_value="15a6f24ad5b30b2ce71a9fcc31ecd88d658c8534fac58d2a9af33a3e7c48a99b"
+            _checksum_value="2a7bb1d27a6a057cbd5f62a5bc2ec77175c71224de8fb1bb5107acb1a07cc02a"
             _libs=""
             _libs_js_array=""
             _staticlibs=""
@@ -312,7 +312,7 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="uv uvx"
             _bins_js_array='"uv","uvx"'
-            _checksum_value="e5a3ebc23c9acba4f8ae2a9f0a4344297e5a604cb24f63751193494f64e42822"
+            _checksum_value="68acbfadd9e100b69b31f4995265b716465df909a7d110bba76d93e8adc3a76b"
             _libs=""
             _libs_js_array=""
             _staticlibs=""
@@ -325,7 +325,7 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="uv uvx"
             _bins_js_array='"uv","uvx"'
-            _checksum_value="f4b4311cd2c2928aadee6b4e85aec2c6db7d779d4f9009eb4733bc8b2f20dbb5"
+            _checksum_value="8caf91b936ede1167abaebae07c2a1cbb22473355fa0ad7ebb2580307e84fb47"
             _libs=""
             _libs_js_array=""
             _staticlibs=""
@@ -338,7 +338,7 @@ download_binary_and_run_installer() {
             _zip_ext=".zip"
             _bins="uv.exe uvx.exe"
             _bins_js_array='"uv.exe","uvx.exe"'
-            _checksum_value="8cb608cdf23b79f4f598969b72890db657c5addab312890c37ab20b9b57c501f"
+            _checksum_value="ee2468e40320a0a2a36435e66bbd0d861228c4c06767f22d97876528138f4ba0"
             _libs=""
             _libs_js_array=""
             _staticlibs=""
@@ -351,7 +351,7 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="uv uvx"
             _bins_js_array='"uv","uvx"'
-            _checksum_value="e9cca3fb618dbc056f770d3ac4d52af491b532e60c8b19b97b9ba24f42db2bc1"
+            _checksum_value="22034760075b92487b326da5aa1a2a3e1917e2e766c12c0fd466fccda77013c7"
             _libs=""
             _libs_js_array=""
             _staticlibs=""
@@ -364,7 +364,7 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="uv uvx"
             _bins_js_array='"uv","uvx"'
-            _checksum_value="f97ffe29c03f01bb19a948eb8eb1e27cefbbf83b8dd54057da0247a664a303ac"
+            _checksum_value="e1ccdfe1691c1f791d84bb6e1697e49416ca4b62103dcdf3b63772f03834f113"
             _libs=""
             _libs_js_array=""
             _staticlibs=""
@@ -752,7 +752,7 @@ select_archive_for_arch() {
             ;;
         "aarch64-unknown-linux-gnu")
             _archive="uv-aarch64-unknown-linux-gnu.tar.gz"
-            if ! check_glibc "2" "31"; then
+            if ! check_glibc "2" "28"; then
                 _archive=""
             fi
             if [ -n "$_archive" ]; then
@@ -802,7 +802,7 @@ select_archive_for_arch() {
             ;;
         "armv7-unknown-linux-gnueabihf")
             _archive="uv-armv7-unknown-linux-gnueabihf.tar.gz"
-            if ! check_glibc "2" "31"; then
+            if ! check_glibc "2" "17"; then
                 _archive=""
             fi
             if [ -n "$_archive" ]; then
@@ -845,7 +845,7 @@ select_archive_for_arch() {
             ;;
         "i686-unknown-linux-gnu")
             _archive="uv-i686-unknown-linux-gnu.tar.gz"
-            if ! check_glibc "2" "31"; then
+            if ! check_glibc "2" "17"; then
                 _archive=""
             fi
             if [ -n "$_archive" ]; then
@@ -874,7 +874,7 @@ select_archive_for_arch() {
             ;;
         "powerpc64-unknown-linux-gnu")
             _archive="uv-powerpc64-unknown-linux-gnu.tar.gz"
-            if ! check_glibc "2" "31"; then
+            if ! check_glibc "2" "17"; then
                 _archive=""
             fi
             if [ -n "$_archive" ]; then
@@ -884,7 +884,7 @@ select_archive_for_arch() {
             ;;
         "powerpc64le-unknown-linux-gnu")
             _archive="uv-powerpc64le-unknown-linux-gnu.tar.gz"
-            if ! check_glibc "2" "31"; then
+            if ! check_glibc "2" "17"; then
                 _archive=""
             fi
             if [ -n "$_archive" ]; then
@@ -894,7 +894,7 @@ select_archive_for_arch() {
             ;;
         "s390x-unknown-linux-gnu")
             _archive="uv-s390x-unknown-linux-gnu.tar.gz"
-            if ! check_glibc "2" "31"; then
+            if ! check_glibc "2" "17"; then
                 _archive=""
             fi
             if [ -n "$_archive" ]; then
@@ -930,7 +930,7 @@ select_archive_for_arch() {
             ;;
         "x86_64-unknown-linux-gnu")
             _archive="uv-x86_64-unknown-linux-gnu.tar.gz"
-            if ! check_glibc "2" "31"; then
+            if ! check_glibc "2" "17"; then
                 _archive=""
             fi
             if [ -n "$_archive" ]; then


### PR DESCRIPTION
Motivated by an attempt to resolve ongoing task failures on the (deprecated) `windows-64-vs2015` distro due to the [absence of a compatible Python version](https://parsley.mongodb.com/evergreen/mongo_cxx_driver_compile_only_matrix_compile_only_vs2015_x64_debug_shared_2f53a561afa7ff06c12b7c6ec7a7f3bd6a5e135b_25_01_06_16_30_46/0/task?bookmarks=0,87&shareLine=44) after https://github.com/mongodb-labs/drivers-evergreen-tools/pull/567 dropped support for Python 3.8 (EOL).

This PR does _not_ succeed in resolving the original vs2015 distro issue, as unfortunately uv appears to have an [unresolved regression since 0.5.9](/astral-sh/uv/issues/10231) that is [preventing its use](https://parsley.mongodb.com/evergreen/mongo_cxx_driver_compile_only_matrix_compile_only_vs2015_x64_debug_shared_patch_2f53a561afa7ff06c12b7c6ec7a7f3bd6a5e135b_677c43d65567600007fe82f9_25_01_06_20_57_59/0/task?bookmarks=0,209&shareLine=187) as a workaround, even after upgrading to 0.5.14.

Instead, the affected tasks are (mostly) migrated to the newer and recommended `windows-vsCurrent` distro, which provides VS 2017 and newer. The compile-only matrix still contains tasks with VS2015 compilation coverage (currently failing) and is pending updates to either Astral UV (fixing the reported segfault on Windows) or [DEVPROD-13875](https://jira.mongodb.org/browse/DEVPROD-13875), whichever comes first, due to refactoring the `compile.sh` script to `etc/calc_release_version.py` via uv rather than DET's `find-python3.sh`.
