### PR TITLE
CXX-3204 add URI setter for `server_selection_try_once`

### DIFF
--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
@@ -299,6 +299,14 @@ class uri {
     server_selection_try_once() const;
 
     ///
+    /// Sets the value of the option "serverSelectionTryOnce" in the uri.
+    ///
+    /// @param val The new value to apply to as "serverSelectionTryOnce".
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(void)
+    server_selection_try_once(bool val);
+
+    ///
     /// Returns the value of the option "socketTimeoutMS" if present in the uri.
     ///
     /// @return An optional std::int32_t

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
@@ -303,6 +303,8 @@ class uri {
     ///
     /// @param val The new value to apply to as "serverSelectionTryOnce".
     ///
+    /// @throws mongocxx::v_noabi::exception if there is an error setting the option.
+    ///
     MONGOCXX_ABI_EXPORT_CDECL(void)
     server_selection_try_once(bool val);
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/uri.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/uri.cpp
@@ -253,6 +253,10 @@ bsoncxx::v_noabi::stdx::optional<bool> uri::server_selection_try_once() const {
     return _bool_option(_impl->uri_t, "serverSelectionTryOnce");
 }
 
+void uri::server_selection_try_once(bool val) {
+    mongoc_uri_set_option_as_bool(_impl->uri_t, "serverSelectionTryOnce", val);
+}
+
 bsoncxx::v_noabi::stdx::optional<std::int32_t> uri::socket_timeout_ms() const {
     return _int32_option(_impl->uri_t, "socketTimeoutMS");
 }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/uri.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/uri.cpp
@@ -254,7 +254,9 @@ bsoncxx::v_noabi::stdx::optional<bool> uri::server_selection_try_once() const {
 }
 
 void uri::server_selection_try_once(bool val) {
-    mongoc_uri_set_option_as_bool(_impl->uri_t, "serverSelectionTryOnce", val);
+    if (!mongoc_uri_set_option_as_bool(_impl->uri_t, "serverSelectionTryOnce", val)) {
+        throw exception{error_code::k_invalid_uri, "failed to set 'serverSelectionTryOnce' option"};
+    }
 }
 
 bsoncxx::v_noabi::stdx::optional<std::int32_t> uri::socket_timeout_ms() const {

--- a/src/mongocxx/test/uri.cpp
+++ b/src/mongocxx/test/uri.cpp
@@ -331,4 +331,46 @@ TEST_CASE("uri::zlib_compression_level()", "[uri]") {
 
 // End special cases.
 
+TEST_CASE("can set server_selection_try_once", "[uri]") {
+    SECTION("URI with no option") {
+        auto uri = mongocxx::uri{"mongodb://host"};
+
+        SECTION("can set to true") {
+            CHECK(!uri.server_selection_try_once());
+            uri.server_selection_try_once(true);
+            CHECK(uri.server_selection_try_once());
+            CHECK(*uri.server_selection_try_once());
+        }
+
+        SECTION("can set to false") {
+            CHECK(!uri.server_selection_try_once());
+            uri.server_selection_try_once(false);
+            CHECK(uri.server_selection_try_once());
+            CHECK(!*uri.server_selection_try_once());
+        }
+    }
+
+    SECTION("URI with serverSelectionTryOnce=true") {
+        auto uri = mongocxx::uri{"mongodb://host/?serverSelectionTryOnce=true"};
+        SECTION("can overwrite to false") {
+            CHECK(uri.server_selection_try_once());
+            CHECK(*uri.server_selection_try_once());
+            uri.server_selection_try_once(false);
+            CHECK(uri.server_selection_try_once());
+            CHECK(!*uri.server_selection_try_once());
+        }
+    }
+
+    SECTION("Test URI with serverSelectionTryOnce=false") {
+        auto uri = mongocxx::uri{"mongodb://host/?serverSelectionTryOnce=false"};
+        SECTION("can overwrite to true") {
+            CHECK(uri.server_selection_try_once());
+            CHECK(!*uri.server_selection_try_once());
+            uri.server_selection_try_once(true);
+            CHECK(uri.server_selection_try_once());
+            CHECK(*uri.server_selection_try_once());
+        }
+    }
+}
+
 } // namespace


### PR DESCRIPTION
# Summary

- Add method to `mongocxx::uri` to set `serverSelectionTryOnce` URI option.

# Background & Motivation

Intended to help simplify a a [workaround](https://github.com/10gen/mongo/blob/e758d87c23d7ffc70bb767e618692063dccaa826/src/mongo/db/modules/enterprise/src/streams/exec/mongocxx_utils.cpp#L72-L110) in Atlas Stream Processing. The workaround applies `serverSelectionTryOnce=false` to a URI if the option is not already specified. I expect this new setter can be used in [streams after constructing the mongocxx::uri](https://github.com/10gen/mongo/blob/e758d87c23d7ffc70bb767e618692063dccaa826/src/mongo/db/modules/enterprise/src/streams/exec/mongocxx_utils.cpp#L332) like:

```c++
auto uri = std::make_unique<mongocxx::uri>(uri);
// Set default "serverSelectionTryOnce=false" if not included in URI:
if (!uri->server_selection_try_once()) {
    uri->server_selection_try_once(false);
}
```

This is the first setter on `mongocxx::uri`. If acceptable, this pattern can be extended in the future to add setters for more URI options to resolve CXX-2146.

## Rejected alternatives

A new option to `mongocxx::options::client` was considered but rejected. Server selection spec [notes](https://github.com/mongodb/specifications/blob/ce35696db1c8da0e15a067b8022c853f1d6d1292/source/server-selection/server-selection.md#serverselectiontryonce):

> Multi-threaded drivers MUST NOT provide this mode.

But `mongocxx::options::client` is applied to both `mongocxx::client` and `mongocxx::pool` constructors.

The spec also notes:

> Conflicting usages of the URI option and the symbol is an error.

A URI setter avoids possible disagreement.