### PR TITLE
CXX-3099 perform refname:split=2 within Python

### DIFF
--- a/etc/calc_release_version.py
+++ b/etc/calc_release_version.py
@@ -250,10 +250,14 @@ def iter_tag_lines():
     the second is a tag that is associated with that commit. Duplicate commits
     are possible.
     """
-    output = check_output(['git', 'for-each-ref', '--format=%(*objectname)|%(objectname)|%(refname:strip=2)', 'refs/tags/*'])
+    output = check_output(['git', 'for-each-ref', '--format=%(*objectname)|%(objectname)|%(refname)', 'refs/tags/*'])
     lines = output.splitlines()
     for l in lines:
-        obj, tagobj, tag = l.split('|', 2)
+        obj, tagobj, rawtag = l.split('|', 2)
+
+        # Support Git 1.x which does not have `%(refname:lstrip=2)`.
+        tag = str('/').join(rawtag.split('/')[:2])
+
         if not tag.startswith('r'):
             continue # We only care about "rX.Y.Z" release tags.
         if re.match(r'r\d+\.\d+', tag):


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1384.

> due to the available git version (2.43.6)

This was incorrect: RHEL 7.6 distros apparently may contain Git versions as old as 1.8.3 (?!), not just 2.43.6. Although `for-each-ref`, `--format`, and `%(refname)` are supported, `:strip=2` is not (requires [Git 2.7+](https://git-scm.com/docs/git-for-each-ref/2.7.6)):

```
fatal: unknown refname: format strip=2
Traceback (most recent call last):
  File "etc/calc_release_version.py", line 372, in <module>
    RELEASE_VER = main()
                  ^^^^^^
  File "etc/calc_release_version.py", line 346, in main
    branch_tags = get_branch_tags(active_branch_name)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "etc/calc_release_version.py", line 236, in get_branch_tags
    tags_by_obj = get_object_tags()
                  ^^^^^^^^^^^^^^^^^
  File "etc/calc_release_version.py", line 269, in get_object_tags
    for obj, tagobj, tag in iter_tag_lines():
  File "etc/calc_release_version.py", line 253, in iter_tag_lines
    output = check_output(['git', 'for-each-ref', '--format=%(*objectname)|%(objectname)|%(refname:strip=2)', 'refs/tags/*'])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "etc/calc_release_version.py", line 131, in check_output
    raise subprocess.CalledProcessError(ret, args[0])
subprocess.CalledProcessError: Command 'git' returned non-zero exit status 128.
```

Therefore, the strip operation is moved into Python with `str.split('/')` to drop the `refs/tags/` prefix.