### PR TITLE
Revert "Temporarily relocate sbom and valgrind tasks from rhel80 to rhel8.8 (#1370)"

### DIFF
--- a/.evergreen/config_generator/components/sbom.py
+++ b/.evergreen/config_generator/components/sbom.py
@@ -134,7 +134,7 @@ def functions():
 
 
 def tasks():
-    distro_name = 'rhel8.8'
+    distro_name = 'rhel80'
     distro = find_small_distro(distro_name)
 
     yield EvgTask(

--- a/.evergreen/config_generator/components/valgrind.py
+++ b/.evergreen/config_generator/components/valgrind.py
@@ -23,7 +23,7 @@ TAG = 'valgrind'
 # fmt: off
 MATRIX = [
     # min-max-latest
-    ('rhel8.8', None, ['shared'], ['4.0', '8.0', 'latest'], ['single', 'replica', 'sharded']),
+    ('rhel80', None, ['shared'], ['4.0', '8.0', 'latest'], ['single', 'replica', 'sharded']),
 ]
 # fmt: on
 # pylint: enable=line-too-long
@@ -38,8 +38,7 @@ def tasks():
         ):
             distro = find_large_distro(distro_name)
 
-            distro_str = make_distro_str('rhel80', compiler, None)  # Avoid breaking task history.
-            name = f'{TAG}-{distro_str}'
+            name = f'{TAG}-{make_distro_str(distro_name, compiler, None)}'
             tags = [TAG, distro_name]
 
             if compiler:

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -60,8 +60,6 @@ MACOS_ARM64_DISTROS = [
 ]
 
 RHEL_DISTROS = [
-    *ls_distro(name='rhel8.8', os='rhel', os_type='linux', os_ver='8.8'),
-
     *ls_distro(name='rhel80', os='rhel', os_type='linux', os_ver='8.0'),
     *ls_distro(name='rhel95', os='rhel', os_type='linux', os_ver='9.5'),
 ]

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -15641,8 +15641,8 @@ tasks:
           example_projects_cxxflags: -fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer
           example_projects_ldflags: -fsanitize=undefined -fno-sanitize-recover=undefined -static-libsan
   - name: sbom
-    run_on: rhel8.8-small
-    tags: [sbom, rhel8.8]
+    run_on: rhel80-small
+    tags: [sbom, rhel80]
     commands:
       - func: setup
       - func: check augmented sbom
@@ -15881,8 +15881,8 @@ tasks:
           platform: x64
       - func: uninstall-check
   - name: valgrind-rhel80-shared-4.0-replica
-    run_on: rhel8.8-large
-    tags: [valgrind, rhel8.8, shared, "4.0", replica]
+    run_on: rhel80-large
+    tags: [valgrind, rhel80, shared, "4.0", replica]
     commands:
       - command: expansions.update
         params:
@@ -15910,8 +15910,8 @@ tasks:
           disable_slow_tests: 1
           use_mongocryptd: true
   - name: valgrind-rhel80-shared-4.0-sharded
-    run_on: rhel8.8-large
-    tags: [valgrind, rhel8.8, shared, "4.0", sharded]
+    run_on: rhel80-large
+    tags: [valgrind, rhel80, shared, "4.0", sharded]
     commands:
       - command: expansions.update
         params:
@@ -15939,8 +15939,8 @@ tasks:
           disable_slow_tests: 1
           use_mongocryptd: true
   - name: valgrind-rhel80-shared-4.0-single
-    run_on: rhel8.8-large
-    tags: [valgrind, rhel8.8, shared, "4.0", single]
+    run_on: rhel80-large
+    tags: [valgrind, rhel80, shared, "4.0", single]
     commands:
       - command: expansions.update
         params:
@@ -15967,8 +15967,8 @@ tasks:
           disable_slow_tests: 1
           use_mongocryptd: true
   - name: valgrind-rhel80-shared-8.0-replica
-    run_on: rhel8.8-large
-    tags: [valgrind, rhel8.8, shared, "8.0", replica]
+    run_on: rhel80-large
+    tags: [valgrind, rhel80, shared, "8.0", replica]
     commands:
       - command: expansions.update
         params:
@@ -15996,8 +15996,8 @@ tasks:
           disable_slow_tests: 1
           use_mongocryptd: true
   - name: valgrind-rhel80-shared-8.0-sharded
-    run_on: rhel8.8-large
-    tags: [valgrind, rhel8.8, shared, "8.0", sharded]
+    run_on: rhel80-large
+    tags: [valgrind, rhel80, shared, "8.0", sharded]
     commands:
       - command: expansions.update
         params:
@@ -16025,8 +16025,8 @@ tasks:
           disable_slow_tests: 1
           use_mongocryptd: true
   - name: valgrind-rhel80-shared-8.0-single
-    run_on: rhel8.8-large
-    tags: [valgrind, rhel8.8, shared, "8.0", single]
+    run_on: rhel80-large
+    tags: [valgrind, rhel80, shared, "8.0", single]
     commands:
       - command: expansions.update
         params:
@@ -16053,8 +16053,8 @@ tasks:
           disable_slow_tests: 1
           use_mongocryptd: true
   - name: valgrind-rhel80-shared-latest-replica
-    run_on: rhel8.8-large
-    tags: [valgrind, rhel8.8, shared, latest, replica]
+    run_on: rhel80-large
+    tags: [valgrind, rhel80, shared, latest, replica]
     commands:
       - command: expansions.update
         params:
@@ -16082,8 +16082,8 @@ tasks:
           disable_slow_tests: 1
           use_mongocryptd: true
   - name: valgrind-rhel80-shared-latest-sharded
-    run_on: rhel8.8-large
-    tags: [valgrind, rhel8.8, shared, latest, sharded]
+    run_on: rhel80-large
+    tags: [valgrind, rhel80, shared, latest, sharded]
     commands:
       - command: expansions.update
         params:
@@ -16111,8 +16111,8 @@ tasks:
           disable_slow_tests: 1
           use_mongocryptd: true
   - name: valgrind-rhel80-shared-latest-single
-    run_on: rhel8.8-large
-    tags: [valgrind, rhel8.8, shared, latest, single]
+    run_on: rhel80-large
+    tags: [valgrind, rhel80, shared, latest, single]
     commands:
       - command: expansions.update
         params:


### PR DESCRIPTION
The issues motivating https://github.com/mongodb/mongo-cxx-driver/pull/1370 have been addressed by [DEVPROD-16404](https://jira.mongodb.org/browse/DEVPROD-16404). Verified by [this patch](https://spruce.mongodb.com/version/67eec32e7df94c0007adc3de/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).