### PR TITLE
CDRIVER-5952 remove mongoc_uri_get_ssl

### DIFF
--- a/src/mongocxx/lib/mongocxx/private/mongoc.hh
+++ b/src/mongocxx/lib/mongocxx/private/mongoc.hh
@@ -388,9 +388,6 @@ BSONCXX_PRIVATE_WARNINGS_POP();
     X(uri_get_read_concern)                                               \
     X(uri_get_read_prefs_t)                                               \
     X(uri_get_replica_set)                                                \
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN                           \
-    X(uri_get_ssl)                                                        \
-    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END                             \
     X(uri_get_string)                                                     \
     X(uri_get_tls)                                                        \
     X(uri_get_username)                                                   \


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1963. No further changes appear to be necessary.