### PR TITLE
Miscellaneous improvements to API examples runner

### DIFF
--- a/examples/api/runner.cpp
+++ b/examples/api/runner.cpp
@@ -482,7 +482,11 @@ void runner_register_forking_component(void (*fn)(), char const* name) {
     runner.add_forking_component(fn, name);
 }
 
-int EXAMPLES_CDECL main(int argc, char** argv) {
+int EXAMPLES_CDECL main(int argc, char** argv)
+#if defined(_MSC_VER)
+    try
+#endif
+{
     bool set_seed = false;
     bool set_jobs = false;
     bool set_use_fork = false;
@@ -534,3 +538,12 @@ int EXAMPLES_CDECL main(int argc, char** argv) {
 
     return runner.run(); // Return directly from forked processes.
 }
+#if defined(_MSC_VER)
+catch (std::exception const& ex) {
+    std::cerr << "API runner failed due to uncaught exception: " << ex.what() << std::endl;
+    return EXIT_FAILURE;
+} catch (...) {
+    std::cerr << "API runner failed due to an uncaught exception" << std::endl;
+    return EXIT_FAILURE;
+}
+#endif

--- a/examples/api/runner.cpp
+++ b/examples/api/runner.cpp
@@ -539,6 +539,7 @@ int EXAMPLES_CDECL main(int argc, char** argv)
     return runner.run(); // Return directly from forked processes.
 }
 #if defined(_MSC_VER)
+// Avoid popup dialog boxes or completely-absent CLI error messages on Windows.
 catch (std::exception const& ex) {
     std::cerr << "API runner failed due to uncaught exception: " << ex.what() << std::endl;
     return EXIT_FAILURE;


### PR DESCRIPTION
Preemptive changes to improve task failure output observed during work on CXX-2665.

Adds try-catch blocks when build with MSVC to improve the uncaught exceptions experience on Windows: uncaught exceptions are printed to stderr rather than a popup dialog box (local execution) or completely-absent program termination message (in CI).

Additionally, the try-catch block used for live server detection may incorrectly catch mongocxx exceptions thrown by a live server component, which would misleadingly emit both the "failed: uncaught exception" message _and_ the "Skipping API examples that require a live server" message, subsequently failing to terminate with `EXIT_FAILURE` as it should.