### PR TITLE
Exclude cryptography package by default for tasks on PowerPC/zSeries distros

### DIFF
--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -358,7 +358,7 @@ Create and activate a fresh Python 3 virtual environment with required packages 
 export UV_PROJECT_ENVIRONMENT="$HOME/mongo-cxx-driver-release-venv"
 
 # Install required packages into a new virtual environment.
-uv sync --frozen
+uv sync --frozen --group make_release
 
 # Activate the virtual environment.
 source "$UV_PROJECT_ENVIRONMENT/bin/activate"

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -358,7 +358,7 @@ Create and activate a fresh Python 3 virtual environment with required packages 
 export UV_PROJECT_ENVIRONMENT="$HOME/mongo-cxx-driver-release-venv"
 
 # Install required packages into a new virtual environment.
-uv sync --frozen --group make_release
+uv sync --frozen --group apidocs --group make_release
 
 # Activate the virtual environment.
 source "$UV_PROJECT_ENVIRONMENT/bin/activate"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = []
 
 [dependency-groups]
 dev = [
-    {include-group="apidocs"},
+    # {include-group="apidocs"},
     {include-group="clang_format"},
     {include-group="config_generator"},
     # {include-group="make_release"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ clang_format = [
 config_generator = [
     # .evergreen/config_generator/generate.py
     "packaging>=14.0",
-    "pydantic>=2.7",
-    "shrub-py>=3.6.0",
+    "pydantic>=2.8",
+    "shrub-py>=3.6",
 ]
 
 make_release = [
@@ -40,5 +40,5 @@ make_release = [
     "gitpython>=3.1",
     "jira>=3.1",
     "looseversion>=1.3",
-    "pygithub>=2.0",
+    "pygithub>=2.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,25 +7,38 @@ dependencies = []
 
 [dependency-groups]
 dev = [
-    # .evergreen/config_generator/generate.py
-    "packaging>=14.0",
-    "pydantic>=2.7",
-    "shrub-py>=3.6.0",
+    {include-group="apidocs"},
+    {include-group="clang_format"},
+    {include-group="config_generator"},
+    # {include-group="make_release"},
+]
 
-    # etc/make_release.py (requires python<3.12)
-    "click>=6.0",
-    "gitpython>=3.1",
-    "jira>=3.1",
-    "looseversion>=1.3",
-    "pygithub>=2.0",
-
+apidocs = [
     # etc/patch-apidocs-current-redirects.py
     "packaging>=14.0",
 
     # etc/patch-apidocs-index-pages.py
     "beautifulsoup4>=4.12",
     "packaging>=14.0",
+]
 
+clang_format = [
     # etc/clang-format-all.sh
     "clang-format~=19.1",
+]
+
+config_generator = [
+    # .evergreen/config_generator/generate.py
+    "packaging>=14.0",
+    "pydantic>=2.7",
+    "shrub-py>=3.6.0",
+]
+
+make_release = [
+    # etc/make_release.py (requires python<3.12)
+    "click>=6.0",
+    "gitpython>=3.1",
+    "jira>=3.1",
+    "looseversion>=1.3",
+    "pygithub>=2.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -293,7 +293,6 @@ config-generator = [
     { name = "shrub-py" },
 ]
 dev = [
-    { name = "beautifulsoup4" },
     { name = "clang-format" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -321,7 +320,6 @@ config-generator = [
     { name = "shrub-py", specifier = ">=3.6" },
 ]
 dev = [
-    { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "clang-format", specifier = "~=19.1" },
     { name = "packaging", specifier = ">=14.0" },
     { name = "pydantic", specifier = ">=2.8" },

--- a/uv.lock
+++ b/uv.lock
@@ -317,22 +317,22 @@ apidocs = [
 clang-format = [{ name = "clang-format", specifier = "~=19.1" }]
 config-generator = [
     { name = "packaging", specifier = ">=14.0" },
-    { name = "pydantic", specifier = ">=2.7" },
-    { name = "shrub-py", specifier = ">=3.6.0" },
+    { name = "pydantic", specifier = ">=2.8" },
+    { name = "shrub-py", specifier = ">=3.6" },
 ]
 dev = [
     { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "clang-format", specifier = "~=19.1" },
     { name = "packaging", specifier = ">=14.0" },
-    { name = "pydantic", specifier = ">=2.7" },
-    { name = "shrub-py", specifier = ">=3.6.0" },
+    { name = "pydantic", specifier = ">=2.8" },
+    { name = "shrub-py", specifier = ">=3.6" },
 ]
 make-release = [
     { name = "click", specifier = ">=6.0" },
     { name = "gitpython", specifier = ">=3.1" },
     { name = "jira", specifier = ">=3.1" },
     { name = "looseversion", specifier = ">=1.3" },
-    { name = "pygithub", specifier = ">=2.0" },
+    { name = "pygithub", specifier = ">=2.1" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -279,34 +279,60 @@ name = "mongo-cxx-driver"
 version = "0.1.0"
 source = { virtual = "." }
 
-[package.dependency-groups]
+[package.dev-dependencies]
+apidocs = [
+    { name = "beautifulsoup4" },
+    { name = "packaging" },
+]
+clang-format = [
+    { name = "clang-format" },
+]
+config-generator = [
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "shrub-py" },
+]
 dev = [
     { name = "beautifulsoup4" },
     { name = "clang-format" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "shrub-py" },
+]
+make-release = [
     { name = "click" },
     { name = "gitpython" },
     { name = "jira" },
     { name = "looseversion" },
-    { name = "packaging" },
-    { name = "pydantic" },
     { name = "pygithub" },
-    { name = "shrub-py" },
 ]
 
 [package.metadata]
 
-[package.metadata.dependency-groups]
+[package.metadata.requires-dev]
+apidocs = [
+    { name = "beautifulsoup4", specifier = ">=4.12" },
+    { name = "packaging", specifier = ">=14.0" },
+]
+clang-format = [{ name = "clang-format", specifier = "~=19.1" }]
+config-generator = [
+    { name = "packaging", specifier = ">=14.0" },
+    { name = "pydantic", specifier = ">=2.7" },
+    { name = "shrub-py", specifier = ">=3.6.0" },
+]
 dev = [
     { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "clang-format", specifier = "~=19.1" },
+    { name = "packaging", specifier = ">=14.0" },
+    { name = "pydantic", specifier = ">=2.7" },
+    { name = "shrub-py", specifier = ">=3.6.0" },
+]
+make-release = [
     { name = "click", specifier = ">=6.0" },
     { name = "gitpython", specifier = ">=3.1" },
     { name = "jira", specifier = ">=3.1" },
     { name = "looseversion", specifier = ">=1.3" },
-    { name = "packaging", specifier = ">=14.0" },
-    { name = "pydantic", specifier = ">=2.7" },
     { name = "pygithub", specifier = ">=2.0" },
-    { name = "shrub-py", specifier = ">=3.6.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Addresses [task failures](https://spruce.mongodb.com/version/mongo_cxx_driver_dcc49bb7953b9b6a0ce756ca84972d988277c107/tasks) on PowerPC and zSeries distros due to [failure](https://parsley.mongodb.com/evergreen/mongo_cxx_driver_compile_only_matrix_compile_only_rhel83_zseries_release_shared_dcc49bb7953b9b6a0ce756ca84972d988277c107_25_01_07_16_26_39/0/task?bookmarks=0,107&shareLine=66) to build the `cryptography` package (43.0.3) despite no notable updates to Rust toolchain dependencies in uv release notes since 0.5.9. Attempts to limit or pin the cryptography package version failed. Therefore, this PR proposes using [dependency groups](https://docs.astral.sh/uv/concepts/projects/dependencies/#dependency-groups) to by-default exclude packages required by the `make_release.py` script which require the `cryptography` package. Verified by [this patch](https://spruce.mongodb.com/version/677d88473b8c4a00075a8c14).

> [!NOTE]
> `uv` installs the `dev` package by default (e.g. during a plain `uv run` command). We only use `dev` because we do not publish this project as a Python package itself (solely for development purposes). Therefore, `include-group` is used to add installed-by-default dev packages (config generation, formatting, and API documentation patching) with far less demanding dependency requirements. This list can be tweaked as necessary going forward.

> [!NOTE]
> The current dependency tree looks as follows (including `make_release`) per `uv tree --frozen`:
> ```
> mongo-cxx-driver v0.1.0
> ├── beautifulsoup4 v4.12.3 (group: apidocs)
> │   └── soupsieve v2.6
> ├── packaging v24.2 (group: apidocs)
> ├── clang-format v19.1.5 (group: dev)
> ├── packaging v24.2 (group: dev)
> ├── pydantic v2.9.2 (group: dev)
> │   ├── annotated-types v0.7.0
> │   ├── pydantic-core v2.23.4
> │   │   └── typing-extensions v4.12.2
> │   └── typing-extensions v4.12.2
> ├── shrub-py v3.6.0 (group: dev)
> │   ├── croniter v1.4.1
> │   │   └── python-dateutil v2.9.0.post0
> │   │       └── six v1.16.0
> │   ├── pydantic v2.9.2 (*)
> │   ├── pyyaml v6.0.2
> │   └── typing-extensions v4.12.2
> ├── click v8.1.7 (group: make-release)
> ├── gitpython v3.1.43 (group: make-release)
> │   └── gitdb v4.0.11
> │       └── smmap v5.0.1
> ├── jira v3.8.0 (group: make-release)
> │   ├── defusedxml v0.7.1
> │   ├── packaging v24.2
> │   ├── pillow v11.0.0
> │   ├── requests v2.32.3
> │   │   ├── certifi v2024.8.30
> │   │   ├── charset-normalizer v3.4.0
> │   │   ├── idna v3.10
> │   │   └── urllib3 v2.2.3
> │   ├── requests-oauthlib v2.0.0
> │   │   ├── oauthlib v3.2.2
> │   │   └── requests v2.32.3 (*)
> │   ├── requests-toolbelt v1.0.0
> │   │   └── requests v2.32.3 (*)
> │   └── typing-extensions v4.12.2
> ├── looseversion v1.3.0 (group: make-release)
> └── pygithub v2.5.0 (group: make-release)
>     ├── deprecated v1.2.15
>     │   └── wrapt v1.16.0
>     ├── pyjwt[crypto] v2.10.0
>     │   └── cryptography v43.0.3 (extra: crypto)
>     │       └── cffi v1.17.1
>     │           └── pycparser v2.22
>     ├── pynacl v1.5.0
>     │   └── cffi v1.17.1 (*)
>     ├── requests v2.32.3 (*)
>     ├── typing-extensions v4.12.2
>     └── urllib3 v2.2.3
> (*) Package tree already displayed
> ```