### PR TITLE
Fix potential duplicate key errors in bulk_write tests

### DIFF
--- a/src/mongocxx/test/bulk_write.cpp
+++ b/src/mongocxx/test/bulk_write.cpp
@@ -36,6 +36,7 @@ TEST_CASE("a bulk_write will setup a mongoc bulk operation", "[bulk_write]") {
     instance::current();
     mongocxx::client client{mongocxx::uri{}};
     mongocxx::collection coll = client["db"]["coll"];
+    CHECK_NOTHROW(coll.drop());
     auto construct = libmongoc::collection_create_bulk_operation_with_opts.create_instance();
     bool construct_called = false;
     bool ordered_value = false;
@@ -75,6 +76,7 @@ TEST_CASE("destruction of a bulk_write will destroy mongoc operation", "[bulk_wr
     instance::current();
     mongocxx::client client{mongocxx::uri{}};
     mongocxx::collection coll = client["db"]["coll"];
+    CHECK_NOTHROW(coll.drop());
     auto destruct = libmongoc::bulk_operation_destroy.create_instance();
     bool destruct_called = false;
 
@@ -184,7 +186,9 @@ class delete_functor {
 TEST_CASE("passing write operations to append calls corresponding C function", "[bulk_write]") {
     instance::current();
     mongocxx::client client{mongocxx::uri{}};
-    auto bw = client["db"]["coll"].create_bulk_write();
+    mongocxx::collection coll = client["db"]["coll"];
+    CHECK_NOTHROW(coll.drop());
+    auto bw = coll.create_bulk_write();
     bsoncxx::builder::basic::document filter_builder, doc_builder, update_doc_builder, collation_builder;
     filter_builder.append(kvp("_id", 1));
     doc_builder.append(kvp("_id", 2));
@@ -358,7 +362,9 @@ TEST_CASE("passing write operations to append calls corresponding C function", "
 TEST_CASE("calling empty on a bulk write before and after appending", "[bulk_write]") {
     instance::current();
     mongocxx::client client{mongocxx::uri{}, test_util::add_test_server_api()};
-    auto bw = client["db"]["coll"].create_bulk_write();
+    mongocxx::collection coll = client["db"]["coll"];
+    CHECK_NOTHROW(coll.drop());
+    auto bw = coll.create_bulk_write();
 
     REQUIRE(bw.empty());
     bw.append(model::insert_one(make_document(kvp("_id", 1))));


### PR DESCRIPTION
Observed during local testing:

```
failed: unexpected exception with message: 'E11000 duplicate key error collection: db.coll index: _id_ dup key: { _id: 1 }: generic server error'
```

The bulk_write tests do not ensure the `db.coll` collection is empty prior to inserting keys with `_id: 1`.

A more comprehensive strategy to ensure a fresh database or collection (i.e. as implemented for the [API examples runner](https://github.com/mongodb/mongo-cxx-driver/blob/22337913e5d9df873491e69612612dd7fda4f575/examples/api/db_lock.hh#L24)) is deferred for later.