### PR TITLE
Download and build-from-source valgrind 3.24.0 when not present

### DIFF
--- a/.evergreen/config_generator/components/funcs/install_valgrind.py
+++ b/.evergreen/config_generator/components/funcs/install_valgrind.py
@@ -24,8 +24,8 @@ class InstallValgrind(Function):
                 mkdir -p "$valgrind_install_dir"
 
                 if ! command -v "$valgrind_install_dir/bin/valgrind" 2>/dev/null; then
-                  env \
-                    install_prefix="${MONGO_CXX_DRIVER_CACHE_DIR}/valgrind-3.24.0" \
+                  env \\
+                    install_prefix="${MONGO_CXX_DRIVER_CACHE_DIR}/valgrind-3.24.0" \\
                     mongo-cxx-driver/.evergreen/scripts/valgrind-installer.sh
                 fi
 

--- a/.evergreen/config_generator/components/funcs/install_valgrind.py
+++ b/.evergreen/config_generator/components/funcs/install_valgrind.py
@@ -1,0 +1,46 @@
+from config_generator.components.funcs.set_cache_dir import SetCacheDir
+
+from config_generator.etc.function import Function
+from config_generator.etc.utils import bash_exec
+
+from shrub.v3.evg_command import EvgCommandType, expansions_update
+
+
+class InstallValgrind(Function):
+    name = 'install-valgrind'
+    commands = SetCacheDir.commands + [
+        bash_exec(
+            command_type=EvgCommandType.SETUP,
+            script='''\
+                set -o errexit
+                set -o pipefail
+
+                if [[ ! -n "${MONGO_CXX_DRIVER_CACHE_DIR}" ]]; then
+                  echo "MONGO_CXX_DRIVER_CACHE_DIR is not defined!" 1>&2
+                  exit 1
+                fi
+
+                valgrind_install_dir="${MONGO_CXX_DRIVER_CACHE_DIR}/valgrind-3.24.0"
+                mkdir -p "$valgrind_install_dir"
+
+                if ! command -v "$valgrind_install_dir/bin/valgrind" 2>/dev/null; then
+                  env \
+                    install_prefix="${MONGO_CXX_DRIVER_CACHE_DIR}/valgrind-3.24.0" \
+                    mongo-cxx-driver/.evergreen/scripts/valgrind-installer.sh
+                fi
+
+                PATH="$valgrind_install_dir/bin:$PATH" command -V valgrind
+                PATH="$valgrind_install_dir/bin:$PATH" valgrind --version
+
+                printf "VALGRIND_INSTALL_DIR: %s\\n" "$valgrind_install_dir/bin" >|expansions.valgrind.yml
+            ''',
+        ),
+        expansions_update(
+            command_type=EvgCommandType.SETUP,
+            file='expansions.valgrind.yml',
+        ),
+    ]
+
+
+def functions():
+    return InstallValgrind.defn()

--- a/.evergreen/config_generator/components/funcs/test.py
+++ b/.evergreen/config_generator/components/funcs/test.py
@@ -37,6 +37,7 @@ class Test(Function):
             'TEST_WITH_VALGRIND',
             'use_mongocryptd',
             'USE_STATIC_LIBS',
+            'VALGRIND_INSTALL_DIR',
         ],
         working_dir='mongo-cxx-driver',
         script='.evergreen/scripts/test.sh',

--- a/.evergreen/config_generator/components/valgrind.py
+++ b/.evergreen/config_generator/components/valgrind.py
@@ -1,6 +1,7 @@
 from config_generator.components.funcs.compile import Compile
 from config_generator.components.funcs.fetch_det import FetchDET
 from config_generator.components.funcs.install_c_driver import InstallCDriver
+from config_generator.components.funcs.install_valgrind import InstallValgrind
 from config_generator.components.funcs.install_uv import InstallUV
 from config_generator.components.funcs.run_kms_servers import RunKMSServers
 from config_generator.components.funcs.setup import Setup
@@ -67,6 +68,7 @@ def tasks():
 
             commands += [
                 Setup.call(),
+                InstallValgrind.call(),
                 StartMongod.call(mongodb_version=mongodb_version, topology=topology),
                 InstallCDriver.call(vars=icd_vars),
                 InstallUV.call(),

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -392,6 +392,68 @@ functions:
       type: setup
       params:
         file: expansions.uv.yml
+  install-valgrind:
+    - command: subprocess.exec
+      type: setup
+      params:
+        binary: bash
+        args:
+          - -c
+          - |
+            if [[ -n "$XDG_CACHE_DIR" ]]; then
+                cache_dir="$XDG_CACHE_DIR" # XDG Base Directory specification.
+            elif [[ -n "$LOCALAPPDATA" ]]; then
+                cache_dir="$LOCALAPPDATA" # Windows.
+            elif [[ -n "$USERPROFILE" ]]; then
+                cache_dir="$USERPROFILE/.cache" # Windows (fallback).
+            elif [[ -d "$HOME/Library/Caches" ]]; then
+                cache_dir="$HOME/Library/Caches" # MacOS.
+            elif [[ -n "$HOME" ]]; then
+                cache_dir="$HOME/.cache" # Linux-like.
+            elif [[ -d ~/.cache ]]; then
+                cache_dir="~/.cache" # Linux-like (fallback).
+            else
+                cache_dir="$(pwd)/.cache" # EVG task directory (fallback).
+            fi
+
+            mkdir -p "$cache_dir/mongo-cxx-driver" || exit
+            cache_dir="$(cd "$cache_dir/mongo-cxx-driver" && pwd)" || exit
+
+            printf "MONGO_CXX_DRIVER_CACHE_DIR: %s\n" "$cache_dir" >|expansions.set-cache-dir.yml
+    - command: expansions.update
+      type: setup
+      params:
+        file: expansions.set-cache-dir.yml
+    - command: subprocess.exec
+      type: setup
+      params:
+        binary: bash
+        args:
+          - -c
+          - |
+            set -o errexit
+            set -o pipefail
+
+            if [[ ! -n "${MONGO_CXX_DRIVER_CACHE_DIR}" ]]; then
+              echo "MONGO_CXX_DRIVER_CACHE_DIR is not defined!" 1>&2
+              exit 1
+            fi
+
+            valgrind_install_dir="${MONGO_CXX_DRIVER_CACHE_DIR}/valgrind-3.24.0"
+            mkdir -p "$valgrind_install_dir"
+
+            if ! command -v "$valgrind_install_dir/bin/valgrind" 2>/dev/null; then
+              env                     install_prefix="${MONGO_CXX_DRIVER_CACHE_DIR}/valgrind-3.24.0"                     mongo-cxx-driver/.evergreen/scripts/valgrind-installer.sh
+            fi
+
+            PATH="$valgrind_install_dir/bin:$PATH" command -V valgrind
+            PATH="$valgrind_install_dir/bin:$PATH" valgrind --version
+
+            printf "VALGRIND_INSTALL_DIR: %s\n" "$valgrind_install_dir/bin" >|expansions.valgrind.yml
+    - command: expansions.update
+      type: setup
+      params:
+        file: expansions.valgrind.yml
   install_c_driver:
     - command: expansions.update
       type: setup
@@ -607,6 +669,7 @@ functions:
         - TEST_WITH_VALGRIND
         - use_mongocryptd
         - USE_STATIC_LIBS
+        - VALGRIND_INSTALL_DIR
       args:
         - -c
         - .evergreen/scripts/test.sh

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -443,7 +443,9 @@ functions:
             mkdir -p "$valgrind_install_dir"
 
             if ! command -v "$valgrind_install_dir/bin/valgrind" 2>/dev/null; then
-              env                     install_prefix="${MONGO_CXX_DRIVER_CACHE_DIR}/valgrind-3.24.0"                     mongo-cxx-driver/.evergreen/scripts/valgrind-installer.sh
+              env \
+                install_prefix="${MONGO_CXX_DRIVER_CACHE_DIR}/valgrind-3.24.0" \
+                mongo-cxx-driver/.evergreen/scripts/valgrind-installer.sh
             fi
 
             PATH="$valgrind_install_dir/bin:$PATH" command -V valgrind

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -15889,6 +15889,7 @@ tasks:
           updates:
             - { key: build_type, value: Debug }
       - func: setup
+      - func: install-valgrind
       - func: start_mongod
         vars:
           TOPOLOGY: replica_set
@@ -15918,6 +15919,7 @@ tasks:
           updates:
             - { key: build_type, value: Debug }
       - func: setup
+      - func: install-valgrind
       - func: start_mongod
         vars:
           TOPOLOGY: sharded_cluster
@@ -15947,6 +15949,7 @@ tasks:
           updates:
             - { key: build_type, value: Debug }
       - func: setup
+      - func: install-valgrind
       - func: start_mongod
         vars:
           mongodb_version: "4.0"
@@ -15975,6 +15978,7 @@ tasks:
           updates:
             - { key: build_type, value: Debug }
       - func: setup
+      - func: install-valgrind
       - func: start_mongod
         vars:
           TOPOLOGY: replica_set
@@ -16004,6 +16008,7 @@ tasks:
           updates:
             - { key: build_type, value: Debug }
       - func: setup
+      - func: install-valgrind
       - func: start_mongod
         vars:
           TOPOLOGY: sharded_cluster
@@ -16033,6 +16038,7 @@ tasks:
           updates:
             - { key: build_type, value: Debug }
       - func: setup
+      - func: install-valgrind
       - func: start_mongod
         vars:
           mongodb_version: "8.0"
@@ -16061,6 +16067,7 @@ tasks:
           updates:
             - { key: build_type, value: Debug }
       - func: setup
+      - func: install-valgrind
       - func: start_mongod
         vars:
           TOPOLOGY: replica_set
@@ -16090,6 +16097,7 @@ tasks:
           updates:
             - { key: build_type, value: Debug }
       - func: setup
+      - func: install-valgrind
       - func: start_mongod
         vars:
           TOPOLOGY: sharded_cluster
@@ -16119,6 +16127,7 @@ tasks:
           updates:
             - { key: build_type, value: Debug }
       - func: setup
+      - func: install-valgrind
       - func: start_mongod
         vars:
           mongodb_version: latest

--- a/.evergreen/scripts/valgrind-installer.sh
+++ b/.evergreen/scripts/valgrind-installer.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -o errexit
+set -o pipefail
+
 : "${install_prefix:?}"
 
 cd "$(mktemp -d)"

--- a/.evergreen/scripts/valgrind-installer.sh
+++ b/.evergreen/scripts/valgrind-installer.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+: "${install_prefix:?}"
+
+cd "$(mktemp -d)"
+
+# https://valgrind.org/downloads/current.html
+curl -sSL -m 60 --retry 5 -o valgrind-3.24.0.tar.bz2 https://sourceware.org/pub/valgrind/valgrind-3.24.0.tar.bz2
+cat >checksum.txt <<<'6fc0470fedc0d85dae3e042297cabd13c6100749 *valgrind-3.24.0.tar.bz2'
+sha1sum -c checksum.txt >/dev/null
+
+tar -xjf valgrind-3.24.0.tar.bz2
+cd valgrind-3.24.0
+
+# https://valgrind.org/docs/manual/manual-core.html#manual-core.install
+./configure --prefix "${install_prefix:?}" >/dev/null
+make --no-print-directory -j "$(nproc)" >/dev/null
+make --no-print-directory install >/dev/null


### PR DESCRIPTION
Unblock ongoing Valgrind task failures while [DEVPROD-16589](https://jira.mongodb.org/browse/DEVPROD-16589) continues to be investigated. Proposes using a pattern similar to [install_uv.py](https://github.com/mongodb/mongo-cxx-driver/blob/88cad643775be0bc2dd53a96cc2fc565ef6441c6/.evergreen/config_generator/components/funcs/install_uv.py#L9), where a recent version of Valgrind is downloaded (verified by SHA1 checksum) and built-from-source. This is meant to be a temporary solution until [DEVPROD-16589](https://jira.mongodb.org/browse/DEVPROD-16589) is resolved (temporary to minimize our use of `curl` commands in CI scripts). Use of a 60 second timeout for curl (`-m 60`) is arbitrary and may be extended if it is observed to be too short (the total download+build+install time is currently around ~60 seconds on EVG).

The valgrind detection-and-download step is also moved to the _front_ of the list of EVG commands executed (immediately after setup rather than within `test.sh`) so any issues with valgrind acquisition will fail early and quickly before other wasteful execution of discarded setup tasks (i.e. install C Driver).