### PR TITLE
Address deprecation warnings-as-errors on RHEL 7.9

### DIFF
--- a/.evergreen/config_generator/components/compile_only.py
+++ b/.evergreen/config_generator/components/compile_only.py
@@ -61,10 +61,6 @@ def generate_tasks():
             if any(pattern in distro_name for pattern in ['power8', 'zseries']):
                 patchable = False
 
-            # etc/calc_release_version.py: error: unknown option `--format=...'
-            if distro_name == 'rhel79':
-                patchable = False
-
             res.append(
                 EvgTask(
                     name=name,

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -168,7 +168,6 @@ tasks:
   - name: compile-only-rhel79-release-shared-impls
     run_on: rhel79-large
     tags: [compile-only, rhel79, release, shared, impls]
-    patchable: false
     commands:
       - func: setup
       - func: fetch_c_driver_source

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/authentication_exception.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/exception/authentication_exception.cpp
@@ -12,6 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <bsoncxx/private/suppress_deprecation_warnings.hh>
+
+//
+
+BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
+
+//
+
 #include <mongocxx/exception/authentication_exception.hpp>
 
 namespace mongocxx {
@@ -21,3 +29,5 @@ authentication_exception::~authentication_exception() = default;
 
 } // namespace v_noabi
 } // namespace mongocxx
+
+BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1311 which overlooked use of the now-deprecated `authentication_exception` class in the [authentication_exception.cpp](https://parsley.mongodb.com/evergreen/mongo_cxx_driver_compile_only_matrix_compile_only_rhel79_release_shared_impls_dcc49bb7953b9b6a0ce756ca84972d988277c107_25_01_07_16_26_39/0/task?bookmarks=0,842&selectedLineRange=L802) file leading to deprecation warnings that are caught by the RHEL 7.9 release build.

Additionally removes a now-obsolete workaround for RHEL 7.9 concerning Python binary version compatibility due to use of Astral uv instead to invoke `calc_release_version.py`.