### PR TITLE
Bump minimum shrub.py to 3.7 for ec2_assume_role

### DIFF
--- a/.evergreen/config_generator/components/sbom.py
+++ b/.evergreen/config_generator/components/sbom.py
@@ -5,7 +5,7 @@ from config_generator.etc.function import Function, merge_defns
 from config_generator.etc.utils import bash_exec
 
 from shrub.v3.evg_build_variant import BuildVariant
-from shrub.v3.evg_command import BuiltInCommand, EvgCommandType, expansions_update, s3_put
+from shrub.v3.evg_command import BuiltInCommand, EvgCommandType, ec2_assume_role, expansions_update, s3_put
 from shrub.v3.evg_task import EvgTask, EvgTaskRef
 
 from pydantic import ConfigDict
@@ -18,23 +18,6 @@ TAG = 'sbom'
 class CustomCommand(BuiltInCommand):
     command: str
     model_config = ConfigDict(arbitrary_types_allowed=True)
-
-
-def ec2_assume_role(
-    role_arn: Optional[str] = None,
-    policy: Optional[str] = None,
-    duration_seconds: Optional[int] = None,
-    command_type: Optional[EvgCommandType] = None,
-) -> CustomCommand:
-    return CustomCommand(
-        command="ec2.assume_role",
-        params={
-            "role_arn": role_arn,
-            "policy": policy,
-            "duration_seconds": duration_seconds,
-        },
-        type=command_type,
-    )
 
 
 class CheckAugmentedSBOM(Function):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ config_generator = [
     # .evergreen/config_generator/generate.py
     "packaging>=14.0",
     "pydantic>=2.8",
-    "shrub-py>=3.6",
+    "shrub-py>=3.7",
 ]
 
 make_release = [

--- a/uv.lock
+++ b/uv.lock
@@ -375,13 +375,13 @@ clang-format = [{ name = "clang-format", specifier = "~=19.1" }]
 config-generator = [
     { name = "packaging", specifier = ">=14.0" },
     { name = "pydantic", specifier = ">=2.8" },
-    { name = "shrub-py", specifier = ">=3.6" },
+    { name = "shrub-py", specifier = ">=3.7" },
 ]
 dev = [
     { name = "clang-format", specifier = "~=19.1" },
     { name = "packaging", specifier = ">=14.0" },
     { name = "pydantic", specifier = ">=2.8" },
-    { name = "shrub-py", specifier = ">=3.6" },
+    { name = "shrub-py", specifier = ">=3.7" },
 ]
 make-release = [
     { name = "click", specifier = ">=6.0" },


### PR DESCRIPTION
https://github.com/evergreen-ci/shrub.py/commit/20afdce457922f8f5096b21c339af938d272c7ed added support for `ec2_assume_role`, so we do not need to use our own.

Note: no updates to the generated config files are needed.