### PR TITLE
CXX-3224 Regenerate SBOM Lite for silkbomb:2.0 forward compatibility

### DIFF
--- a/etc/augmented.sbom.json
+++ b/etc/augmented.sbom.json
@@ -62,7 +62,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2024-06-05T21:16:58.419485+00:00",
+    "timestamp": "2025-02-19T21:13:48.578590+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -105,7 +105,7 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:dd68fbb0-f77c-4bb9-90cd-606dd854f301",
+  "serialNumber": "urn:uuid:369d9c5b-e19f-4b17-9446-30a5149a4700",
   "version": 1,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -2,6 +2,7 @@
   "components": [
     {
       "bom-ref": "pkg:github/mnmlstc/core@v1.1.0",
+      "copyright": "Copyright \u00a9 2013 - 2014 MNMLSTC",
       "externalReferences": [
         {
           "type": "distribution",
@@ -13,6 +14,13 @@
         }
       ],
       "group": "mnmlstc",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
       "name": "core",
       "purl": "pkg:github/mnmlstc/core@v1.1.0",
       "type": "library",
@@ -20,6 +28,7 @@
     },
     {
       "bom-ref": "pkg:github/mongodb/mongo-c-driver@v1.25.0",
+      "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
@@ -31,6 +40,13 @@
         }
       ],
       "group": "mongodb",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
       "name": "mongo-c-driver",
       "purl": "pkg:github/mongodb/mongo-c-driver@v1.25.0",
       "type": "library",

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -2,7 +2,6 @@
   "components": [
     {
       "bom-ref": "pkg:github/mnmlstc/core@v1.1.0",
-      "copyright": "Copyright \u00a9 2013 - 2014 MNMLSTC",
       "externalReferences": [
         {
           "type": "distribution",
@@ -14,13 +13,6 @@
         }
       ],
       "group": "mnmlstc",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
       "name": "core",
       "purl": "pkg:github/mnmlstc/core@v1.1.0",
       "type": "library",
@@ -28,7 +20,6 @@
     },
     {
       "bom-ref": "pkg:github/mongodb/mongo-c-driver@v1.25.0",
-      "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
@@ -40,13 +31,6 @@
         }
       ],
       "group": "mongodb",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
       "name": "mongo-c-driver",
       "purl": "pkg:github/mongodb/mongo-c-driver@v1.25.0",
       "type": "library",
@@ -62,7 +46,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2024-06-05T21:16:58.419485+00:00",
+    "timestamp": "2025-02-19T21:13:48.578590+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -105,9 +89,10 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:dd68fbb0-f77c-4bb9-90cd-606dd854f301",
+  "serialNumber": "urn:uuid:369d9c5b-e19f-4b17-9446-30a5149a4700",
   "version": 1,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
-  "specVersion": "1.5"
+  "specVersion": "1.5",
+  "vulnerabilities": []
 }


### PR DESCRIPTION
Resolves CXX-3224 for the releases/v3.10 branch. See https://github.com/mongodb/mongo-cxx-driver/pull/1340 for more info.