### PR TITLE
Re-exclude rhel79 from compile-only matrix in patch builds

### DIFF
--- a/.evergreen/config_generator/components/compile_only.py
+++ b/.evergreen/config_generator/components/compile_only.py
@@ -61,7 +61,10 @@ def generate_tasks():
             if any(pattern in distro_name for pattern in ['power8', 'zseries']):
                 patchable = False
 
-            # etc/calc_release_version.py: error: unknown option `--format=...'
+            # In etc/calc_release_version.py:
+            #   error: unknown option `format=...'
+            #   usage: git tag ...
+            #      or: ...
             if distro_name == 'rhel79':
                 patchable = False
 

--- a/.evergreen/config_generator/components/compile_only.py
+++ b/.evergreen/config_generator/components/compile_only.py
@@ -61,6 +61,10 @@ def generate_tasks():
             if any(pattern in distro_name for pattern in ['power8', 'zseries']):
                 patchable = False
 
+            # etc/calc_release_version.py: error: unknown option `--format=...'
+            if distro_name == 'rhel79':
+                patchable = False
+
             res.append(
                 EvgTask(
                     name=name,

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -168,6 +168,7 @@ tasks:
   - name: compile-only-rhel79-release-shared-impls
     run_on: rhel79-large
     tags: [compile-only, rhel79, release, shared, impls]
+    patchable: false
     commands:
       - func: setup
       - func: fetch_c_driver_source


### PR DESCRIPTION
https://github.com/mongodb/mongo-cxx-driver/pull/1313/ incorrectly reverted a patch-only workaround introduced in https://github.com/mongodb/mongo-cxx-driver/pull/1313, which unintentionally reintroduced `compile-only-rhel79-release-shared-impls` task failure in GitHub PR patch builds.