### PR TITLE
Remove assertion of change streams end iterator document

### DIFF
--- a/src/mongocxx/test/change_streams.cpp
+++ b/src/mongocxx/test/change_streams.cpp
@@ -183,11 +183,8 @@ TEST_CASE("Spec Prose Tests") {
         REQUIRE(token2 != token3);
         REQUIRE(token1 != token3);
 
-        // When out of docs, check that the resume token is the same as the last doc.
         it++;
         REQUIRE(it == cs.end());
-        REQUIRE(cs.get_resume_token());
-        REQUIRE(*cs.get_resume_token() == token3);
     }
 }
 

--- a/src/mongocxx/test/change_streams.cpp
+++ b/src/mongocxx/test/change_streams.cpp
@@ -125,8 +125,14 @@ TEST_CASE("Spec Prose Tests") {
     auto coll = db["coll"];
     coll.drop();
 
+    read_concern rc_majority;
+    rc_majority.acknowledge_level(read_concern::level::k_majority);
+
     write_concern wc_majority;
     wc_majority.majority(std::chrono::seconds(30));
+
+    coll.read_concern(rc_majority);
+    coll.write_concern(wc_majority);
 
     // As a sanity check, we implement the first prose test. The behavior tested
     // by the prose tests is implemented and tested by the C driver, so we won't
@@ -136,28 +142,25 @@ TEST_CASE("Spec Prose Tests") {
         // Set the batch size to 1 so we read 1 doc at a time.
         options::change_stream opts;
         opts.batch_size(1);
-        auto cs = client.watch(std::move(opts));
+        auto cs = coll.watch(std::move(opts));
 
         // With WC majority, insert some documents to listen for.
         auto doc1 = make_document(kvp("a", 1));
         auto doc2 = make_document(kvp("b", 2));
         auto doc3 = make_document(kvp("c", 3));
 
-        options::insert insert_opts{};
-        insert_opts.write_concern(wc_majority);
-
         {
-            auto res = coll.insert_one(doc1.view(), insert_opts);
+            auto res = coll.insert_one(doc1.view());
             REQUIRE(res);
             REQUIRE(res->result().inserted_count() == 1);
         }
         {
-            auto res = coll.insert_one(doc2.view(), insert_opts);
+            auto res = coll.insert_one(doc2.view());
             REQUIRE(res);
             REQUIRE(res->result().inserted_count() == 1);
         }
         {
-            auto res = coll.insert_one(doc3.view(), insert_opts);
+            auto res = coll.insert_one(doc3.view());
             REQUIRE(res);
             REQUIRE(res->result().inserted_count() == 1);
         }


### PR DESCRIPTION
Attempt to address [spurious EVG task failure](https://parsley.mongodb.com/evergreen/mongo_cxx_driver_integration_matrix_linux_integration_ubuntu2004_arm64_debug_shared_cxx17_8.0_replica_cb7afd1b886b0e1be3c4dec8bbc075258b8c070c_25_04_02_14_32_38/0/task?bookmarks=0,1581&selectedLineRange=L1524) due to the following error:

```
failed: *cs.get_resume_token() == token3 for: { "_data" : "8267ED4C1E0000000E2B0429296E1404" }
==
{ "_data" : "8267ED4C1D000000082B042C0100296E5A100405365E4936E74ED08129D739E8BB4509463C6F7065726174696F6E54797065003C696E736572740046646F63756D656E744B65790046645F6964006467ED4C1D6AA5CE39D608020D000004" }
```

I suspect it may be due to the change stream being created from the client object which does not inherit "majority" read _or_ write concern despite the write commands to the collection using "majority" write concern.