### PR TITLE
CXX-3241 deprecated hedged reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 - Support for MacOS 11 (EOL since Nov 2020) and MacOS 12 (EOL since Oct 2021).
 - `storage_options()` in `mongocxx::v_noabi::options::index`: use `storage_engine()` instead.
   - `base_storage_options` and `wiredtiger_storage_options` in `mongocxx::v_noabi::options::index` are also deprecated.
+- `mongocxx::v_noabi::read_preference::hedge()`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 - Support for MacOS 11 (EOL since Nov 2020) and MacOS 12 (EOL since Oct 2021).
 - `storage_options()` in `mongocxx::v_noabi::options::index`: use `storage_engine()` instead.
   - `base_storage_options` and `wiredtiger_storage_options` in `mongocxx::v_noabi::options::index` are also deprecated.
-- `mongocxx::v_noabi::read_preference::hedge()`
+- `hedge()` in `mongocxx::v_noabi::read_preference`: hedged reads will no longer be supported by MongoDB.
 
 ### Changed
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
@@ -289,7 +289,8 @@ class read_preference {
     ///
     /// @return A hedge document if one was set.
     ///
-    MONGOCXX_DEPRECATED MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::view> const)
+    MONGOCXX_DEPRECATED MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v_noabi::stdx::optional<
+                                                  bsoncxx::v_noabi::document::view> const)
     hedge() const;
 
     ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/read_preference.hpp
@@ -274,18 +274,22 @@ class read_preference {
     /// @param hedge
     ///   The hedge document to set. For example, the document { enabled: true }.
     ///
+    /// @deprecated Hedged reads are deprecated in MongoDB Server version 8.0.
+    ///
     /// @return A reference to the object on which this member function is being called. This
     /// facilitates method chaining.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(read_preference&)
-    hedge(bsoncxx::v_noabi::document::view_or_value hedge);
+    MONGOCXX_DEPRECATED MONGOCXX_ABI_EXPORT_CDECL(read_preference&) hedge(
+        bsoncxx::v_noabi::document::view_or_value hedge);
 
     ///
     /// Gets the current hedge document to be used for the read preference.
     ///
+    /// @deprecated Hedged reads are deprecated in MongoDB Server version 8.0.
+    ///
     /// @return A hedge document if one was set.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::view> const)
+    MONGOCXX_DEPRECATED MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::view> const)
     hedge() const;
 
     ///

--- a/src/mongocxx/test/read_preference.cpp
+++ b/src/mongocxx/test/read_preference.cpp
@@ -199,7 +199,9 @@ TEST_CASE("Read preference methods call underlying mongoc methods", "[read_prefe
 
     SECTION("hedge() calls mongoc_read_prefs_set_hedge") {
         /* No hedge should return a disengaged optional. */
+        BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
         REQUIRE(!rp.hedge());
+        BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
 
         read_prefs_set_hedge->visit([&](mongoc_read_prefs_t*, bson_t const* doc) {
             bson_iter_t iter;
@@ -209,8 +211,10 @@ TEST_CASE("Read preference methods call underlying mongoc methods", "[read_prefe
             called = true;
         });
 
+        BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_BEGIN
         rp.hedge(make_document(kvp("hedge", true)));
         REQUIRE((*rp.hedge())["hedge"].get_bool().value == true);
+        BSONCXX_SUPPRESS_DEPRECATION_WARNINGS_END
         REQUIRE(called);
     }
 }


### PR DESCRIPTION
Deprecates `mongocxx::v_noabi::read_preference::hedge()`.