### PR TITLE
ccache: expand usage and /Zi -> /Z7 for MSVC debug flags

### DIFF
--- a/.evergreen/scripts/compile-scan-build.sh
+++ b/.evergreen/scripts/compile-scan-build.sh
@@ -14,6 +14,13 @@ export cmake_binary
 cmake_binary="$(find_cmake_latest)"
 command -v "$cmake_binary"
 
+# Use ccache if available.
+if [[ -f "../mongoc/.evergreen/scripts/find-ccache.sh" ]]; then
+  # shellcheck source=/dev/null
+  . "../mongoc/.evergreen/scripts/find-ccache.sh"
+  find_ccache_and_export_vars "$(pwd)" || true
+fi
+
 # scan-build binary is available in different locations depending on the distro.
 # Search for a match in order of preference as listed.
 declare -a scan_build_directories

--- a/.evergreen/scripts/compile.sh
+++ b/.evergreen/scripts/compile.sh
@@ -144,6 +144,12 @@ cxx_flags=()
 case "${OSTYPE:?}" in
 cygwin)
   # Most compiler flags are not applicable to builds on Windows distros.
+
+  # Replace `/Zi`, which is incompatible with ccache, with `/Z7` while preserving other default debug flags.
+  cmake_flags+=(
+    "-DCMAKE_POLICY_DEFAULT_CMP0141=NEW"
+    "-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded"
+  )
   ;;
 darwin*)
   cc_flags+=("${cc_flags_init[@]}")

--- a/.evergreen/scripts/install-c-driver.sh
+++ b/.evergreen/scripts/install-c-driver.sh
@@ -122,6 +122,12 @@ declare -a compile_flags
 case "${OSTYPE:?}" in
 cygwin)
   compile_flags+=("/maxcpucount:$(nproc)")
+
+  # Replace `/Zi`, which is incompatible with ccache, with `/Z7` while preserving other default debug flags.
+  cmake_flags+=(
+    "-DCMAKE_POLICY_DEFAULT_CMP0141=NEW"
+    "-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded"
+  )
   ;;
 darwin*)
   configure_flags+=("-DCMAKE_C_FLAGS=-fPIC")

--- a/.evergreen/scripts/test.sh
+++ b/.evergreen/scripts/test.sh
@@ -343,11 +343,11 @@ export PKG_CONFIG_PATH
 export CMAKE_GENERATOR="${generator:-}"
 export CMAKE_GENERATOR_PLATFORM="${platform:-}"
 export BUILD_TYPE="${build_type:?}"
-export CXXFLAGS="${example_projects_cxxflags}"
-export LDFLAGS="${example_projects_ldflags}"
-export CC="${example_projects_cc}"
-export CXX="${example_projects_cxx}"
-export CXX_STANDARD="${example_projects_cxx_standard}"
+export CXXFLAGS="${example_projects_cxxflags:-}"
+export LDFLAGS="${example_projects_ldflags:-}"
+export CC="${example_projects_cc:-"cc"}"
+export CXX="${example_projects_cxx:-"c++"}"
+export CXX_STANDARD="${example_projects_cxx_standard:-11}"
 
 if [[ "$OSTYPE" =~ cygwin ]]; then
   export MSVC=1

--- a/.evergreen/scripts/test.sh
+++ b/.evergreen/scripts/test.sh
@@ -105,6 +105,13 @@ export cmake_binary
 cmake_binary="$(find_cmake_latest)"
 command -v "${cmake_binary:?}"
 
+# Use ccache if available.
+if [[ -f "${mongoc_dir:?}/.evergreen/scripts/find-ccache.sh" ]]; then
+  # shellcheck source=/dev/null
+  . "${mongoc_dir:?}/.evergreen/scripts/find-ccache.sh"
+  find_ccache_and_export_vars "$(pwd)" || true
+fi
+
 export MONGOCXX_TEST_TLS_CA_FILE="${DRIVERS_TOOLS:?}/.evergreen/x509gen/ca.pem"
 
 if [[ "${TEST_WITH_CSFLE:-}" != "ON" ]]; then

--- a/etc/run-clang-tidy.sh
+++ b/etc/run-clang-tidy.sh
@@ -24,6 +24,13 @@ uvx clang-tidy --version
 cmake_binary="$(find_cmake_latest)"
 command -v "${cmake_binary:?}"
 
+# Use ccache if available.
+if [[ -f "../mongoc/.evergreen/scripts/find-ccache.sh" ]]; then
+  # shellcheck source=/dev/null
+  . "../mongoc/.evergreen/scripts/find-ccache.sh"
+  find_ccache_and_export_vars "$(pwd)" || true
+fi
+
 cmake_config_flags=(
   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
   -DCMAKE_BUILD_TYPE=Debug

--- a/examples/projects/bsoncxx/cmake/shared/build.sh
+++ b/examples/projects/bsoncxx/cmake/shared/build.sh
@@ -3,16 +3,12 @@
 set -o errexit
 set -o pipefail
 
-BUILD_TYPE=${BUILD_TYPE:-Release}
-CXX_STANDARD=${CXX_STANDARD:-11}
-CMAKE=${cmake_binary:-cmake}
-
 rm -rf build/*
 cd build
 if [ -z "$MSVC" ]; then
-    "$CMAKE" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
-    "$CMAKE" --build . --target run
+  "${cmake_binary:?}" -DCMAKE_BUILD_TYPE="${build_type:?}" -DCMAKE_CXX_STANDARD="${CXX_STANDARD:?}" ..
+  "${cmake_binary:?}" --build . --target run
 else
-    "$CMAKE" -G "Visual Studio 15 2017" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
-    "$CMAKE" --build . --target run --config "${BUILD_TYPE}" -- /verbosity:minimal
+  "${cmake_binary:?}" -G "Visual Studio 15 2017" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD:?}" ..
+  "${cmake_binary:?}" --build . --target run --config "${build_type:?}" -- /verbosity:minimal
 fi

--- a/examples/projects/bsoncxx/cmake/shared/build.sh
+++ b/examples/projects/bsoncxx/cmake/shared/build.sh
@@ -9,6 +9,6 @@ if [ -z "$MSVC" ]; then
   "${cmake_binary:?}" -DCMAKE_BUILD_TYPE="${build_type:?}" -DCMAKE_CXX_STANDARD="${CXX_STANDARD:?}" ..
   "${cmake_binary:?}" --build . --target run
 else
-  "${cmake_binary:?}" -G "Visual Studio 15 2017" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD:?}" ..
+  "${cmake_binary:?}" -G "Visual Studio 15 2017" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD:?}" -DCMAKE_POLICY_DEFAULT_CMP0141=NEW -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded ..
   "${cmake_binary:?}" --build . --target run --config "${build_type:?}" -- /verbosity:minimal
 fi

--- a/examples/projects/bsoncxx/cmake/static/build.sh
+++ b/examples/projects/bsoncxx/cmake/static/build.sh
@@ -3,16 +3,12 @@
 set -o errexit
 set -o pipefail
 
-BUILD_TYPE=${BUILD_TYPE:-Release}
-CXX_STANDARD=${CXX_STANDARD:-11}
-CMAKE=${cmake_binary:-cmake}
-
 rm -rf build/*
 cd build
 if [ -z "$MSVC" ]; then
-    "$CMAKE" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
-    "$CMAKE" --build . --target run
+  "${cmake_binary:?}" -DCMAKE_BUILD_TYPE="${build_type:?}" -DCMAKE_CXX_STANDARD="${CXX_STANDARD:?}" ..
+  "${cmake_binary:?}" --build . --target run
 else
-    "$CMAKE" -G "Visual Studio 15 2017" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
-    "$CMAKE" --build . --target run --config "${BUILD_TYPE}" -- /verbosity:minimal
+  "${cmake_binary:?}" -G "Visual Studio 15 2017" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD:?}" ..
+  "${cmake_binary:?}" --build . --target run --config "${build_type:?}" -- /verbosity:minimal
 fi

--- a/examples/projects/bsoncxx/cmake/static/build.sh
+++ b/examples/projects/bsoncxx/cmake/static/build.sh
@@ -9,6 +9,6 @@ if [ -z "$MSVC" ]; then
   "${cmake_binary:?}" -DCMAKE_BUILD_TYPE="${build_type:?}" -DCMAKE_CXX_STANDARD="${CXX_STANDARD:?}" ..
   "${cmake_binary:?}" --build . --target run
 else
-  "${cmake_binary:?}" -G "Visual Studio 15 2017" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD:?}" ..
+  "${cmake_binary:?}" -G "Visual Studio 15 2017" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD:?}" -DCMAKE_POLICY_DEFAULT_CMP0141=NEW -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded ..
   "${cmake_binary:?}" --build . --target run --config "${build_type:?}" -- /verbosity:minimal
 fi

--- a/examples/projects/bsoncxx/pkg-config/shared/build.sh
+++ b/examples/projects/bsoncxx/pkg-config/shared/build.sh
@@ -3,16 +3,16 @@
 set -o errexit
 set -o pipefail
 
-CXX=${CXX:-c++}
-CXX_STANDARD=${CXX_STANDARD:-11}
-
 # Sanity-check that static library macros are not set when building against the shared library.
 # Users don't need to include this section in their projects.
-( pkg-config --cflags libbsoncxx | grep -v -- -DBSONCXX_STATIC ) \
-    || ( echo "Expected BSONCXX_STATIC to not be set" >&2; exit 1 )
+(pkg-config --cflags libbsoncxx | grep -v -- -DBSONCXX_STATIC) ||
+  (
+    echo "Expected BSONCXX_STATIC to not be set" >&2
+    exit 1
+  )
 
 rm -rf build/*
 cd build
-$CXX $CXXFLAGS -Wall -Wextra -Werror -std="c++${CXX_STANDARD}" -c -o hello_bsoncxx.o ../../../hello_bsoncxx.cpp $(pkg-config --cflags libbsoncxx)
-$CXX $LDFLAGS -std="c++${CXX_STANDARD}" -o hello_bsoncxx hello_bsoncxx.o $(pkg-config --libs libbsoncxx)
+"${CXX:?}" $CXXFLAGS -Wall -Wextra -Werror -std="c++${CXX_STANDARD:?}" -c -o hello_bsoncxx.o ../../../hello_bsoncxx.cpp $(pkg-config --cflags libbsoncxx)
+"${CXX:?}" $LDFLAGS -std="c++${CXX_STANDARD:?}" -o hello_bsoncxx hello_bsoncxx.o $(pkg-config --libs libbsoncxx)
 ./hello_bsoncxx

--- a/examples/projects/bsoncxx/pkg-config/static/build.sh
+++ b/examples/projects/bsoncxx/pkg-config/static/build.sh
@@ -3,17 +3,17 @@
 set -o errexit
 set -o pipefail
 
-CXX=${CXX:-c++}
-CXX_STANDARD=${CXX_STANDARD:-11}
-
 # Sanity-check that static library macros are set when building against the static library.  Users
 # don't need to include this section in their projects.
-( pkg-config --cflags libbsoncxx-static | grep -- -DBSONCXX_STATIC ) \
-    || ( echo "Expected BSONCXX_STATIC to be set" >&2; exit 1 )
+(pkg-config --cflags libbsoncxx-static | grep -- -DBSONCXX_STATIC) ||
+  (
+    echo "Expected BSONCXX_STATIC to be set" >&2
+    exit 1
+  )
 
 rm -rf build/*
 cd build
-$CXX $CXXFLAGS -Wall -Wextra -Werror -std="c++${CXX_STANDARD}" -c -o hello_bsoncxx.o ../../../hello_bsoncxx.cpp $(pkg-config --cflags libbsoncxx-static)
+"${CXX:?}" $CXXFLAGS -Wall -Wextra -Werror -std="c++${CXX_STANDARD:?}" -c -o hello_bsoncxx.o ../../../hello_bsoncxx.cpp $(pkg-config --cflags libbsoncxx-static)
 # TODO: remove `-pthread` once CDRIVER-4776 is resolved.
-$CXX $LDFLAGS -pthread -std="c++${CXX_STANDARD}" -o hello_bsoncxx hello_bsoncxx.o $(pkg-config --libs libbsoncxx-static)
+"${CXX:?}" $LDFLAGS -pthread -std="c++${CXX_STANDARD:?}" -o hello_bsoncxx hello_bsoncxx.o $(pkg-config --libs libbsoncxx-static)
 ./hello_bsoncxx

--- a/examples/projects/mongocxx/cmake/shared/build.sh
+++ b/examples/projects/mongocxx/cmake/shared/build.sh
@@ -3,16 +3,12 @@
 set -o errexit
 set -o pipefail
 
-BUILD_TYPE=${BUILD_TYPE:-Release}
-CXX_STANDARD=${CXX_STANDARD:-11}
-CMAKE=${cmake_binary:-cmake}
-
 rm -rf build/*
 cd build
 if [ -z "$MSVC" ]; then
-    "$CMAKE" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
-    "$CMAKE" --build . --target run
+  "${cmake_binary:?}" -DCMAKE_BUILD_TYPE="${build_type:?}" -DCMAKE_CXX_STANDARD="${CXX_STANDARD:?}" ..
+  "${cmake_binary:?}" --build . --target run
 else
-    "$CMAKE" -G "Visual Studio 15 2017" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
-    "$CMAKE" --build . --target run --config "${BUILD_TYPE}" -- /verbosity:minimal
+  "${cmake_binary:?}" -G "Visual Studio 15 2017" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD:?}" ..
+  "${cmake_binary:?}" --build . --target run --config "${build_type:?}" -- /verbosity:minimal
 fi

--- a/examples/projects/mongocxx/cmake/shared/build.sh
+++ b/examples/projects/mongocxx/cmake/shared/build.sh
@@ -9,6 +9,6 @@ if [ -z "$MSVC" ]; then
   "${cmake_binary:?}" -DCMAKE_BUILD_TYPE="${build_type:?}" -DCMAKE_CXX_STANDARD="${CXX_STANDARD:?}" ..
   "${cmake_binary:?}" --build . --target run
 else
-  "${cmake_binary:?}" -G "Visual Studio 15 2017" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD:?}" ..
+  "${cmake_binary:?}" -G "Visual Studio 15 2017" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD:?}" -DCMAKE_POLICY_DEFAULT_CMP0141=NEW -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded ..
   "${cmake_binary:?}" --build . --target run --config "${build_type:?}" -- /verbosity:minimal
 fi

--- a/examples/projects/mongocxx/cmake/static/build.sh
+++ b/examples/projects/mongocxx/cmake/static/build.sh
@@ -9,6 +9,6 @@ if [ -z "$MSVC" ]; then
   "${cmake_binary:?}" -DCMAKE_BUILD_TYPE="${build_type}" -DCMAKE_CXX_STANDARD="${CXX_STANDARD:?}" ..
   "${cmake_binary:?}" --build . --target run
 else
-  "${cmake_binary:?}" -G "Visual Studio 15 2017" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD:?}" ..
+  "${cmake_binary:?}" -G "Visual Studio 15 2017" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD:?}" -DCMAKE_POLICY_DEFAULT_CMP0141=NEW -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded ..
   "${cmake_binary:?}" --build . --target run --config "${build_type:?}" -- /verbosity:minimal
 fi

--- a/examples/projects/mongocxx/cmake/static/build.sh
+++ b/examples/projects/mongocxx/cmake/static/build.sh
@@ -3,16 +3,12 @@
 set -o errexit
 set -o pipefail
 
-BUILD_TYPE=${BUILD_TYPE:-Release}
-CXX_STANDARD=${CXX_STANDARD:-11}
-CMAKE=${cmake_binary:-cmake}
-
 rm -rf build/*
 cd build
 if [ -z "$MSVC" ]; then
-    "$CMAKE" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
-    "$CMAKE" --build . --target run
+  "${cmake_binary:?}" -DCMAKE_BUILD_TYPE="${build_type}" -DCMAKE_CXX_STANDARD="${CXX_STANDARD:?}" ..
+  "${cmake_binary:?}" --build . --target run
 else
-    "$CMAKE" -G "Visual Studio 15 2017" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" ..
-    "$CMAKE" --build . --target run --config "${BUILD_TYPE}" -- /verbosity:minimal
+  "${cmake_binary:?}" -G "Visual Studio 15 2017" -A "x64" -DCMAKE_CXX_STANDARD="${CXX_STANDARD:?}" ..
+  "${cmake_binary:?}" --build . --target run --config "${build_type:?}" -- /verbosity:minimal
 fi

--- a/examples/projects/mongocxx/pkg-config/shared/build.sh
+++ b/examples/projects/mongocxx/pkg-config/shared/build.sh
@@ -3,21 +3,24 @@
 set -o errexit
 set -o pipefail
 
-CXX=${CXX:-c++}
-CXX_STANDARD=${CXX_STANDARD:-11}
-
 # Sanity-check that static library macros are not set when building against the shared library.
 # Users don't need to include this section in their projects.
-( pkg-config --cflags libmongocxx | grep -v -- -DBSONCXX_STATIC ) \
-    || ( echo "Expected BSONCXX_STATIC to not be set" >&2; exit 1 )
-( pkg-config --cflags libmongocxx | grep -v -- -DMONGOCXX_STATIC ) \
-    || ( echo "Expected MONGOCXX_STATIC to not be set" >&2; exit 1 )
+(pkg-config --cflags libmongocxx | grep -v -- -DBSONCXX_STATIC) ||
+  (
+    echo "Expected BSONCXX_STATIC to not be set" >&2
+    exit 1
+  )
+(pkg-config --cflags libmongocxx | grep -v -- -DMONGOCXX_STATIC) ||
+  (
+    echo "Expected MONGOCXX_STATIC to not be set" >&2
+    exit 1
+  )
 
 rm -rf build/*
 cd build
 
-$CXX $CXXFLAGS -Wall -Wextra -Werror -std="c++${CXX_STANDARD}" -c -o hello_mongocxx.o ../../../hello_mongocxx.cpp $(pkg-config --cflags libmongocxx)
+"${CXX:?}" $CXXFLAGS -Wall -Wextra -Werror -std="c++${CXX_STANDARD:?}" -c -o hello_mongocxx.o ../../../hello_mongocxx.cpp $(pkg-config --cflags libmongocxx)
 
-$CXX $LDFLAGS -std="c++${CXX_STANDARD}" -o hello_mongocxx hello_mongocxx.o $(pkg-config --libs libmongocxx)
+"${CXX:?}" $LDFLAGS -std="c++${CXX_STANDARD:?}" -o hello_mongocxx hello_mongocxx.o $(pkg-config --libs libmongocxx)
 
 ./hello_mongocxx

--- a/examples/projects/mongocxx/pkg-config/static/build.sh
+++ b/examples/projects/mongocxx/pkg-config/static/build.sh
@@ -3,19 +3,22 @@
 set -o errexit
 set -o pipefail
 
-CXX=${CXX:-c++}
-CXX_STANDARD=${CXX_STANDARD:-11}
-
 # Sanity-check that static library macros are set when building against the static library.  Users
 # don't need to include this section in their projects.
-( pkg-config --cflags libmongocxx-static | grep -- -DBSONCXX_STATIC ) \
-    || ( echo "Expected BSONCXX_STATIC to be set" >&2; exit 1 )
-( pkg-config --cflags libmongocxx-static | grep -- -DMONGOCXX_STATIC ) \
-    || ( echo "Expected MONGOCXX_STATIC to be set" >&2; exit 1 )
+(pkg-config --cflags libmongocxx-static | grep -- -DBSONCXX_STATIC) ||
+  (
+    echo "Expected BSONCXX_STATIC to be set" >&2
+    exit 1
+  )
+(pkg-config --cflags libmongocxx-static | grep -- -DMONGOCXX_STATIC) ||
+  (
+    echo "Expected MONGOCXX_STATIC to be set" >&2
+    exit 1
+  )
 
 rm -rf build/*
 cd build
-$CXX $CXXFLAGS -Wall -Wextra -Werror -std="c++${CXX_STANDARD}" -c -o hello_mongocxx.o ../../../hello_mongocxx.cpp $(pkg-config --cflags libmongocxx-static)
+"${CXX:?}" $CXXFLAGS -Wall -Wextra -Werror -std="c++${CXX_STANDARD:?}" -c -o hello_mongocxx.o ../../../hello_mongocxx.cpp $(pkg-config --cflags libmongocxx-static)
 # TODO: remove `-pthread` once CDRIVER-4776 is resolved.
-$CXX $LDFLAGS -pthread -std="c++${CXX_STANDARD}" -o hello_mongocxx hello_mongocxx.o $(pkg-config --libs libmongocxx-static)
+"${CXX:?}" $LDFLAGS -pthread -std="c++${CXX_STANDARD:?}" -o hello_mongocxx hello_mongocxx.o $(pkg-config --libs libmongocxx-static)
 ./hello_mongocxx


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1853 by applying similar improvements to the C++ Driver. Includes some minor drive-by improvements to the `build-example-projects` scripts to ensure they inherit and better (re)use existing environment variables.