### PR TITLE
Manually invoke python3 on windows-64-vs2015

### DIFF
--- a/.evergreen/config_generator/components/compile_only.py
+++ b/.evergreen/config_generator/components/compile_only.py
@@ -70,7 +70,10 @@ def generate_tasks():
                     commands=[
                         Setup.call(),
                         FetchCDriverSource.call(),
-                        InstallUV.call(),
+                    ] + (
+                        # DEVPROD-13875 + astral-sh/uv/issues/10231.
+                        [] if "vs2015" in distro_name else [InstallUV.call()]
+                    ) + [
                         Compile.call(
                             build_type=build_type,
                             compiler=compiler,

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -238,7 +238,6 @@ tasks:
     commands:
       - func: setup
       - func: fetch_c_driver_source
-      - func: install-uv
       - func: compile
         vars:
           build_type: Debug
@@ -250,7 +249,6 @@ tasks:
     commands:
       - func: setup
       - func: fetch_c_driver_source
-      - func: install-uv
       - func: compile
         vars:
           build_type: Release

--- a/.evergreen/scripts/compile.sh
+++ b/.evergreen/scripts/compile.sh
@@ -83,9 +83,9 @@ esac
 
 # Create a VERSION_CURRENT file in the build directory to include in the dist tarball.
 if [[ "${distro_id:?}" == windows-64-vs2015* ]]; then
-  # DEVPROD-13875: Python 3.8+ is not available on this distro.
-  # Astral UV is not able to run properly on this OS+platform either.
-  # Manually fallback to Python 3.8 instead.
+  # DEVPROD-13875: Python 3.9 and newer is not available on this distro.
+  # astral-sh/uv/issues/10231: Astral UV is not able to run properly on this OS+platform either.
+  # Manually use the Python 3.8 binary instead.
   PATH="C:/python/Python38:${PATH:-}" python.exe ./etc/calc_release_version.py >./build/VERSION_CURRENT
 else
   PATH="${UV_INSTALL_DIR:?}:${PATH:-}" uv run --frozen python ./etc/calc_release_version.py >./build/VERSION_CURRENT


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1312.

Due to [DEVPROD-13875](https://jira.mongodb.org/browse/DEVPROD-13875), this PR proposes we resort to using a manual workaround for the C++ Driver instead until we drop VS 2015 coverage. The Python 3.8 binary which was being used prior to https://github.com/mongodb-labs/drivers-evergreen-tools/pull/567 is now manually invoked only on the `windows-64-vs2015` distro which requires it.