### PR TITLE
Attempt to address miscellaneous integration task errors on macos-14-arm64

### DIFF
--- a/.evergreen/scripts/install-c-driver.sh
+++ b/.evergreen/scripts/install-c-driver.sh
@@ -44,7 +44,7 @@ else
   # RegEx pattern to match SemVer strings. See https://semver.org/.
   declare -r semver_regex="^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
   if echo "${mongoc_version}" | perl -ne "$(printf 'exit 1 unless /%s/' "${semver_regex}")"; then
-    # If $VERSION is already SemVer compliant, use as-is.
+    # If $mongoc_version is already SemVer compliant, use as-is.
     echo "${mongoc_version}" >|"${mongoc_dir}/VERSION_CURRENT"
   else
     # Otherwise, use the tag name of the latest release to construct a prerelease version string.

--- a/.evergreen/scripts/install-c-driver.sh
+++ b/.evergreen/scripts/install-c-driver.sh
@@ -38,29 +38,36 @@ curl -sS -o mongo-c-driver.tar.gz -L "https://api.github.com/repos/mongodb/mongo
 tar xzf mongo-c-driver.tar.gz --directory "${mongoc_dir}" --strip-components=1
 
 # C Driver needs VERSION_CURRENT to compute BUILD_VERSION.
-# RegEx pattern to match SemVer strings. See https://semver.org/.
-declare -r semver_regex="^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
-if echo "${mongoc_version}" | perl -ne "$(printf 'exit 1 unless /%s/' "${semver_regex}")"; then
-  # If $VERSION is already SemVer compliant, use as-is.
-  echo "${mongoc_version}" >|"${mongoc_dir}/VERSION_CURRENT"
+if [[ -f "${mongoc_dir}/VERSION_CURRENT" ]]; then
+  : # Use the existing VERSION_CURRENT bundled with the release tarball.
 else
-  # Otherwise, use the tag name of the latest release to construct a prerelease version string.
+  # RegEx pattern to match SemVer strings. See https://semver.org/.
+  declare -r semver_regex="^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+  if echo "${mongoc_version}" | perl -ne "$(printf 'exit 1 unless /%s/' "${semver_regex}")"; then
+    # If $VERSION is already SemVer compliant, use as-is.
+    echo "${mongoc_version}" >|"${mongoc_dir}/VERSION_CURRENT"
+  else
+    # Otherwise, use the tag name of the latest release to construct a prerelease version string.
 
-  # Extract "tag_name" from latest Github release.
-  declare build_version
-  build_version=$(curl -sS -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/mongodb/mongo-c-driver/releases/latest | perl -ne 'print for /"tag_name": "(.+)"/')
+    # Extract "tag_name" from latest Github release.
+    declare build_version
+    build_version="$(curl -sS -H "Accept: application/vnd.github+json" https://api.github.com/repos/mongodb/mongo-c-driver/releases/latest | perl -ne 'print for /"tag_name": "(.+)"/')"
 
-  # Assert the tag name is a SemVer string via errexit.
-  echo "${build_version}" | perl -ne "$(printf 'exit 1 unless /%s/' "${semver_regex}")"
+    # Assert the tag name is a SemVer string via errexit.
+    echo "${build_version}" | perl -ne "exit 1 unless /${semver_regex}/" || {
+      echo "could not obtain a build version from the tag name of the latest release" 1>&2
+      exit 1
+    }
 
-  # Bump to the next minor version, e.g. 1.0.1 -> 1.1.0.
-  build_version="$(echo "${build_version}" | perl -ne "$(printf '/%s/; print $+{major} . "." . ($+{minor}+1) . ".0"' "${semver_regex}")")"
+    # Bump to the next minor version, e.g. 1.0.1 -> 1.1.0.
+    build_version="$(echo "${build_version}" | perl -ne "$(printf '/%s/; print $+{major} . "." . ($+{minor}+1) . ".0"' "${semver_regex}")")"
 
-  # Append a prerelease tag, e.g. 1.1.0-pre+<version>.
-  build_version="$(printf "%s-pre+%s" "${build_version}" "${mongoc_version}")"
+    # Append a prerelease tag, e.g. 1.1.0-pre+<version>.
+    build_version="$(printf "%s-pre+%s" "${build_version}" "${mongoc_version}")"
 
-  # Use the constructed prerelease build version when building the C driver.
-  echo "${build_version}" >|"${mongoc_dir}/VERSION_CURRENT"
+    # Use the constructed prerelease build version when building the C driver.
+    echo "${build_version}" >|"${mongoc_dir}/VERSION_CURRENT"
+  fi
 fi
 
 # shellcheck source=/dev/null

--- a/.evergreen/scripts/start-mongod.sh
+++ b/.evergreen/scripts/start-mongod.sh
@@ -35,6 +35,9 @@ export PATH="${MONGODB_BINARIES:?}:${PATH:-}"
 echo "{ \"releases\": { \"default\": \"${MONGODB_BINARIES:?}\" }}" >"${MONGO_ORCHESTRATION_HOME:?}/orchestration.config"
 ./.evergreen/run-orchestration.sh
 
+# MacOS needs some assistance to ensure executable permissions(?).
+chmod +x ${MONGODB_BINARIES:?}/*
+
 declare mongosh_binary
 if command -v mongosh >/dev/null; then
   mongosh_binary="mongosh"
@@ -45,6 +48,7 @@ else
   exit 1
 fi
 : "${mongosh_binary:?}"
+"${mongosh_binary:?}" --version
 
 # Ensure server on port 27017 is the primary server.
 if [[ "${TOPOLOGY:-}" == replica_set ]]; then

--- a/.evergreen/scripts/start-mongod.sh
+++ b/.evergreen/scripts/start-mongod.sh
@@ -16,12 +16,6 @@ if [ ! -d "drivers-evergreen-tools" ]; then
 fi
 cd drivers-evergreen-tools
 
-# The legacy shell is only present in server 5.0 builds and earlier,
-# but there is no 5.0 build for RHEL9, so we have to avoid it
-if [[ "${build_variant}" =~ "rhel9" ]]; then
-  export SKIP_LEGACY_SHELL=1
-fi
-
 DRIVERS_TOOLS="$(pwd)"
 if [ "Windows_NT" == "$OS" ]; then
   DRIVERS_TOOLS="$(cygpath -m "${DRIVERS_TOOLS:?}")"
@@ -40,6 +34,17 @@ export PATH="${MONGODB_BINARIES:?}:${PATH:-}"
 
 echo "{ \"releases\": { \"default\": \"${MONGODB_BINARIES:?}\" }}" >"${MONGO_ORCHESTRATION_HOME:?}/orchestration.config"
 ./.evergreen/run-orchestration.sh
+
+declare mongosh_binary
+if command -v mongosh >/dev/null; then
+  mongosh_binary="mongosh"
+elif command -v mongo >/dev/null; then
+  mongosh_binary="mongo"
+else
+  echo "could not find a MongoDB Shell binary to use" 1>&2
+  exit 1
+fi
+: "${mongosh_binary:?}"
 
 # Ensure server on port 27017 is the primary server.
 if [[ "${TOPOLOGY:-}" == replica_set ]]; then
@@ -63,13 +68,12 @@ if [[ "${TOPOLOGY:-}" == replica_set ]]; then
     "let c = rs.conf()" \
     "c.members.find((m) => m.host.includes('27017')).priority = 10" \
     "rs.reconfig(c)"
-
-  mongosh --quiet "${uri:?}" --eval "${script:?}"
+  "${mongosh_binary:?}" --quiet "${uri:?}" --eval "${script:?}"
 
   # Wait up to a minute for member on port 27017 to become primary.
   wait_for_primary() {
     for _ in $(seq 60); do
-      if mongosh --quiet "${uri:?}" --eval "quit(rs.hello().primary.includes('27017') ? 0 : 1)"; then
+      if "${mongosh_binary:?}" --quiet "${uri:?}" --eval "quit(rs.hello().primary.includes('27017') ? 0 : 1)"; then
         return 0
       else
         sleep 1

--- a/examples/mongocxx/gridfs.cpp
+++ b/examples/mongocxx/gridfs.cpp
@@ -63,7 +63,7 @@ int EXAMPLES_CDECL main() {
     auto buffer_size = std::min(file_length, static_cast<std::int64_t>(downloader.chunk_size()));
 
     // Use `std::make_unique` with C++14 and newer.
-    auto buffer = std::unique_ptr<std::uint8_t[]>(new std::uint8_t[buffer_size]);
+    auto buffer = std::unique_ptr<std::uint8_t[]>(new std::uint8_t[static_cast<std::size_t>(buffer_size)]);
 
     while (auto length_read = downloader.read(buffer.get(), static_cast<std::size_t>(buffer_size))) {
         bytes_counter += static_cast<std::int32_t>(length_read);


### PR DESCRIPTION
Preemptive changes to address macos-14-arm64 task failures observed during work on CXX-2665.

- The curl command to obtain the tag name of the latest release seems to spuriously fail due to unknown reasons specifically when executed on MacOS distros. Following https://github.com/mongodb/mongo-c-driver/pull/1521, a `VERSION_CURRENT` file is guaranteed for latest releases, so that file is detected and used instead when available.

- The `start-mongod.sh` script occasionally fails on MacOS distros due to permission errors. A call to `chmod -x` is added to ensure binaries under `MONGODB_BINARIES` are actually executable as they should be. An obsolete workaround for rhel9 distros is removed in favor of a simple fallback routine for legacy mongo shell binaries.

- A `-Wsign-conversion` warning blocks compilation of examples on MacOS distros when maintainer flags are enabled. The warning is addressed by an explicit cast to `std::size_t` from `std::int64_t`.