### PR TITLE
Remove display tasks from EVG config

### DIFF
--- a/.evergreen/config_generator/components/abi_stability.py
+++ b/.evergreen/config_generator/components/abi_stability.py
@@ -4,7 +4,7 @@ from config_generator.etc.distros import find_large_distro
 from config_generator.etc.function import Function, merge_defns
 from config_generator.etc.utils import bash_exec
 
-from shrub.v3.evg_build_variant import BuildVariant, DisplayTask
+from shrub.v3.evg_build_variant import BuildVariant
 from shrub.v3.evg_command import EvgCommandType, git_get_project, s3_put
 from shrub.v3.evg_task import EvgTask, EvgTaskRef
 from shrub.v3.evg_task_group import EvgTaskGroup
@@ -222,12 +222,6 @@ def variants():
             tasks=[
                 EvgTaskRef(name=f'tg-{TAG}-{polyfill}-cxx{cxx_standard}')
                 for polyfill, cxx_standard in MATRIX
-            ],
-            display_tasks=[
-                DisplayTask(
-                    name=f'ABI Stability Checks',
-                    execution_tasks=[f'.{TAG}'],
-                )
             ],
         )
     ]

--- a/.evergreen/config_generator/components/atlas_search_indexes.py
+++ b/.evergreen/config_generator/components/atlas_search_indexes.py
@@ -8,7 +8,7 @@ from config_generator.etc.distros import find_large_distro
 from config_generator.etc.function import Function
 from config_generator.etc.utils import bash_exec
 
-from shrub.v3.evg_build_variant import BuildVariant, DisplayTask
+from shrub.v3.evg_build_variant import BuildVariant
 from shrub.v3.evg_command import EvgCommandType, expansions_update
 from shrub.v3.evg_task import EvgTask, EvgTaskRef
 from shrub.v3.evg_task_group import EvgTaskGroup
@@ -101,11 +101,5 @@ def variants():
             name=f'{TAG}-matrix',
             display_name=f'{TAG}-matrix',
             tasks=[EvgTaskRef(name=f'tg-{TAG}-{mongodb_version}') for mongodb_version in MATRIX],
-            display_tasks=[
-                DisplayTask(
-                    name=f'{TAG}-matrix',
-                    execution_tasks=[f'.{TAG}'],
-                )
-            ],
         ),
     ]

--- a/.evergreen/config_generator/components/compile_only.py
+++ b/.evergreen/config_generator/components/compile_only.py
@@ -5,7 +5,7 @@ from config_generator.components.funcs.setup import Setup
 
 from config_generator.etc.distros import compiler_to_vars, find_large_distro, make_distro_str
 
-from shrub.v3.evg_build_variant import BuildVariant, DisplayTask
+from shrub.v3.evg_build_variant import BuildVariant
 from shrub.v3.evg_command import KeyValueParam, expansions_update
 from shrub.v3.evg_task import EvgTask, EvgTaskRef
 
@@ -114,10 +114,4 @@ def variants():
         name=f'{TAG}-matrix',
         display_name=f'{TAG}-matrix',
         tasks=tasks,
-        display_tasks=[
-            DisplayTask(
-                name=f'{TAG}-matrix',
-                execution_tasks=[f'.{TAG}' + ''.join(f' !.{distro}' for distro in batched)],
-            )
-        ],
     )

--- a/.evergreen/config_generator/components/integration.py
+++ b/.evergreen/config_generator/components/integration.py
@@ -9,7 +9,7 @@ from config_generator.components.funcs.test import Test
 
 from config_generator.etc.distros import compiler_to_vars, find_large_distro, make_distro_str
 
-from shrub.v3.evg_build_variant import BuildVariant, DisplayTask
+from shrub.v3.evg_build_variant import BuildVariant
 from shrub.v3.evg_command import KeyValueParam, expansions_update
 from shrub.v3.evg_task import EvgTask, EvgTaskRef
 
@@ -211,10 +211,4 @@ def variants():
             name=f'{TAG}-matrix-{name}',
             display_name=f'{TAG}-matrix-{name}',
             tasks=tasks,
-            display_tasks=[
-                DisplayTask(
-                    name=f'{TAG}-matrix-{name}',
-                    execution_tasks=[f'.{TAG}' + ''.join(f' !.{distro}' for distro in batched)],
-                )
-            ],
         )

--- a/.evergreen/config_generator/components/macro_guards.py
+++ b/.evergreen/config_generator/components/macro_guards.py
@@ -5,7 +5,7 @@ from config_generator.components.funcs.setup import Setup
 
 from config_generator.etc.distros import find_large_distro, make_distro_str
 
-from shrub.v3.evg_build_variant import BuildVariant, DisplayTask
+from shrub.v3.evg_build_variant import BuildVariant
 from shrub.v3.evg_task import EvgTask, EvgTaskRef
 
 
@@ -62,11 +62,5 @@ def variants():
             name=f'{TAG}-matrix',
             display_name=f'{TAG}-matrix',
             tasks=[EvgTaskRef(name=f'.{TAG}')],
-            display_tasks=[
-                DisplayTask(
-                    name=f'{TAG}-matrix',
-                    execution_tasks=[f'.{TAG}'],
-                )
-            ],
         ),
     ]

--- a/.evergreen/config_generator/components/sanitizers.py
+++ b/.evergreen/config_generator/components/sanitizers.py
@@ -9,7 +9,7 @@ from config_generator.components.funcs.test import Test
 
 from config_generator.etc.distros import find_large_distro, make_distro_str
 
-from shrub.v3.evg_build_variant import BuildVariant, DisplayTask
+from shrub.v3.evg_build_variant import BuildVariant
 from shrub.v3.evg_command import KeyValueParam, expansions_update
 from shrub.v3.evg_task import EvgTask, EvgTaskRef
 
@@ -132,11 +132,5 @@ def variants():
             name=f'{TAG}-matrix',
             display_name=f'{TAG}-matrix',
             tasks=[EvgTaskRef(name=f'.{TAG}')],
-            display_tasks=[
-                DisplayTask(
-                    name=f'{TAG}-matrix',
-                    execution_tasks=[f'.{TAG}'],
-                )
-            ],
         ),
     ]

--- a/.evergreen/config_generator/components/scan_build.py
+++ b/.evergreen/config_generator/components/scan_build.py
@@ -5,7 +5,7 @@ from config_generator.etc.distros import find_large_distro
 from config_generator.etc.function import Function, merge_defns
 from config_generator.etc.utils import bash_exec
 
-from shrub.v3.evg_build_variant import BuildVariant, DisplayTask
+from shrub.v3.evg_build_variant import BuildVariant
 from shrub.v3.evg_command import EvgCommandType, s3_put
 from shrub.v3.evg_task import EvgTask, EvgTaskRef
 
@@ -136,11 +136,5 @@ def variants():
             name=f'{TAG}-matrix',
             display_name=f'{TAG}-matrix',
             tasks=[EvgTaskRef(name=f'.{TAG}')],
-            display_tasks=[
-                DisplayTask(
-                    name=f'{TAG}-matrix',
-                    execution_tasks=[f'.{TAG}'],
-                )
-            ],
         ),
     ]

--- a/.evergreen/config_generator/components/uninstall_check.py
+++ b/.evergreen/config_generator/components/uninstall_check.py
@@ -7,7 +7,7 @@ from config_generator.etc.distros import find_large_distro, make_distro_str
 from config_generator.etc.function import Function
 from config_generator.etc.utils import bash_exec
 
-from shrub.v3.evg_build_variant import BuildVariant, DisplayTask
+from shrub.v3.evg_build_variant import BuildVariant
 from shrub.v3.evg_command import EvgCommandType
 from shrub.v3.evg_task import EvgTask, EvgTaskRef
 
@@ -83,11 +83,5 @@ def variants():
             name=TAG,
             display_name='Uninstall Check',
             tasks=[EvgTaskRef(name=f'.{TAG}')],
-            display_tasks=[
-                DisplayTask(
-                    name=f'uninstall-check',
-                    execution_tasks=[f'.{TAG}'],
-                )
-            ],
         ),
     ]

--- a/.evergreen/config_generator/components/valgrind.py
+++ b/.evergreen/config_generator/components/valgrind.py
@@ -9,7 +9,7 @@ from config_generator.components.funcs.test import Test
 
 from config_generator.etc.distros import find_large_distro, make_distro_str
 
-from shrub.v3.evg_build_variant import BuildVariant, DisplayTask
+from shrub.v3.evg_build_variant import BuildVariant
 from shrub.v3.evg_command import KeyValueParam, expansions_update
 from shrub.v3.evg_task import EvgTask, EvgTaskRef
 
@@ -104,11 +104,5 @@ def variants():
             name=f'{TAG}-matrix',
             display_name=f'{TAG}-matrix',
             tasks=[EvgTaskRef(name=f'.{TAG}')],
-            display_tasks=[
-                DisplayTask(
-                    name=f'{TAG}-matrix',
-                    execution_tasks=[f'.{TAG}'],
-                )
-            ],
         ),
     ]

--- a/.evergreen/config_generator/components/versioned_api.py
+++ b/.evergreen/config_generator/components/versioned_api.py
@@ -9,7 +9,7 @@ from config_generator.components.funcs.test import Test
 
 from config_generator.etc.distros import find_large_distro, make_distro_str
 
-from shrub.v3.evg_build_variant import BuildVariant, DisplayTask
+from shrub.v3.evg_build_variant import BuildVariant
 from shrub.v3.evg_task import EvgTask, EvgTaskRef
 
 from itertools import product
@@ -97,11 +97,5 @@ def variants():
             name=f'{TAG}-matrix',
             display_name=f'{TAG}-matrix',
             tasks=[EvgTaskRef(name=f'.{TAG}')],
-            display_tasks=[
-                DisplayTask(
-                    name=f'{TAG}-matrix',
-                    execution_tasks=[f'.{TAG}'],
-                )
-            ],
         ),
     ]

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -1,10 +1,6 @@
 buildvariants:
   - name: abi-stability
     display_name: ABI Stability Checks
-    display_tasks:
-      - name: ABI Stability Checks
-        execution_tasks:
-          - .abi-stability
     tasks:
       - name: tg-abi-stability-impls-cxx11
       - name: tg-abi-stability-impls-cxx17
@@ -13,10 +9,6 @@ buildvariants:
       - name: tg-abi-stability-stdlib-cxx23
   - name: atlas-search-indexes-matrix
     display_name: atlas-search-indexes-matrix
-    display_tasks:
-      - name: atlas-search-indexes-matrix
-        execution_tasks:
-          - .atlas-search-indexes
     tasks:
       - name: tg-atlas-search-indexes-7.0
       - name: tg-atlas-search-indexes-8.0
@@ -30,10 +22,6 @@ buildvariants:
       - name: .clang-tidy
   - name: compile-only-matrix
     display_name: compile-only-matrix
-    display_tasks:
-      - name: compile-only-matrix
-        execution_tasks:
-          - .compile-only !.rhel8-power !.rhel8-zseries
     tasks:
       - name: .compile-only .rhel8-power
         batchtime: 1440
@@ -46,10 +34,6 @@ buildvariants:
       - name: .docker-build
   - name: integration-matrix-extra_alignment
     display_name: integration-matrix-extra_alignment
-    display_tasks:
-      - name: integration-matrix-extra_alignment
-        execution_tasks:
-          - .integration !.rhel8-power !.rhel8-zseries
     tasks:
       - name: .integration .extra_alignment .rhel8-power
         batchtime: 1440
@@ -58,10 +42,6 @@ buildvariants:
       - name: .integration .extra_alignment !.rhel8-power !.rhel8-zseries
   - name: integration-matrix-linux
     display_name: integration-matrix-linux
-    display_tasks:
-      - name: integration-matrix-linux
-        execution_tasks:
-          - .integration !.rhel8-power !.rhel8-zseries
     tasks:
       - name: .integration .linux !.mongocryptd !.extra_alignment .rhel8-power
         batchtime: 1440
@@ -70,18 +50,10 @@ buildvariants:
       - name: .integration .linux !.mongocryptd !.extra_alignment !.rhel8-power !.rhel8-zseries
   - name: integration-matrix-macos
     display_name: integration-matrix-macos
-    display_tasks:
-      - name: integration-matrix-macos
-        execution_tasks:
-          - .integration
     tasks:
       - name: .integration .macos !.mongocryptd !.extra_alignment
   - name: integration-matrix-mongocryptd
     display_name: integration-matrix-mongocryptd
-    display_tasks:
-      - name: integration-matrix-mongocryptd
-        execution_tasks:
-          - .integration !.rhel8-power !.rhel8-zseries
     tasks:
       - name: .integration .mongocryptd .rhel8-power
         batchtime: 1440
@@ -90,10 +62,6 @@ buildvariants:
       - name: .integration .mongocryptd !.rhel8-power !.rhel8-zseries
   - name: integration-matrix-windows
     display_name: integration-matrix-windows
-    display_tasks:
-      - name: integration-matrix-windows
-        execution_tasks:
-          - .integration
     tasks:
       - name: .integration .windows !.mongocryptd !.extra_alignment
   - name: lint
@@ -102,10 +70,6 @@ buildvariants:
       - name: .lint
   - name: macro-guards-matrix
     display_name: macro-guards-matrix
-    display_tasks:
-      - name: macro-guards-matrix
-        execution_tasks:
-          - .macro-guards
     tasks:
       - name: .macro-guards
   - name: mongohouse
@@ -118,10 +82,6 @@ buildvariants:
       - name: .packaging
   - name: sanitizers-matrix
     display_name: sanitizers-matrix
-    display_tasks:
-      - name: sanitizers-matrix
-        execution_tasks:
-          - .sanitizers
     tasks:
       - name: .sanitizers
   - name: sbom
@@ -130,33 +90,17 @@ buildvariants:
       - name: .sbom
   - name: scan-build-matrix
     display_name: scan-build-matrix
-    display_tasks:
-      - name: scan-build-matrix
-        execution_tasks:
-          - .scan-build
     tasks:
       - name: .scan-build
   - name: uninstall-check
     display_name: Uninstall Check
-    display_tasks:
-      - name: uninstall-check
-        execution_tasks:
-          - .uninstall-check
     tasks:
       - name: .uninstall-check
   - name: valgrind-matrix
     display_name: valgrind-matrix
-    display_tasks:
-      - name: valgrind-matrix
-        execution_tasks:
-          - .valgrind
     tasks:
       - name: .valgrind
   - name: versioned-api-matrix
     display_name: versioned-api-matrix
-    display_tasks:
-      - name: versioned-api-matrix
-        execution_tasks:
-          - .versioned-api
     tasks:
       - name: .versioned-api


### PR DESCRIPTION
Abandoning the initiative started by https://github.com/mongodb/mongo-cxx-driver/pull/1083 to use display tasks (aka "execution tasks") for structured task lists.

> The "display tasks" EVG feature is used to reduce verbosity of the EVG results page. This also allows for the uploaded files to be conveniently grouped by display task [...]

This is due to deprioritization of related feature requests and bug fixes ([DEVPROD-5091](https://jira.mongodb.org/browse/DEVPROD-5091), [DEVPROD-7440](https://jira.mongodb.org/browse/DEVPROD-7440), [DEVPROD-12402](https://jira.mongodb.org/browse/DEVPROD-12402), [DEVPROD-13331](https://jira.mongodb.org/browse/DEVPROD-13331) (https://github.com/mongodb/mongo-cxx-driver/pull/1298), [DEVPROD-14794](https://jira.mongodb.org/browse/DEVPROD-14794), [DEVPROD-14888](https://jira.mongodb.org/browse/DEVPROD-14888)) and the obscuring of useful information for display tasks in the Evergreen Waterfall UI (a single status box does not convey the difference between 1 task failure vs. 100 task failures).

Grouping of tasks (in both Spruce and during CLI patch scheduling) may be accomplished using Evergreen UI's (much better) support for task filtering via regex patterns (e.g. `--regex_tasks` / `--rt`) and/or via task tags instead.