### PR TITLE
CXX-2745 remove obsolete include paths for generated config headers

### DIFF
--- a/cmake/BsoncxxUtil.cmake
+++ b/cmake/BsoncxxUtil.cmake
@@ -147,7 +147,6 @@ function(bsoncxx_add_library TARGET OUTPUT_NAME LINK_TYPE)
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib/bsoncxx/v_noabi>
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib>
-        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/lib/bsoncxx/v_noabi>
         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/lib>
     )
     target_compile_definitions(${TARGET} PRIVATE ${libbson_definitions})

--- a/cmake/MongocxxUtil.cmake
+++ b/cmake/MongocxxUtil.cmake
@@ -109,7 +109,6 @@ function(mongocxx_add_library TARGET OUTPUT_NAME LINK_TYPE)
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib/mongocxx/v_noabi>
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib>
-        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/lib/mongocxx/v_noabi>
         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/lib>
     )
     target_compile_definitions(${TARGET} PRIVATE ${libmongoc_definitions})


### PR DESCRIPTION
Minor followup to https://github.com/mongodb/mongo-cxx-driver/pull/1318, which relocated all generated config headers out of `v_noabi`. Addresses the following compilation warnings with Clang 21 in a fresh binary directory:

```
warning: no such include directory: 'src/mongocxx/lib/mongocxx/v_noabi' [-Wmissing-include-dirs]
```

All generated headers under `v1` and `private` continue to use the existing root-level include path (i.e. `${PROJECT_BINARY_DIR}/lib`).