### PR TITLE
doxygen: fix and improve macro expansion configuration options

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -2397,7 +2397,7 @@ MACRO_EXPANSION        = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = YES
+EXPAND_ONLY_PREDEF     = NO
 
 # If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -2430,8 +2430,12 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = BSONCXX_ABI_EXPORT_CDECL(...)=__VA_ARGS__ \
+PREDEFINED             = BSONCXX_ABI_CDECL= \
+                         BSONCXX_ABI_EXPORT= \
+                         BSONCXX_ABI_EXPORT_CDECL(...)=__VA_ARGS__ \
                          BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR= \
+                         MONGOCXX_ABI_CDECL= \
+                         MONGOCXX_ABI_EXPORT= \
                          MONGOCXX_ABI_EXPORT_CDECL(...)=__VA_ARGS__ \
                          MONGOCXX_PRIVATE_DOXYGEN_PREPROCESSOR=
 
@@ -2442,14 +2446,7 @@ PREDEFINED             = BSONCXX_ABI_EXPORT_CDECL(...)=__VA_ARGS__ \
 # definition found in the source code.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_AS_DEFINED      = BSONCXX_ABI_CDECL \
-                         BSONCXX_ABI_EXPORT \
-                         BSONCXX_ABI_NO_EXPORT \
-                         BSONCXX_DEPRECATED \
-                         MONGOCXX_ABI_CDECL \
-                         MONGOCXX_ABI_EXPORT \
-                         MONGOCXX_ABI_NO_EXPORT \
-                         MONGOCXX_DEPRECATED
+EXPAND_AS_DEFINED      =
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then Doxygen's preprocessor will
 # remove all references to function-like macros that are alone on a line, have
@@ -2459,7 +2456,7 @@ EXPAND_AS_DEFINED      = BSONCXX_ABI_CDECL \
 # The default value is: YES.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-SKIP_FUNCTION_MACROS   = YES
+SKIP_FUNCTION_MACROS   = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to external references

--- a/src/bsoncxx/CMakeLists.txt
+++ b/src/bsoncxx/CMakeLists.txt
@@ -153,6 +153,11 @@ if(1)
 /// @warning For internal use only!
 ///
 
+// Doxygen `PREDEFINED` does not define the macro *in code* as required by `@def`.
+#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+#define BSONCXX_ABI_EXPORT ...
+#endif
+
 ///
 /// @def BSONCXX_ABI_EXPORT
 /// @hideinitializer

--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -121,6 +121,11 @@ if(1)
 
 #define MONGOCXX_ABI_EXPORT_CDECL(...) MONGOCXX_ABI_EXPORT __VA_ARGS__ MONGOCXX_ABI_CDECL
 
+// Doxygen `PREDEFINED` does not define the macro *in code* as required by `@def`.
+#if defined(MONGOCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
+#define MONGOCXX_ABI_EXPORT ...
+#endif
+
 ///
 /// @file
 /// Provides macros to control the set of symbols exported in the ABI.


### PR DESCRIPTION
Workaround [doxgyen/doxygen#11495](/doxygen/doxygen/issues/11495) and [doxygen/doxygen#11496](/doxygen/doxygen/issues/11496) which are affecting CXX-2745 API documentation by tidying up the preprocessor-related Doxygen configuration options following https://github.com/mongodb/mongo-cxx-driver/pull/1301. Since all relevant macro definitions are now visible, they can be expanded as-is with `MACRO_EXPANSION = YES` without using `EXPAND_AS_DEFINED`.

`EXPAND_ONLY_PREDEF = YES` and `SKIP_FUNCTION_MACROS = YES` are no longer required to guard against the attempted expansion of complex macros, as all problematic expansions are already being guarded with `\cond DOXYGEN_DISABLE` (these options do not help us avoid these issues) and we do not parse non-header files (where most other macros, including those from external libraries, are used).

Due to the complexity of export macro definitions confusing the Doxygen preprocessor (notably their expansion into `__attribute__` and `__declspec` specifiers), `PREDEFINED` is used to replace the definitions of `*_ABI_EXPORT`, `*_ABI_CDECL`, and `*_ABI_EXPORT_CDECL` with simpler alternatives. All three must be predefined to fully avoid preprocessor and parser failures.

Given the `*_ABI_EXPORT=` predefinitions, the `*_ABI_EXPORT` macro is never defined _in code_ due to the `#ifndef` guard in the generated export header. A Doxygen preprocessor branch which unconditionally defines the export macro (as a stub: `...`) is needed to satisfy the `\def` special command's requirement that the documented macro is defined _in code_ prior to the doc comment.