### PR TITLE
Address -Wsign-conversion warnings with Clang

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/vector/iterators.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/vector/iterators.hpp
@@ -278,7 +278,7 @@ class packed_bit_byte {
     constexpr packed_bit_byte(packed_bit_element<Iterator> element, packed_bit_element<Iterator> element_end)
         : byte{element.byte},
           byte_end{(element_end + 7u).byte},
-          last_byte_mask{value_type(0xFFu << (-element_end.bit & 7u))} {}
+          last_byte_mask{value_type(0xFFu << (-element_end.bit & 7))} {}
 
     constexpr packed_bit_byte(Iterator byte, Iterator byte_end, value_type last_byte_mask)
         : byte{byte}, byte_end{byte_end}, last_byte_mask{last_byte_mask} {}


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1356, where a `-Wsign-conversion` Clang warning due to the following expression was overlooked:

```cpp
0xFFu << (-element_end.bit & 7u)
```

`element_end.bit` is a `std::uint8_t`. The unary negation operator implicitly promotes the result to an `int`, whose signedness is inconsistent with `7u` (warning: `signed & unsigned`). The literal is made a signed `int` for consistency. This should not impact the behavior of the overall expression ([tested exhaustively](https://godbolt.org/z/M3Tvfe68h)). (Updated link: static assert `unsigned << signed -> unsigned` (after promotion) + test `UINT8_MAX` as well.)