### PR TITLE
CDRIVER-5946 remove deprecated index management API

### DIFF
--- a/src/mongocxx/lib/mongocxx/private/mongoc.hh
+++ b/src/mongocxx/lib/mongocxx/private/mongoc.hh
@@ -314,9 +314,6 @@ BSONCXX_PRIVATE_WARNINGS_POP();
     X(find_and_modify_opts_set_sort)                                      \
     X(find_and_modify_opts_set_update)                                    \
     X(handshake_data_append)                                              \
-    X(index_opt_geo_init)                                                 \
-    X(index_opt_init)                                                     \
-    X(index_opt_wt_init)                                                  \
     X(init)                                                               \
     /* X(log_set_handler) CDRIVER-5678: not __cdecl. */                   \
     X(read_concern_copy)                                                  \

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/index.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/index.cpp
@@ -204,6 +204,12 @@ bsoncxx::v_noabi::stdx::optional<double> const& index::haystack_bucket_size() co
     return haystack_bucket_size_deprecated();
 }
 
+// CDRIVER-5946: mongoc_index_storage_opt_type_t was removed in mongoc 2.0.
+enum mongoc_index_storage_opt_type_t {
+    MONGOC_INDEX_STORAGE_OPT_MMAPV1,
+    MONGOC_INDEX_STORAGE_OPT_WIREDTIGER,
+};
+
 index::operator bsoncxx::v_noabi::document::view_or_value() {
     using namespace bsoncxx;
     using builder::basic::kvp;


### PR DESCRIPTION
Related to CDRIVER-5946. Followup to https://github.com/mongodb/mongo-c-driver/pull/1957.

The `mongoc_index_opt_*` functions are not corrently used despite being added to `mongoc.hh` by [CXX-687](https://jira.mongodb.org/browse/CXX-687) ([commit](https://github.com/mongodb/mongo-cxx-driver/commit/a468a81c2894225b6ef839a6ebeaaa9bf00b6468)) due to their replacement with a BSON-based approach in [CXX-1359](https://jira.mongodb.org/browse/CXX-1359) ([commit](https://github.com/mongodb/mongo-cxx-driver/commit/0f10af95486812dc64adfd1e0495c129409f67b5)). Therefore, it is sufficient to simply remove the functions from the list with no further changes required.

> [!NOTE]
> mongocxx currently supports index management by [manually constructing commands](https://github.com/mongodb/mongo-cxx-driver/blob/22337913e5d9df873491e69612612dd7fda4f575/src/mongocxx/lib/mongocxx/private/index_view.hh#L126) and passing them to [mongoc_collection_write_command_with_opts](https://github.com/mongodb/mongo-cxx-driver/blob/22337913e5d9df873491e69612612dd7fda4f575/src/mongocxx/lib/mongocxx/private/index_view.hh#L167).

The `mongoc_index_storage_opt_type_t` enumeration _is_ being used, but only for the `MONGOC_INDEX_STORAGE_OPT_WIREDTIGER` enumerator in a very limited scope. The definition of the enumeration that was removed by https://github.com/mongodb/mongo-c-driver/pull/1957 is cloned as-is for traceability and backward compatibility. This can be simplified if preferable (the `MONGOC_INDEX_STORAGE_OPT_MMAPV1` enumerator is unused).

No other changes seem to be required following https://github.com/mongodb/mongo-c-driver/pull/1957, although we might want to consider deprecating the `wiredtiger_storage_options` class given its equivalents in the C Driver have been deprecated and removed.