### PR TITLE
doxygen: predefine non-standard specifiers and fix include paths

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -2397,7 +2397,7 @@ MACRO_EXPANSION        = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = YES
+EXPAND_ONLY_PREDEF     = NO
 
 # If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -2412,7 +2412,9 @@ SEARCH_INCLUDES        = YES
 # RECURSIVE has no effect here.
 # This tag requires that the tag SEARCH_INCLUDES is set to YES.
 
-INCLUDE_PATH           = build/doxygen/install/include
+INCLUDE_PATH           = build/doxygen/install/include/bsoncxx/v_noabi \
+                         build/doxygen/install/include/mongocxx/v_noabi \
+                         build/doxygen/install/include
 
 # You can use the INCLUDE_FILE_PATTERNS tag to specify one or more wildcard
 # patterns (like *.h and *.hpp) to filter out the header-files in the
@@ -2430,9 +2432,11 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = BSONCXX_ABI_EXPORT_CDECL(...)=__VA_ARGS__ \
+PREDEFINED             = __attribute__(...)= \
+                         __declspec(...)= \
+                         _Pragma(...)= \
+                         __pragma(...)= \
                          BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR= \
-                         MONGOCXX_ABI_EXPORT_CDECL(...)=__VA_ARGS__ \
                          MONGOCXX_PRIVATE_DOXYGEN_PREPROCESSOR=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
@@ -2442,14 +2446,7 @@ PREDEFINED             = BSONCXX_ABI_EXPORT_CDECL(...)=__VA_ARGS__ \
 # definition found in the source code.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_AS_DEFINED      = BSONCXX_ABI_CDECL \
-                         BSONCXX_ABI_EXPORT \
-                         BSONCXX_ABI_NO_EXPORT \
-                         BSONCXX_DEPRECATED \
-                         MONGOCXX_ABI_CDECL \
-                         MONGOCXX_ABI_EXPORT \
-                         MONGOCXX_ABI_NO_EXPORT \
-                         MONGOCXX_DEPRECATED
+EXPAND_AS_DEFINED      =
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then Doxygen's preprocessor will
 # remove all references to function-like macros that are alone on a line, have
@@ -2459,7 +2456,7 @@ EXPAND_AS_DEFINED      = BSONCXX_ABI_CDECL \
 # The default value is: YES.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-SKIP_FUNCTION_MACROS   = YES
+SKIP_FUNCTION_MACROS   = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to external references

--- a/Doxyfile
+++ b/Doxyfile
@@ -2397,7 +2397,7 @@ MACRO_EXPANSION        = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = NO
+EXPAND_ONLY_PREDEF     = YES
 
 # If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -2430,12 +2430,8 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = BSONCXX_ABI_CDECL= \
-                         BSONCXX_ABI_EXPORT= \
-                         BSONCXX_ABI_EXPORT_CDECL(...)=__VA_ARGS__ \
+PREDEFINED             = BSONCXX_ABI_EXPORT_CDECL(...)=__VA_ARGS__ \
                          BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR= \
-                         MONGOCXX_ABI_CDECL= \
-                         MONGOCXX_ABI_EXPORT= \
                          MONGOCXX_ABI_EXPORT_CDECL(...)=__VA_ARGS__ \
                          MONGOCXX_PRIVATE_DOXYGEN_PREPROCESSOR=
 
@@ -2446,7 +2442,14 @@ PREDEFINED             = BSONCXX_ABI_CDECL= \
 # definition found in the source code.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_AS_DEFINED      =
+EXPAND_AS_DEFINED      = BSONCXX_ABI_CDECL \
+                         BSONCXX_ABI_EXPORT \
+                         BSONCXX_ABI_NO_EXPORT \
+                         BSONCXX_DEPRECATED \
+                         MONGOCXX_ABI_CDECL \
+                         MONGOCXX_ABI_EXPORT \
+                         MONGOCXX_ABI_NO_EXPORT \
+                         MONGOCXX_DEPRECATED
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then Doxygen's preprocessor will
 # remove all references to function-like macros that are alone on a line, have
@@ -2456,7 +2459,7 @@ EXPAND_AS_DEFINED      =
 # The default value is: YES.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-SKIP_FUNCTION_MACROS   = NO
+SKIP_FUNCTION_MACROS   = YES
 
 #---------------------------------------------------------------------------
 # Configuration options related to external references

--- a/src/bsoncxx/CMakeLists.txt
+++ b/src/bsoncxx/CMakeLists.txt
@@ -153,11 +153,6 @@ if(1)
 /// @warning For internal use only!
 ///
 
-// Doxygen `PREDEFINED` does not define the macro *in code* as required by `@def`.
-#if defined(BSONCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
-#define BSONCXX_ABI_EXPORT ...
-#endif
-
 ///
 /// @def BSONCXX_ABI_EXPORT
 /// @hideinitializer

--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -121,11 +121,6 @@ if(1)
 
 #define MONGOCXX_ABI_EXPORT_CDECL(...) MONGOCXX_ABI_EXPORT __VA_ARGS__ MONGOCXX_ABI_CDECL
 
-// Doxygen `PREDEFINED` does not define the macro *in code* as required by `@def`.
-#if defined(MONGOCXX_PRIVATE_DOXYGEN_PREPROCESSOR)
-#define MONGOCXX_ABI_EXPORT ...
-#endif
-
 ///
 /// @file
 /// Provides macros to control the set of symbols exported in the ABI.


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1353. After further investigation, it seems preferable to [predefine the non-standard attribute syntax](/doxygen/doxygen/issues/11495#issuecomment-2730431058) as macros rather than predefining/redefining the library macros which they are used with. This avoids the need for Doxygen preprocessor handling in the export headers (reverted the changes in https://github.com/mongodb/mongo-cxx-driver/pull/1353), simplifies the list of predefined macros in the Doxygen configuration file, and extends Doxygen parser confusion mitigation to all non-standard syntax (declspec and pragmas).

This revealed some Doxygen preprocessor confusion concerning how v_noabi prelude headers transitively include v1 headers, such that macros in `bsoncxx/v1/config/export.hpp` are not being correctly provided by `bsoncxx/config/prelude.hpp` during Doxygen preprocessing. This produces the same indistinguishable `warning: Found ';' while parsing initializer list!` as what were being caused by the `__attribute__` syntax, but this time due to the `*_ABI_EXPORT_CDECL()` function macro being _undefined_ at point of use (according to Doxygen). It seems adding the `v_noabi` paths to `INCLUDE_PATH` (mirroring the actual include paths used by the libraries themselves) is sufficient to clear up Doxygen's confusion. See [doxygen/doxygen#11501](/doxygen/doxygen/issues/11501) for more details.