### PR TITLE
CXX-2745 Add advanced CMake options to toggle root namespace redeclarations

### DIFF
--- a/cmake/BsoncxxUtil.cmake
+++ b/cmake/BsoncxxUtil.cmake
@@ -117,6 +117,10 @@ function(bsoncxx_add_library TARGET OUTPUT_NAME LINK_TYPE)
         DEFINE_SYMBOL BSONCXX_EXPORT
     )
 
+    if(BSONCXX_API_OVERRIDE_DEFAULT_ABI)
+        target_compile_definitions(${TARGET} PUBLIC BSONCXX_API_OVERRIDE_DEFAULT_ABI)
+    endif()
+
     if(ENABLE_ABI_TAG_IN_LIBRARY_FILENAMES)
         set_target_properties(${TARGET} PROPERTIES OUTPUT_NAME ${OUTPUT_NAME}${abi_tag})
     else()

--- a/cmake/MongocxxUtil.cmake
+++ b/cmake/MongocxxUtil.cmake
@@ -79,6 +79,10 @@ function(mongocxx_add_library TARGET OUTPUT_NAME LINK_TYPE)
         DEFINE_SYMBOL MONGOCXX_EXPORTS
     )
 
+    if(MONGOCXX_API_OVERRIDE_DEFAULT_ABI)
+        target_compile_definitions(${TARGET} PUBLIC MONGOCXX_API_OVERRIDE_DEFAULT_ABI)
+    endif()
+
     if(ENABLE_ABI_TAG_IN_LIBRARY_FILENAMES)
         set_target_properties(${TARGET} PROPERTIES OUTPUT_NAME ${OUTPUT_NAME}${abi_tag})
     else()

--- a/src/bsoncxx/CMakeLists.txt
+++ b/src/bsoncxx/CMakeLists.txt
@@ -23,6 +23,12 @@ message(STATUS "bsoncxx version: ${BSONCXX_VERSION}")
 option(BSONCXX_POLY_USE_IMPLS "Use bsoncxx implementations for stdx polyfills" OFF)
 option(BSONCXX_POLY_USE_STD "Use C++17 std library for stdx polyfills" OFF)
 
+option(BSONCXX_API_OVERRIDE_DEFAULT_ABI "The default ABI namespace to use for root namespace redeclarations" OFF)
+mark_as_advanced(BSONCXX_API_OVERRIDE_DEFAULT_ABI)
+if(BSONCXX_API_OVERRIDE_DEFAULT_ABI)
+    message(WARNING "BSONCXX_API_OVERRIDE_DEFAULT_ABI is an experimental feature")
+endif()
+
 set(BSONCXX_OUTPUT_BASENAME "bsoncxx" CACHE STRING "Output bsoncxx library base name")
 
 # Count how many polyfill options are true-ish

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/optional.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/optional.hpp
@@ -34,12 +34,25 @@ using v1::stdx::optional;
 namespace bsoncxx {
 namespace stdx {
 
+#if defined(BSONCXX_API_OVERRIDE_DEFAULT_ABI)
+
+using v1::stdx::in_place;
+using v1::stdx::in_place_t;
+using v1::stdx::make_optional;
+using v1::stdx::nullopt;
+using v1::stdx::nullopt_t;
+using v1::stdx::optional;
+
+#else
+
 using v_noabi::stdx::in_place;
 using v_noabi::stdx::in_place_t;
 using v_noabi::stdx::make_optional;
 using v_noabi::stdx::nullopt;
 using v_noabi::stdx::nullopt_t;
 using v_noabi::stdx::optional;
+
+#endif // defined(BSONCXX_API_OVERRIDE_DEFAULT_ABI)
 
 } // namespace stdx
 } // namespace bsoncxx

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/string_view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/string_view.hpp
@@ -30,8 +30,17 @@ using v1::stdx::string_view;
 namespace bsoncxx {
 namespace stdx {
 
+#if defined(BSONCXX_API_OVERRIDE_DEFAULT_ABI)
+
+using v1::stdx::basic_string_view;
+using v1::stdx::string_view;
+
+#else
+
 using v_noabi::stdx::basic_string_view;
 using v_noabi::stdx::string_view;
+
+#endif // defined(BSONCXX_API_OVERRIDE_DEFAULT_ABI)
 
 } // namespace stdx
 } // namespace bsoncxx

--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -24,7 +24,7 @@ option(MONGOCXX_ENABLE_SSL "Enable SSL - if the underlying C driver offers it" O
 option(MONGOCXX_ENABLE_SLOW_TESTS "Run slow tests when invoking the the test target" OFF)
 
 option(MONGOCXX_API_OVERRIDE_DEFAULT_ABI "The default ABI namespace to use for root namespace redeclarations" OFF)
-mark_as_advanced(BSONCXX_API_OVERRIDE_DEFAULT_ABI)
+mark_as_advanced(MONGOCXX_API_OVERRIDE_DEFAULT_ABI)
 if(MONGOCXX_API_OVERRIDE_DEFAULT_ABI)
     message(WARNING "MONGOCXX_API_OVERRIDE_DEFAULT_ABI is an experimental feature")
 endif ()

--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -23,6 +23,12 @@ message(STATUS "mongocxx version: ${MONGOCXX_VERSION}")
 option(MONGOCXX_ENABLE_SSL "Enable SSL - if the underlying C driver offers it" ON)
 option(MONGOCXX_ENABLE_SLOW_TESTS "Run slow tests when invoking the the test target" OFF)
 
+option(MONGOCXX_API_OVERRIDE_DEFAULT_ABI "The default ABI namespace to use for root namespace redeclarations" OFF)
+mark_as_advanced(BSONCXX_API_OVERRIDE_DEFAULT_ABI)
+if(MONGOCXX_API_OVERRIDE_DEFAULT_ABI)
+    message(WARNING "MONGOCXX_API_OVERRIDE_DEFAULT_ABI is an experimental feature")
+endif ()
+
 set(MONGOCXX_OUTPUT_BASENAME "mongocxx" CACHE STRING "Output mongocxx library base name")
 
 set(MONGOCXX_PKG_DEP "") # Required by mongocxx-config.cmake.in.


### PR DESCRIPTION
An intermediate PR related to CXX-2745 following https://github.com/mongodb/mongo-cxx-driver/pull/1318.

Add advanced, for-development-only CMake options `BSONCXX_API_OVERRIDE_DEFAULT_ABI` and `MONGOCXX_API_OVERRIDE_DEFAULT_ABI` to permit toggling the ABI namespace that is used by root namespace redeclarations.

> [!IMPORTANT]
> These options are NOT intended for public use. This is strictly for development purposes. Enabling these options will emit CMake configuration warnings:
> ```
> CMake Warning at src/bsoncxx/CMakeLists.txt:29 (message):
>   BSONCXX_API_OVERRIDE_DEFAULT_ABI is an experimental feature
> CMake Warning at src/mongocxx/CMakeLists.txt:29 (message):
>   MONGOCXX_API_OVERRIDE_DEFAULT_ABI is an experimental feature
> ```
> The options are also marked as "advanced" so they do not show up in CMake GUIs by default.

When enabled, relevant root namespace redeclarations will use `v1` interfaces instead of `v_noabi` interfaces, e.g.:

```cpp
#if defined(BSONCXX_API_OVERRIDE_DEFAULT_ABI)
using v1::document::view; // New v1 equivalent or successor API.
#else
using v_noabi::document::view; // Current v_noabi API.
#endif
```

This permits manually verifying compilation and runtime compatibility of `v1` interfaces via root namespace redeclarations against existing code (e.g. `bsoncxx::document::view (bsoncxx::v1::document::view)`). This toggle will continue to be used throughout upcoming PRs to both document and control the set of v1 interfaces which are "ready for use". These options may be toggled individually for each library (although mongocxx should be only be enabled when bsoncxx is also enabled).

At the moment, this PR only applies this option to `stdx::string_view` and `stdx::optional<T>`. These are the only v1 interfaces which are currently "ready for use". This can be validated right now by building and running the C++ Driver with the `BSONCXX_API_OVERRIDE_DEFAULT_ABI` option enabled.

As more `v1` interfaces are introduced and `v_noabi` interfaces updated to support forward-compatibility with `v1` interfaces, the application of this configuration option will be incrementally extended to allow for reuse of existing (test) code for API and behavioral testing of `v1` interfaces. This macro may also be used to denote v_noabi interfaces which do _not_ have direct v1 counterparts (no corresponding `v1` redeclarations), e.g.:

```cpp
#if defined(BSONCXX_API_OVERRIDE_DEFAULT_ABI)
// No v1 API equivalent or successor.
#else
using v_noabi::builder::stream::document; // Current v_noabi API.
#endif
```

Conversely, new v1 interfaces, or those which substantially differ from their v_noabi equivalents, may introduce new redeclarations without v_noabi counterparts (reverse of the above).

Once v1 interfaces are sufficiently ready for use, this pattern will also permit users to opt-into using `v1` interfaces early and migrate from `v_noabi` to `v1`. This may be done either with a different CMake option designed to target user configuration rather than internal development, or by converting this CMake option from advanced, for-development-only into a user-facing CMake option.