### PR TITLE
Apply changes after 4.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changes prior to 3.9.0 are documented as [release notes on GitHub](https://github.com/mongodb/mongo-cxx-driver/releases).
 
+## 4.2.0 [Unreleased]
+
+<!-- Will contain entries for the next minor release. -->
+
 ## 4.1.0
 
 ### Fixed

--- a/Doxyfile
+++ b/Doxyfile
@@ -1602,7 +1602,7 @@ TOC_EXPAND             = NO
 # protocol see https://www.sitemaps.org
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-SITEMAP_URL            = https://mongocxx.org/api/mongocxx-4.0.0/
+SITEMAP_URL            = https://mongocxx.org/api/mongocxx-4.1.0/
 
 # If the GENERATE_QHP tag is set to YES and both QHP_NAMESPACE and
 # QHP_VIRTUAL_FOLDER are set, an additional index file will be generated that

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ git clone -b releases/stable https://github.com/mongodb/mongo-cxx-driver.git
 | Version     | ABI Stability   | Development Stability       | Development Status |
 | :---------: | :-------------: | :-------------------------: | :----------------: |
 | master      | N/A             | _Do not use in production!_ | Active             |
-| 4.0.0       | None            | Ready for Use               | Bug Fixes Only     |
+| 4.1.0       | None            | Ready for Use               | Bug Fixes Only     |
+| 4.0.0       | None            | Ready for Use               | Not Supported      |
 | 3.11.0      | None            | Ready for Use               | Bug Fixes Only     |
 | 3.10.2      | None            | Ready for Use               | Not Supported      |
 | ...         | ...             | ...                         | ...                |

--- a/etc/apidocmenu.md
+++ b/etc/apidocmenu.md
@@ -2,7 +2,7 @@
 
 ## Driver Documentation By Version
 
-[4.0.0](../mongocxx-4.0.0) | [3.11.0](../mongocxx-3.11.0) | [3.10.2](../mongocxx-3.10.2) | [3.10.1](../mongocxx-3.10.1) | [3.10.0](../mongocxx-3.10.0) | [3.9.0](../mongocxx-3.9.0) | [3.8.1](../mongocxx-3.8.1) | [3.8.0](../mongocxx-3.8.0) | [3.7.2](../mongocxx-3.7.2) | [3.7.1](../mongocxx-3.7.1) | [3.7.0](../mongocxx-3.7.0) | [3.6.7](../mongocxx-3.6.7) | [3.6.6](../mongocxx-3.6.6) | [3.6.5](../mongocxx-3.6.5) | [3.6.4](../mongocxx-3.6.4) | [3.6.3](../mongocxx-3.6.3) | [3.6.2](../mongocxx-3.6.2) | [3.6.1](../mongocxx-3.6.1) | [3.6.0](../mongocxx-3.6.0) | [3.5.1](../mongocxx-3.5.1) | [3.5.0](../mongocxx-3.5.0) | [3.4.2](../mongocxx-3.4.2) | [3.4.1](../mongocxx-3.4.1) | [3.4.0](../mongocxx-3.4.0) | [3.3.2](../mongocxx-3.3.2) | [3.3.1](../mongocxx-3.3.1) | [3.3.0](../mongocxx-3.3.0) | [3.2.1](../mongocxx-3.2.1) | [3.2.0](../mongocxx-3.2.0) | [3.1.4](../mongocxx-3.1.4/) | [3.1.3](../mongocxx-3.1.3/) | [3.1.2](../mongocxx-3.1.2/) | [3.1.1](../mongocxx-3.1.1/) | [3.1.0](../mongocxx-3.1.0/) | [3.0.3](../mongocxx-3.0.3/) | [3.0.2](../mongocxx-3.0.2/) | [3.0.1](../mongocxx-3.0.1/) | [3.0.0](../mongocxx-3.0.0/)
+[4.1.0](../mongocxx-4.1.0) | [4.0.0](../mongocxx-4.0.0) | [3.11.0](../mongocxx-3.11.0) | [3.10.2](../mongocxx-3.10.2) | [3.10.1](../mongocxx-3.10.1) | [3.10.0](../mongocxx-3.10.0) | [3.9.0](../mongocxx-3.9.0) | [3.8.1](../mongocxx-3.8.1) | [3.8.0](../mongocxx-3.8.0) | [3.7.2](../mongocxx-3.7.2) | [3.7.1](../mongocxx-3.7.1) | [3.7.0](../mongocxx-3.7.0) | [3.6.7](../mongocxx-3.6.7) | [3.6.6](../mongocxx-3.6.6) | [3.6.5](../mongocxx-3.6.5) | [3.6.4](../mongocxx-3.6.4) | [3.6.3](../mongocxx-3.6.3) | [3.6.2](../mongocxx-3.6.2) | [3.6.1](../mongocxx-3.6.1) | [3.6.0](../mongocxx-3.6.0) | [3.5.1](../mongocxx-3.5.1) | [3.5.0](../mongocxx-3.5.0) | [3.4.2](../mongocxx-3.4.2) | [3.4.1](../mongocxx-3.4.1) | [3.4.0](../mongocxx-3.4.0) | [3.3.2](../mongocxx-3.3.2) | [3.3.1](../mongocxx-3.3.1) | [3.3.0](../mongocxx-3.3.0) | [3.2.1](../mongocxx-3.2.1) | [3.2.0](../mongocxx-3.2.0) | [3.1.4](../mongocxx-3.1.4/) | [3.1.3](../mongocxx-3.1.3/) | [3.1.2](../mongocxx-3.1.2/) | [3.1.1](../mongocxx-3.1.1/) | [3.1.0](../mongocxx-3.1.0/) | [3.0.3](../mongocxx-3.0.3/) | [3.0.2](../mongocxx-3.0.2/) | [3.0.1](../mongocxx-3.0.1/) | [3.0.0](../mongocxx-3.0.0/)
 
 ## Driver Development Status
 
@@ -12,7 +12,8 @@
 | Version     | ABI Stability   | Development Stability       | Development Status |
 | :---------: | :-------------: | :-------------------------: | :----------------: |
 | master      | N/A             | _Do not use in production!_ | Active             |
-| 4.0.0       | None            | Ready for Use               | Bug Fixes Only     |
+| 4.1.0       | None            | Ready for Use               | Bug Fixes Only     |
+| 4.0.0       | None            | Ready for Use               | Not Supported      |
 | 3.11.0      | None            | Ready for Use               | Bug Fixes Only     |
 | 3.10.2      | None            | Ready for Use               | Not Supported      |
 | ...         | ...             | ...                         | ...                |

--- a/etc/augmented.sbom.json
+++ b/etc/augmented.sbom.json
@@ -76,7 +76,7 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:d27194f6-e5a2-45d3-b9cd-0da1502fb655",
+  "serialNumber": "urn:uuid:c1c87561-6868-46b2-9e0c-d2f7f3bdf028",
   "version": 1,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -33,7 +33,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2025-04-02T19:47:45.682404+00:00",
+    "timestamp": "2025-05-01T20:23:28.401764+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -76,7 +76,7 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:d27194f6-e5a2-45d3-b9cd-0da1502fb655",
+  "serialNumber": "urn:uuid:c1c87561-6868-46b2-9e0c-d2f7f3bdf028",
   "version": 1,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",

--- a/etc/generate-latest-apidocs.sh
+++ b/etc/generate-latest-apidocs.sh
@@ -10,7 +10,7 @@
 set -o errexit
 set -o pipefail
 
-LATEST_VERSION="4.0.0"
+LATEST_VERSION="4.1.0"
 DOXYGEN_VERSION_REQUIRED="1.13.2"
 
 # Permit using a custom Doxygen binary.

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -205,6 +205,8 @@ git fetch upstream
 git checkout releases/vX.Y
 ```
 
+In `etc/apidocmenu.md`, update the list of versions under "Driver Documentation By Version" and the table under "Driver Development Status" with a new entry corresponding to this release.
+
 Update `CHANGELOG.md` with a summary of important changes in this release. Consult the list of related Jira tickets (updated ealier) as well as the list of commits since the last release.
 
 Remove the `[Unreleased]` tag from the relevant patch release section, e.g. for release `1.2.3`:
@@ -220,7 +222,7 @@ Remove the `[Unreleased]` tag from the relevant patch release section, e.g. for 
 
 ```
 
-Commit and push the updates to `CHANGELOG.md` to `releases/vX.Y` (a PR is not required):
+Commit and push the updates to `etc/apidocmenu.md` and `CHANGELOG.md` to `releases/vX.Y` (a PR is not required):
 
 ```bash
 git commit -m 'Update CHANGELOG for X.Y.Z'
@@ -235,6 +237,8 @@ Create a new branch named `pre-release-changes` on `master`. This branch will be
 git fetch upstream
 git checkout -b pre-release-changes upstream/master
 ```
+
+In `etc/apidocmenu.md`, update the list of versions under "Driver Documentation By Version" and the table under "Driver Development Status" with a new entry corresponding to this release.
 
 Update `CHANGELOG.md` with a summary of important changes in this release. Consult the list of related Jira tickets (updated earlier) as well as the list of commits since the last release.
 
@@ -254,7 +258,7 @@ Remove the `[Unreleased]` tag from the relevant non-patch release section, e.g. 
 > [!IMPORTANT]
 > If there are entries under an unreleased patch release section with the old minor release number, move the entries into this release's section and remove the unreleased patch release section. For example, for a `1.3.0` minor release, move entries from `1.2.3 [Unreleased]` to `1.3.0` and remove `1.2.3 [Unreleased]`. Due to cherry-picking, a non-patch release should always (already) contain the changes targeting a patch release with a prior minor version number. (This is analogous to updating the fix version of Jira tickets, as done earlier.)
 
-Commit the updates to `CHANGELOG.md`.
+Commit the updates to `etc/apidocmenu.md` and `CHANGELOG.md`.
 
 ```bash
 git commit -m 'Update CHANGELOG for X.Y.Z'
@@ -524,7 +528,7 @@ This branch will be used to create a PR later.
 > [!IMPORTANT]
 > Make sure the `post-release-changes` branch is created on `master`, not `rX.Y.Z` or `releases/vX.Y`!
 
-In `etc/apidocmenu.md`, update the list of versions under "Driver Documentation By Version" and the table under "Driver Development Status" with a new entry corresponding to this release.
+For a patch release, in `etc/apidocmenu.md`, update the list of versions under "Driver Documentation By Version" and the table under "Driver Development Status" with a new entry corresponding to this release.
 
 In `README.md`, sync the "Driver Development Status" table with the updated table from `etc/apidocmenu.md`.
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -493,13 +493,14 @@ snyk auth "${SNYK_API_TOKEN:?}"
 
 # Verify third party dependency sources listed in etc/purls.txt are detected by Snyk.
 # If not, see: https://support.snyk.io/hc/en-us/requests/new
+# Use --exclude=extras until CXX-3042 is resolved
 snyk_args=(
   --org=dev-prod
   --remote-repo-url=https://github.com/mongodb/mongo-cxx-driver/
   --target-reference="${release_tag:?}"
   --unmanaged
   --all-projects
-  --exclude=extras # CXX-3042
+  --exclude=extras
 )
 snyk test "${snyk_args[@]:?}" --print-deps
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -630,8 +630,6 @@ cmake --build build --target doxygen-latest
 
 Verify that the `build/docs/api/mongocxx-X.Y.Z` directory is present and populated. Verify the resulting API doc looks as expected.
 
-Remove all contents of `build/docs/api` before running the next commands.
-
 > [!IMPORTANT]
 > Remove all contents of `build/docs/api` before running the next commands.
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -148,8 +148,6 @@ Ensure the `sbom` task is passing on Evergreen for the relevant release branch.
 
 Review the contents of the new Augmented SBOM and ensure any new or known vulnerabilities with severity "Medium" or greater have a corresponding JIRA ticket (CXX or VULN) that is scheduled to be resolved within its remediation timeline.
 
-Update the [SSDLC Report spreadsheet](https://docs.google.com/spreadsheets/d/1sp0bLjj29xO9T8BwDIxUk5IPJ493QkBVCJKIgptxEPc/edit?usp=sharing) with any updates to new or known vulnerabilities.
-
 Update `etc/third_party_vulnerabilities.md` with any updates to new or known vulnerabilities for third party dependencies that have not yet been fixed by the upcoming release.
 
 Download the "Augmented SBOM (Updated)" file from the latest EVG commit build in the `sbom` task and commit it into the repo as `etc/augmented.sbom.json` (even if the only notable change is the timestamp field).


### PR DESCRIPTION
Apply changes associated with the 4.1.0 release and some release step tweaks.

# Details

Steps to update the `etc/apidocmenu.md` file are moved before creating the tag. This is intended to include the change in the published docs. The `doxygen-latest` target (used by `doxygen-deploy`) builds from the latest tag.

Outside of this PR, the `dbx-c-cxx-releases` team was added to the bypass list for [Restrict Updates (Branches)](https://github.com/mongodb/mongo-cxx-driver/settings/rules/4939020) to permit the force push of the `releases/stable` branch.
