### PR TITLE
CXX-3253 reintroduce VS 2015 task coverage

### DIFF
--- a/.evergreen/config_generator/components/compile_only.py
+++ b/.evergreen/config_generator/components/compile_only.py
@@ -80,6 +80,7 @@ def tasks():
                 Compile.call(
                     build_type=build_type,
                     compiler=compiler,
+                    vars=compile_vars,
                 )
             ]
 

--- a/.evergreen/config_generator/components/compile_only.py
+++ b/.evergreen/config_generator/components/compile_only.py
@@ -9,8 +9,6 @@ from shrub.v3.evg_build_variant import BuildVariant
 from shrub.v3.evg_command import KeyValueParam, expansions_update
 from shrub.v3.evg_task import EvgTask, EvgTaskRef
 
-from itertools import product
-
 
 TAG = 'compile-only'
 
@@ -18,30 +16,55 @@ TAG = 'compile-only'
 # pylint: disable=line-too-long
 # fmt: off
 MATRIX = [
-    ('rhel80', 'gcc',   ['Debug', 'Release'], ['shared', 'static'], [11, 17, 20, 23]),
-    ('rhel80', 'clang', ['Debug', 'Release'], ['shared', 'static'], [11, 17, 20, 23]),
+    # C++ standard and compiler coverage
 
-    ('ubuntu2004-arm64', 'gcc',   ['Debug', 'Release'], ['shared', 'static'], [11, 17, 20, 23]),
-    ('ubuntu2004-arm64', 'clang', ['Debug', 'Release'], ['shared', 'static'], [11, 17, 20, 23]),
+    ('rhel80',     'clang',    [11, 17, 20,   ]), # Clang  7.0 (max: C++20)
+    ('ubuntu2004', 'clang-10', [11, 17, 20,   ]), # Clang 10.0 (max: C++20)
+    ('rhel84',     'clang',    [11, 17, 20,   ]), # Clang 11.0 (max: C++20)
+    ('ubuntu2204', 'clang-12', [11, 17, 20, 23]), # Clang 12.0 (max: C++23)
+    ('rhel90',     'clang',    [11, 17, 20, 23]), # Clang 13.0 (max: C++23)
+    ('rhel91',     'clang',    [11, 17, 20, 23]), # Clang 14.0 (max: C++23)
+    ('rhel92',     'clang',    [11, 17, 20, 23]), # Clang 15.0 (max: C++23)
+    ('rhel93',     'clang',    [11, 17, 20, 23]), # Clang 16.0 (max: C++23)
+    ('rhel94',     'clang',    [11, 17, 20, 23]), # Clang 17.0 (max: C++23)
+    ('rhel95',     'clang',    [11, 17, 20, 23]), # Clang 18.0 (max: C++23)
 
-    ('rhel8-power',   None, ['Debug', 'Release'], ['shared', 'static'], [11, 17]),
-    ('rhel8-zseries', None, ['Debug', 'Release'], ['shared', 'static'], [11, 17]),
+    ('rhel76',     'gcc',    [11, 14,       ]), # GCC  4.8 (max: C++14)
+    ('rhel80',     'gcc',    [11, 17, 20,   ]), # GCC  8.2 (max: C++20)
+    ('debian10',   'gcc-8',  [11, 17, 20,   ]), # GCC  8.3 (max: C++20)
+    ('rhel84',     'gcc',    [11, 17, 20,   ]), # GCC  8.4 (max: C++20)
+    ('ubuntu2004', 'gcc-9',  [11, 17, 20,   ]), # GCC  9.4 (max: C++20)
+    ('debian11',   'gcc-10', [11, 17, 20,   ]), # GCC 10.2 (max: C++20)
+    ('rhel90',     'gcc',    [11, 17, 20, 23]), # GCC 11.2 (max: C++23)
+    ('rhel92',     'gcc',    [11, 17, 20, 23]), # GCC 11.3 (max: C++23)
+    ('rhel94',     'gcc',    [11, 17, 20, 23]), # GCC 11.4 (max: C++23)
+    ('rhel95',     'gcc',    [11, 17, 20, 23]), # GCC 11.5 (max: C++23)
 
-    ('macos-14-arm64', None, ['Debug', 'Release'], ['shared', 'static'], [11, 17]),
-    ('macos-14',       None, ['Debug', 'Release'], ['shared', 'static'], [11, 17]),
+    ('windows-vsCurrent', 'vs2015x64', [11, 14,             'latest']), # Max: C++14
+    ('windows-vsCurrent', 'vs2017x64', [11, 14, 17, 20,     'latest']), # Max: C++20
+    ('windows-vsCurrent', 'vs2019x64', [11, 14, 17, 20, 23, 'latest']), # Max: C++23
+    ('windows-vsCurrent', 'vs2022x64', [11, 14, 17, 20, 23, 'latest']), # Max: C++23
 
-    ('windows-vsCurrent', 'vs2015x64', ['Debug', 'Release'], ['shared', 'static'],  [11, 17,       ]),
-    ('windows-vsCurrent', 'vs2017x64', ['Debug', 'Release'], ['shared', 'static'],  [11, 17,       ]),
-    ('windows-vsCurrent', 'vs2019x64', ['Debug', 'Release'], ['shared', 'static'],  [11, 17, 20,   ]),
-    ('windows-vsCurrent', 'vs2022x64', ['Debug', 'Release'], ['shared', 'static'],  [11, 17, 20, 23]),
+    # Other coverage.
+
+    ('ubuntu2004-arm64', 'gcc',   [11, 17]), # Clang 10
+    ('ubuntu2004-arm64', 'clang', [11, 17]), # Clang 10
+
+    ('rhel8-power',   None, [11, 17]),
+    ('rhel8-zseries', None, [11, 17]),
+
+    ('macos-14-arm64', None, [11, 17]),
+    ('macos-14',       None, [11, 17]),
 ]
 # fmt: on
 # pylint: enable=line-too-long
 
 
 def tasks():
-    for distro_name, compiler, build_types, link_types, cxx_standards in MATRIX:
-        for build_type, link_type, cxx_standard in product(build_types, link_types, cxx_standards):
+    build_type = 'Debug'
+
+    for distro_name, compiler, cxx_standards in MATRIX:
+        for cxx_standard in cxx_standards:
             distro = find_large_distro(distro_name)
 
             name = f'{TAG}-{make_distro_str(distro_name, compiler, None)}'
@@ -54,20 +77,17 @@ def tasks():
             if compiler is not None:
                 tags.append(compiler)
 
-            name += f'-{build_type.lower()}-{link_type}'
-            tags += [build_type.lower(), link_type]
+            name += f'-{build_type.lower()}'
+            tags += [build_type.lower()]
 
             updates = []
-            compile_vars = {}
+            compile_vars = {'BUILD_SHARED_AND_STATIC_LIBS': 'ON'}
 
             updates += [KeyValueParam(key='build_type', value=build_type)]
             updates += [KeyValueParam(key=key, value=value) for key, value in compiler_to_vars(compiler).items()]
 
             if cxx_standard is not None:
                 compile_vars |= {'REQUIRED_CXX_STANDARD': cxx_standard}
-
-            if link_type == 'static':
-                compile_vars |= {'USE_STATIC_LIBS': 1}
 
             # PowerPC and zSeries are limited resources.
             patchable = False if any(pattern in distro_name for pattern in ['power', 'zseries']) else None

--- a/.evergreen/config_generator/components/compile_only.py
+++ b/.evergreen/config_generator/components/compile_only.py
@@ -30,6 +30,7 @@ MATRIX = [
     ('macos-14-arm64', None, ['Debug', 'Release'], ['shared', 'static'], [11, 17]),
     ('macos-14',       None, ['Debug', 'Release'], ['shared', 'static'], [11, 17]),
 
+    ('windows-vsCurrent', 'vs2015x64', ['Debug', 'Release'], ['shared', 'static'],  [11, 17,       ]),
     ('windows-vsCurrent', 'vs2017x64', ['Debug', 'Release'], ['shared', 'static'],  [11, 17,       ]),
     ('windows-vsCurrent', 'vs2019x64', ['Debug', 'Release'], ['shared', 'static'],  [11, 17, 20,   ]),
     ('windows-vsCurrent', 'vs2022x64', ['Debug', 'Release'], ['shared', 'static'],  [11, 17, 20, 23]),

--- a/.evergreen/config_generator/components/funcs/install_c_driver.py
+++ b/.evergreen/config_generator/components/funcs/install_c_driver.py
@@ -29,6 +29,10 @@ class InstallCDriver(Function):
         bash_exec(
             command_type=EvgCommandType.SETUP,
             add_expansions_to_env=True,
+            env={
+                'CC': '${cc_compiler}',
+                'CXX': '${cxx_compiler}',
+            },
             script='mongo-cxx-driver/.evergreen/scripts/install-c-driver.sh'
         ),
     ]

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -22,7 +22,6 @@ class Distro(BaseModel):
     os_type: Literal['linux', 'macos', 'windows'] | None = None
     os_ver: str | None = None
     vs_ver: Literal[
-        '2013',
         '2015',
         '2017',
         '2019',
@@ -151,19 +150,6 @@ def make_distro_str(distro_name, compiler, arch) -> str:
                 distro_name[len('windows-vsCurrent-'):] + f'-{compiler_str}'
         else:
             distro_str = 'windows-2019' + f'-{compiler_str}'
-    elif distro_name.startswith('windows-64-vs'):
-        # Abbreviate 'windows-64-vs<type>' as 'vs<type>' and append '-<arch>' if
-        # given in compiler string as 'vs<type><arch>', e.g.:
-        #     ('windows-64-vs2017', 'vs2017x64', None) -> vs2017-x64
-        #     ('windows-64-vs2017', 'mingw',     None) -> vs2017-mingw
-        distro_str = distro_name[len('windows-64-'):] + {
-            'vs2017x64': '-x64',
-            'vs2017x86': '-x86',
-            'vs2019x64': '-x64',
-            'vs2019x86': '-x86',
-            'vs2022x64': '-x64',
-            'vs2022x86': '-x86',
-        }.get(compiler, f'-{compiler}')
     else:
         distro_str = distro_name
         if compiler:
@@ -177,6 +163,8 @@ def make_distro_str(distro_name, compiler, arch) -> str:
 
 def to_cc(compiler):
     return {
+        'vs2015x64': 'Visual Studio 14 2015',
+        'vs2015x86': 'Visual Studio 14 2015',
         'vs2017x64': 'Visual Studio 15 2017',
         'vs2017x86': 'Visual Studio 15 2017',
         'vs2019x64': 'Visual Studio 16 2019',
@@ -188,6 +176,8 @@ def to_cc(compiler):
 
 def to_platform(compiler):
     return {
+        'vs2015x64': 'x64',
+        'vs2015x86': 'Win32',
         'vs2017x64': 'x64',
         'vs2017x86': 'Win32',
         'vs2019x64': 'x64',

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -47,6 +47,8 @@ def ls_distro(name, **kwargs):
 
 
 DEBIAN_DISTROS = [
+    *ls_distro(name='debian10', os='debian', os_type='linux', os_ver='10'),
+    *ls_distro(name='debian11', os='debian', os_type='linux', os_ver='10'),
     *ls_distro(name='debian12-latest', os='debian', os_type='linux', os_ver='latest'),
 ]
 
@@ -59,8 +61,16 @@ MACOS_ARM64_DISTROS = [
 ]
 
 RHEL_DISTROS = [
+    *ls_distro(name='rhel76', os='rhel', os_type='linux', os_ver='7.6'),
     *ls_distro(name='rhel80', os='rhel', os_type='linux', os_ver='8.0'),
+    *ls_distro(name='rhel84', os='rhel', os_type='linux', os_ver='8.4'),
+    *ls_distro(name='rhel90', os='rhel', os_type='linux', os_ver='9.0'),
+    *ls_distro(name='rhel91', os='rhel', os_type='linux', os_ver='9.1'),
+    *ls_distro(name='rhel92', os='rhel', os_type='linux', os_ver='9.2'),
+    *ls_distro(name='rhel93', os='rhel', os_type='linux', os_ver='9.3'),
+    *ls_distro(name='rhel94', os='rhel', os_type='linux', os_ver='9.4'),
     *ls_distro(name='rhel95', os='rhel', os_type='linux', os_ver='9.5'),
+    *ls_distro(name='rhel92', os='rhel', os_type='linux', os_ver='9.0'),
 ]
 
 RHEL_ARM64_DISTROS = [
@@ -77,6 +87,7 @@ RHEL_ZSERIES_DISTROS = [
 ]
 
 UBUNTU_DISTROS = [
+    *ls_distro(name='ubuntu2004', os='ubuntu', os_type='linux', os_ver='20.04'),
     *ls_distro(name='ubuntu2204', os='ubuntu', os_type='linux', os_ver='22.04'),
 ]
 

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -188,24 +188,30 @@ def to_platform(compiler):
 
 
 def compiler_to_vars(compiler):
-    match compiler:
-        case 'gcc':
+    if compiler is None:
+        return {}
+
+    match compiler, compiler.split('-'):
+        case _, ['gcc', *rest]:
             return {
-                'cc_compiler': 'gcc',
-                'cxx_compiler': 'g++',
+                'cc_compiler': '-'.join(['gcc'] + rest),
+                'cxx_compiler': '-'.join(['g++'] + rest),
             }
 
-        case 'clang':
+        case _, ['clang', *rest]:
             return {
-                'cc_compiler': 'clang',
-                'cxx_compiler': 'clang++',
+                'cc_compiler': '-'.join(['clang'] + rest),
+                'cxx_compiler': '-'.join(['clang++'] + rest),
             }
 
-        case str(vs) if 'vs' in vs:
+        case str(vs), _ if 'vs' in vs:
             return {
                 'generator': to_cc(vs),
                 'platform': to_platform(vs),
             }
 
-        case _:
-            return {}
+        case compiler, _:
+            return {
+                'cc_compiler': compiler,
+                'cxx_compiler': compiler,
+            }

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -403,6 +403,9 @@ functions:
       params:
         binary: bash
         add_expansions_to_env: true
+        env:
+          CC: ${cc_compiler}
+          CXX: ${cxx_compiler}
         args:
           - -c
           - mongo-cxx-driver/.evergreen/scripts/install-c-driver.sh

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -179,6 +179,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Debug
   - name: compile-only-macos-14-arm64-cxx11-debug-static
     run_on: macos-14-arm64
@@ -193,6 +194,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Debug
   - name: compile-only-macos-14-arm64-cxx11-release-shared
     run_on: macos-14-arm64
@@ -207,6 +210,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Release
   - name: compile-only-macos-14-arm64-cxx11-release-static
     run_on: macos-14-arm64
@@ -221,6 +225,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Release
   - name: compile-only-macos-14-arm64-cxx17-debug-shared
     run_on: macos-14-arm64
@@ -235,6 +241,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Debug
   - name: compile-only-macos-14-arm64-cxx17-debug-static
     run_on: macos-14-arm64
@@ -249,6 +256,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Debug
   - name: compile-only-macos-14-arm64-cxx17-release-shared
     run_on: macos-14-arm64
@@ -263,6 +272,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Release
   - name: compile-only-macos-14-arm64-cxx17-release-static
     run_on: macos-14-arm64
@@ -277,6 +287,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Release
   - name: compile-only-macos-14-cxx11-debug-shared
     run_on: macos-14
@@ -291,6 +303,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Debug
   - name: compile-only-macos-14-cxx11-debug-static
     run_on: macos-14
@@ -305,6 +318,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Debug
   - name: compile-only-macos-14-cxx11-release-shared
     run_on: macos-14
@@ -319,6 +334,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Release
   - name: compile-only-macos-14-cxx11-release-static
     run_on: macos-14
@@ -333,6 +349,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Release
   - name: compile-only-macos-14-cxx17-debug-shared
     run_on: macos-14
@@ -347,6 +365,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Debug
   - name: compile-only-macos-14-cxx17-debug-static
     run_on: macos-14
@@ -361,6 +380,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Debug
   - name: compile-only-macos-14-cxx17-release-shared
     run_on: macos-14
@@ -375,6 +396,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Release
   - name: compile-only-macos-14-cxx17-release-static
     run_on: macos-14
@@ -389,6 +411,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Release
   - name: compile-only-rhel8-power-cxx11-debug-shared
     run_on: rhel8-power-large
@@ -404,6 +428,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Debug
   - name: compile-only-rhel8-power-cxx11-debug-static
     run_on: rhel8-power-large
@@ -419,6 +444,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Debug
   - name: compile-only-rhel8-power-cxx11-release-shared
     run_on: rhel8-power-large
@@ -434,6 +461,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Release
   - name: compile-only-rhel8-power-cxx11-release-static
     run_on: rhel8-power-large
@@ -449,6 +477,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Release
   - name: compile-only-rhel8-power-cxx17-debug-shared
     run_on: rhel8-power-large
@@ -464,6 +494,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Debug
   - name: compile-only-rhel8-power-cxx17-debug-static
     run_on: rhel8-power-large
@@ -479,6 +510,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Debug
   - name: compile-only-rhel8-power-cxx17-release-shared
     run_on: rhel8-power-large
@@ -494,6 +527,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Release
   - name: compile-only-rhel8-power-cxx17-release-static
     run_on: rhel8-power-large
@@ -509,6 +543,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Release
   - name: compile-only-rhel8-zseries-cxx11-debug-shared
     run_on: rhel8-zseries-large
@@ -524,6 +560,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Debug
   - name: compile-only-rhel8-zseries-cxx11-debug-static
     run_on: rhel8-zseries-large
@@ -539,6 +576,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Debug
   - name: compile-only-rhel8-zseries-cxx11-release-shared
     run_on: rhel8-zseries-large
@@ -554,6 +593,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Release
   - name: compile-only-rhel8-zseries-cxx11-release-static
     run_on: rhel8-zseries-large
@@ -569,6 +609,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Release
   - name: compile-only-rhel8-zseries-cxx17-debug-shared
     run_on: rhel8-zseries-large
@@ -584,6 +626,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Debug
   - name: compile-only-rhel8-zseries-cxx17-debug-static
     run_on: rhel8-zseries-large
@@ -599,6 +642,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Debug
   - name: compile-only-rhel8-zseries-cxx17-release-shared
     run_on: rhel8-zseries-large
@@ -614,6 +659,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Release
   - name: compile-only-rhel8-zseries-cxx17-release-static
     run_on: rhel8-zseries-large
@@ -629,6 +675,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Release
   - name: compile-only-rhel80-clang-cxx11-debug-shared
     run_on: rhel80-large
@@ -645,6 +693,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
@@ -663,6 +712,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
@@ -681,6 +732,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Release
           cc_compiler: clang
           cxx_compiler: clang++
@@ -699,6 +751,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Release
           cc_compiler: clang
           cxx_compiler: clang++
@@ -717,6 +771,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
@@ -735,6 +790,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
@@ -753,6 +810,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Release
           cc_compiler: clang
           cxx_compiler: clang++
@@ -771,6 +829,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Release
           cc_compiler: clang
           cxx_compiler: clang++
@@ -789,6 +849,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
@@ -807,6 +868,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
+          USE_STATIC_LIBS: 1
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
@@ -825,6 +888,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
           build_type: Release
           cc_compiler: clang
           cxx_compiler: clang++
@@ -843,6 +907,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
+          USE_STATIC_LIBS: 1
           build_type: Release
           cc_compiler: clang
           cxx_compiler: clang++
@@ -861,6 +927,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 23
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
@@ -879,6 +946,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 23
+          USE_STATIC_LIBS: 1
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
@@ -897,6 +966,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 23
           build_type: Release
           cc_compiler: clang
           cxx_compiler: clang++
@@ -915,6 +985,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 23
+          USE_STATIC_LIBS: 1
           build_type: Release
           cc_compiler: clang
           cxx_compiler: clang++
@@ -933,6 +1005,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
@@ -951,6 +1024,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
@@ -969,6 +1044,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
@@ -987,6 +1063,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1005,6 +1083,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1023,6 +1102,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1041,6 +1122,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1059,6 +1141,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1077,6 +1161,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1095,6 +1180,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
+          USE_STATIC_LIBS: 1
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1113,6 +1200,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1131,6 +1219,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
+          USE_STATIC_LIBS: 1
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1149,6 +1239,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 23
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1167,6 +1258,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 23
+          USE_STATIC_LIBS: 1
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1185,6 +1278,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 23
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1203,6 +1297,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 23
+          USE_STATIC_LIBS: 1
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1221,6 +1317,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
@@ -1239,6 +1336,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
@@ -1257,6 +1356,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Release
           cc_compiler: clang
           cxx_compiler: clang++
@@ -1275,6 +1375,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Release
           cc_compiler: clang
           cxx_compiler: clang++
@@ -1293,6 +1395,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
@@ -1311,6 +1414,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
@@ -1329,6 +1434,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Release
           cc_compiler: clang
           cxx_compiler: clang++
@@ -1347,6 +1453,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Release
           cc_compiler: clang
           cxx_compiler: clang++
@@ -1365,6 +1473,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
@@ -1383,6 +1492,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
+          USE_STATIC_LIBS: 1
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
@@ -1401,6 +1512,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
           build_type: Release
           cc_compiler: clang
           cxx_compiler: clang++
@@ -1419,6 +1531,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
+          USE_STATIC_LIBS: 1
           build_type: Release
           cc_compiler: clang
           cxx_compiler: clang++
@@ -1437,6 +1551,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 23
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
@@ -1455,6 +1570,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 23
+          USE_STATIC_LIBS: 1
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
@@ -1473,6 +1590,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 23
           build_type: Release
           cc_compiler: clang
           cxx_compiler: clang++
@@ -1491,6 +1609,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 23
+          USE_STATIC_LIBS: 1
           build_type: Release
           cc_compiler: clang
           cxx_compiler: clang++
@@ -1509,6 +1629,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1527,6 +1648,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1545,6 +1668,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1563,6 +1687,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1581,6 +1707,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1599,6 +1726,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1617,6 +1746,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1635,6 +1765,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1653,6 +1785,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1671,6 +1804,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
+          USE_STATIC_LIBS: 1
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1689,6 +1824,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1707,6 +1843,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
+          USE_STATIC_LIBS: 1
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1725,6 +1863,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 23
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1743,6 +1882,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 23
+          USE_STATIC_LIBS: 1
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1761,6 +1902,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 23
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1779,6 +1921,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 23
+          USE_STATIC_LIBS: 1
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
@@ -1797,6 +1941,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Debug
           generator: Visual Studio 14 2015
           platform: x64
@@ -1815,6 +1960,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Debug
           generator: Visual Studio 14 2015
           platform: x64
@@ -1833,6 +1980,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Release
           generator: Visual Studio 14 2015
           platform: x64
@@ -1851,6 +1999,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Release
           generator: Visual Studio 14 2015
           platform: x64
@@ -1869,6 +2019,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Debug
           generator: Visual Studio 14 2015
           platform: x64
@@ -1887,6 +2038,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Debug
           generator: Visual Studio 14 2015
           platform: x64
@@ -1905,6 +2058,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Release
           generator: Visual Studio 14 2015
           platform: x64
@@ -1923,6 +2077,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Release
           generator: Visual Studio 14 2015
           platform: x64
@@ -1941,6 +2097,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Debug
           generator: Visual Studio 15 2017
           platform: x64
@@ -1959,6 +2116,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Debug
           generator: Visual Studio 15 2017
           platform: x64
@@ -1977,6 +2136,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Release
           generator: Visual Studio 15 2017
           platform: x64
@@ -1995,6 +2155,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Release
           generator: Visual Studio 15 2017
           platform: x64
@@ -2013,6 +2175,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Debug
           generator: Visual Studio 15 2017
           platform: x64
@@ -2031,6 +2194,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Debug
           generator: Visual Studio 15 2017
           platform: x64
@@ -2049,6 +2214,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Release
           generator: Visual Studio 15 2017
           platform: x64
@@ -2067,6 +2233,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Release
           generator: Visual Studio 15 2017
           platform: x64
@@ -2085,6 +2253,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Debug
           generator: Visual Studio 16 2019
           platform: x64
@@ -2103,6 +2272,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Debug
           generator: Visual Studio 16 2019
           platform: x64
@@ -2121,6 +2292,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Release
           generator: Visual Studio 16 2019
           platform: x64
@@ -2139,6 +2311,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Release
           generator: Visual Studio 16 2019
           platform: x64
@@ -2157,6 +2331,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Debug
           generator: Visual Studio 16 2019
           platform: x64
@@ -2175,6 +2350,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Debug
           generator: Visual Studio 16 2019
           platform: x64
@@ -2193,6 +2370,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Release
           generator: Visual Studio 16 2019
           platform: x64
@@ -2211,6 +2389,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Release
           generator: Visual Studio 16 2019
           platform: x64
@@ -2229,6 +2409,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
           build_type: Debug
           generator: Visual Studio 16 2019
           platform: x64
@@ -2247,6 +2428,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
+          USE_STATIC_LIBS: 1
           build_type: Debug
           generator: Visual Studio 16 2019
           platform: x64
@@ -2265,6 +2448,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
           build_type: Release
           generator: Visual Studio 16 2019
           platform: x64
@@ -2283,6 +2467,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
+          USE_STATIC_LIBS: 1
           build_type: Release
           generator: Visual Studio 16 2019
           platform: x64
@@ -2301,6 +2487,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Debug
           generator: Visual Studio 17 2022
           platform: x64
@@ -2319,6 +2506,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Debug
           generator: Visual Studio 17 2022
           platform: x64
@@ -2337,6 +2526,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
           build_type: Release
           generator: Visual Studio 17 2022
           platform: x64
@@ -2355,6 +2545,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
           build_type: Release
           generator: Visual Studio 17 2022
           platform: x64
@@ -2373,6 +2565,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Debug
           generator: Visual Studio 17 2022
           platform: x64
@@ -2391,6 +2584,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Debug
           generator: Visual Studio 17 2022
           platform: x64
@@ -2409,6 +2604,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
           build_type: Release
           generator: Visual Studio 17 2022
           platform: x64
@@ -2427,6 +2623,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
           build_type: Release
           generator: Visual Studio 17 2022
           platform: x64
@@ -2445,6 +2643,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
           build_type: Debug
           generator: Visual Studio 17 2022
           platform: x64
@@ -2463,6 +2662,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
+          USE_STATIC_LIBS: 1
           build_type: Debug
           generator: Visual Studio 17 2022
           platform: x64
@@ -2481,6 +2682,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
           build_type: Release
           generator: Visual Studio 17 2022
           platform: x64
@@ -2499,6 +2701,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 20
+          USE_STATIC_LIBS: 1
           build_type: Release
           generator: Visual Studio 17 2022
           platform: x64
@@ -2517,6 +2721,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 23
           build_type: Debug
           generator: Visual Studio 17 2022
           platform: x64
@@ -2535,6 +2740,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 23
+          USE_STATIC_LIBS: 1
           build_type: Debug
           generator: Visual Studio 17 2022
           platform: x64
@@ -2553,6 +2760,7 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 23
           build_type: Release
           generator: Visual Studio 17 2022
           platform: x64
@@ -2571,6 +2779,8 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          REQUIRED_CXX_STANDARD: 23
+          USE_STATIC_LIBS: 1
           build_type: Release
           generator: Visual Studio 17 2022
           platform: x64

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -166,9 +166,129 @@ tasks:
         vars:
           cc_compiler: clang
           cxx_compiler: clang++
-  - name: compile-only-macos-14-arm64-cxx11-debug-shared
+  - name: compile-only-debian10-gcc-8-cxx11-debug
+    run_on: debian10-large
+    tags: [compile-only, debian10, cxx11, gcc-8, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc-8 }
+            - { key: cxx_compiler, value: g++-8 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          build_type: Debug
+          cc_compiler: gcc-8
+          cxx_compiler: g++-8
+  - name: compile-only-debian10-gcc-8-cxx17-debug
+    run_on: debian10-large
+    tags: [compile-only, debian10, cxx17, gcc-8, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc-8 }
+            - { key: cxx_compiler, value: g++-8 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          build_type: Debug
+          cc_compiler: gcc-8
+          cxx_compiler: g++-8
+  - name: compile-only-debian10-gcc-8-cxx20-debug
+    run_on: debian10-large
+    tags: [compile-only, debian10, cxx20, gcc-8, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc-8 }
+            - { key: cxx_compiler, value: g++-8 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 20
+          build_type: Debug
+          cc_compiler: gcc-8
+          cxx_compiler: g++-8
+  - name: compile-only-debian11-gcc-10-cxx11-debug
+    run_on: debian11-large
+    tags: [compile-only, debian11, cxx11, gcc-10, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc-10 }
+            - { key: cxx_compiler, value: g++-10 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          build_type: Debug
+          cc_compiler: gcc-10
+          cxx_compiler: g++-10
+  - name: compile-only-debian11-gcc-10-cxx17-debug
+    run_on: debian11-large
+    tags: [compile-only, debian11, cxx17, gcc-10, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc-10 }
+            - { key: cxx_compiler, value: g++-10 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          build_type: Debug
+          cc_compiler: gcc-10
+          cxx_compiler: g++-10
+  - name: compile-only-debian11-gcc-10-cxx20-debug
+    run_on: debian11-large
+    tags: [compile-only, debian11, cxx20, gcc-10, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc-10 }
+            - { key: cxx_compiler, value: g++-10 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 20
+          build_type: Debug
+          cc_compiler: gcc-10
+          cxx_compiler: g++-10
+  - name: compile-only-macos-14-arm64-cxx11-debug
     run_on: macos-14-arm64
-    tags: [compile-only, macos-14-arm64, cxx11, debug, shared]
+    tags: [compile-only, macos-14-arm64, cxx11, debug]
     commands:
       - command: expansions.update
         params:
@@ -179,11 +299,12 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 11
           build_type: Debug
-  - name: compile-only-macos-14-arm64-cxx11-debug-static
+  - name: compile-only-macos-14-arm64-cxx17-debug
     run_on: macos-14-arm64
-    tags: [compile-only, macos-14-arm64, cxx11, debug, static]
+    tags: [compile-only, macos-14-arm64, cxx17, debug]
     commands:
       - command: expansions.update
         params:
@@ -194,105 +315,12 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
-          build_type: Debug
-  - name: compile-only-macos-14-arm64-cxx11-release-shared
-    run_on: macos-14-arm64
-    tags: [compile-only, macos-14-arm64, cxx11, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          build_type: Release
-  - name: compile-only-macos-14-arm64-cxx11-release-static
-    run_on: macos-14-arm64
-    tags: [compile-only, macos-14-arm64, cxx11, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
-          build_type: Release
-  - name: compile-only-macos-14-arm64-cxx17-debug-shared
-    run_on: macos-14-arm64
-    tags: [compile-only, macos-14-arm64, cxx17, debug, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 17
           build_type: Debug
-  - name: compile-only-macos-14-arm64-cxx17-debug-static
-    run_on: macos-14-arm64
-    tags: [compile-only, macos-14-arm64, cxx17, debug, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
-          build_type: Debug
-  - name: compile-only-macos-14-arm64-cxx17-release-shared
-    run_on: macos-14-arm64
-    tags: [compile-only, macos-14-arm64, cxx17, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          build_type: Release
-  - name: compile-only-macos-14-arm64-cxx17-release-static
-    run_on: macos-14-arm64
-    tags: [compile-only, macos-14-arm64, cxx17, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
-          build_type: Release
-  - name: compile-only-macos-14-cxx11-debug-shared
+  - name: compile-only-macos-14-cxx11-debug
     run_on: macos-14
-    tags: [compile-only, macos-14, cxx11, debug, shared]
+    tags: [compile-only, macos-14, cxx11, debug]
     commands:
       - command: expansions.update
         params:
@@ -303,11 +331,12 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 11
           build_type: Debug
-  - name: compile-only-macos-14-cxx11-debug-static
+  - name: compile-only-macos-14-cxx17-debug
     run_on: macos-14
-    tags: [compile-only, macos-14, cxx11, debug, static]
+    tags: [compile-only, macos-14, cxx17, debug]
     commands:
       - command: expansions.update
         params:
@@ -318,105 +347,52 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 17
           build_type: Debug
-  - name: compile-only-macos-14-cxx11-release-shared
-    run_on: macos-14
-    tags: [compile-only, macos-14, cxx11, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          build_type: Release
-  - name: compile-only-macos-14-cxx11-release-static
-    run_on: macos-14
-    tags: [compile-only, macos-14, cxx11, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
-          build_type: Release
-  - name: compile-only-macos-14-cxx17-debug-shared
-    run_on: macos-14
-    tags: [compile-only, macos-14, cxx17, debug, shared]
+  - name: compile-only-rhel76-gcc-cxx11-debug
+    run_on: rhel76-large
+    tags: [compile-only, rhel76, cxx11, gcc, debug]
     commands:
       - command: expansions.update
         params:
           updates:
             - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc }
+            - { key: cxx_compiler, value: g++ }
       - func: setup
       - func: install_c_driver
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 17
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 11
           build_type: Debug
-  - name: compile-only-macos-14-cxx17-debug-static
-    run_on: macos-14
-    tags: [compile-only, macos-14, cxx17, debug, static]
+          cc_compiler: gcc
+          cxx_compiler: g++
+  - name: compile-only-rhel76-gcc-cxx14-debug
+    run_on: rhel76-large
+    tags: [compile-only, rhel76, cxx14, gcc, debug]
     commands:
       - command: expansions.update
         params:
           updates:
             - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc }
+            - { key: cxx_compiler, value: g++ }
       - func: setup
       - func: install_c_driver
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 14
           build_type: Debug
-  - name: compile-only-macos-14-cxx17-release-shared
-    run_on: macos-14
-    tags: [compile-only, macos-14, cxx17, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          build_type: Release
-  - name: compile-only-macos-14-cxx17-release-static
-    run_on: macos-14
-    tags: [compile-only, macos-14, cxx17, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
-          build_type: Release
-  - name: compile-only-rhel8-power-cxx11-debug-shared
+          cc_compiler: gcc
+          cxx_compiler: g++
+  - name: compile-only-rhel8-power-cxx11-debug
     run_on: rhel8-power-large
-    tags: [compile-only, rhel8-power, cxx11, debug, shared]
+    tags: [compile-only, rhel8-power, cxx11, debug]
     patchable: false
     commands:
       - command: expansions.update
@@ -428,11 +404,12 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 11
           build_type: Debug
-  - name: compile-only-rhel8-power-cxx11-debug-static
+  - name: compile-only-rhel8-power-cxx17-debug
     run_on: rhel8-power-large
-    tags: [compile-only, rhel8-power, cxx11, debug, static]
+    tags: [compile-only, rhel8-power, cxx17, debug]
     patchable: false
     commands:
       - command: expansions.update
@@ -444,111 +421,12 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
-          build_type: Debug
-  - name: compile-only-rhel8-power-cxx11-release-shared
-    run_on: rhel8-power-large
-    tags: [compile-only, rhel8-power, cxx11, release, shared]
-    patchable: false
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          build_type: Release
-  - name: compile-only-rhel8-power-cxx11-release-static
-    run_on: rhel8-power-large
-    tags: [compile-only, rhel8-power, cxx11, release, static]
-    patchable: false
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
-          build_type: Release
-  - name: compile-only-rhel8-power-cxx17-debug-shared
-    run_on: rhel8-power-large
-    tags: [compile-only, rhel8-power, cxx17, debug, shared]
-    patchable: false
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 17
           build_type: Debug
-  - name: compile-only-rhel8-power-cxx17-debug-static
-    run_on: rhel8-power-large
-    tags: [compile-only, rhel8-power, cxx17, debug, static]
-    patchable: false
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
-          build_type: Debug
-  - name: compile-only-rhel8-power-cxx17-release-shared
-    run_on: rhel8-power-large
-    tags: [compile-only, rhel8-power, cxx17, release, shared]
-    patchable: false
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          build_type: Release
-  - name: compile-only-rhel8-power-cxx17-release-static
-    run_on: rhel8-power-large
-    tags: [compile-only, rhel8-power, cxx17, release, static]
-    patchable: false
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
-          build_type: Release
-  - name: compile-only-rhel8-zseries-cxx11-debug-shared
+  - name: compile-only-rhel8-zseries-cxx11-debug
     run_on: rhel8-zseries-large
-    tags: [compile-only, rhel8-zseries, cxx11, debug, shared]
+    tags: [compile-only, rhel8-zseries, cxx11, debug]
     patchable: false
     commands:
       - command: expansions.update
@@ -560,11 +438,12 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 11
           build_type: Debug
-  - name: compile-only-rhel8-zseries-cxx11-debug-static
+  - name: compile-only-rhel8-zseries-cxx17-debug
     run_on: rhel8-zseries-large
-    tags: [compile-only, rhel8-zseries, cxx11, debug, static]
+    tags: [compile-only, rhel8-zseries, cxx17, debug]
     patchable: false
     commands:
       - command: expansions.update
@@ -576,111 +455,12 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
-          build_type: Debug
-  - name: compile-only-rhel8-zseries-cxx11-release-shared
-    run_on: rhel8-zseries-large
-    tags: [compile-only, rhel8-zseries, cxx11, release, shared]
-    patchable: false
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          build_type: Release
-  - name: compile-only-rhel8-zseries-cxx11-release-static
-    run_on: rhel8-zseries-large
-    tags: [compile-only, rhel8-zseries, cxx11, release, static]
-    patchable: false
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
-          build_type: Release
-  - name: compile-only-rhel8-zseries-cxx17-debug-shared
-    run_on: rhel8-zseries-large
-    tags: [compile-only, rhel8-zseries, cxx17, debug, shared]
-    patchable: false
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 17
           build_type: Debug
-  - name: compile-only-rhel8-zseries-cxx17-debug-static
-    run_on: rhel8-zseries-large
-    tags: [compile-only, rhel8-zseries, cxx17, debug, static]
-    patchable: false
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
-          build_type: Debug
-  - name: compile-only-rhel8-zseries-cxx17-release-shared
-    run_on: rhel8-zseries-large
-    tags: [compile-only, rhel8-zseries, cxx17, release, shared]
-    patchable: false
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          build_type: Release
-  - name: compile-only-rhel8-zseries-cxx17-release-static
-    run_on: rhel8-zseries-large
-    tags: [compile-only, rhel8-zseries, cxx17, release, static]
-    patchable: false
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
-          build_type: Release
-  - name: compile-only-rhel80-clang-cxx11-debug-shared
+  - name: compile-only-rhel80-clang-cxx11-debug
     run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx11, clang, debug, shared]
+    tags: [compile-only, rhel80, cxx11, clang, debug]
     commands:
       - command: expansions.update
         params:
@@ -693,13 +473,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 11
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
-  - name: compile-only-rhel80-clang-cxx11-debug-static
+  - name: compile-only-rhel80-clang-cxx17-debug
     run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx11, clang, debug, static]
+    tags: [compile-only, rhel80, cxx17, clang, debug]
     commands:
       - command: expansions.update
         params:
@@ -712,53 +493,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 17
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
-  - name: compile-only-rhel80-clang-cxx11-release-shared
+  - name: compile-only-rhel80-clang-cxx20-debug
     run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx11, clang, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          build_type: Release
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-rhel80-clang-cxx11-release-static
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx11, clang, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-rhel80-clang-cxx17-debug-shared
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx17, clang, debug, shared]
+    tags: [compile-only, rhel80, cxx20, clang, debug]
     commands:
       - command: expansions.update
         params:
@@ -771,228 +513,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 17
-          build_type: Debug
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-rhel80-clang-cxx17-debug-static
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx17, clang, debug, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
-          build_type: Debug
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-rhel80-clang-cxx17-release-shared
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx17, clang, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          build_type: Release
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-rhel80-clang-cxx17-release-static
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx17, clang, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-rhel80-clang-cxx20-debug-shared
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx20, clang, debug, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 20
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
-  - name: compile-only-rhel80-clang-cxx20-debug-static
+  - name: compile-only-rhel80-gcc-cxx11-debug
     run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx20, clang, debug, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 20
-          USE_STATIC_LIBS: 1
-          build_type: Debug
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-rhel80-clang-cxx20-release-shared
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx20, clang, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 20
-          build_type: Release
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-rhel80-clang-cxx20-release-static
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx20, clang, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 20
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-rhel80-clang-cxx23-debug-shared
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx23, clang, debug, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 23
-          build_type: Debug
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-rhel80-clang-cxx23-debug-static
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx23, clang, debug, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 23
-          USE_STATIC_LIBS: 1
-          build_type: Debug
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-rhel80-clang-cxx23-release-shared
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx23, clang, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 23
-          build_type: Release
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-rhel80-clang-cxx23-release-static
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx23, clang, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 23
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-rhel80-gcc-cxx11-debug-shared
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx11, gcc, debug, shared]
+    tags: [compile-only, rhel80, cxx11, gcc, debug]
     commands:
       - command: expansions.update
         params:
@@ -1005,13 +533,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 11
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
-  - name: compile-only-rhel80-gcc-cxx11-debug-static
+  - name: compile-only-rhel80-gcc-cxx17-debug
     run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx11, gcc, debug, static]
+    tags: [compile-only, rhel80, cxx17, gcc, debug]
     commands:
       - command: expansions.update
         params:
@@ -1024,72 +553,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
-          build_type: Debug
-          cc_compiler: gcc
-          cxx_compiler: g++
-  - name: compile-only-rhel80-gcc-cxx11-release-shared
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx11, gcc, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: gcc }
-            - { key: cxx_compiler, value: g++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          build_type: Release
-          cc_compiler: gcc
-          cxx_compiler: g++
-  - name: compile-only-rhel80-gcc-cxx11-release-static
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx11, gcc, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: gcc }
-            - { key: cxx_compiler, value: g++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          cc_compiler: gcc
-          cxx_compiler: g++
-  - name: compile-only-rhel80-gcc-cxx17-debug-shared
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx17, gcc, debug, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-            - { key: cc_compiler, value: gcc }
-            - { key: cxx_compiler, value: g++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 17
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
-  - name: compile-only-rhel80-gcc-cxx17-debug-static
+  - name: compile-only-rhel80-gcc-cxx20-debug
     run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx17, gcc, debug, static]
+    tags: [compile-only, rhel80, cxx20, gcc, debug]
     commands:
       - command: expansions.update
         params:
@@ -1102,209 +573,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
-          build_type: Debug
-          cc_compiler: gcc
-          cxx_compiler: g++
-  - name: compile-only-rhel80-gcc-cxx17-release-shared
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx17, gcc, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: gcc }
-            - { key: cxx_compiler, value: g++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          build_type: Release
-          cc_compiler: gcc
-          cxx_compiler: g++
-  - name: compile-only-rhel80-gcc-cxx17-release-static
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx17, gcc, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: gcc }
-            - { key: cxx_compiler, value: g++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          cc_compiler: gcc
-          cxx_compiler: g++
-  - name: compile-only-rhel80-gcc-cxx20-debug-shared
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx20, gcc, debug, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-            - { key: cc_compiler, value: gcc }
-            - { key: cxx_compiler, value: g++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 20
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
-  - name: compile-only-rhel80-gcc-cxx20-debug-static
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx20, gcc, debug, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-            - { key: cc_compiler, value: gcc }
-            - { key: cxx_compiler, value: g++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 20
-          USE_STATIC_LIBS: 1
-          build_type: Debug
-          cc_compiler: gcc
-          cxx_compiler: g++
-  - name: compile-only-rhel80-gcc-cxx20-release-shared
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx20, gcc, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: gcc }
-            - { key: cxx_compiler, value: g++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 20
-          build_type: Release
-          cc_compiler: gcc
-          cxx_compiler: g++
-  - name: compile-only-rhel80-gcc-cxx20-release-static
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx20, gcc, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: gcc }
-            - { key: cxx_compiler, value: g++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 20
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          cc_compiler: gcc
-          cxx_compiler: g++
-  - name: compile-only-rhel80-gcc-cxx23-debug-shared
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx23, gcc, debug, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-            - { key: cc_compiler, value: gcc }
-            - { key: cxx_compiler, value: g++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 23
-          build_type: Debug
-          cc_compiler: gcc
-          cxx_compiler: g++
-  - name: compile-only-rhel80-gcc-cxx23-debug-static
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx23, gcc, debug, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-            - { key: cc_compiler, value: gcc }
-            - { key: cxx_compiler, value: g++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 23
-          USE_STATIC_LIBS: 1
-          build_type: Debug
-          cc_compiler: gcc
-          cxx_compiler: g++
-  - name: compile-only-rhel80-gcc-cxx23-release-shared
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx23, gcc, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: gcc }
-            - { key: cxx_compiler, value: g++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 23
-          build_type: Release
-          cc_compiler: gcc
-          cxx_compiler: g++
-  - name: compile-only-rhel80-gcc-cxx23-release-static
-    run_on: rhel80-large
-    tags: [compile-only, rhel80, cxx23, gcc, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: gcc }
-            - { key: cxx_compiler, value: g++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 23
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          cc_compiler: gcc
-          cxx_compiler: g++
-  - name: compile-only-ubuntu2004-arm64-clang-cxx11-debug-shared
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx11, clang, debug, shared]
+  - name: compile-only-rhel84-clang-cxx11-debug
+    run_on: rhel84-large
+    tags: [compile-only, rhel84, cxx11, clang, debug]
     commands:
       - command: expansions.update
         params:
@@ -1317,13 +593,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 11
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
-  - name: compile-only-ubuntu2004-arm64-clang-cxx11-debug-static
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx11, clang, debug, static]
+  - name: compile-only-rhel84-clang-cxx17-debug
+    run_on: rhel84-large
+    tags: [compile-only, rhel84, cxx17, clang, debug]
     commands:
       - command: expansions.update
         params:
@@ -1336,72 +613,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
-          build_type: Debug
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-ubuntu2004-arm64-clang-cxx11-release-shared
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx11, clang, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          build_type: Release
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-ubuntu2004-arm64-clang-cxx11-release-static
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx11, clang, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-ubuntu2004-arm64-clang-cxx17-debug-shared
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx17, clang, debug, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 17
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
-  - name: compile-only-ubuntu2004-arm64-clang-cxx17-debug-static
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx17, clang, debug, static]
+  - name: compile-only-rhel84-clang-cxx20-debug
+    run_on: rhel84-large
+    tags: [compile-only, rhel84, cxx20, clang, debug]
     commands:
       - command: expansions.update
         params:
@@ -1414,209 +633,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
-          build_type: Debug
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-ubuntu2004-arm64-clang-cxx17-release-shared
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx17, clang, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          build_type: Release
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-ubuntu2004-arm64-clang-cxx17-release-static
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx17, clang, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-ubuntu2004-arm64-clang-cxx20-debug-shared
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx20, clang, debug, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 20
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
-  - name: compile-only-ubuntu2004-arm64-clang-cxx20-debug-static
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx20, clang, debug, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 20
-          USE_STATIC_LIBS: 1
-          build_type: Debug
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-ubuntu2004-arm64-clang-cxx20-release-shared
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx20, clang, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 20
-          build_type: Release
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-ubuntu2004-arm64-clang-cxx20-release-static
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx20, clang, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 20
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-ubuntu2004-arm64-clang-cxx23-debug-shared
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx23, clang, debug, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 23
-          build_type: Debug
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-ubuntu2004-arm64-clang-cxx23-debug-static
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx23, clang, debug, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 23
-          USE_STATIC_LIBS: 1
-          build_type: Debug
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-ubuntu2004-arm64-clang-cxx23-release-shared
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx23, clang, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 23
-          build_type: Release
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-ubuntu2004-arm64-clang-cxx23-release-static
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx23, clang, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: clang }
-            - { key: cxx_compiler, value: clang++ }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 23
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          cc_compiler: clang
-          cxx_compiler: clang++
-  - name: compile-only-ubuntu2004-arm64-gcc-cxx11-debug-shared
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx11, gcc, debug, shared]
+  - name: compile-only-rhel84-gcc-cxx11-debug
+    run_on: rhel84-large
+    tags: [compile-only, rhel84, cxx11, gcc, debug]
     commands:
       - command: expansions.update
         params:
@@ -1629,13 +653,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 11
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
-  - name: compile-only-ubuntu2004-arm64-gcc-cxx11-debug-static
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx11, gcc, debug, static]
+  - name: compile-only-rhel84-gcc-cxx17-debug
+    run_on: rhel84-large
+    tags: [compile-only, rhel84, cxx17, gcc, debug]
     commands:
       - command: expansions.update
         params:
@@ -1648,19 +673,119 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          build_type: Debug
+          cc_compiler: gcc
+          cxx_compiler: g++
+  - name: compile-only-rhel84-gcc-cxx20-debug
+    run_on: rhel84-large
+    tags: [compile-only, rhel84, cxx20, gcc, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc }
+            - { key: cxx_compiler, value: g++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 20
+          build_type: Debug
+          cc_compiler: gcc
+          cxx_compiler: g++
+  - name: compile-only-rhel90-clang-cxx11-debug
+    run_on: rhel90-large
+    tags: [compile-only, rhel90, cxx11, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
           build_type: Debug
-          cc_compiler: gcc
-          cxx_compiler: g++
-  - name: compile-only-ubuntu2004-arm64-gcc-cxx11-release-shared
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx11, gcc, release, shared]
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel90-clang-cxx17-debug
+    run_on: rhel90-large
+    tags: [compile-only, rhel90, cxx17, clang, debug]
     commands:
       - command: expansions.update
         params:
           updates:
-            - { key: build_type, value: Release }
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel90-clang-cxx20-debug
+    run_on: rhel90-large
+    tags: [compile-only, rhel90, cxx20, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 20
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel90-clang-cxx23-debug
+    run_on: rhel90-large
+    tags: [compile-only, rhel90, cxx23, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 23
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel90-gcc-cxx11-debug
+    run_on: rhel90-large
+    tags: [compile-only, rhel90, cxx11, gcc, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
             - { key: cc_compiler, value: gcc }
             - { key: cxx_compiler, value: g++ }
       - func: setup
@@ -1668,18 +793,19 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 11
-          build_type: Release
+          build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
-  - name: compile-only-ubuntu2004-arm64-gcc-cxx11-release-static
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx11, gcc, release, static]
+  - name: compile-only-rhel90-gcc-cxx17-debug
+    run_on: rhel90-large
+    tags: [compile-only, rhel90, cxx17, gcc, debug]
     commands:
       - command: expansions.update
         params:
           updates:
-            - { key: build_type, value: Release }
+            - { key: build_type, value: Debug }
             - { key: cc_compiler, value: gcc }
             - { key: cxx_compiler, value: g++ }
       - func: setup
@@ -1687,14 +813,214 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          build_type: Debug
+          cc_compiler: gcc
+          cxx_compiler: g++
+  - name: compile-only-rhel90-gcc-cxx20-debug
+    run_on: rhel90-large
+    tags: [compile-only, rhel90, cxx20, gcc, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc }
+            - { key: cxx_compiler, value: g++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 20
+          build_type: Debug
+          cc_compiler: gcc
+          cxx_compiler: g++
+  - name: compile-only-rhel90-gcc-cxx23-debug
+    run_on: rhel90-large
+    tags: [compile-only, rhel90, cxx23, gcc, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc }
+            - { key: cxx_compiler, value: g++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 23
+          build_type: Debug
+          cc_compiler: gcc
+          cxx_compiler: g++
+  - name: compile-only-rhel91-clang-cxx11-debug
+    run_on: rhel91-large
+    tags: [compile-only, rhel91, cxx11, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          cc_compiler: gcc
-          cxx_compiler: g++
-  - name: compile-only-ubuntu2004-arm64-gcc-cxx17-debug-shared
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx17, gcc, debug, shared]
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel91-clang-cxx17-debug
+    run_on: rhel91-large
+    tags: [compile-only, rhel91, cxx17, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel91-clang-cxx20-debug
+    run_on: rhel91-large
+    tags: [compile-only, rhel91, cxx20, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 20
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel91-clang-cxx23-debug
+    run_on: rhel91-large
+    tags: [compile-only, rhel91, cxx23, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 23
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel92-clang-cxx11-debug
+    run_on: rhel92-large
+    tags: [compile-only, rhel92, cxx11, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel92-clang-cxx17-debug
+    run_on: rhel92-large
+    tags: [compile-only, rhel92, cxx17, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel92-clang-cxx20-debug
+    run_on: rhel92-large
+    tags: [compile-only, rhel92, cxx20, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 20
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel92-clang-cxx23-debug
+    run_on: rhel92-large
+    tags: [compile-only, rhel92, cxx23, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 23
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel92-gcc-cxx11-debug
+    run_on: rhel92-large
+    tags: [compile-only, rhel92, cxx11, gcc, debug]
     commands:
       - command: expansions.update
         params:
@@ -1707,13 +1033,34 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          build_type: Debug
+          cc_compiler: gcc
+          cxx_compiler: g++
+  - name: compile-only-rhel92-gcc-cxx17-debug
+    run_on: rhel92-large
+    tags: [compile-only, rhel92, cxx17, gcc, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc }
+            - { key: cxx_compiler, value: g++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 17
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
-  - name: compile-only-ubuntu2004-arm64-gcc-cxx17-debug-static
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx17, gcc, debug, static]
+  - name: compile-only-rhel92-gcc-cxx20-debug
+    run_on: rhel92-large
+    tags: [compile-only, rhel92, cxx20, gcc, debug]
     commands:
       - command: expansions.update
         params:
@@ -1726,38 +1073,199 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 20
+          build_type: Debug
+          cc_compiler: gcc
+          cxx_compiler: g++
+  - name: compile-only-rhel92-gcc-cxx23-debug
+    run_on: rhel92-large
+    tags: [compile-only, rhel92, cxx23, gcc, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc }
+            - { key: cxx_compiler, value: g++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 23
+          build_type: Debug
+          cc_compiler: gcc
+          cxx_compiler: g++
+  - name: compile-only-rhel93-clang-cxx11-debug
+    run_on: rhel93-large
+    tags: [compile-only, rhel93, cxx11, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel93-clang-cxx17-debug
+    run_on: rhel93-large
+    tags: [compile-only, rhel93, cxx17, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
           build_type: Debug
-          cc_compiler: gcc
-          cxx_compiler: g++
-  - name: compile-only-ubuntu2004-arm64-gcc-cxx17-release-shared
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx17, gcc, release, shared]
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel93-clang-cxx20-debug
+    run_on: rhel93-large
+    tags: [compile-only, rhel93, cxx20, clang, debug]
     commands:
       - command: expansions.update
         params:
           updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: gcc }
-            - { key: cxx_compiler, value: g++ }
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
       - func: setup
       - func: install_c_driver
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 20
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel93-clang-cxx23-debug
+    run_on: rhel93-large
+    tags: [compile-only, rhel93, cxx23, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 23
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel94-clang-cxx11-debug
+    run_on: rhel94-large
+    tags: [compile-only, rhel94, cxx11, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel94-clang-cxx17-debug
+    run_on: rhel94-large
+    tags: [compile-only, rhel94, cxx17, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 17
-          build_type: Release
-          cc_compiler: gcc
-          cxx_compiler: g++
-  - name: compile-only-ubuntu2004-arm64-gcc-cxx17-release-static
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx17, gcc, release, static]
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel94-clang-cxx20-debug
+    run_on: rhel94-large
+    tags: [compile-only, rhel94, cxx20, clang, debug]
     commands:
       - command: expansions.update
         params:
           updates:
-            - { key: build_type, value: Release }
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 20
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel94-clang-cxx23-debug
+    run_on: rhel94-large
+    tags: [compile-only, rhel94, cxx23, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 23
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel94-gcc-cxx11-debug
+    run_on: rhel94-large
+    tags: [compile-only, rhel94, cxx11, gcc, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
             - { key: cc_compiler, value: gcc }
             - { key: cxx_compiler, value: g++ }
       - func: setup
@@ -1765,14 +1273,34 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          build_type: Debug
+          cc_compiler: gcc
+          cxx_compiler: g++
+  - name: compile-only-rhel94-gcc-cxx17-debug
+    run_on: rhel94-large
+    tags: [compile-only, rhel94, cxx17, gcc, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc }
+            - { key: cxx_compiler, value: g++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
-          build_type: Release
+          build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
-  - name: compile-only-ubuntu2004-arm64-gcc-cxx20-debug-shared
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx20, gcc, debug, shared]
+  - name: compile-only-rhel94-gcc-cxx20-debug
+    run_on: rhel94-large
+    tags: [compile-only, rhel94, cxx20, gcc, debug]
     commands:
       - command: expansions.update
         params:
@@ -1785,13 +1313,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 20
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
-  - name: compile-only-ubuntu2004-arm64-gcc-cxx20-debug-static
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx20, gcc, debug, static]
+  - name: compile-only-rhel94-gcc-cxx23-debug
+    run_on: rhel94-large
+    tags: [compile-only, rhel94, cxx23, gcc, debug]
     commands:
       - command: expansions.update
         params:
@@ -1804,53 +1333,94 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 20
-          USE_STATIC_LIBS: 1
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 23
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
-  - name: compile-only-ubuntu2004-arm64-gcc-cxx20-release-shared
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx20, gcc, release, shared]
+  - name: compile-only-rhel95-clang-cxx11-debug
+    run_on: rhel95-large
+    tags: [compile-only, rhel95, cxx11, clang, debug]
     commands:
       - command: expansions.update
         params:
           updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: gcc }
-            - { key: cxx_compiler, value: g++ }
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
       - func: setup
       - func: install_c_driver
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 20
-          build_type: Release
-          cc_compiler: gcc
-          cxx_compiler: g++
-  - name: compile-only-ubuntu2004-arm64-gcc-cxx20-release-static
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx20, gcc, release, static]
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel95-clang-cxx17-debug
+    run_on: rhel95-large
+    tags: [compile-only, rhel95, cxx17, clang, debug]
     commands:
       - command: expansions.update
         params:
           updates:
-            - { key: build_type, value: Release }
-            - { key: cc_compiler, value: gcc }
-            - { key: cxx_compiler, value: g++ }
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
       - func: setup
       - func: install_c_driver
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel95-clang-cxx20-debug
+    run_on: rhel95-large
+    tags: [compile-only, rhel95, cxx20, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 20
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          cc_compiler: gcc
-          cxx_compiler: g++
-  - name: compile-only-ubuntu2004-arm64-gcc-cxx23-debug-shared
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx23, gcc, debug, shared]
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel95-clang-cxx23-debug
+    run_on: rhel95-large
+    tags: [compile-only, rhel95, cxx23, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 23
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel95-gcc-cxx11-debug
+    run_on: rhel95-large
+    tags: [compile-only, rhel95, cxx11, gcc, debug]
     commands:
       - command: expansions.update
         params:
@@ -1863,13 +1433,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 23
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 11
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
-  - name: compile-only-ubuntu2004-arm64-gcc-cxx23-debug-static
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx23, gcc, debug, static]
+  - name: compile-only-rhel95-gcc-cxx17-debug
+    run_on: rhel95-large
+    tags: [compile-only, rhel95, cxx17, gcc, debug]
     commands:
       - command: expansions.update
         params:
@@ -1882,19 +1453,19 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 23
-          USE_STATIC_LIBS: 1
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 17
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
-  - name: compile-only-ubuntu2004-arm64-gcc-cxx23-release-shared
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx23, gcc, release, shared]
+  - name: compile-only-rhel95-gcc-cxx20-debug
+    run_on: rhel95-large
+    tags: [compile-only, rhel95, cxx20, gcc, debug]
     commands:
       - command: expansions.update
         params:
           updates:
-            - { key: build_type, value: Release }
+            - { key: build_type, value: Debug }
             - { key: cc_compiler, value: gcc }
             - { key: cxx_compiler, value: g++ }
       - func: setup
@@ -1902,18 +1473,19 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 23
-          build_type: Release
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 20
+          build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
-  - name: compile-only-ubuntu2004-arm64-gcc-cxx23-release-static
-    run_on: ubuntu2004-arm64-large
-    tags: [compile-only, ubuntu2004-arm64, cxx23, gcc, release, static]
+  - name: compile-only-rhel95-gcc-cxx23-debug
+    run_on: rhel95-large
+    tags: [compile-only, rhel95, cxx23, gcc, debug]
     commands:
       - command: expansions.update
         params:
           updates:
-            - { key: build_type, value: Release }
+            - { key: build_type, value: Debug }
             - { key: cc_compiler, value: gcc }
             - { key: cxx_compiler, value: g++ }
       - func: setup
@@ -1921,14 +1493,294 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 23
-          USE_STATIC_LIBS: 1
-          build_type: Release
+          build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
-  - name: compile-only-windows-2019-vs2015-x64-cxx11-debug-shared
+  - name: compile-only-ubuntu2004-arm64-clang-cxx11-debug
+    run_on: ubuntu2004-arm64-large
+    tags: [compile-only, ubuntu2004-arm64, cxx11, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-ubuntu2004-arm64-clang-cxx17-debug
+    run_on: ubuntu2004-arm64-large
+    tags: [compile-only, ubuntu2004-arm64, cxx17, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-ubuntu2004-arm64-gcc-cxx11-debug
+    run_on: ubuntu2004-arm64-large
+    tags: [compile-only, ubuntu2004-arm64, cxx11, gcc, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc }
+            - { key: cxx_compiler, value: g++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          build_type: Debug
+          cc_compiler: gcc
+          cxx_compiler: g++
+  - name: compile-only-ubuntu2004-arm64-gcc-cxx17-debug
+    run_on: ubuntu2004-arm64-large
+    tags: [compile-only, ubuntu2004-arm64, cxx17, gcc, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc }
+            - { key: cxx_compiler, value: g++ }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          build_type: Debug
+          cc_compiler: gcc
+          cxx_compiler: g++
+  - name: compile-only-ubuntu2004-clang-10-cxx11-debug
+    run_on: ubuntu2004-large
+    tags: [compile-only, ubuntu2004, cxx11, clang-10, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang-10 }
+            - { key: cxx_compiler, value: clang++-10 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          build_type: Debug
+          cc_compiler: clang-10
+          cxx_compiler: clang++-10
+  - name: compile-only-ubuntu2004-clang-10-cxx17-debug
+    run_on: ubuntu2004-large
+    tags: [compile-only, ubuntu2004, cxx17, clang-10, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang-10 }
+            - { key: cxx_compiler, value: clang++-10 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          build_type: Debug
+          cc_compiler: clang-10
+          cxx_compiler: clang++-10
+  - name: compile-only-ubuntu2004-clang-10-cxx20-debug
+    run_on: ubuntu2004-large
+    tags: [compile-only, ubuntu2004, cxx20, clang-10, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang-10 }
+            - { key: cxx_compiler, value: clang++-10 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 20
+          build_type: Debug
+          cc_compiler: clang-10
+          cxx_compiler: clang++-10
+  - name: compile-only-ubuntu2004-gcc-9-cxx11-debug
+    run_on: ubuntu2004-large
+    tags: [compile-only, ubuntu2004, cxx11, gcc-9, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc-9 }
+            - { key: cxx_compiler, value: g++-9 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          build_type: Debug
+          cc_compiler: gcc-9
+          cxx_compiler: g++-9
+  - name: compile-only-ubuntu2004-gcc-9-cxx17-debug
+    run_on: ubuntu2004-large
+    tags: [compile-only, ubuntu2004, cxx17, gcc-9, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc-9 }
+            - { key: cxx_compiler, value: g++-9 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          build_type: Debug
+          cc_compiler: gcc-9
+          cxx_compiler: g++-9
+  - name: compile-only-ubuntu2004-gcc-9-cxx20-debug
+    run_on: ubuntu2004-large
+    tags: [compile-only, ubuntu2004, cxx20, gcc-9, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc-9 }
+            - { key: cxx_compiler, value: g++-9 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 20
+          build_type: Debug
+          cc_compiler: gcc-9
+          cxx_compiler: g++-9
+  - name: compile-only-ubuntu2204-clang-12-cxx11-debug
+    run_on: ubuntu2204-large
+    tags: [compile-only, ubuntu2204, cxx11, clang-12, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang-12 }
+            - { key: cxx_compiler, value: clang++-12 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          build_type: Debug
+          cc_compiler: clang-12
+          cxx_compiler: clang++-12
+  - name: compile-only-ubuntu2204-clang-12-cxx17-debug
+    run_on: ubuntu2204-large
+    tags: [compile-only, ubuntu2204, cxx17, clang-12, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang-12 }
+            - { key: cxx_compiler, value: clang++-12 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          build_type: Debug
+          cc_compiler: clang-12
+          cxx_compiler: clang++-12
+  - name: compile-only-ubuntu2204-clang-12-cxx20-debug
+    run_on: ubuntu2204-large
+    tags: [compile-only, ubuntu2204, cxx20, clang-12, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang-12 }
+            - { key: cxx_compiler, value: clang++-12 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 20
+          build_type: Debug
+          cc_compiler: clang-12
+          cxx_compiler: clang++-12
+  - name: compile-only-ubuntu2204-clang-12-cxx23-debug
+    run_on: ubuntu2204-large
+    tags: [compile-only, ubuntu2204, cxx23, clang-12, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang-12 }
+            - { key: cxx_compiler, value: clang++-12 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 23
+          build_type: Debug
+          cc_compiler: clang-12
+          cxx_compiler: clang++-12
+  - name: compile-only-windows-2019-vs2015-x64-cxx11-debug
     run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx11, vs2015x64, debug, shared]
+    tags: [compile-only, windows-vsCurrent, cxx11, vs2015x64, debug]
     commands:
       - command: expansions.update
         params:
@@ -1941,13 +1793,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 11
           build_type: Debug
           generator: Visual Studio 14 2015
           platform: x64
-  - name: compile-only-windows-2019-vs2015-x64-cxx11-debug-static
+  - name: compile-only-windows-2019-vs2015-x64-cxx14-debug
     run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx11, vs2015x64, debug, static]
+    tags: [compile-only, windows-vsCurrent, cxx14, vs2015x64, debug]
     commands:
       - command: expansions.update
         params:
@@ -1960,53 +1813,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 14
           build_type: Debug
           generator: Visual Studio 14 2015
           platform: x64
-  - name: compile-only-windows-2019-vs2015-x64-cxx11-release-shared
+  - name: compile-only-windows-2019-vs2015-x64-cxxlatest-debug
     run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx11, vs2015x64, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: generator, value: Visual Studio 14 2015 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          build_type: Release
-          generator: Visual Studio 14 2015
-          platform: x64
-  - name: compile-only-windows-2019-vs2015-x64-cxx11-release-static
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx11, vs2015x64, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: generator, value: Visual Studio 14 2015 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          generator: Visual Studio 14 2015
-          platform: x64
-  - name: compile-only-windows-2019-vs2015-x64-cxx17-debug-shared
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx17, vs2015x64, debug, shared]
+    tags: [compile-only, windows-vsCurrent, cxxlatest, vs2015x64, debug]
     commands:
       - command: expansions.update
         params:
@@ -2019,72 +1833,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 17
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: latest
           build_type: Debug
           generator: Visual Studio 14 2015
           platform: x64
-  - name: compile-only-windows-2019-vs2015-x64-cxx17-debug-static
+  - name: compile-only-windows-2019-vs2017-x64-cxx11-debug
     run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx17, vs2015x64, debug, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-            - { key: generator, value: Visual Studio 14 2015 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
-          build_type: Debug
-          generator: Visual Studio 14 2015
-          platform: x64
-  - name: compile-only-windows-2019-vs2015-x64-cxx17-release-shared
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx17, vs2015x64, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: generator, value: Visual Studio 14 2015 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          build_type: Release
-          generator: Visual Studio 14 2015
-          platform: x64
-  - name: compile-only-windows-2019-vs2015-x64-cxx17-release-static
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx17, vs2015x64, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: generator, value: Visual Studio 14 2015 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          generator: Visual Studio 14 2015
-          platform: x64
-  - name: compile-only-windows-2019-vs2017-x64-cxx11-debug-shared
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx11, vs2017x64, debug, shared]
+    tags: [compile-only, windows-vsCurrent, cxx11, vs2017x64, debug]
     commands:
       - command: expansions.update
         params:
@@ -2097,13 +1853,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 11
           build_type: Debug
           generator: Visual Studio 15 2017
           platform: x64
-  - name: compile-only-windows-2019-vs2017-x64-cxx11-debug-static
+  - name: compile-only-windows-2019-vs2017-x64-cxx14-debug
     run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx11, vs2017x64, debug, static]
+    tags: [compile-only, windows-vsCurrent, cxx14, vs2017x64, debug]
     commands:
       - command: expansions.update
         params:
@@ -2116,53 +1873,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 14
           build_type: Debug
           generator: Visual Studio 15 2017
           platform: x64
-  - name: compile-only-windows-2019-vs2017-x64-cxx11-release-shared
+  - name: compile-only-windows-2019-vs2017-x64-cxx17-debug
     run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx11, vs2017x64, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: generator, value: Visual Studio 15 2017 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          build_type: Release
-          generator: Visual Studio 15 2017
-          platform: x64
-  - name: compile-only-windows-2019-vs2017-x64-cxx11-release-static
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx11, vs2017x64, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: generator, value: Visual Studio 15 2017 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          generator: Visual Studio 15 2017
-          platform: x64
-  - name: compile-only-windows-2019-vs2017-x64-cxx17-debug-shared
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx17, vs2017x64, debug, shared]
+    tags: [compile-only, windows-vsCurrent, cxx17, vs2017x64, debug]
     commands:
       - command: expansions.update
         params:
@@ -2175,13 +1893,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 17
           build_type: Debug
           generator: Visual Studio 15 2017
           platform: x64
-  - name: compile-only-windows-2019-vs2017-x64-cxx17-debug-static
+  - name: compile-only-windows-2019-vs2017-x64-cxx20-debug
     run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx17, vs2017x64, debug, static]
+    tags: [compile-only, windows-vsCurrent, cxx20, vs2017x64, debug]
     commands:
       - command: expansions.update
         params:
@@ -2194,19 +1913,19 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 20
           build_type: Debug
           generator: Visual Studio 15 2017
           platform: x64
-  - name: compile-only-windows-2019-vs2017-x64-cxx17-release-shared
+  - name: compile-only-windows-2019-vs2017-x64-cxxlatest-debug
     run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx17, vs2017x64, release, shared]
+    tags: [compile-only, windows-vsCurrent, cxxlatest, vs2017x64, debug]
     commands:
       - command: expansions.update
         params:
           updates:
-            - { key: build_type, value: Release }
+            - { key: build_type, value: Debug }
             - { key: generator, value: Visual Studio 15 2017 }
             - { key: platform, value: x64 }
       - func: setup
@@ -2214,33 +1933,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 17
-          build_type: Release
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: latest
+          build_type: Debug
           generator: Visual Studio 15 2017
           platform: x64
-  - name: compile-only-windows-2019-vs2017-x64-cxx17-release-static
+  - name: compile-only-windows-2019-vs2019-x64-cxx11-debug
     run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx17, vs2017x64, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: generator, value: Visual Studio 15 2017 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          generator: Visual Studio 15 2017
-          platform: x64
-  - name: compile-only-windows-2019-vs2019-x64-cxx11-debug-shared
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx11, vs2019x64, debug, shared]
+    tags: [compile-only, windows-vsCurrent, cxx11, vs2019x64, debug]
     commands:
       - command: expansions.update
         params:
@@ -2253,13 +1953,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 11
           build_type: Debug
           generator: Visual Studio 16 2019
           platform: x64
-  - name: compile-only-windows-2019-vs2019-x64-cxx11-debug-static
+  - name: compile-only-windows-2019-vs2019-x64-cxx14-debug
     run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx11, vs2019x64, debug, static]
+    tags: [compile-only, windows-vsCurrent, cxx14, vs2019x64, debug]
     commands:
       - command: expansions.update
         params:
@@ -2272,53 +1973,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 14
           build_type: Debug
           generator: Visual Studio 16 2019
           platform: x64
-  - name: compile-only-windows-2019-vs2019-x64-cxx11-release-shared
+  - name: compile-only-windows-2019-vs2019-x64-cxx17-debug
     run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx11, vs2019x64, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: generator, value: Visual Studio 16 2019 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          build_type: Release
-          generator: Visual Studio 16 2019
-          platform: x64
-  - name: compile-only-windows-2019-vs2019-x64-cxx11-release-static
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx11, vs2019x64, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: generator, value: Visual Studio 16 2019 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          generator: Visual Studio 16 2019
-          platform: x64
-  - name: compile-only-windows-2019-vs2019-x64-cxx17-debug-shared
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx17, vs2019x64, debug, shared]
+    tags: [compile-only, windows-vsCurrent, cxx17, vs2019x64, debug]
     commands:
       - command: expansions.update
         params:
@@ -2331,13 +1993,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 17
           build_type: Debug
           generator: Visual Studio 16 2019
           platform: x64
-  - name: compile-only-windows-2019-vs2019-x64-cxx17-debug-static
+  - name: compile-only-windows-2019-vs2019-x64-cxx20-debug
     run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx17, vs2019x64, debug, static]
+    tags: [compile-only, windows-vsCurrent, cxx20, vs2019x64, debug]
     commands:
       - command: expansions.update
         params:
@@ -2350,53 +2013,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 20
           build_type: Debug
           generator: Visual Studio 16 2019
           platform: x64
-  - name: compile-only-windows-2019-vs2019-x64-cxx17-release-shared
+  - name: compile-only-windows-2019-vs2019-x64-cxx23-debug
     run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx17, vs2019x64, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: generator, value: Visual Studio 16 2019 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          build_type: Release
-          generator: Visual Studio 16 2019
-          platform: x64
-  - name: compile-only-windows-2019-vs2019-x64-cxx17-release-static
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx17, vs2019x64, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: generator, value: Visual Studio 16 2019 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          generator: Visual Studio 16 2019
-          platform: x64
-  - name: compile-only-windows-2019-vs2019-x64-cxx20-debug-shared
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx20, vs2019x64, debug, shared]
+    tags: [compile-only, windows-vsCurrent, cxx23, vs2019x64, debug]
     commands:
       - command: expansions.update
         params:
@@ -2409,13 +2033,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 20
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 23
           build_type: Debug
           generator: Visual Studio 16 2019
           platform: x64
-  - name: compile-only-windows-2019-vs2019-x64-cxx20-debug-static
+  - name: compile-only-windows-2019-vs2019-x64-cxxlatest-debug
     run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx20, vs2019x64, debug, static]
+    tags: [compile-only, windows-vsCurrent, cxxlatest, vs2019x64, debug]
     commands:
       - command: expansions.update
         params:
@@ -2428,53 +2053,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 20
-          USE_STATIC_LIBS: 1
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: latest
           build_type: Debug
           generator: Visual Studio 16 2019
           platform: x64
-  - name: compile-only-windows-2019-vs2019-x64-cxx20-release-shared
+  - name: compile-only-windows-2019-vs2022-x64-cxx11-debug
     run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx20, vs2019x64, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: generator, value: Visual Studio 16 2019 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 20
-          build_type: Release
-          generator: Visual Studio 16 2019
-          platform: x64
-  - name: compile-only-windows-2019-vs2019-x64-cxx20-release-static
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx20, vs2019x64, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: generator, value: Visual Studio 16 2019 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 20
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          generator: Visual Studio 16 2019
-          platform: x64
-  - name: compile-only-windows-2019-vs2022-x64-cxx11-debug-shared
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx11, vs2022x64, debug, shared]
+    tags: [compile-only, windows-vsCurrent, cxx11, vs2022x64, debug]
     commands:
       - command: expansions.update
         params:
@@ -2487,13 +2073,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 11
           build_type: Debug
           generator: Visual Studio 17 2022
           platform: x64
-  - name: compile-only-windows-2019-vs2022-x64-cxx11-debug-static
+  - name: compile-only-windows-2019-vs2022-x64-cxx14-debug
     run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx11, vs2022x64, debug, static]
+    tags: [compile-only, windows-vsCurrent, cxx14, vs2022x64, debug]
     commands:
       - command: expansions.update
         params:
@@ -2506,53 +2093,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 14
           build_type: Debug
           generator: Visual Studio 17 2022
           platform: x64
-  - name: compile-only-windows-2019-vs2022-x64-cxx11-release-shared
+  - name: compile-only-windows-2019-vs2022-x64-cxx17-debug
     run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx11, vs2022x64, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: generator, value: Visual Studio 17 2022 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          build_type: Release
-          generator: Visual Studio 17 2022
-          platform: x64
-  - name: compile-only-windows-2019-vs2022-x64-cxx11-release-static
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx11, vs2022x64, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: generator, value: Visual Studio 17 2022 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 11
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          generator: Visual Studio 17 2022
-          platform: x64
-  - name: compile-only-windows-2019-vs2022-x64-cxx17-debug-shared
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx17, vs2022x64, debug, shared]
+    tags: [compile-only, windows-vsCurrent, cxx17, vs2022x64, debug]
     commands:
       - command: expansions.update
         params:
@@ -2565,13 +2113,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 17
           build_type: Debug
           generator: Visual Studio 17 2022
           platform: x64
-  - name: compile-only-windows-2019-vs2022-x64-cxx17-debug-static
+  - name: compile-only-windows-2019-vs2022-x64-cxx20-debug
     run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx17, vs2022x64, debug, static]
+    tags: [compile-only, windows-vsCurrent, cxx20, vs2022x64, debug]
     commands:
       - command: expansions.update
         params:
@@ -2584,72 +2133,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
-          build_type: Debug
-          generator: Visual Studio 17 2022
-          platform: x64
-  - name: compile-only-windows-2019-vs2022-x64-cxx17-release-shared
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx17, vs2022x64, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: generator, value: Visual Studio 17 2022 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          build_type: Release
-          generator: Visual Studio 17 2022
-          platform: x64
-  - name: compile-only-windows-2019-vs2022-x64-cxx17-release-static
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx17, vs2022x64, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: generator, value: Visual Studio 17 2022 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 17
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          generator: Visual Studio 17 2022
-          platform: x64
-  - name: compile-only-windows-2019-vs2022-x64-cxx20-debug-shared
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx20, vs2022x64, debug, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-            - { key: generator, value: Visual Studio 17 2022 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 20
           build_type: Debug
           generator: Visual Studio 17 2022
           platform: x64
-  - name: compile-only-windows-2019-vs2022-x64-cxx20-debug-static
+  - name: compile-only-windows-2019-vs2022-x64-cxx23-debug
     run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx20, vs2022x64, debug, static]
+    tags: [compile-only, windows-vsCurrent, cxx23, vs2022x64, debug]
     commands:
       - command: expansions.update
         params:
@@ -2662,72 +2153,14 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 20
-          USE_STATIC_LIBS: 1
-          build_type: Debug
-          generator: Visual Studio 17 2022
-          platform: x64
-  - name: compile-only-windows-2019-vs2022-x64-cxx20-release-shared
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx20, vs2022x64, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: generator, value: Visual Studio 17 2022 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 20
-          build_type: Release
-          generator: Visual Studio 17 2022
-          platform: x64
-  - name: compile-only-windows-2019-vs2022-x64-cxx20-release-static
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx20, vs2022x64, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: generator, value: Visual Studio 17 2022 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 20
-          USE_STATIC_LIBS: 1
-          build_type: Release
-          generator: Visual Studio 17 2022
-          platform: x64
-  - name: compile-only-windows-2019-vs2022-x64-cxx23-debug-shared
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx23, vs2022x64, debug, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Debug }
-            - { key: generator, value: Visual Studio 17 2022 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 23
           build_type: Debug
           generator: Visual Studio 17 2022
           platform: x64
-  - name: compile-only-windows-2019-vs2022-x64-cxx23-debug-static
+  - name: compile-only-windows-2019-vs2022-x64-cxxlatest-debug
     run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx23, vs2022x64, debug, static]
+    tags: [compile-only, windows-vsCurrent, cxxlatest, vs2022x64, debug]
     commands:
       - command: expansions.update
         params:
@@ -2740,48 +2173,9 @@ tasks:
       - func: install-uv
       - func: compile
         vars:
-          REQUIRED_CXX_STANDARD: 23
-          USE_STATIC_LIBS: 1
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: latest
           build_type: Debug
-          generator: Visual Studio 17 2022
-          platform: x64
-  - name: compile-only-windows-2019-vs2022-x64-cxx23-release-shared
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx23, vs2022x64, release, shared]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: generator, value: Visual Studio 17 2022 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 23
-          build_type: Release
-          generator: Visual Studio 17 2022
-          platform: x64
-  - name: compile-only-windows-2019-vs2022-x64-cxx23-release-static
-    run_on: windows-vsCurrent-large
-    tags: [compile-only, windows-vsCurrent, cxx23, vs2022x64, release, static]
-    commands:
-      - command: expansions.update
-        params:
-          updates:
-            - { key: build_type, value: Release }
-            - { key: generator, value: Visual Studio 17 2022 }
-            - { key: platform, value: x64 }
-      - func: setup
-      - func: install_c_driver
-      - func: install-uv
-      - func: compile
-        vars:
-          REQUIRED_CXX_STANDARD: 23
-          USE_STATIC_LIBS: 1
-          build_type: Release
           generator: Visual Studio 17 2022
           platform: x64
   - name: docker-build-ubuntu2204

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -1782,6 +1782,150 @@ tasks:
           build_type: Release
           cc_compiler: gcc
           cxx_compiler: g++
+  - name: compile-only-windows-2019-vs2015-x64-cxx11-debug-shared
+    run_on: windows-vsCurrent-large
+    tags: [compile-only, windows-vsCurrent, cxx11, vs2015x64, debug, shared]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: generator, value: Visual Studio 14 2015 }
+            - { key: platform, value: x64 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          build_type: Debug
+          generator: Visual Studio 14 2015
+          platform: x64
+  - name: compile-only-windows-2019-vs2015-x64-cxx11-debug-static
+    run_on: windows-vsCurrent-large
+    tags: [compile-only, windows-vsCurrent, cxx11, vs2015x64, debug, static]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: generator, value: Visual Studio 14 2015 }
+            - { key: platform, value: x64 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          build_type: Debug
+          generator: Visual Studio 14 2015
+          platform: x64
+  - name: compile-only-windows-2019-vs2015-x64-cxx11-release-shared
+    run_on: windows-vsCurrent-large
+    tags: [compile-only, windows-vsCurrent, cxx11, vs2015x64, release, shared]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Release }
+            - { key: generator, value: Visual Studio 14 2015 }
+            - { key: platform, value: x64 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          build_type: Release
+          generator: Visual Studio 14 2015
+          platform: x64
+  - name: compile-only-windows-2019-vs2015-x64-cxx11-release-static
+    run_on: windows-vsCurrent-large
+    tags: [compile-only, windows-vsCurrent, cxx11, vs2015x64, release, static]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Release }
+            - { key: generator, value: Visual Studio 14 2015 }
+            - { key: platform, value: x64 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          build_type: Release
+          generator: Visual Studio 14 2015
+          platform: x64
+  - name: compile-only-windows-2019-vs2015-x64-cxx17-debug-shared
+    run_on: windows-vsCurrent-large
+    tags: [compile-only, windows-vsCurrent, cxx17, vs2015x64, debug, shared]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: generator, value: Visual Studio 14 2015 }
+            - { key: platform, value: x64 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          build_type: Debug
+          generator: Visual Studio 14 2015
+          platform: x64
+  - name: compile-only-windows-2019-vs2015-x64-cxx17-debug-static
+    run_on: windows-vsCurrent-large
+    tags: [compile-only, windows-vsCurrent, cxx17, vs2015x64, debug, static]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: generator, value: Visual Studio 14 2015 }
+            - { key: platform, value: x64 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          build_type: Debug
+          generator: Visual Studio 14 2015
+          platform: x64
+  - name: compile-only-windows-2019-vs2015-x64-cxx17-release-shared
+    run_on: windows-vsCurrent-large
+    tags: [compile-only, windows-vsCurrent, cxx17, vs2015x64, release, shared]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Release }
+            - { key: generator, value: Visual Studio 14 2015 }
+            - { key: platform, value: x64 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          build_type: Release
+          generator: Visual Studio 14 2015
+          platform: x64
+  - name: compile-only-windows-2019-vs2015-x64-cxx17-release-static
+    run_on: windows-vsCurrent-large
+    tags: [compile-only, windows-vsCurrent, cxx17, vs2015x64, release, static]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Release }
+            - { key: generator, value: Visual Studio 14 2015 }
+            - { key: platform, value: x64 }
+      - func: setup
+      - func: install_c_driver
+      - func: install-uv
+      - func: compile
+        vars:
+          build_type: Release
+          generator: Visual Studio 14 2015
+          platform: x64
   - name: compile-only-windows-2019-vs2017-x64-cxx11-debug-shared
     run_on: windows-vsCurrent-large
     tags: [compile-only, windows-vsCurrent, cxx11, vs2017x64, debug, shared]

--- a/.evergreen/scripts/compile.sh
+++ b/.evergreen/scripts/compile.sh
@@ -80,8 +80,21 @@ darwin* | linux*)
   ;;
 esac
 
-# Create a VERSION_CURRENT file in the build directory to include in the dist tarball.
-PATH="${UV_INSTALL_DIR:?}:${PATH:-}" uv run --frozen python ./etc/calc_release_version.py >./build/VERSION_CURRENT
+mkdir -p build
+
+(
+  # calc_release_version.py is a standalone script.
+  uv_flags=(--no-project)
+
+  # Avoid "error: unknown option `format=...'" with CPython 3.11.
+  if [[ "${distro_id:?}" == rhel7* ]]; then
+    uv_flags+=(-p 3.12)
+  fi
+
+  # Create a VERSION_CURRENT file in the build directory to include in the dist tarball.
+  PATH="${UV_INSTALL_DIR:?}:${PATH:-}" uv run "${uv_flags[@]:?}" python ./etc/calc_release_version.py >./build/VERSION_CURRENT
+)
+
 cd build
 
 cmake_flags=(

--- a/.evergreen/scripts/compile.sh
+++ b/.evergreen/scripts/compile.sh
@@ -154,10 +154,6 @@ linux*)
   cc_flags+=("${cc_flags_init[@]}")
   cxx_flags+=("${cxx_flags_init[@]}" -Wno-missing-field-initializers)
 
-  if [[ "${CXX:-}" != "clang++" ]]; then
-    cxx_flags+=(-Wno-aligned-new)
-  fi
-
   if [[ "${distro_id:?}" != rhel7* ]]; then
     cxx_flags+=("-Wno-expansion-to-defined")
   else

--- a/.evergreen/scripts/compile.sh
+++ b/.evergreen/scripts/compile.sh
@@ -216,7 +216,7 @@ if [[ "${ENABLE_CODE_COVERAGE:-}" == "ON" ]]; then
   cmake_flags+=("-DENABLE_CODE_COVERAGE=ON")
 fi
 
-if [ "${USE_STATIC_LIBS:-}" ]; then
+if [[ "${USE_STATIC_LIBS:-}" == 1 ]]; then
   cmake_flags+=("-DBUILD_SHARED_LIBS=OFF")
 fi
 

--- a/.evergreen/scripts/compile.sh
+++ b/.evergreen/scripts/compile.sh
@@ -80,21 +80,8 @@ darwin* | linux*)
   ;;
 esac
 
-mkdir -p build
-
-(
-  # calc_release_version.py is a standalone script.
-  uv_flags=(--no-project)
-
-  # Avoid "error: unknown option `format=...'" with CPython 3.11.
-  if [[ "${distro_id:?}" == rhel7* ]]; then
-    uv_flags+=(-p 3.12)
-  fi
-
-  # Create a VERSION_CURRENT file in the build directory to include in the dist tarball.
-  PATH="${UV_INSTALL_DIR:?}:${PATH:-}" uv run "${uv_flags[@]:?}" python ./etc/calc_release_version.py >./build/VERSION_CURRENT
-)
-
+# Create a VERSION_CURRENT file in the build directory to include in the dist tarball.
+PATH="${UV_INSTALL_DIR:?}:${PATH:-}" uv run --frozen python ./etc/calc_release_version.py >./build/VERSION_CURRENT
 cd build
 
 cmake_flags=(

--- a/etc/run-clang-tidy.sh
+++ b/etc/run-clang-tidy.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o pipefail
 
-: "${UV_INSTALL_DIR:?}" # Not on windows-64-vs2015.
+: "${UV_INSTALL_DIR:?}"
 
 export CC="${cc_compiler:?}"
 export CXX="${cxx_compiler:?}"

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/validate.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/validate.cpp
@@ -90,13 +90,14 @@ validate(std::uint8_t const* data, std::size_t length, validator const& validato
     ::bson_t bson;
     if (!::bson_init_static(&bson, data, length)) {
         // if we can't even initialize a bson_t we just say the error is at offset 0.
-        if (invalid_offset)
+        if (invalid_offset) {
             *invalid_offset = 0u;
-        return {};
+        }
+        return bsoncxx::v_noabi::stdx::nullopt;
     }
 
     if (!::bson_validate(&bson, flags, invalid_offset)) {
-        return {};
+        return bsoncxx::v_noabi::stdx::nullopt;
     }
 
     return document::view{data, length};

--- a/src/mongocxx/lib/mongocxx/private/change_stream.hh
+++ b/src/mongocxx/lib/mongocxx/private/change_stream.hh
@@ -106,7 +106,7 @@ class change_stream::impl {
     bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::view> get_resume_token() {
         auto token = libmongoc::change_stream_get_resume_token(this->change_stream_);
         if (!token) {
-            return {};
+            return bsoncxx::v_noabi::stdx::nullopt;
         }
 
         return {bsoncxx::v_noabi::document::view{bson_get_data(token), token->len}};

--- a/src/mongocxx/lib/mongocxx/private/change_stream.hh
+++ b/src/mongocxx/lib/mongocxx/private/change_stream.hh
@@ -104,7 +104,8 @@ class change_stream::impl {
     }
 
     bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::view> get_resume_token() {
-        auto token = libmongoc::change_stream_get_resume_token(this->change_stream_);
+        bson_t const* const token = libmongoc::change_stream_get_resume_token(this->change_stream_);
+
         if (!token) {
             return bsoncxx::v_noabi::stdx::nullopt;
         }

--- a/src/mongocxx/lib/mongocxx/private/client_session.hh
+++ b/src/mongocxx/lib/mongocxx/private/client_session.hh
@@ -114,7 +114,8 @@ class client_session::impl {
 
     // Get session id, also known as "logical session id" or "lsid".
     bsoncxx::v_noabi::document::view id() const noexcept {
-        return bsoncxx::helpers::view_from_bson_t(libmongoc::client_session_get_lsid(_session_t.get()));
+        bson_t const* const bson = libmongoc::client_session_get_lsid(_session_t.get());
+        return bsoncxx::helpers::view_from_bson_t(bson);
     }
 
     bsoncxx::v_noabi::document::view cluster_time() const noexcept {

--- a/src/mongocxx/lib/mongocxx/private/index_view.hh
+++ b/src/mongocxx/lib/mongocxx/private/index_view.hh
@@ -149,7 +149,7 @@ class index_view::impl {
             if (!server_description.sd)
                 throw_exception<write_exception>(error);
 
-            auto hello = libmongoc::server_description_hello_response(server_description.sd);
+            bson_t const* const hello = libmongoc::server_description_hello_response(server_description.sd);
 
             bson_iter_t iter;
             if (!bson_iter_init_find(&iter, hello, "maxWireVersion") || bson_iter_int32(&iter) < 9) {

--- a/src/mongocxx/lib/mongocxx/private/mock.hh
+++ b/src/mongocxx/lib/mongocxx/private/mock.hh
@@ -65,7 +65,9 @@ struct mock_invoke<CRTP, R(Args...)> {
 };
 
 BSONCXX_PRIVATE_WARNINGS_PUSH();
+#if defined(__GNUC__) && (__GNUC__ >= 6) && !defined(__clang__)
 BSONCXX_PRIVATE_WARNINGS_DISABLE(GNU("-Wignored-attributes"));
+#endif
 
 template <typename CRTP, typename... Args>
 struct mock_invoke<CRTP, bson_t const*(Args...)> {

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_failed_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_failed_event.cpp
@@ -32,7 +32,7 @@ command_failed_event::command_failed_event(void const* event) : _failed_event(ev
 command_failed_event::~command_failed_event() = default;
 
 bsoncxx::v_noabi::document::view command_failed_event::failure() const {
-    auto failure =
+    bson_t const* const failure =
         libmongoc::apm_command_failed_get_reply(static_cast<mongoc_apm_command_failed_t const*>(_failed_event));
     return {bson_get_data(failure), failure->len};
 }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_started_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_started_event.cpp
@@ -28,7 +28,7 @@ command_started_event::command_started_event(void const* event) : _started_event
 command_started_event::~command_started_event() = default;
 
 bsoncxx::v_noabi::document::view command_started_event::command() const {
-    auto command =
+    bson_t const* const command =
         libmongoc::apm_command_started_get_command(static_cast<mongoc_apm_command_started_t const*>(_started_event));
     return {bson_get_data(command), command->len};
 }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_succeeded_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/command_succeeded_event.cpp
@@ -28,7 +28,7 @@ command_succeeded_event::command_succeeded_event(void const* event) : _succeeded
 command_succeeded_event::~command_succeeded_event() = default;
 
 bsoncxx::v_noabi::document::view command_succeeded_event::reply() const {
-    auto reply = libmongoc::apm_command_succeeded_get_reply(
+    bson_t const* const reply = libmongoc::apm_command_succeeded_get_reply(
         static_cast<mongoc_apm_command_succeeded_t const*>(_succeeded_event));
     return {bson_get_data(reply), reply->len};
 }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/heartbeat_succeeded_event.cpp
@@ -26,7 +26,7 @@ heartbeat_succeeded_event::~heartbeat_succeeded_event() = default;
 
 bsoncxx::v_noabi::document::view heartbeat_succeeded_event::reply() const {
     auto casted = static_cast<mongoc_apm_server_heartbeat_succeeded_t const*>(_succeeded_event);
-    auto reply = libmongoc::apm_server_heartbeat_succeeded_get_reply(casted);
+    bson_t const* const reply = libmongoc::apm_server_heartbeat_succeeded_get_reply(casted);
     return {bson_get_data(reply), reply->len};
 }
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/server_description.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/events/server_description.cpp
@@ -41,7 +41,8 @@ bsoncxx::v_noabi::document::view server_description::is_master() const {
 }
 
 bsoncxx::v_noabi::document::view server_description::hello() const {
-    auto reply = libmongoc::server_description_hello_response(static_cast<mongoc_server_description_t const*>(_sd));
+    bson_t const* const reply =
+        libmongoc::server_description_hello_response(static_cast<mongoc_server_description_t const*>(_sd));
     return {bson_get_data(reply), reply->len};
 }
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/transaction.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/transaction.hh
@@ -64,7 +64,7 @@ class transaction::impl {
     bsoncxx::v_noabi::stdx::optional<mongocxx::v_noabi::read_concern> read_concern() const {
         auto rc = libmongoc::transaction_opts_get_read_concern(_transaction_opt_t.get());
         if (!rc) {
-            return {};
+            return bsoncxx::v_noabi::stdx::nullopt;
         }
         mongocxx::v_noabi::read_concern rci(bsoncxx::make_unique<read_concern::impl>(libmongoc::read_concern_copy(rc)));
         return bsoncxx::v_noabi::stdx::optional<mongocxx::v_noabi::read_concern>(std::move(rci));
@@ -77,7 +77,7 @@ class transaction::impl {
     bsoncxx::v_noabi::stdx::optional<mongocxx::v_noabi::write_concern> write_concern() const {
         auto wc = libmongoc::transaction_opts_get_write_concern(_transaction_opt_t.get());
         if (!wc) {
-            return {};
+            return bsoncxx::v_noabi::stdx::nullopt;
         }
         mongocxx::v_noabi::write_concern wci(
             bsoncxx::make_unique<write_concern::impl>(libmongoc::write_concern_copy(wc)));
@@ -91,7 +91,7 @@ class transaction::impl {
     bsoncxx::v_noabi::stdx::optional<mongocxx::v_noabi::read_preference> read_preference() const {
         auto rp = libmongoc::transaction_opts_get_read_prefs(_transaction_opt_t.get());
         if (!rp) {
-            return {};
+            return bsoncxx::v_noabi::stdx::nullopt;
         }
         mongocxx::v_noabi::read_preference rpi(
             bsoncxx::make_unique<read_preference::impl>(libmongoc::read_prefs_copy(rp)));
@@ -105,15 +105,7 @@ class transaction::impl {
     bsoncxx::v_noabi::stdx::optional<std::chrono::milliseconds> max_commit_time_ms() const {
         auto ms = libmongoc::transaction_opts_get_max_commit_time_ms(_transaction_opt_t.get());
         if (!ms) {
-#if !defined(__clang__) && defined(__GNUC__) && (__cplusplus >= 201709L)
-// Silence false positive with g++ 10.2.1 on Debian 11.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-            return {};
-#if !defined(__clang__) && defined(__GNUC__) && (__cplusplus >= 201709L)
-#pragma GCC diagnostic pop
-#endif
+            return bsoncxx::v_noabi::stdx::nullopt;
         }
         return {std::chrono::milliseconds{ms}};
     }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/read_preference.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/read_preference.cpp
@@ -119,13 +119,16 @@ bsoncxx::v_noabi::stdx::optional<std::chrono::seconds> read_preference::max_stal
 
 read_preference& read_preference::hedge(bsoncxx::v_noabi::document::view_or_value hedge) {
     libbson::scoped_bson_t hedge_bson{std::move(hedge)};
-
+    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
     libmongoc::read_prefs_set_hedge(_impl->read_preference_t, hedge_bson.bson());
+    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
     return *this;
 }
 
 bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::view> const read_preference::hedge() const {
+    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
     bson_t const* hedge_bson = libmongoc::read_prefs_get_hedge(_impl->read_preference_t);
+    BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
 
     if (!bson_empty(hedge_bson)) {
         return bsoncxx::v_noabi::document::view(bson_get_data(hedge_bson), hedge_bson->len);

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/uri.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/uri.cpp
@@ -138,7 +138,7 @@ static bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::stdx::string_view> _st
 
     value = libmongoc::uri_get_option_as_utf8(uri, opt_name.c_str(), nullptr);
     if (!value) {
-        return {};
+        return bsoncxx::v_noabi::stdx::nullopt;
     }
 
     return bsoncxx::v_noabi::stdx::string_view{value};
@@ -149,7 +149,7 @@ static bsoncxx::v_noabi::stdx::optional<std::int32_t> _int32_option(mongoc_uri_t
     bson_t const* options_bson = libmongoc::uri_get_options(uri);
 
     if (!bson_iter_init_find_case(&iter, options_bson, opt_name.c_str()) || !BSON_ITER_HOLDS_INT32(&iter)) {
-        return {};
+        return bsoncxx::v_noabi::stdx::nullopt;
     }
     return bson_iter_int32(&iter);
 }
@@ -159,7 +159,7 @@ static bsoncxx::v_noabi::stdx::optional<bool> _bool_option(mongoc_uri_t* uri, st
     bson_t const* options_bson = libmongoc::uri_get_options(uri);
 
     if (!bson_iter_init_find_case(&iter, options_bson, opt_name.c_str()) || !BSON_ITER_HOLDS_BOOL(&iter)) {
-        return {};
+        return bsoncxx::v_noabi::stdx::nullopt;
     }
     return bson_iter_bool(&iter);
 }
@@ -184,7 +184,7 @@ static bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::view> _crede
     bson_t const* options_bson = libmongoc::uri_get_credentials(uri);
 
     if (!bson_iter_init_find_case(&iter, options_bson, opt_name.c_str()) || !BSON_ITER_HOLDS_DOCUMENT(&iter)) {
-        return {};
+        return bsoncxx::v_noabi::stdx::nullopt;
     }
     bson_iter_document(&iter, &len, &data);
     return bsoncxx::v_noabi::document::view(data, len);

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/uri.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/uri.cpp
@@ -86,7 +86,7 @@ std::vector<uri::host> uri::hosts() const {
 }
 
 bsoncxx::v_noabi::document::view uri::options() const {
-    auto opts_bson = libmongoc::uri_get_options(_impl->uri_t);
+    bson_t const* const opts_bson = libmongoc::uri_get_options(_impl->uri_t);
     return bsoncxx::v_noabi::document::view{::bson_get_data(opts_bson), opts_bson->len};
 }
 

--- a/src/mongocxx/test/client_helpers.cpp
+++ b/src/mongocxx/test/client_helpers.cpp
@@ -344,7 +344,7 @@ bsoncxx::stdx::optional<bsoncxx::document::value> parse_test_file(std::string pa
     std::ifstream test_file{path};
 
     if (test_file.bad()) {
-        return {};
+        return bsoncxx::v_noabi::stdx::nullopt;
     }
 
     stream << test_file.rdbuf();
@@ -385,7 +385,7 @@ static bsoncxx::stdx::optional<type> is_type_operator(types::bson_value::view va
         }
         throw std::logic_error{"unsupported type for $$type"};
     }
-    return {};
+    return bsoncxx::v_noabi::stdx::nullopt;
 }
 
 bool matches(types::bson_value::view main, types::bson_value::view pattern, match_visitor visitor_fn) {

--- a/src/mongocxx/test/spec/operation.cpp
+++ b/src/mongocxx/test/spec/operation.cpp
@@ -76,7 +76,7 @@ bsoncxx::stdx::optional<read_concern> lookup_read_concern(document::view doc) {
         return rc;
     }
 
-    return {};
+    return bsoncxx::v_noabi::stdx::nullopt;
 }
 
 bsoncxx::stdx::optional<write_concern> lookup_write_concern(document::view doc) {
@@ -98,7 +98,7 @@ bsoncxx::stdx::optional<write_concern> lookup_write_concern(document::view doc) 
         return wc;
     }
 
-    return {};
+    return bsoncxx::v_noabi::stdx::nullopt;
 }
 
 bsoncxx::stdx::optional<read_preference> lookup_read_preference(document::view doc) {
@@ -119,7 +119,7 @@ bsoncxx::stdx::optional<read_preference> lookup_read_preference(document::view d
         return rp;
     }
 
-    return {};
+    return bsoncxx::v_noabi::stdx::nullopt;
 }
 
 client_session* operation_runner::_lookup_session(bsoncxx::stdx::string_view key) {

--- a/src/mongocxx/test/spec/unified_tests/operations.cpp
+++ b/src/mongocxx/test/spec/unified_tests/operations.cpp
@@ -2299,7 +2299,7 @@ bsoncxx::stdx::optional<read_concern> operations::lookup_read_concern(document::
         return rc;
     }
 
-    return {};
+    return bsoncxx::v_noabi::stdx::nullopt;
 }
 
 bsoncxx::stdx::optional<write_concern> operations::lookup_write_concern(document::view doc) {
@@ -2321,7 +2321,7 @@ bsoncxx::stdx::optional<write_concern> operations::lookup_write_concern(document
         return wc;
     }
 
-    return {};
+    return bsoncxx::v_noabi::stdx::nullopt;
 }
 
 bsoncxx::stdx::optional<read_preference> operations::lookup_read_preference(document::view doc) {
@@ -2342,7 +2342,7 @@ bsoncxx::stdx::optional<read_preference> operations::lookup_read_preference(docu
         return rp;
     }
 
-    return {};
+    return bsoncxx::v_noabi::stdx::nullopt;
 }
 
 } // namespace mongocxx


### PR DESCRIPTION
Resolves CXX-3253. Followup to https://github.com/mongodb/mongo-c-driver/pull/1991.