### PR TITLE
CXX-3002 fix keyring and trust for verifying GPG signatures

### DIFF
--- a/etc/garasign_dist_file.sh
+++ b/etc/garasign_dist_file.sh
@@ -58,5 +58,7 @@ plugin_commands=(
   GNUPGHOME="$(mktemp -d)"
   export GNUPGHOME
   curl -sS https://pgp.mongodb.com/cpp-driver.pub | gpg -q --no-default-keyring --import -
-  gpgv "${dist_file_signed:?}" "${dist_file:?}"
+  gpg -q --import-ownertrust <<<"DC7F679B8A34DD606C1E54CAC4FC994D21532195:6:" # Set trust to "ultimate".
+  gpg -q --update-trustdb
+  gpg -q --verify "${dist_file_signed:?}" "${dist_file:?}"
 )

--- a/etc/garasign_release_tag.sh
+++ b/etc/garasign_release_tag.sh
@@ -48,8 +48,9 @@ git_tag_command=(
   "\"${release_tag:?}\""
 )
 plugin_commands=""
-plugin_commands+="gpg --list-key DC7F679B8A34DD606C1E54CAC4FC994D21532195"
-plugin_commands+="&& ${git_tag_command[*]:?}"
+plugin_commands+="gpg -q --update-trustdb"
+plugin_commands+=" && gpg --list-key DC7F679B8A34DD606C1E54CAC4FC994D21532195"
+plugin_commands+=" && ${git_tag_command[*]:?}"
 "${launcher:?}" run \
   --env-file="${garasign_creds:?}" \
   -e "PLUGIN_COMMANDS=${plugin_commands:?}" \
@@ -63,5 +64,7 @@ plugin_commands+="&& ${git_tag_command[*]:?}"
   GNUPGHOME="$(mktemp -d)"
   export GNUPGHOME
   curl -sS https://pgp.mongodb.com/cpp-driver.pub | gpg -q --no-default-keyring --import -
+  gpg -q --import-ownertrust <<<"DC7F679B8A34DD606C1E54CAC4FC994D21532195:6:" # Set trust to "ultimate".
+  gpg -q --update-trustdb
   git verify-tag "${release_tag:?}"
 )


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1388 which fixes/improves two observed issues.

---

The `gpgv` command for verifying the dist tarball signature was failing due to the following error(s):

```
gpgv: unknown type of key resource 'trustedkeys.kbx'
gpgv: keyblock resource '/tmp/tmp.qioUjF6CI1/trustedkeys.kbx': General error
gpgv: Signature made Tue Apr 22 09:32:28 2025 CDT
gpgv:                using RSA key DC7F679B8A34DD606C1E54CAC4FC994D21532195
gpgv: Can't check signature: No public key
```

This is apparently due to `gpgv` expecting a keyring named `trustedkeys.kbx`, whereas `gpg` uses `pubring.kbx` by default. (Note: this was not an issue prior to https://github.com/mongodb/mongo-cxx-driver/pull/1388 due to using a temporary file as the keyring rather than a temporary `GNUPGHOME` directory.) This PR initially specified `--keyring pubring.kbx` in the `gpgv` command so the keyring used is consistent with the default for `gpg`.

```
gpgv: Signature made Tue Apr 22 09:32:28 2025 CDT
gpgv:                using RSA key DC7F679B8A34DD606C1E54CAC4FC994D21532195
gpgv: Good signature from "MongoDB C++ Release Signing Key <packaging@mongodb.com>"
```

However, the command is changed from `gpgv` to `gpg --verify` as described below, so this issue is no longer relevant.

---

The `gpgv` command is actually somewhat lax in requirements, per man pages:

> This  program  is  actually a stripped-down version of `gpg` which is only able to check signatures. It is somewhat smaller than the fully-blown `gpg` and uses a different (and simpler) way to check that the public keys used to make the signature are valid. There are no configuration files and only a few options are implemented. `gpgv` assumes that all keys in the keyring are trustworthy. That does also mean that it does not check for expired or revoked keys.

This command was therefore evading a warning that is emitted with `git tag -v`, which appears to use `gpg --verify` rather than `gpgv`:

```
gpg: Signature made Tue Apr 22 09:44:54 2025 CDT
gpg:                using RSA key DC7F679B8A34DD606C1E54CAC4FC994D21532195
gpg: Good signature from "MongoDB C++ Release Signing Key <packaging@mongodb.com>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
```

To use the stricted signature validation requirements, both verification commands (for the dist tarball and for the git tag) are made consistent to use `gpg --verify`. These commands also now include a preceeding `--import-ownertrust` command which sets the trust level for the Release Signing Key to "Ultimate" prior to verification (this level matches the trust level of the key when signing with garasign-gpg / garasign-git).

As a drive-by improvement, the `--update-trustdb` command is manually invoked with `--quiet` before other gpg operations to avoid unnecessary noise in the output which looks like:

```
gpg: checking the trustdb
gpg: marginals needed: 3  completes needed: 1  trust model: pgp
gpg: depth: 0  valid:   1  signed:   0  trust: 0-, 0q, 0n, 0m, 0f, 1u
```