### PR TITLE
CXX-3266 avoid inheriting BUILD_VERSION by auto-downloaded C Driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ## 4.1.0 [Unreleased]
 
+### Fixed
+
+- The API version of auto-downloaded C Driver libraries no longer incorrectly inherits the C++ Driver's `BUILD_VERSION` value.
+
 ### Added
 
 - `storage_engine()` in `mongocxx::v_noabi::options::index`.

--- a/cmake/FetchMongoC.cmake
+++ b/cmake/FetchMongoC.cmake
@@ -3,7 +3,7 @@
 include(FetchContent)
 
 function(fetch_mongoc)
-    message(STATUS "Download and configure C driver version ${LIBMONGOC_DOWNLOAD_VERSION} ... end")
+    message(STATUS "Download and configure C driver version ${LIBMONGOC_DOWNLOAD_VERSION} ... begin")
 
     set(fetch_args "")
     if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.25.0")

--- a/cmake/FetchMongoC.cmake
+++ b/cmake/FetchMongoC.cmake
@@ -23,11 +23,7 @@ function(fetch_mongoc)
 
     if(NOT mongo-c-driver_POPULATED)
         # Must ensure BUILD_VERSION is not inherited either as a normal variable or as a cache variable.
-        unset(OLD_BUILD_VERSION)
-        if(DEFINED BUILD_VERSION)
-            set(OLD_BUILD_VERSION ${BUILD_VERSION})
-            unset(BUILD_VERSION)
-        endif()
+        unset(BUILD_VERSION)
         unset(OLD_CACHE_BUILD_VERSION)
         if(DEFINED CACHE{BUILD_VERSION})
             set(OLD_CACHE_BUILD_VERSION $CACHE{BUILD_VERSION})
@@ -42,10 +38,7 @@ function(fetch_mongoc)
 
         FetchContent_MakeAvailable(mongo-c-driver)
 
-        # Restore prior value of BUILD_VERSION only when they were previously set.
-        if(DEFINED OLD_BUILD_VERSION)
-            set(BUILD_VERSION ${OLD_BUILD_VERSION})
-        endif()
+        # Restore prior value of BUILD_VERSION cache variable only if was previously set.
         if(DEFINED OLD_CACHE_BUILD_VERSION)
             set(BUILD_VERSION ${OLD_CACHE_BUILD_VERSION} CACHE STRING "Library version (for both bsoncxx and mongocxx)")
         endif()

--- a/cmake/FetchMongoC.cmake
+++ b/cmake/FetchMongoC.cmake
@@ -14,7 +14,7 @@ function(fetch_mongoc)
     FetchContent_Declare(
         mongo-c-driver
         GIT_REPOSITORY https://github.com/mongodb/mongo-c-driver.git
-        GIT_TAG ${MONGOC_DOWNLOAD_VERSION}
+        GIT_TAG ${LIBMONGOC_DOWNLOAD_VERSION}
 
         ${fetch_args}
     )

--- a/cmake/FetchMongoC.cmake
+++ b/cmake/FetchMongoC.cmake
@@ -2,43 +2,56 @@
 
 include(FetchContent)
 
-message(STATUS "Download and configure C driver version ${LIBMONGOC_DOWNLOAD_VERSION} ... begin")
+function(fetch_mongoc)
+    message(STATUS "Download and configure C driver version ${LIBMONGOC_DOWNLOAD_VERSION} ... end")
 
-set(fetch_args "")
-if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.25.0")
-    set(fetch_args "SYSTEM")
-endif()
+    set(fetch_args "")
+    if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.25.0")
+        list(APPEND fetch_args "SYSTEM")
+    endif()
 
-# Declare mongo-c-driver as a dependency
-FetchContent_Declare(
-    mongo-c-driver
-    GIT_REPOSITORY https://github.com/mongodb/mongo-c-driver.git
-    GIT_TAG ${LIBMONGOC_DOWNLOAD_VERSION}
+    # Declare mongo-c-driver as a dependency
+    FetchContent_Declare(
+        mongo-c-driver
+        GIT_REPOSITORY https://github.com/mongodb/mongo-c-driver.git
+        GIT_TAG ${MONGOC_DOWNLOAD_VERSION}
 
-    ${fetch_args}
-)
+        ${fetch_args}
+    )
 
-FetchContent_GetProperties(mongo-c-driver)
+    FetchContent_GetProperties(mongo-c-driver)
 
-if(NOT mongo-c-driver_POPULATED)
-    set(OLD_ENABLE_TESTS ${ENABLE_TESTS})
-    set(OLD_BUILD_TESTING ${BUILD_TESTING})
-    set(OLD_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
-    set(OLD_CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
+    if(NOT mongo-c-driver_POPULATED)
+        # Must ensure BUILD_VERSION is not inherited either as a normal variable or as a cache variable.
+        unset(OLD_BUILD_VERSION)
+        if(DEFINED BUILD_VERSION)
+            set(OLD_BUILD_VERSION ${BUILD_VERSION})
+            unset(BUILD_VERSION)
+        endif()
+        unset(OLD_CACHE_BUILD_VERSION)
+        if(DEFINED CACHE{BUILD_VERSION})
+            set(OLD_CACHE_BUILD_VERSION $CACHE{BUILD_VERSION})
+            unset(BUILD_VERSION CACHE)
+        endif()
 
-    # Set ENABLE_TESTS to OFF to disable the test-libmongoc target in the C driver.
-    # This prevents the LoadTests.cmake script from attempting to execute test-libmongoc.
-    # test-libmongoc is not built with the "all" target.
-    # Attempting to execute test-libmongoc results in an error: "Unable to find executable: NOT_FOUND"
-    set(ENABLE_TESTS OFF)
-    set(BUILD_TESTING OFF)
-    string(REPLACE " -Werror" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-    string(REPLACE " -Werror" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
-    FetchContent_MakeAvailable(mongo-c-driver)
-    set(CMAKE_CXX_FLAGS ${OLD_CMAKE_CXX_FLAGS})
-    set(CMAKE_C_FLAGS ${OLD_CMAKE_C_FLAGS})
-    set(ENABLE_TESTS ${OLD_ENABLE_TESTS})
-    set(BUILD_TESTING ${OLD_BUILD_TESTING})
-endif()
+        # Disable unnecessary targets and potential conflicts with C++ Driver options.
+        set(ENABLE_TESTS OFF)
+        set(BUILD_TESTING OFF)
+        string(REPLACE " -Werror" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+        string(REPLACE " -Werror" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
 
-message(STATUS "Download and configure C driver version ${LIBMONGOC_DOWNLOAD_VERSION} ... end")
+        FetchContent_MakeAvailable(mongo-c-driver)
+
+        # Restore prior value of BUILD_VERSION only when they were previously set.
+        if(DEFINED OLD_BUILD_VERSION)
+            set(BUILD_VERSION ${OLD_BUILD_VERSION})
+        endif()
+        if(DEFINED OLD_CACHE_BUILD_VERSION)
+            set(BUILD_VERSION ${OLD_CACHE_BUILD_VERSION} CACHE STRING "Library version (for both bsoncxx and mongocxx)")
+        endif()
+    endif()
+
+    message(STATUS "Download and configure C driver version ${LIBMONGOC_DOWNLOAD_VERSION} ... end")
+endfunction()
+
+fetch_mongoc()


### PR DESCRIPTION
Resolves CXX-3266.

> [!IMPORTANT]
> This PR is only concerned with a C Driver project whose CMake targets are imported via `add_subdirectory()` instead of `find_package()`. This may either be an auto-downloaded C Driver (via `FetchMongoC.cmake`) or a manual call to `add_subdirectory()` by a higher-level CMake project.

The API version numbers embedded in the C Driver v2 install paths revealed suspicious behavior during local development and testing for CXX-3101. Given `LIBMONGOC_DOWNLOAD_VERSION` (+ related variables) set to `2.0.0` and using the [latest commit](fe7bfd3599c0dd7e1f6b9aacbef362c193f36c37) (targeting a 4.1.0 release), the following install directory structure was observed (the API version for C Driver libraries is `0.0.0`?!):

```
<prefix>
├── include
│   ├── bson-0.0.0
│   ├── mongoc-0.0.0
│   └── ...
└── lib
    ├── cmake
    │   ├── bson-0.0.0
    │   ├── mongoc-0.0.0
    │   └── ...
    ├── pkgconfig
    │   ├── bson0.pc
    │   ├── mongoc0.pc
    │   └── ...
    ├── libbson0.so.0.0.0
    ├── libmongoc0.so.0.0.0
    └── ...
```

This led down a rabbit hole of tracking down the root cause of this issue. Investigation revealed this bug is actually present since C++ Driver 3.9.0, which introduced auto-download support in https://github.com/mongodb/mongo-cxx-driver/pull/967 ([CXX-2695](https://jira.mongodb.org/browse/CXX-2695)). However, it was not observed due to the 3.9.0 release auto-downloading C Driver 1.25.0, which temporarily disabled support for `BUILD_VERSION` as a config option in https://github.com/mongodb/mongo-c-driver/pull/1382 ([CDRIVER-4777](https://jira.mongodb.org/browse/CDRIVER-4777)). Support was restored in 1.26.0 by https://github.com/mongodb/mongo-c-driver/pull/1462 ([CDRIVER-4763](https://jira.mongodb.org/browse/CDRIVER-4763)), but the C++ Driver continued to use 1.25.0 until https://github.com/mongodb/mongo-cxx-driver/pull/1162 ([CXX-2828](https://jira.mongodb.org/browse/CXX-2828)) in the 3.11.0 release.

> [!IMPORTANT]
> This bug is present since C++ Driver 3.9.0 when the auto-downloaded C Driver was introduced.

> [!IMPORTANT]
> This bug is present since C Driver 1.14.0 when `BUILD_VERSION` was introduced, _except_ for 1.25.0 when support for `BUILD_VERSION` as a CMake config option was temporarily removed, which also happened to be the version auto-downloaded by C++ Driver 3.9.0.

The problem is twofold. The C Driver may incorrectly inherit `BUILD_VERSION` during initial configuration:

```
# Initial configuration with BUILD_VERSION=5.0.0.
$ cmake -S . -B build -D BUILD_VERSION=5.0.0

# Auto-downloaded C Driver incorrectly inherited BUILD_VERSION.
$ grep -Rho --include 'bson-version.h' '#define BSON_.*VERSION (.*' build
#define BSON_MAJOR_VERSION (5)
#define BSON_MINOR_VERSION (0)
#define BSON_MICRO_VERSION (0)
#define BSON_PRERELEASE_VERSION ()
#define BSON_VERSION (2.0.0)
```

or on subsequent reconfiguration using an existing CMake cache:

```
# Initial configuration without BUILD_VERSION.
$ cmake -S . -B build

# Auto-downloaded C Driver computed its version correctly (for now...).
$ grep -Rho --include 'bson-version.h' '#define BSON_.*VERSION (.*' build
#define BSON_MAJOR_VERSION (2)
#define BSON_MINOR_VERSION (0)
#define BSON_MICRO_VERSION (0)
#define BSON_PRERELEASE_VERSION ()
#define BSON_VERSION (2.0.0)

# Reconfigure the project without making any changes.
$ cmake -S . -B build

# Auto-downloaded C Driver incorrectly inherited BUILD_VERSION.
$ grep -Rho --include 'bson-version.h' '#define BSON_.*VERSION (.*' build
#define BSON_MAJOR_VERSION (0)
#define BSON_MINOR_VERSION (0)
#define BSON_MICRO_VERSION (0)
#define BSON_PRERELEASE_VERSION ()
#define BSON_VERSION (2.0.0)
```

Note also the confusing mix of version numbers, which depend on whether the computation was derived from the `BUILD_VERSION` cache variable (via `BuildVersion.cmake`) or from the C Driver's own copy of the `VERSION_CURRENT` file (via `LoadVersion.cmake`).

This problem is further exacerbated by the following conditions:

- configuration output suggests the correct C Driver version is being computed and used: emits `libmongoc version (from VERSION_CURRENT file): 2.0.0` despite bad version numbers.
- requiring a specific configuration which selects auto-downloaded C Driver with either `BUILD_VERSION` set or reconfiguration step to trigger reuse of the `BUILD_VERSION` cache variable.
- a [deliberate(?)](https://github.com/mongodb/mongo-cxx-driver/blob/fe7bfd3599c0dd7e1f6b9aacbef362c193f36c37/CMakeLists.txt#L65) lack of version checks when C Driver targets are imported via `add_subdirectory()`.
- the [absence](https://github.com/mongodb/mongo-cxx-driver/blob/fe7bfd3599c0dd7e1f6b9aacbef362c193f36c37/src/bsoncxx/CMakeLists.txt#L86) of API version checks in CMake dependency requirements for downstream projects (no `<version>` included in call to `find_dependency(bson-1.0)` in `bsoncxx-config.cmake`).
- the absence of API version numbers in directory or file names (to make the discrepancy more immediately obvious on inspection of the install directory contents).
- the absence of auto-downloaded C Driver installation integrity checks as part of the C++ Driver's EVG configuration.
- most of our EVG config having migrated to using a pre-installed C Driver with `find_package()` (for CSFLE support) rather than the auto-downloaded C Driver (only used by benchmarks, macro guard tests, mongohouse tests, scan-build tests, uninstall checks, and versioned API tests).

Most of these issues will be addressed in a followup PR as part of CXX-3101.

The changes in PR are planned to be cherry-picked onto the v4.0 and v3.11 release branches.