### PR TITLE
CXX-3099 use for-each-ref for Git 2.43 compatibility

### DIFF
--- a/etc/calc_release_version.py
+++ b/etc/calc_release_version.py
@@ -250,10 +250,12 @@ def iter_tag_lines():
     the second is a tag that is associated with that commit. Duplicate commits
     are possible.
     """
-    output = check_output(['git', 'tag', '--list', '--format=%(*objectname)|%(objectname)|%(refname:strip=2)'])
+    output = check_output(['git', 'for-each-ref', '--format=%(*objectname)|%(objectname)|%(refname:strip=2)', 'refs/tags/*'])
     lines = output.splitlines()
     for l in lines:
         obj, tagobj, tag = l.split('|', 2)
+        if not tag.startswith('r'):
+            continue # We only care about "rX.Y.Z" release tags.
         if re.match(r'r\d+\.\d+', tag):
             yield obj, tagobj, tag
 

--- a/etc/calc_release_version_selftest.sh
+++ b/etc/calc_release_version_selftest.sh
@@ -67,7 +67,7 @@ echo "Test next minor version ... begin"
     # failed, then it is probably because a new major/minor release was made.
     # Update the expected output to represent the correct next version.
     # XXX NOTE XXX NOTE XXX
-    assert_eq "$got" "3.10.0-$DATE+git$CURRENT_SHORTREF"
+    assert_eq "$got" "4.1.0-$DATE+git$CURRENT_SHORTREF"
 }
 echo "Test next minor version ... end"
 


### PR DESCRIPTION
Addresses rhel76 task failure in proposed changes to https://github.com/mongodb/mongo-cxx-driver/pull/1381 due to the available git version (2.43.6) not supporting the `--format` flag used by `calc_release_version.py`.

This PR proposes changing the git command from `git tag --list` to `git for-each-ref "refs/tags/*"`, as `for-each-ref` [is supported](https://git-scm.com/docs/git-for-each-ref/2.43.0) by 2.43 and also supports the required `--format` flag.

> [!NOTE]
> This PR also includes the same [update](https://github.com/mongodb/mongo-cxx-driver/pull/1379/commits/46f020b81e3dd7d3d0152c0836ca5105c1714b6a) to self-test scripts in https://github.com/mongodb/mongo-cxx-driver/pull/1379. Either PR may be merged first.