### PR TITLE
Retry valgrind curl command via script instead of --retry

### DIFF
--- a/.evergreen/scripts/valgrind-installer.sh
+++ b/.evergreen/scripts/valgrind-installer.sh
@@ -8,7 +8,9 @@ set -o pipefail
 cd "$(mktemp -d)"
 
 # https://valgrind.org/downloads/current.html
-curl -sSL -m 60 --retry 5 -o valgrind-3.24.0.tar.bz2 https://sourceware.org/pub/valgrind/valgrind-3.24.0.tar.bz2
+for _ in $(seq 5); do
+    curl -L -m 60 -o valgrind-3.24.0.tar.bz2 https://sourceware.org/pub/valgrind/valgrind-3.24.0.tar.bz2 && break
+done
 cat >checksum.txt <<<'6fc0470fedc0d85dae3e042297cabd13c6100749 *valgrind-3.24.0.tar.bz2'
 sha1sum -c checksum.txt >/dev/null
 


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1383 to address spurious task failure due to the [following error](https://parsley.mongodb.com/evergreen/mongo_cxx_driver_valgrind_matrix_valgrind_rhel80_shared_8.0_replica_eec6bd435ea06e0e87243b900f03af9b5e873f9f_25_04_22_20_21_01/0/task?bookmarks=0,73&shareLine=51):

```
curl: (16) Error in the HTTP2 framing layer
```

`curl` does not appear to `--retry` for this error code. Considered using `--retry-all-errors`, but docs state:

> This option is the "sledgehammer" of retrying. Do not use this option by default (for example in your curlrc), there may be unintended consequences such as sending or receiving duplicate data. Do not use with redirected input or output. You'd be much better off handling your unique problems in shell script. Please read the example below.

Therefore, applied the suggestion to handle the problem via shell script by using a simple for loop in Bash instead of `--retry 5`. The subsequent `sha1sum` command will fail if the `curl` command did not succeed with either:

```
sha1sum: valgrind-3.24.0.tar.bz2: No such file or directory
sha1sum: WARNING: 1 listed file could not be read
```

or:

```
sha1sum: WARNING: 1 computed checksum did NOT match
```