### PR TITLE
Use majority concern for tailable cursor tests

### DIFF
--- a/src/mongocxx/test/collection.cpp
+++ b/src/mongocxx/test/collection.cpp
@@ -2359,7 +2359,7 @@ TEST_CASE("Cursor iteration", "[collection][cursor]") {
         ret.read_concern(rc_majority);
 
         return ret;
-    }(); // IILE
+    }();
 
     // Tests will use all three cursor types.
     options::find opts;


### PR DESCRIPTION
Attempt to address the following [flaky test failure](https://spruce.mongodb.com/task/mongo_cxx_driver_integration_matrix_macos_integration_macos_14_arm64_debug_shared_cxx17_csfle_8.0_sharded_patch_a50c2f6018a804e11c03e8aafb2439c0e7122637_67f6cd788236020007393486_25_04_09_19_41_47/logs?execution=0):

```
collection.cpp:2413: FAILED: iter != cursor.end() for: {?} != {?} with 1 message: 'k_tailable_await'
```

Applies majority concern in a manner similar to https://github.com/mongodb/mongo-cxx-driver/pull/1375.