### PR TITLE
CXX-2745 fix missing include directives for SSL-related config macros

### DIFF
--- a/src/mongocxx/lib/CMakeLists.txt
+++ b/src/mongocxx/lib/CMakeLists.txt
@@ -206,6 +206,7 @@ set_dist_list(src_mongocxx_lib_DIST
     mongocxx/private/scoped_bson_value.hh
     mongocxx/private/search_index_model.hh
     mongocxx/private/search_index_view.hh
+    mongocxx/private/ssl.hh
     mongocxx/private/uri.hh
     mongocxx/private/write_concern.hh
     mongocxx/v_noabi/mongocxx/gridfs/bucket.hh

--- a/src/mongocxx/lib/mongocxx/private/ssl.hh
+++ b/src/mongocxx/lib/mongocxx/private/ssl.hh
@@ -1,0 +1,24 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/private/config/config.hh>
+#include <mongocxx/private/mongoc.hh>
+
+#if defined(MONGOCXX_ENABLE_SSL) && defined(MONGOC_ENABLE_SSL)
+#define MONGOCXX_SSL_IS_ENABLED() true
+#else
+#define MONGOCXX_SSL_IS_ENABLED() false
+#endif

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client.cpp
@@ -29,6 +29,8 @@
 #include <mongocxx/private/bson.hh>
 #include <mongocxx/private/client.hh>
 #include <mongocxx/private/client_session.hh>
+#include <mongocxx/private/config/config.hh>
+#include <mongocxx/private/mongoc.hh>
 #include <mongocxx/private/mongoc_error.hh>
 #include <mongocxx/private/pipeline.hh>
 #include <mongocxx/private/read_concern.hh>

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client.cpp
@@ -29,12 +29,11 @@
 #include <mongocxx/private/bson.hh>
 #include <mongocxx/private/client.hh>
 #include <mongocxx/private/client_session.hh>
-#include <mongocxx/private/config/config.hh>
-#include <mongocxx/private/mongoc.hh>
 #include <mongocxx/private/mongoc_error.hh>
 #include <mongocxx/private/pipeline.hh>
 #include <mongocxx/private/read_concern.hh>
 #include <mongocxx/private/read_preference.hh>
+#include <mongocxx/private/ssl.hh>
 #include <mongocxx/private/uri.hh>
 #include <mongocxx/private/write_concern.hh>
 
@@ -76,7 +75,7 @@ class database_names {
 client::client() noexcept = default;
 
 client::client(mongocxx::v_noabi::uri const& uri, options::client const& options) {
-#if defined(MONGOCXX_ENABLE_SSL) && defined(MONGOC_ENABLE_SSL)
+#if MONGOCXX_SSL_IS_ENABLED()
     if (options.tls_opts()) {
         if (!uri.tls())
             throw exception{error_code::k_invalid_parameter, "cannot set TLS options if 'tls=true' not in URI"};
@@ -129,7 +128,7 @@ client::client(mongocxx::v_noabi::uri const& uri, options::client const& options
         }
     }
 
-#if defined(MONGOCXX_ENABLE_SSL) && defined(MONGOC_ENABLE_SSL)
+#if MONGOCXX_SSL_IS_ENABLED()
     if (options.tls_opts()) {
         auto mongoc_opts = options::make_tls_opts(*options.tls_opts());
         _impl->tls_options = std::move(mongoc_opts.second);

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/tls.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/tls.hh
@@ -20,6 +20,7 @@
 
 #include <list>
 
+#include <mongocxx/private/config/config.hh>
 #include <mongocxx/private/mongoc.hh>
 
 namespace mongocxx {

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/tls.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/tls.hh
@@ -20,14 +20,14 @@
 
 #include <list>
 
-#include <mongocxx/private/config/config.hh>
 #include <mongocxx/private/mongoc.hh>
+#include <mongocxx/private/ssl.hh>
 
 namespace mongocxx {
 namespace v_noabi {
 namespace options {
 
-#if defined(MONGOCXX_ENABLE_SSL) && defined(MONGOC_ENABLE_SSL)
+#if MONGOCXX_SSL_IS_ENABLED()
 inline std::pair<::mongoc_ssl_opt_t, std::list<bsoncxx::v_noabi::string::view_or_value>> make_tls_opts(
     tls const& tls_opts) {
     ::mongoc_ssl_opt_t out{};

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
@@ -27,10 +27,9 @@
 #include <bsoncxx/private/make_unique.hh>
 
 #include <mongocxx/private/client.hh>
-#include <mongocxx/private/config/config.hh>
-#include <mongocxx/private/mongoc.hh>
 #include <mongocxx/private/mongoc_error.hh>
 #include <mongocxx/private/pool.hh>
+#include <mongocxx/private/ssl.hh>
 #include <mongocxx/private/uri.hh>
 
 namespace mongocxx {
@@ -59,7 +58,7 @@ pool::~pool() = default;
 
 pool::pool(uri const& uri, options::pool const& options)
     : _impl{bsoncxx::make_unique<impl>(construct_client_pool(uri._impl->uri_t))} {
-#if defined(MONGOCXX_ENABLE_SSL) && defined(MONGOC_ENABLE_SSL)
+#if MONGOCXX_SSL_IS_ENABLED()
     if (options.client_opts().tls_opts()) {
         if (!uri.tls())
             throw exception{error_code::k_invalid_parameter, "cannot set TLS options if 'tls=true' not in URI"};

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
@@ -27,6 +27,8 @@
 #include <bsoncxx/private/make_unique.hh>
 
 #include <mongocxx/private/client.hh>
+#include <mongocxx/private/config/config.hh>
+#include <mongocxx/private/mongoc.hh>
 #include <mongocxx/private/mongoc_error.hh>
 #include <mongocxx/private/pool.hh>
 #include <mongocxx/private/uri.hh>

--- a/src/mongocxx/test/catch_helpers.hh
+++ b/src/mongocxx/test/catch_helpers.hh
@@ -16,8 +16,8 @@
 
 #include <mongocxx/exception/exception.hpp>
 
-#include <mongocxx/private/config/config.hh>
 #include <mongocxx/private/mongoc.hh>
+#include <mongocxx/private/ssl.hh>
 
 #include <bsoncxx/test/catch.hh>
 
@@ -74,7 +74,7 @@ class mongocxx_exception_matcher : public Catch::Matchers::MatcherBase<mongocxx:
     auto client_pool_try_pop = libmongoc::client_pool_try_pop.create_instance();               \
     ((void)0)
 
-#if defined(MONGOCXX_ENABLE_SSL) && defined(MONGOC_ENABLE_SSL)
+#if MONGOCXX_SSL_IS_ENABLED()
 #define MOCK_POOL                                                                                   \
     MOCK_POOL_NOSSL;                                                                                \
     auto client_pool_set_ssl_opts = libmongoc::client_pool_set_ssl_opts.create_instance();          \
@@ -102,7 +102,7 @@ class mongocxx_exception_matcher : public Catch::Matchers::MatcherBase<mongocxx:
     auto client_find_databases_with_opts = mongocxx::libmongoc::client_find_databases_with_opts.create_instance(); \
     ((void)0)
 
-#if defined(MONGOCXX_ENABLE_SSL) && defined(MONGOC_ENABLE_SSL)
+#if MONGOCXX_SSL_IS_ENABLED()
 #define MOCK_CLIENT                                                                       \
     MOCK_CLIENT_NOSSL;                                                                    \
     auto client_set_ssl_opts = libmongoc::client_set_ssl_opts.create_instance();          \

--- a/src/mongocxx/test/catch_helpers.hh
+++ b/src/mongocxx/test/catch_helpers.hh
@@ -16,6 +16,7 @@
 
 #include <mongocxx/exception/exception.hpp>
 
+#include <mongocxx/private/config/config.hh>
 #include <mongocxx/private/mongoc.hh>
 
 #include <bsoncxx/test/catch.hh>

--- a/src/mongocxx/test/client.cpp
+++ b/src/mongocxx/test/client.cpp
@@ -25,6 +25,7 @@
 #include <mongocxx/pool.hpp>
 #include <mongocxx/uri.hpp>
 
+#include <mongocxx/private/config/config.hh>
 #include <mongocxx/private/conversions.hh>
 #include <mongocxx/private/mongoc.hh>
 

--- a/src/mongocxx/test/client.cpp
+++ b/src/mongocxx/test/client.cpp
@@ -25,9 +25,9 @@
 #include <mongocxx/pool.hpp>
 #include <mongocxx/uri.hpp>
 
-#include <mongocxx/private/config/config.hh>
 #include <mongocxx/private/conversions.hh>
 #include <mongocxx/private/mongoc.hh>
+#include <mongocxx/private/ssl.hh>
 
 #include <bsoncxx/test/catch.hh>
 
@@ -424,7 +424,7 @@ TEST_CASE("integration tests for client metadata handshake feature") {
     }
 }
 
-#if defined(MONGOCXX_ENABLE_SSL) && defined(MONGOC_ENABLE_SSL)
+#if MONGOCXX_SSL_IS_ENABLED()
 TEST_CASE("A client can be constructed with SSL options", "[client]") {
     MOCK_CLIENT;
 

--- a/src/mongocxx/test/pool.cpp
+++ b/src/mongocxx/test/pool.cpp
@@ -21,6 +21,7 @@
 #include <mongocxx/options/tls.hpp>
 #include <mongocxx/pool.hpp>
 
+#include <mongocxx/private/mongoc.hh>
 #include <mongocxx/private/ssl.hh>
 
 #include <bsoncxx/test/catch.hh>

--- a/src/mongocxx/test/pool.cpp
+++ b/src/mongocxx/test/pool.cpp
@@ -21,6 +21,7 @@
 #include <mongocxx/options/tls.hpp>
 #include <mongocxx/pool.hpp>
 
+#include <mongocxx/private/config/config.hh>
 #include <mongocxx/private/mongoc.hh>
 
 #include <bsoncxx/test/catch.hh>

--- a/src/mongocxx/test/pool.cpp
+++ b/src/mongocxx/test/pool.cpp
@@ -21,8 +21,7 @@
 #include <mongocxx/options/tls.hpp>
 #include <mongocxx/pool.hpp>
 
-#include <mongocxx/private/config/config.hh>
-#include <mongocxx/private/mongoc.hh>
+#include <mongocxx/private/ssl.hh>
 
 #include <bsoncxx/test/catch.hh>
 
@@ -65,7 +64,7 @@ TEST_CASE("a pool is created with the correct MongoDB URI", "[pool]") {
     REQUIRE(destroy_called);
 }
 
-#if defined(MONGOCXX_ENABLE_SSL) && defined(MONGOC_ENABLE_SSL)
+#if MONGOCXX_SSL_IS_ENABLED()
 TEST_CASE(
     "If we pass an engaged SSL options struct to the pool class, we will use it to configure the "
     "underlying mongoc pool",


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1323 to address `atlas-search-indexes-matrix` task failures due to incorrect SSL configuration detection based on `MONGOCXX_ENABLE_SSL` and `MONGOC_ENABLE_SSL` macros which (incorrectly) may not be defined due to missing include directives, leading to false-positive "SSL support not available" exceptions.