### PR TITLE
CXX-3261 sync change streams unified spec tests with 0aee4aad (#1366)

### DIFF
--- a/data/change-streams/unified/change-streams-clusterTime.json
+++ b/data/change-streams/unified/change-streams-clusterTime.json
@@ -1,0 +1,81 @@
+{
+  "description": "change-streams-clusterTime",
+  "schemaVersion": "1.4",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "collection0"
+      }
+    }
+  ],
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0.0",
+      "topologies": [
+        "replicaset",
+        "load-balanced",
+        "sharded"
+      ],
+      "serverless": "forbid"
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "collection0",
+      "databaseName": "database0",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "clusterTime is present",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "clusterTime": {
+              "$$exists": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/data/change-streams/unified/change-streams-disambiguatedPaths.json
+++ b/data/change-streams/unified/change-streams-disambiguatedPaths.json
@@ -1,0 +1,187 @@
+{
+  "description": "disambiguatedPaths",
+  "schemaVersion": "1.4",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "collection0"
+      }
+    }
+  ],
+  "runOnRequirements": [
+    {
+      "minServerVersion": "6.1.0",
+      "topologies": [
+        "replicaset",
+        "load-balanced",
+        "sharded"
+      ],
+      "serverless": "forbid"
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "collection0",
+      "databaseName": "database0",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "disambiguatedPaths is present on updateDescription when an ambiguous path is present",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": {
+                "1": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "showExpandedEvents": true
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "a.1": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "updateDescription": {
+              "updatedFields": {
+                "$$exists": true
+              },
+              "removedFields": {
+                "$$exists": true
+              },
+              "truncatedArrays": {
+                "$$exists": true
+              },
+              "disambiguatedPaths": {
+                "a.1": [
+                  "a",
+                  "1"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "disambiguatedPaths returns array indices as integers",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": [
+                {
+                  "1": 1
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "showExpandedEvents": true
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "a.0.1": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "updateDescription": {
+              "updatedFields": {
+                "$$exists": true
+              },
+              "removedFields": {
+                "$$exists": true
+              },
+              "truncatedArrays": {
+                "$$exists": true
+              },
+              "disambiguatedPaths": {
+                "a.0.1": [
+                  "a",
+                  {
+                    "$$type": "int"
+                  },
+                  "1"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/data/change-streams/unified/change-streams-nsType.json
+++ b/data/change-streams/unified/change-streams-nsType.json
@@ -1,0 +1,145 @@
+{
+  "description": "change-streams-nsType",
+  "schemaVersion": "1.7",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "8.1.0",
+      "topologies": [
+        "replicaset",
+        "sharded"
+      ],
+      "serverless": "forbid"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "nsType is present when creating collections",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "foo"
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "database0",
+          "arguments": {
+            "pipeline": [],
+            "showExpandedEvents": true
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "foo"
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "create",
+            "nsType": "collection"
+          }
+        }
+      ]
+    },
+    {
+      "description": "nsType is present when creating timeseries",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "foo"
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "database0",
+          "arguments": {
+            "pipeline": [],
+            "showExpandedEvents": true
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "foo",
+            "timeseries": {
+              "timeField": "time",
+              "metaField": "meta",
+              "granularity": "minutes"
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "create",
+            "nsType": "timeseries"
+          }
+        }
+      ]
+    },
+    {
+      "description": "nsType is present when creating views",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "foo"
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "database0",
+          "arguments": {
+            "pipeline": [],
+            "showExpandedEvents": true
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "foo",
+            "viewOn": "testName"
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "create",
+            "nsType": "view"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/data/change-streams/unified/change-streams-showExpandedEvents.json
+++ b/data/change-streams/unified/change-streams-showExpandedEvents.json
@@ -1,0 +1,516 @@
+{
+  "description": "change-streams-showExpandedEvents",
+  "schemaVersion": "1.7",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "6.0.0",
+      "topologies": [
+        "replicaset",
+        "sharded"
+      ],
+      "serverless": "forbid"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "ignoreCommandMonitoringEvents": [
+          "killCursors"
+        ],
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "collection0"
+      }
+    },
+    {
+      "database": {
+        "id": "database1",
+        "client": "client0",
+        "databaseName": "database1"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database1",
+        "collectionName": "collection1"
+      }
+    },
+    {
+      "database": {
+        "id": "shardedDb",
+        "client": "client0",
+        "databaseName": "shardedDb"
+      }
+    },
+    {
+      "database": {
+        "id": "adminDb",
+        "client": "client0",
+        "databaseName": "admin"
+      }
+    },
+    {
+      "collection": {
+        "id": "shardedCollection",
+        "database": "shardedDb",
+        "collectionName": "shardedCollection"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "collection0",
+      "databaseName": "database0",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "when provided, showExpandedEvents is sent as a part of the aggregate command",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "showExpandedEvents": true
+          },
+          "saveResultAsEntity": "changeStream0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "cursor": {},
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "showExpandedEvents": true
+                      }
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "database0"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "when omitted, showExpandedEvents is not sent as a part of the aggregate command",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "cursor": {},
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "showExpandedEvents": {
+                          "$$exists": false
+                        }
+                      }
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "database0"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "when showExpandedEvents is true, new fields on change stream events are handled appropriately",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "foo"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "foo"
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "showExpandedEvents": true
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "createIndex",
+          "object": "collection0",
+          "arguments": {
+            "keys": {
+              "x": 1
+            },
+            "name": "x_1"
+          }
+        },
+        {
+          "name": "rename",
+          "object": "collection0",
+          "arguments": {
+            "to": "foo",
+            "dropTarget": true
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "collectionUUID": {
+              "$$exists": true
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "createIndexes",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "operationDescription": {
+              "$$exists": true
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "rename",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "to": {
+              "db": "database0",
+              "coll": "foo"
+            },
+            "operationDescription": {
+              "dropTarget": {
+                "$$exists": true
+              },
+              "to": {
+                "db": "database0",
+                "coll": "foo"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "when showExpandedEvents is true, createIndex events are reported",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "operationType": {
+                    "$ne": "create"
+                  }
+                }
+              }
+            ],
+            "showExpandedEvents": true
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "createIndex",
+          "object": "collection0",
+          "arguments": {
+            "keys": {
+              "x": 1
+            },
+            "name": "x_1"
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "createIndexes"
+          }
+        }
+      ]
+    },
+    {
+      "description": "when showExpandedEvents is true, dropIndexes events are reported",
+      "operations": [
+        {
+          "name": "createIndex",
+          "object": "collection0",
+          "arguments": {
+            "keys": {
+              "x": 1
+            },
+            "name": "x_1"
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "showExpandedEvents": true
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "dropIndex",
+          "object": "collection0",
+          "arguments": {
+            "name": "x_1"
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "dropIndexes"
+          }
+        }
+      ]
+    },
+    {
+      "description": "when showExpandedEvents is true, create events are reported",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "foo"
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "database0",
+          "arguments": {
+            "pipeline": [],
+            "showExpandedEvents": true
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "foo"
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "create"
+          }
+        }
+      ]
+    },
+    {
+      "description": "when showExpandedEvents is true, create events on views are reported",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "foo"
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "database0",
+          "arguments": {
+            "pipeline": [],
+            "showExpandedEvents": true
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "foo",
+            "viewOn": "testName"
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "create"
+          }
+        }
+      ]
+    },
+    {
+      "description": "when showExpandedEvents is true, modify events are reported",
+      "operations": [
+        {
+          "name": "createIndex",
+          "object": "collection0",
+          "arguments": {
+            "keys": {
+              "x": 1
+            },
+            "name": "x_2"
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "showExpandedEvents": true
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "command": {
+              "collMod": "collection0"
+            },
+            "commandName": "collMod"
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "modify"
+          }
+        }
+      ]
+    },
+    {
+      "description": "when showExpandedEvents is true, shardCollection events are reported",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "shardedDb",
+          "arguments": {
+            "collection": "shardedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "shardedDb",
+          "arguments": {
+            "collection": "shardedCollection"
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "shardedCollection",
+          "arguments": {
+            "pipeline": [],
+            "showExpandedEvents": true
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "runCommand",
+          "object": "adminDb",
+          "arguments": {
+            "command": {
+              "shardCollection": "shardedDb.shardedCollection",
+              "key": {
+                "_id": 1
+              }
+            },
+            "commandName": "shardCollection"
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "shardCollection"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/data/change-streams/unified/change-streams.json
+++ b/data/change-streams/unified/change-streams.json
@@ -181,7 +181,12 @@
                   "field": "array",
                   "newSize": 2
                 }
-              ]
+              ],
+              "disambiguatedPaths": {
+                "$$unsetOrMatches": {
+                  "$$exists": true
+                }
+              }
             }
           }
         }
@@ -1405,6 +1410,11 @@
               },
               "removedFields": [],
               "truncatedArrays": {
+                "$$unsetOrMatches": {
+                  "$$exists": true
+                }
+              },
+              "disambiguatedPaths": {
                 "$$unsetOrMatches": {
                   "$$exists": true
                 }

--- a/data/change-streams/unified/test_files.txt
+++ b/data/change-streams/unified/test_files.txt
@@ -1,5 +1,9 @@
+change-streams-clusterTime.json
+change-streams-disambiguatedPaths.json
 change-streams-errors.json
+change-streams-nsType.json
 change-streams-pre_and_post_images.json
 change-streams-resume-allowlist.json
 change-streams-resume-errorLabels.json
+change-streams-showExpandedEvents.json
 change-streams.json

--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -1346,7 +1346,16 @@ TEST_CASE("CRUD unified format spec automated tests", "[unified_format_specs]") 
 }
 
 TEST_CASE("change streams unified format spec automated tests", "[unified_format_specs]") {
-    run_unified_format_tests_in_env_dir("CHANGE_STREAMS_UNIFIED_TESTS_PATH");
+    std::set<bsoncxx::stdx::string_view> const unsupported_tests = {
+        // Waiting on CXX-2493 (showExpandedEvents).
+        "change-streams-disambiguatedPaths.json",
+        // Waiting on CXX-2493 (showExpandedEvents).
+        "change-streams-nsType.json",
+        // Waiting on CXX-2493 (showExpandedEvents).
+        "change-streams-showExpandedEvents.json",
+    };
+
+    run_unified_format_tests_in_env_dir("CHANGE_STREAMS_UNIFIED_TESTS_PATH", unsupported_tests);
 }
 
 TEST_CASE("retryable reads unified format spec automated tests", "[unified_format_specs]") {


### PR DESCRIPTION
Cherry-picks https://github.com/mongodb/mongo-cxx-driver/commit/cb7afd1b886b0e1be3c4dec8bbc075258b8c070c (https://github.com/mongodb/mongo-cxx-driver/pull/1366) onto the v3.11 release branch to address task failures against latest MongoDB servers.