### PR TITLE
add trailing `.sh` to instruction

### DIFF
--- a/etc/clang-format-all.sh
+++ b/etc/clang-format-all.sh
@@ -3,7 +3,7 @@
 # clang-format-all.sh
 #
 # Usage:
-#   uv run --frozen etc/clang-format-all
+#   uv run --frozen etc/clang-format-all.sh
 #
 # This script is meant to be run from the project root directory.
 


### PR DESCRIPTION
To fix instruction to run format script with `uv`:

```bash
% uv run --frozen etc/clang-format-all
error: Failed to spawn: `etc/clang-format-all`
  Caused by: No such file or directory (os error 2)
% uv run --frozen etc/clang-format-all.sh
clang-format version 19.1.5
[...]
```
