### PR TITLE
CXX-3208 update SDAM monitoring tests following mongo-c-driver a91d6f6a

### DIFF
--- a/src/mongocxx/test/sdam-monitoring.cpp
+++ b/src/mongocxx/test/sdam-monitoring.cpp
@@ -171,14 +171,18 @@ TEST_CASE("SDAM Monitoring", "[sdam_monitoring]") {
                 REQUIRE_FALSE(old_td.has_writable_server());
             }
 
-            if (topology_type == "replicaset") {
-                if (new_td.has_writable_server()) {
-                    REQUIRE(new_type == "ReplicaSetWithPrimary");
+            // A topology_changed_event may also be triggered when server monitoring closes,
+            // which transitions the topology description into an "Unknown" state.
+            CHECKED_IF(new_type != "Unknown") {
+                if (topology_type == "replicaset") {
+                    if (new_td.has_writable_server()) {
+                        REQUIRE(new_type == "ReplicaSetWithPrimary");
+                    } else {
+                        REQUIRE(new_type == "ReplicaSetNoPrimary");
+                    }
                 } else {
-                    REQUIRE(new_type == "ReplicaSetNoPrimary");
+                    REQUIRE(new_type == "Single");
                 }
-            } else {
-                REQUIRE(new_type == "Single");
             }
 
             for (auto&& new_sd : new_servers) {


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1331 which overlooked an update to SDAM Monitoring behavior as part of [CDRIVER-3775](https://jira.mongodb.org/browse/CDRIVER-3775):

```
sdam-monitoring.cpp:181: failed: new_type == "Single" for: "Unknown" == "Single"
```

Specifically due to https://github.com/mongodb/mongo-c-driver/pull/1842, which included the following change(s):

```
* Fies for lifecycle events generated for Structured Log and APM consumers:
  * ServerOpeningEvent is deferred based on topology 'opening' state, not based on when callbacks are installed.
  * Required ServerClosedEvent and topology Unknown state changes are emitted prior to TopologyClosedEvent.
```

This PR proposes simply ignoring the Unknown topology description state during the "Topology Events" assertions, as AFAIK there is not a deterministic way to know in advance that a particular TopologyDescriptionChanged event is specifically due to server monitoring shutdown without significant refactoring of the SDAM Monitoring test case (e.g. we likely do not want to hardcode assumptions about the number of members in the replica set).

The Catch2 [`CHECKED_IF`](https://github.com/catchorg/Catch2/blob/devel/docs/other-macros.md#assertion-related-macros) macro is used for improved test debugging experience and verify runtime behavior (example output is paraphrased to reduce verbosity):

```
$ ./test_driver --reporter compact --success --section "Topology Events" "SDAM Monitoring"
Filters: "SDAM Monitoring"
RNG seed: [...]
...
sdam-monitoring.cpp:176: passed: new_type != "Unknown" for: "ReplicaSetNoPrimary" != "Unknown"
sdam-monitoring.cpp:181: passed: new_type == "ReplicaSetNoPrimary" for: "ReplicaSetNoPrimary" == "ReplicaSetNoPrimary"
...
sdam-monitoring.cpp:176: passed: new_type != "Unknown" for: "ReplicaSetWithPrimary" != "Unknown"
sdam-monitoring.cpp:179: passed: new_type == "ReplicaSetWithPrimary" for: "ReplicaSetWithPrimary" == "ReplicaSetWithPrimary"
...
sdam-monitoring.cpp:176: passed: new_type != "Unknown" for: "ReplicaSetWithPrimary" != "Unknown"
sdam-monitoring.cpp:179: passed: new_type == "ReplicaSetWithPrimary" for: "ReplicaSetWithPrimary" == "ReplicaSetWithPrimary"
...
sdam-monitoring.cpp:176: passed: new_type != "Unknown" for: "ReplicaSetWithPrimary" != "Unknown"
sdam-monitoring.cpp:179: passed: new_type == "ReplicaSetWithPrimary" for: "ReplicaSetWithPrimary" == "ReplicaSetWithPrimary"
...
sdam-monitoring.cpp:176: failed - but was ok: new_type != "Unknown" for: "Unknown" != "Unknown"
...
sdam-monitoring.cpp:221: passed: topology_opening_events > 0 for: 1 > 0
sdam-monitoring.cpp:222: passed: topology_changed_events > 0 for: 5 > 0
sdam-monitoring.cpp:223: passed: topology_closed_events > 0 for: 1 > 0
sdam-monitoring.cpp:224: passed: found_servers for: true
All tests passed (56 assertions in 1 test case)
```

AFAICT this is the first use of the Catch2 v3 `CHECKED_IF` macro in the test suite. It was present in Catch2 v2, but negative conditions were treated as an assertion failure rather than simply a recorded result.

No other changes appear to be necessary.
