### PR TITLE
DEVPROD-17369 - Update generated config to use new data send script to replace perf.send

### DIFF
--- a/.evergreen/config_generator/components/benchmarks.py
+++ b/.evergreen/config_generator/components/benchmarks.py
@@ -26,14 +26,11 @@ class RunBenchmarks(Function):
             working_dir='mongo-cxx-driver',
             script='build/benchmark/microbenchmarks all',
         ),
-
-        BuiltInCommand(
-            command='perf.send',
-            type=EvgCommandType.SYSTEM,
-            params={
-                'name': 'perf',
-                'file': 'mongo-cxx-driver/results.json',
-            }
+        bash_exec(
+            command_type=EvgCommandType.SYSTEM,
+            working_dir='mongo-cxx-driver',
+            script='.evergreen/scripts/send-perf-data.sh',
+            include_expansions_in_env=['project_id', 'version_id', 'build_variant', 'parsed_order_id', 'task_name', 'task_id', 'execution', 'requester', 'revision_order_id'],
         ),
     ]
 

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -142,11 +142,24 @@ functions:
         args:
           - -c
           - build/benchmark/microbenchmarks all
-    - command: perf.send
+    - command: subprocess.exec
       type: system
       params:
-        name: perf
-        file: mongo-cxx-driver/results.json
+        binary: bash
+        working_dir: mongo-cxx-driver
+        include_expansions_in_env:
+          - project_id
+          - version_id
+          - build_variant
+          - parsed_order_id
+          - task_name
+          - task_id
+          - execution
+          - requester
+          - revision_order_id
+        args:
+          - -c
+          - .evergreen/scripts/send-perf-data.sh
   build-package-debian:
     - command: subprocess.exec
       type: test

--- a/.evergreen/scripts/send-perf-data.sh
+++ b/.evergreen/scripts/send-perf-data.sh
@@ -10,7 +10,7 @@ else
     is_mainline=false
 fi
 
-# We parse the username out of the order_id as patches append that in and the raw perf results end point does not need that information
+# Parse the username out of the order_id. Patches append the username. The raw perf results end point does not need the other information.
 parsed_order_id=$(echo "${revision_order_id}" | awk -F'_' '{print $NF}')
 
 response=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X 'POST' \


### PR DESCRIPTION
The perf.send command is no longer being maintained and is in a maintenance state and will be decommissioned eventually. It has been replaced instead by a new end point that users are able to call from their evergreen files; [this doc](https://github.com/10gen/performance-tooling-docs/blob/main/getting_started/migrating_from_perfSend_to_sps.md) outlines a drop in solution that we apply to the existing evergreen config file in this PR.

This PR updates the Mongo-cxx-driver project to send performance data downstream using the newest supported method. I added a new send-perf-data.sh script that is called within the `benchmarks-run` function. I also added this to the config generator and recreated the functions.yml file using the generator.

Successful patch:
https://spruce.mongodb.com/version/681517ca46fcad0007f2aada/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC