### PR TITLE
CXX-2745 add v1 forward headers and component files (bsoncxx)

### DIFF
--- a/src/bsoncxx/include/bsoncxx/docs/top.hpp
+++ b/src/bsoncxx/include/bsoncxx/docs/top.hpp
@@ -81,10 +81,10 @@
 
 ///
 /// @namespace bsoncxx::types
-/// Declares entities representing BSON value types.
+/// Declares entities representing a BSON type.
 ///
 
 ///
 /// @namespace bsoncxx::types::bson_value
-/// Declares entities representing any BSON value type.
+/// Declares entities representing a BSON type.
 ///

--- a/src/bsoncxx/include/bsoncxx/docs/v1.hpp
+++ b/src/bsoncxx/include/bsoncxx/docs/v1.hpp
@@ -71,6 +71,11 @@
 ///
 
 ///
+/// @namespace bsoncxx::v1::error
+/// Declares entities describing @ref bsoncxx::v1 errors.
+///
+
+///
 /// @namespace bsoncxx::v1::stdx
 /// @copydoc bsoncxx::stdx
 ///

--- a/src/bsoncxx/include/bsoncxx/docs/v1.hpp
+++ b/src/bsoncxx/include/bsoncxx/docs/v1.hpp
@@ -34,6 +34,11 @@
 ///
 
 ///
+/// @dir bsoncxx/v1/document
+/// Provides headers declaring entities in @ref bsoncxx::v1::document.
+///
+
+///
 /// @dir bsoncxx/v1/config
 /// Provides headers related to bsoncxx library configuration.
 ///
@@ -58,6 +63,11 @@
 ///
 /// @namespace bsoncxx::v1::array
 /// @copydoc bsoncxx::array
+///
+
+///
+/// @namespace bsoncxx::v1::document
+/// @copydoc bsoncxx::document
 ///
 
 ///

--- a/src/bsoncxx/include/bsoncxx/docs/v1.hpp
+++ b/src/bsoncxx/include/bsoncxx/docs/v1.hpp
@@ -29,6 +29,11 @@
 ///
 
 ///
+/// @dir bsoncxx/v1/array
+/// Provides headers declaring entities in @ref bsoncxx::v1::array.
+///
+
+///
 /// @dir bsoncxx/v1/config
 /// Provides headers related to bsoncxx library configuration.
 ///
@@ -48,6 +53,11 @@
 ///
 /// @namespace bsoncxx::v1
 /// Declares entities whose ABI stability is guaranteed for documented symbols.
+///
+
+///
+/// @namespace bsoncxx::v1::array
+/// @copydoc bsoncxx::array
 ///
 
 ///

--- a/src/bsoncxx/include/bsoncxx/docs/v1.hpp
+++ b/src/bsoncxx/include/bsoncxx/docs/v1.hpp
@@ -56,6 +56,11 @@
 ///
 
 ///
+/// @dir bsoncxx/v1/types
+/// Provides headers declaring entities in @ref bsoncxx::v1::types.
+///
+
+///
 /// @namespace bsoncxx::v1
 /// Declares entities whose ABI stability is guaranteed for documented symbols.
 ///
@@ -78,4 +83,9 @@
 ///
 /// @namespace bsoncxx::v1::stdx
 /// @copydoc bsoncxx::stdx
+///
+
+///
+/// @namespace bsoncxx::v1::types
+/// @copydoc bsoncxx::types
 ///

--- a/src/bsoncxx/include/bsoncxx/docs/v1.hpp
+++ b/src/bsoncxx/include/bsoncxx/docs/v1.hpp
@@ -34,11 +34,6 @@
 ///
 
 ///
-/// @dir bsoncxx/v1/document
-/// Provides headers declaring entities in @ref bsoncxx::v1::document.
-///
-
-///
 /// @dir bsoncxx/v1/config
 /// Provides headers related to bsoncxx library configuration.
 ///
@@ -48,6 +43,11 @@
 /// Provides headers for internal use only.
 ///
 /// @warning For internal use only!
+///
+
+///
+/// @dir bsoncxx/v1/document
+/// Provides headers declaring entities in @ref bsoncxx::v1::document.
 ///
 
 ///

--- a/src/bsoncxx/include/bsoncxx/docs/v_noabi.hpp
+++ b/src/bsoncxx/include/bsoncxx/docs/v_noabi.hpp
@@ -138,7 +138,7 @@
 
 ///
 /// @namespace bsoncxx::v_noabi::types
-/// @copydoc bsoncxx::types
+/// Declares entities representing BSON value types.
 ///
 /// @see
 /// - @ref bsoncxx::v_noabi::types::bson_value

--- a/src/bsoncxx/include/bsoncxx/v1/array/element-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/array/element-fwd.hpp
@@ -1,0 +1,34 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace array {
+
+class element;
+
+} // namespace array
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v1::array::element.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/array/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/array/element.hpp
@@ -1,0 +1,43 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/array/element-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace array {
+
+///
+/// An element within a BSON array.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+class element {};
+
+} // namespace array
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v1::array::element.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/array/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/array/value-fwd.hpp
@@ -1,0 +1,34 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace array {
+
+class value;
+
+} // namespace array
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v1::array::value.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/array/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/array/value.hpp
@@ -1,0 +1,43 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/array/value-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace array {
+
+///
+/// A BSON array.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+class value {};
+
+} // namespace array
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v1::array::value.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/array/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/array/view-fwd.hpp
@@ -1,0 +1,34 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace array {
+
+class view;
+
+} // namespace array
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v1::array::view.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/array/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/array/view.hpp
@@ -1,0 +1,43 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/array/view-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace array {
+
+///
+/// A non-owning, read-only BSON array.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+class view {};
+
+} // namespace array
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v1::array::view.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/decimal128-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/decimal128-fwd.hpp
@@ -1,0 +1,32 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+
+class decimal128;
+
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v1::decimal128.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/decimal128.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/decimal128.hpp
@@ -1,0 +1,41 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/decimal128-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+
+///
+/// A BSON Decimal128.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+class decimal128 {};
+
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v1::decimal128.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/document/element-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/document/element-fwd.hpp
@@ -1,0 +1,34 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace document {
+
+class element;
+
+} // namespace document
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v1::document::element.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/document/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/document/element.hpp
@@ -1,0 +1,43 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/document/element-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace document {
+
+///
+/// An element within a BSON document.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+class element {};
+
+} // namespace document
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v1::document::element.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/document/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/document/value-fwd.hpp
@@ -1,0 +1,34 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace document {
+
+class value;
+
+} // namespace document
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v1::document::value.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/document/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/document/value.hpp
@@ -1,0 +1,43 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/document/value-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace document {
+
+///
+/// A BSON document.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+class value {};
+
+} // namespace document
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v1::document::value.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/document/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/document/view-fwd.hpp
@@ -1,0 +1,34 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace document {
+
+class view;
+
+} // namespace document
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v1::document::view.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/document/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/document/view.hpp
@@ -1,0 +1,43 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/document/view-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace document {
+
+///
+/// A non-owning, read-only BSON document.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+class view {};
+
+} // namespace document
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v1::document::view.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/exception-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/exception-fwd.hpp
@@ -1,0 +1,44 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace error {
+
+enum class source;
+
+enum class type;
+
+} // namespace error
+} // namespace v1
+} // namespace bsoncxx
+
+namespace bsoncxx {
+namespace v1 {
+
+class exception;
+
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares bsoncxx error-handling utilities.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/exception.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/exception.hpp
@@ -1,0 +1,65 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/exception-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+#include <system_error>
+
+namespace bsoncxx {
+namespace v1 {
+namespace error {
+
+///
+/// Enumeration identifying the source of a @ref bsoncxx::v1 error.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+enum class source {};
+
+///
+/// Enumeration identifying the type (cause) of a @ref bsoncxx::v1 error.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+enum class type {};
+
+} // namespace error
+} // namespace v1
+} // namespace bsoncxx
+
+namespace bsoncxx {
+namespace v1 {
+
+///
+/// Base class for all exceptions thrown by @ref bsoncxx::v1.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+class exception {};
+
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides bsoncxx error-handling utilities.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/fwd.hpp
@@ -1,0 +1,41 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+#include <bsoncxx/v1/array/element-fwd.hpp>
+#include <bsoncxx/v1/array/value-fwd.hpp>
+#include <bsoncxx/v1/array/view-fwd.hpp>
+#include <bsoncxx/v1/decimal128-fwd.hpp>
+#include <bsoncxx/v1/document/element-fwd.hpp>
+#include <bsoncxx/v1/document/value-fwd.hpp>
+#include <bsoncxx/v1/document/view-fwd.hpp>
+#include <bsoncxx/v1/exception-fwd.hpp>
+#include <bsoncxx/v1/oid-fwd.hpp>
+#include <bsoncxx/v1/types-fwd.hpp>
+#include <bsoncxx/v1/types/element-fwd.hpp>
+#include <bsoncxx/v1/types/value-fwd.hpp>
+#include <bsoncxx/v1/types/view-fwd.hpp>
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Aggregate of all forward headers declaring entities in @ref bsoncxx::v1.
+///
+/// @par Includes
+/// - All header files under `bsoncxx/v1` whose filename ends with `-fwd.hpp`.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/oid-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/oid-fwd.hpp
@@ -1,0 +1,32 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+
+class oid;
+
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v1::oid.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/oid.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/oid.hpp
@@ -1,0 +1,41 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/oid-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+
+///
+/// A BSON ObjectID.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+class oid {};
+
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v1::oid.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/types-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/types-fwd.hpp
@@ -21,6 +21,10 @@
 ///
 /// X-macro over the name and value of BSON types.
 ///
+/// @important The addition of new expansions to this X-macro ARE NOT considered an API breaking change.
+/// The modification or removal of existing expansions to this X-macro ARE considered an API breaking change.
+/// This X-macro MUST used in a manner that is compatible with these API compatibility guidelines!
+///
 /// @par "Example"
 /// ```cpp
 /// #define EXAMPLE(name, value) std::cout << (#name) << ": " << (value) << '\n';
@@ -63,6 +67,10 @@
 
 ///
 /// X-macro over the name and value of BSON binary subtypes.
+///
+/// @important The addition of new expansions to this X-macro ARE NOT considered an API breaking change.
+/// The modification or removal of existing expansions to this X-macro ARE considered an API breaking change.
+/// This X-macro MUST used in a manner that is compatible with these API compatibility guidelines!
 ///
 /// @par "Example"
 /// ```cpp

--- a/src/bsoncxx/include/bsoncxx/v1/types-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/types-fwd.hpp
@@ -23,7 +23,7 @@
 ///
 /// @important The addition of new expansions to this X-macro ARE NOT considered an API breaking change.
 /// The modification or removal of existing expansions to this X-macro ARE considered an API breaking change.
-/// This X-macro MUST used in a manner that is compatible with these API compatibility guidelines!
+/// This X-macro MUST be used in a manner that is compatible with these API compatibility guidelines!
 ///
 /// @par "Example"
 /// ```cpp
@@ -70,7 +70,7 @@
 ///
 /// @important The addition of new expansions to this X-macro ARE NOT considered an API breaking change.
 /// The modification or removal of existing expansions to this X-macro ARE considered an API breaking change.
-/// This X-macro MUST used in a manner that is compatible with these API compatibility guidelines!
+/// This X-macro MUST be used in a manner that is compatible with these API compatibility guidelines!
 ///
 /// @par "Example"
 /// ```cpp

--- a/src/bsoncxx/include/bsoncxx/v1/types-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/types-fwd.hpp
@@ -1,0 +1,110 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+#include <cstdint>
+
+///
+/// X-macro over the name and value of BSON types.
+///
+/// @par "Example"
+/// ```cpp
+/// #define EXAMPLE(name, value) std::cout << (#name) << ": " << (value) << '\n';
+///
+/// void print_bson_types() {
+///     // Expands to:
+///     //     std::cout << ("double") << ": " << (0x01) << '\n';
+///     //     std::cout << ("string") << ": " << (0x02) << '\n';
+///     //     ...
+///     BSONCXX_V1_TYPES_XMACRO(EXAMPLE)
+/// }
+/// ```
+///
+/// @param X the user-defined macro to be expanded.
+///
+// clang-format off
+#define BSONCXX_V1_TYPES_XMACRO(X) \
+    X(double,     0x01) \
+    X(string,     0x02) \
+    X(document,   0x03) \
+    X(array,      0x04) \
+    X(binary,     0x05) \
+    X(undefined,  0x06) \
+    X(oid,        0x07) \
+    X(bool,       0x08) \
+    X(date,       0x09) \
+    X(null,       0x0A) \
+    X(regex,      0x0B) \
+    X(dbpointer,  0x0C) \
+    X(code,       0x0D) \
+    X(symbol,     0x0E) \
+    X(codewscope, 0x0F) \
+    X(int32,      0x10) \
+    X(timestamp,  0x11) \
+    X(int64,      0x12) \
+    X(decimal128, 0x13) \
+    X(maxkey,     0x7F) \
+    X(minkey,     0xFF)
+// clang-format on
+
+///
+/// X-macro over the name and value of BSON binary subtypes.
+///
+/// @par "Example"
+/// ```cpp
+/// #define EXAMPLE(name, value) std::cout << #name << ": " << value << '\n';
+///
+/// void print_bson_binary_subtypes() {
+///     // Expands to:
+///     //     std::cout << ("binary") << ": " << (0x00) << '\n';
+///     //     std::cout << ("function") << ": " << (0x01) << '\n';
+///     //     ...
+///     BSONCXX_V1_BINARY_SUBTYPES_XMACRO(EXAMPLE)
+/// }
+/// ```
+///
+/// @param X the user-defined macro to be expanded.
+///
+// clang-format off
+#define BSONCXX_V1_BINARY_SUBTYPES_XMACRO(X) \
+    X(binary,            0x00) \
+    X(function,          0x01) \
+    X(binary_deprecated, 0x02) \
+    X(uuid_deprecated,   0x03) \
+    X(uuid,              0x04) \
+    X(md5,               0x05) \
+    X(encrypted,         0x06) \
+    X(column,            0x07) \
+    X(sensitive,         0x08) \
+    X(user,              0x80)
+// clang-format on
+
+namespace bsoncxx {
+namespace v1 {
+
+enum class type : std::uint8_t;
+enum class binary_subtype : std::uint8_t;
+
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares entities describing BSON types.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/types.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/types.hpp
@@ -1,0 +1,48 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/types-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+
+///
+/// Enumeration identifying all BSON types.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+enum class type : std::uint8_t {};
+
+///
+/// Enumeration identifying all BSON binary subtypes.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+enum class binary_subtype : std::uint8_t {};
+
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides entities representing BSON types.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/types/element-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/types/element-fwd.hpp
@@ -1,0 +1,40 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+#include <bsoncxx/v1/types-fwd.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace types {
+
+#pragma push_macro("X")
+#undef X
+#define X(_name, _value) struct b_##_name;
+BSONCXX_V1_TYPES_XMACRO(X)
+#pragma pop_macro("X")
+
+} // namespace types
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares entities representing BSON types.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/types/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/types/element.hpp
@@ -1,0 +1,183 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/types/element-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace types {
+
+///
+/// A BSON type "64-bit Binary Floating Point".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_double {};
+
+///
+/// A BSON type "UTF-8 String".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_string {};
+
+///
+/// A BSON type "Embedded Document".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_document {};
+
+///
+/// A BSON type "Array".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_array {};
+
+///
+/// A BSON type "Binary Data".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_binary {};
+
+///
+/// A BSON type "Undefined (Value)".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_undefined {};
+
+///
+/// A BSON type "ObjectID".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_oid {};
+
+///
+/// A BSON type "Boolean".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_bool {};
+
+///
+/// A BSON type "UTC Datetime".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_date {};
+
+///
+/// A BSON type "Null Value".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_null {};
+
+///
+/// A BSON type "Regular Expression".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_regex {};
+
+///
+/// A BSON type "DBPointer".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_dbpointer {};
+
+///
+/// A BSON type "JavaScript Code".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_code {};
+
+///
+/// A BSON type "Symbol".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_symbol {};
+
+///
+/// A BSON type "JavaScript Code With Scope".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_codewscope {};
+
+///
+/// A BSON type "32-bit Integer".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_int32 {};
+
+///
+/// A BSON type "Timestamp".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_timestamp {};
+
+///
+/// A BSON type "64-bit Integer".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_int64 {};
+
+///
+/// A BSON type "Decimal128".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_decimal128 {};
+
+///
+/// A BSON type "Max Key".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_maxkey {};
+
+///
+/// A BSON type "Min Key".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_minkey {};
+
+} // namespace types
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides entities representing BSON types.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/types/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/types/value-fwd.hpp
@@ -1,0 +1,34 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace types {
+
+class value;
+
+} // namespace types
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v1::types::value.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/types/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/types/value.hpp
@@ -1,0 +1,43 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/types/value-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace types {
+
+///
+/// A union of BSON types.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+class value {};
+
+} // namespace types
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v1::types::value.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/types/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/types/view-fwd.hpp
@@ -1,0 +1,34 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace types {
+
+class view;
+
+} // namespace types
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v1::types::view.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/types/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/types/view.hpp
@@ -1,0 +1,43 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/types/view-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace types {
+
+///
+/// A non-owning, read-only union of BSON types.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+class view {};
+
+} // namespace types
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v1::types::view.
+///

--- a/src/bsoncxx/lib/CMakeLists.txt
+++ b/src/bsoncxx/lib/CMakeLists.txt
@@ -50,6 +50,7 @@ set(bsoncxx_sources_v1
     bsoncxx/v1/detail/prelude.cpp
     bsoncxx/v1/document/element.cpp
     bsoncxx/v1/document/value.cpp
+    bsoncxx/v1/document/view.cpp
 )
 
 list(APPEND bsoncxx_sources

--- a/src/bsoncxx/lib/CMakeLists.txt
+++ b/src/bsoncxx/lib/CMakeLists.txt
@@ -52,6 +52,7 @@ set(bsoncxx_sources_v1
     bsoncxx/v1/document/value.cpp
     bsoncxx/v1/document/view.cpp
     bsoncxx/v1/types/element.cpp
+    bsoncxx/v1/types/value.cpp
 )
 
 list(APPEND bsoncxx_sources

--- a/src/bsoncxx/lib/CMakeLists.txt
+++ b/src/bsoncxx/lib/CMakeLists.txt
@@ -49,6 +49,7 @@ set(bsoncxx_sources_v1
     bsoncxx/v1/detail/postlude.cpp
     bsoncxx/v1/detail/prelude.cpp
     bsoncxx/v1/document/element.cpp
+    bsoncxx/v1/document/value.cpp
 )
 
 list(APPEND bsoncxx_sources

--- a/src/bsoncxx/lib/CMakeLists.txt
+++ b/src/bsoncxx/lib/CMakeLists.txt
@@ -53,6 +53,7 @@ set(bsoncxx_sources_v1
     bsoncxx/v1/document/value.cpp
     bsoncxx/v1/document/view.cpp
     bsoncxx/v1/exception.cpp
+    bsoncxx/v1/oid.cpp
     bsoncxx/v1/types.cpp
     bsoncxx/v1/types/element.cpp
     bsoncxx/v1/types/value.cpp

--- a/src/bsoncxx/lib/CMakeLists.txt
+++ b/src/bsoncxx/lib/CMakeLists.txt
@@ -52,6 +52,7 @@ set(bsoncxx_sources_v1
     bsoncxx/v1/document/element.cpp
     bsoncxx/v1/document/value.cpp
     bsoncxx/v1/document/view.cpp
+    bsoncxx/v1/exception.cpp
     bsoncxx/v1/types.cpp
     bsoncxx/v1/types/element.cpp
     bsoncxx/v1/types/value.cpp

--- a/src/bsoncxx/lib/CMakeLists.txt
+++ b/src/bsoncxx/lib/CMakeLists.txt
@@ -40,6 +40,7 @@ set(bsoncxx_sources_v_noabi
 )
 
 set(bsoncxx_sources_v1
+    bsoncxx/v1/array/element.cpp
     bsoncxx/v1/config/config.cpp
     bsoncxx/v1/config/export.cpp
     bsoncxx/v1/config/version.cpp

--- a/src/bsoncxx/lib/CMakeLists.txt
+++ b/src/bsoncxx/lib/CMakeLists.txt
@@ -41,6 +41,7 @@ set(bsoncxx_sources_v_noabi
 
 set(bsoncxx_sources_v1
     bsoncxx/v1/array/element.cpp
+    bsoncxx/v1/array/value.cpp
     bsoncxx/v1/config/config.cpp
     bsoncxx/v1/config/export.cpp
     bsoncxx/v1/config/version.cpp

--- a/src/bsoncxx/lib/CMakeLists.txt
+++ b/src/bsoncxx/lib/CMakeLists.txt
@@ -51,6 +51,7 @@ set(bsoncxx_sources_v1
     bsoncxx/v1/document/element.cpp
     bsoncxx/v1/document/value.cpp
     bsoncxx/v1/document/view.cpp
+    bsoncxx/v1/types.cpp
     bsoncxx/v1/types/element.cpp
     bsoncxx/v1/types/value.cpp
     bsoncxx/v1/types/view.cpp

--- a/src/bsoncxx/lib/CMakeLists.txt
+++ b/src/bsoncxx/lib/CMakeLists.txt
@@ -51,6 +51,7 @@ set(bsoncxx_sources_v1
     bsoncxx/v1/document/element.cpp
     bsoncxx/v1/document/value.cpp
     bsoncxx/v1/document/view.cpp
+    bsoncxx/v1/types/element.cpp
 )
 
 list(APPEND bsoncxx_sources

--- a/src/bsoncxx/lib/CMakeLists.txt
+++ b/src/bsoncxx/lib/CMakeLists.txt
@@ -46,6 +46,7 @@ set(bsoncxx_sources_v1
     bsoncxx/v1/config/config.cpp
     bsoncxx/v1/config/export.cpp
     bsoncxx/v1/config/version.cpp
+    bsoncxx/v1/decimal128.cpp
     bsoncxx/v1/detail/postlude.cpp
     bsoncxx/v1/detail/prelude.cpp
     bsoncxx/v1/document/element.cpp

--- a/src/bsoncxx/lib/CMakeLists.txt
+++ b/src/bsoncxx/lib/CMakeLists.txt
@@ -42,6 +42,7 @@ set(bsoncxx_sources_v_noabi
 set(bsoncxx_sources_v1
     bsoncxx/v1/array/element.cpp
     bsoncxx/v1/array/value.cpp
+    bsoncxx/v1/array/view.cpp
     bsoncxx/v1/config/config.cpp
     bsoncxx/v1/config/export.cpp
     bsoncxx/v1/config/version.cpp

--- a/src/bsoncxx/lib/CMakeLists.txt
+++ b/src/bsoncxx/lib/CMakeLists.txt
@@ -53,6 +53,7 @@ set(bsoncxx_sources_v1
     bsoncxx/v1/document/view.cpp
     bsoncxx/v1/types/element.cpp
     bsoncxx/v1/types/value.cpp
+    bsoncxx/v1/types/view.cpp
 )
 
 list(APPEND bsoncxx_sources

--- a/src/bsoncxx/lib/CMakeLists.txt
+++ b/src/bsoncxx/lib/CMakeLists.txt
@@ -48,6 +48,7 @@ set(bsoncxx_sources_v1
     bsoncxx/v1/config/version.cpp
     bsoncxx/v1/detail/postlude.cpp
     bsoncxx/v1/detail/prelude.cpp
+    bsoncxx/v1/document/element.cpp
 )
 
 list(APPEND bsoncxx_sources

--- a/src/bsoncxx/lib/bsoncxx/v1/array/element.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/array/element.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/array/element.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/array/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/array/value.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/array/value.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/array/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/array/view.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/array/view.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/decimal128.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/decimal128.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/decimal128.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/document/element.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/document/element.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/document/element.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/document/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/document/value.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/document/value.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/document/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/document/view.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/document/view.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/exception.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/exception.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/exception.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/oid.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/oid.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/oid.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/types.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/types.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/types.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/types/element.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/types/element.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/types/element.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/types/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/types/value.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/types/value.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/types/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/types/view.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/types/view.hpp>


### PR DESCRIPTION
## Summary

An intermediate PR related to CXX-2745 following https://github.com/mongodb/mongo-cxx-driver/pull/1318 and https://github.com/mongodb/mongo-cxx-driver/pull/1323.

This PR is focused on adding (non-internal) component files, implementing forward declarations, and adding API documentation stubs for bsoncxx v1 interfaces to be implemented in upcoming PRs. This PR is a "lightweight" preview of the bsoncxx v1 interface, file structure, and corresponding API documentation. The v1 interfaces themselves (data members, member functions, and non-member functions) will be implemented in a followup PR.

## Relative Changelog (v1 <- v_noabi)

### Additional Features

- X-macros over BSON types and subtypes: `BSONCXX_V1_TYPES_XMACRO` and `BSONCXX_V1_BINARY_SUBTYPES_XMACRO`.
    - Replaces the X-macro header `#include` pattern.
    - Much friendlier pattern for IDEs and compiler diagnostics.
    - Renamed `binary_sub_type` to `binary_subtype` for terminology consistency (e.g. [Drivers Specifications](https://specifications.readthedocs.io/en/latest/bson-binary-encrypted/binary-encrypted/), [MongoDB Manual](https://www.mongodb.com/docs/manual/reference/bson-types/#binary-data), and [BSON Spec](https://bsonspec.org/spec.html)).
- `bsoncxx::v1::error` for user-facing error conditions. ([CXX-834](https://jira.mongodb.org/browse/CXX-834))
    - The "better" approach to `mongoc_error_domain_t`.
        - "Domains" are component-specific error codes (enumerations).
        - Avoids global error value enumerations (i.e. `mongoc_error_domain_t`, `bsoncxx::v_noabi::error_code`, etc.).
    - Most users likely do not programmatically require an expansive and detailed set of error values.
        - Most users likely only handle errors by read-inspect the corresponding error messages.
        - Provide only bare minimum set of error conditions which users are most likely to programmatically care about:
            - source: library or application from which the error comes from.
            - type: invalid argument (due to user error), runtime error (not due to user error).
    - To be explored in further detail in upcoming PRs.

### Changed Features

- Headers under `types/bson_value/` (v_noabi) are moved up into `types/` (v1).
    - `types/value.hpp` (v_noabi) was removed in [CXX-3158](https://jira.mongodb.org/browse/CXX-3158).
    - `types/view.hpp` (v1) <- `types/bson_value/view.hpp` (v_noabi)
    - `types/value.hpp` (v1) <- `types/bson_value/value.hpp` (v_noabi)
    - `bson_value` is removed to avoid confusion with highly overloaded "value" terminology.
- BSON type "elements" are moved into `types/element.hpp`.
    - Enumerations remain in `types.hpp`.
    - Symmetry with `array/` and `document/` components.
    - Avoid pulling in large number of transitive dependencies required to represent BSON types when only the enumerations are required.
    - Avoid messy circular dependency issues between `types.hpp` (v_noabi) and `types/*.hpp` (v_noabi) headers.
- Grouped `exception/exception.hpp` (v_noabi) and `exception/error_code.hpp` (v_noabi) into a single `exception.hpp` (v1) header.

### Removed Features

- `enums/*.hpp`.
    - Replaced by new X-macros provided by `types-fwd.hpp`.
- `view_or_value.hpp`. ([CXX-1827](https://jira.mongodb.org/browse/CXX-1827))
    - Adopt C++ convention established by `std::string` and `std::string_view`.
    - To be explored in further detail in upcoming PRs.
- `string/to_string.hpp`.
    - Already superceded by the explicit conversion operator in `stdx::string_view` emulating `explicit std::string::string(std::string_view)`.

### Skipped/Deferred Features

- BSON builders (basic, stream, and JSON).
    - Defer exploration of BSON builder redesign which requires dedicated effort beyond the scope of v1 migration ([CXX-997](https://jira.mongodb.org/browse/CXX-997), [CXX-1634](https://jira.mongodb.org/browse/CXX-1634), [CXX-2115](https://jira.mongodb.org/browse/CXX-2115), etc.)
    - Interim workaround: use v_noabi builders to create v_noabi documents, then convert v_noabi documents to v1 documents using `to_v1()` (to be explored in further detail in upcoming PRs; see [this comment](https://github.com/mongodb/mongo-cxx-driver/pull/1182#discussion_r1704329261) for a preview of the expected pattern).

## Absolute Changelog (v_noabi)

- None.

## API Documentation

### Stubs

Deliberately kept minimal at the moment.

All forward-declared v1 interfaces are currently labeled with the following message:

> **Attention** This feature is experimental! It is not ready for use!

This message will be updated as their interfaces are filled and implemented going forward.

### Embedded API Examples

- X-Macros: first instance of an embedded example using `\par "Example"` and Markdown codeblocks when a dedicated API Examples page is not necessary.

## Component File Structure

A component's headers are always included before any other header to mitigate against dependency resolution via transitive inclusion.

- A "forward" header (`foo-fwd.hpp`) is at the top of the component header hierarchy.
- A "normal" header (`foo.hpp`) includes the forward header first.
- An "internal" header (`foo.hh`) includes the normal header first.
- An "implementation" (aka source) file (`foo.cpp`) includes the internal or normal header first.

This is enforced by inserting a blank `//` comment between the component header and other dependency headers, including macro guard headers.

The source file contains out-of-line definitions for interfaces provided by both the normal and internal header. Non-trivial function definitions or those which introduce additional header dependencies should preferably be moved into implementation files to minimize cost of (re)compilation when such headers are updated (keep the include dependency graph "wide" rather than "tall").
