### PR TITLE
CXX-3224 Regenerate SBOM Lite for silkbomb:2.0 forward compatibility

### DIFF
--- a/etc/augmented.sbom.json
+++ b/etc/augmented.sbom.json
@@ -33,7 +33,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2025-02-12T20:25:30.226005+00:00",
+    "timestamp": "2025-02-19T20:40:45.380357+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -76,8 +76,8 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:dd68fbb0-f77c-4bb9-90cd-606dd854f301",
-  "version": 6,
+  "serialNumber": "urn:uuid:d27194f6-e5a2-45d3-b9cd-0da1502fb655",
+  "version": 1,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -2,6 +2,7 @@
   "components": [
     {
       "bom-ref": "pkg:github/mongodb/mongo-c-driver@v1.30.0",
+      "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
@@ -13,6 +14,13 @@
         }
       ],
       "group": "mongodb",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
       "name": "mongo-c-driver",
       "purl": "pkg:github/mongodb/mongo-c-driver@v1.30.0",
       "type": "library",

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -2,7 +2,6 @@
   "components": [
     {
       "bom-ref": "pkg:github/mongodb/mongo-c-driver@v1.30.0",
-      "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
@@ -14,13 +13,6 @@
         }
       ],
       "group": "mongodb",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
       "name": "mongo-c-driver",
       "purl": "pkg:github/mongodb/mongo-c-driver@v1.30.0",
       "type": "library",
@@ -33,7 +25,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2025-02-12T20:06:56.562655+00:00",
+    "timestamp": "2025-02-19T20:40:45.380357+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -76,8 +68,8 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:dd68fbb0-f77c-4bb9-90cd-606dd854f301",
-  "version": 6,
+  "serialNumber": "urn:uuid:d27194f6-e5a2-45d3-b9cd-0da1502fb655",
+  "version": 1,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",


### PR DESCRIPTION
Resolves CXX-3224 for the master branch. Similar changes to https://github.com/mongodb/libmongocrypt/pull/960, but applied to the C++ Driver.

The Augmented SBOM file for this PR (and related) were updated using Evergreen patch builds with pending updates to the EVG configuration to support SilkBomb 2.0. These changes will be proposed in a followup PR.