### PR TITLE
CXX-3261 temporarily restrict updateDescription tests to 8.1 or older

### DIFF
--- a/data/change-streams/unified/change-streams-pre_and_post_images.json
+++ b/data/change-streams/unified/change-streams-pre_and_post_images.json
@@ -4,6 +4,7 @@
   "runOnRequirements": [
     {
       "minServerVersion": "6.0.0",
+      "maxServerVersion": "8.1.0",
       "topologies": [
         "replicaset",
         "sharded",

--- a/data/change-streams/unified/change-streams.json
+++ b/data/change-streams/unified/change-streams.json
@@ -4,6 +4,7 @@
   "runOnRequirements": [
     {
       "minServerVersion": "3.6",
+      "maxServerVersion": "8.1",
       "topologies": [
         "replicaset"
       ],


### PR DESCRIPTION
Preemptive changes to unblock failing tasks on Evergreen until a proper solution is implemented for [DRIVERS-3151](https://jira.mongodb.org/browse/DRIVERS-3151).