### PR TITLE
ClangFormat: set InsertNewlineAtEOF to true

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -200,7 +200,7 @@ IndentRequiresClause: true
 IndentWidth:     4
 IndentWrappedFunctionNames: false
 InsertBraces:    false
-InsertNewlineAtEOF: false
+InsertNewlineAtEOF: true
 InsertTrailingCommas: None
 IntegerLiteralSeparator:
   Binary:          0


### PR DESCRIPTION
To ensure all source files have an EOF newline.

No source file currently requires modifications (they already have an EOF newline).