### PR TITLE
CXX-3231 add v1 forward headers and component files

### DIFF
--- a/src/bsoncxx/include/bsoncxx/docs/v1.hpp
+++ b/src/bsoncxx/include/bsoncxx/docs/v1.hpp
@@ -41,8 +41,36 @@
 ///
 
 ///
+/// @dir bsoncxx/v1/array
+/// Provides headers declaring entities in @ref bsoncxx::v1::array.
+///
+/// @warning For internal use only!
+///
+
+///
+/// @dir bsoncxx/v1/document
+/// Provides headers declaring entities in @ref bsoncxx::v1::document.
+///
+/// @warning For internal use only!
+///
+
+///
+/// @dir bsoncxx/v1/element
+/// Provides headers declaring entities in @ref bsoncxx::v1::element.
+///
+/// @warning For internal use only!
+///
+
+///
 /// @dir bsoncxx/v1/stdx
 /// Provides headers declaring entities in @ref bsoncxx::v1::stdx.
+///
+
+///
+/// @dir bsoncxx/v1/types
+/// Provides headers declaring entities in @ref bsoncxx::v1::types.
+///
+/// @warning For internal use only!
 ///
 
 ///
@@ -51,6 +79,28 @@
 ///
 
 ///
+/// @namespace bsoncxx::v1::array
+/// @copydoc bsoncxx::array
+///
+
+///
+/// @namespace bsoncxx::v1::document
+/// @copydoc bsoncxx::array
+///
+
+///
+/// @namespace bsoncxx::v1::element
+/// Declares entities representing a BSON element.
+///
+
+///
 /// @namespace bsoncxx::v1::stdx
 /// @copydoc bsoncxx::stdx
+///
+
+///
+/// @namespace bsoncxx::v1::types
+/// Declares entities representing a BSON type value.
+///
+/// @note A "BSON type value" refers to the value of a BSON element without its key.
 ///

--- a/src/bsoncxx/include/bsoncxx/docs/v1.hpp
+++ b/src/bsoncxx/include/bsoncxx/docs/v1.hpp
@@ -85,7 +85,7 @@
 
 ///
 /// @namespace bsoncxx::v1::document
-/// @copydoc bsoncxx::array
+/// @copydoc bsoncxx::document
 ///
 
 ///

--- a/src/bsoncxx/include/bsoncxx/v1/array/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/array/value-fwd.hpp
@@ -1,0 +1,34 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace array {
+
+class value;
+
+} // namespace array
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v1::array::value.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/array/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/array/value.hpp
@@ -1,0 +1,43 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/array/value-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace array {
+
+///
+/// A BSON array.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+class value {};
+
+} // namespace array
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v1::array::value.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/array/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/array/view-fwd.hpp
@@ -1,0 +1,34 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace array {
+
+class view;
+
+} // namespace array
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v1::array::view.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/array/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/array/view.hpp
@@ -1,0 +1,43 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/array/view-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace array {
+
+///
+/// A non-owning, read-only BSON array.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+class view {};
+
+} // namespace array
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v1::array::view.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/decimal128-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/decimal128-fwd.hpp
@@ -1,0 +1,32 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+
+class decimal128;
+
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v1::decimal128.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/decimal128.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/decimal128.hpp
@@ -1,0 +1,41 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/decimal128-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+
+///
+/// A BSON Decimal128.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+class decimal128 {};
+
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v1::decimal128.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/document/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/document/value-fwd.hpp
@@ -1,0 +1,34 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace document {
+
+class value;
+
+} // namespace document
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v1::document::value.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/document/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/document/value.hpp
@@ -1,0 +1,43 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/document/value-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace document {
+
+///
+/// A BSON document.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+class value {};
+
+} // namespace document
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v1::document::value.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/document/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/document/view-fwd.hpp
@@ -1,0 +1,34 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace document {
+
+class view;
+
+} // namespace document
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v1::document::view.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/document/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/document/view.hpp
@@ -1,0 +1,43 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/document/view-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace document {
+
+///
+/// A non-owning, read-only BSON document.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+class view {};
+
+} // namespace document
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v1::document::view.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/element/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/element/view-fwd.hpp
@@ -1,0 +1,34 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace element {
+
+class view;
+
+} // namespace element
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v1::element::view.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/element/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/element/view.hpp
@@ -1,0 +1,43 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/element/view-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace element {
+
+///
+/// A non-owning, read-only BSON element.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+class view {};
+
+} // namespace element
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v1::element::view.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/exception-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/exception-fwd.hpp
@@ -1,0 +1,44 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace error {
+
+enum class source;
+
+enum class type;
+
+} // namespace error
+} // namespace v1
+} // namespace bsoncxx
+
+namespace bsoncxx {
+namespace v1 {
+
+class exception;
+
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares bsoncxx error-handling utilities.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/exception.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/exception.hpp
@@ -1,0 +1,65 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/exception-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+#include <system_error>
+
+namespace bsoncxx {
+namespace v1 {
+namespace error {
+
+///
+/// Enumeration identifying the source of a @ref bsoncxx::v1 error.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+enum class source {};
+
+///
+/// Enumeration identifying the type (cause) of a @ref bsoncxx::v1 error.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+enum class type {};
+
+} // namespace error
+} // namespace v1
+} // namespace bsoncxx
+
+namespace bsoncxx {
+namespace v1 {
+
+///
+/// Base class for all exceptions thrown by @ref bsoncxx::v1.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+class exception {};
+
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides bsoncxx error-handling utilities.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/oid-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/oid-fwd.hpp
@@ -1,0 +1,32 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+
+class oid;
+
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v1::oid.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/oid.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/oid.hpp
@@ -1,0 +1,41 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/oid-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+
+///
+/// A BSON ObjectID.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+class oid {};
+
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref bsoncxx::v1::oid.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/types/id-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/types/id-fwd.hpp
@@ -1,0 +1,121 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+#include <cstdint>
+
+///
+/// X-macro over the name and value of BSON types.
+///
+/// @important The addition of new expansions to this X-macro ARE NOT considered an API breaking change.
+/// The modification or removal of existing expansions to this X-macro ARE considered an API breaking change.
+/// This X-macro MUST be used in a manner that is compatible with these API compatibility guidelines!
+///
+/// @par "Example"
+/// ```cpp
+/// #define EXAMPLE(name, value) std::cout << (#name) << ": " << (value) << '\n';
+///
+/// void print_bson_types() {
+///     // Expands to:
+///     //     std::cout << ("double") << ": " << (0x01) << '\n';
+///     //     std::cout << ("string") << ": " << (0x02) << '\n';
+///     //     ...
+///     BSONCXX_V1_TYPES_XMACRO(EXAMPLE)
+/// }
+/// ```
+///
+/// @param X the user-defined macro to be expanded.
+///
+// clang-format off
+#define BSONCXX_V1_TYPES_XMACRO(X) \
+    X(double,     0x01) \
+    X(string,     0x02) \
+    X(document,   0x03) \
+    X(array,      0x04) \
+    X(binary,     0x05) \
+    X(undefined,  0x06) \
+    X(oid,        0x07) \
+    X(bool,       0x08) \
+    X(date,       0x09) \
+    X(null,       0x0A) \
+    X(regex,      0x0B) \
+    X(dbpointer,  0x0C) \
+    X(code,       0x0D) \
+    X(symbol,     0x0E) \
+    X(codewscope, 0x0F) \
+    X(int32,      0x10) \
+    X(timestamp,  0x11) \
+    X(int64,      0x12) \
+    X(decimal128, 0x13) \
+    X(maxkey,     0x7F) \
+    X(minkey,     0xFF)
+// clang-format on
+
+///
+/// X-macro over the name and value of BSON binary subtypes.
+///
+/// @important The addition of new expansions to this X-macro ARE NOT considered an API breaking change.
+/// The modification or removal of existing expansions to this X-macro ARE considered an API breaking change.
+/// This X-macro MUST be used in a manner that is compatible with these API compatibility guidelines!
+///
+/// @par "Example"
+/// ```cpp
+/// #define EXAMPLE(name, value) std::cout << #name << ": " << value << '\n';
+///
+/// void print_bson_binary_subtypes() {
+///     // Expands to:
+///     //     std::cout << ("binary") << ": " << (0x00) << '\n';
+///     //     std::cout << ("function") << ": " << (0x01) << '\n';
+///     //     ...
+///     BSONCXX_V1_BINARY_SUBTYPES_XMACRO(EXAMPLE)
+/// }
+/// ```
+///
+/// @param X the user-defined macro to be expanded.
+///
+// clang-format off
+#define BSONCXX_V1_BINARY_SUBTYPES_XMACRO(X) \
+    X(binary,            0x00) \
+    X(function,          0x01) \
+    X(binary_deprecated, 0x02) \
+    X(uuid_deprecated,   0x03) \
+    X(uuid,              0x04) \
+    X(md5,               0x05) \
+    X(encrypted,         0x06) \
+    X(column,            0x07) \
+    X(sensitive,         0x08) \
+    X(vector,            0x09) \
+    X(user,              0x80)
+// clang-format on
+
+namespace bsoncxx {
+namespace v1 {
+namespace types {
+
+enum class id : std::uint8_t;
+enum class binary_subtype : std::uint8_t;
+
+} // namespace types
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares enumerations identifying the type of a BSON element.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/types/id.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/types/id.hpp
@@ -1,0 +1,54 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/types/id-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace types {
+
+///
+/// Enumeration identifying a BSON type.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+/// @showenumvalues
+///
+enum class id : std::uint8_t {};
+
+///
+/// Enumeration identifying a BSON binary subtype.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+/// @showenumvalues
+///
+enum class binary_subtype : std::uint8_t {};
+
+} // namespace types
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides enumerations identifying the type of a BSON element.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/types/value-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/types/value-fwd.hpp
@@ -1,0 +1,36 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+#include <bsoncxx/v1/types/value-fwd.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace types {
+
+class value;
+
+} // namespace types
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref bsoncxx::v1::types::value.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/types/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/types/value.hpp
@@ -1,0 +1,46 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/types/value-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace types {
+
+///
+/// A union of BSON type values.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+/// @note A "BSON type value" refers to the value of a BSON element without its key.
+///
+class value {};
+
+} // namespace types
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+///
+/// @file
+/// Provides @ref bsoncxx::v1::types::value.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/types/view-fwd.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/types/view-fwd.hpp
@@ -1,0 +1,44 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+#include <bsoncxx/v1/types/id-fwd.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace types {
+
+#pragma push_macro("X")
+#undef X
+#define X(_name, _value) struct b_##_name;
+BSONCXX_V1_TYPES_XMACRO(X)
+#pragma pop_macro("X")
+
+class view;
+
+} // namespace types
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares non-owning, read-only entities representing a BSON type value.
+///
+/// @note A "BSON type value" refers to the value of a BSON element without its key.
+///

--- a/src/bsoncxx/include/bsoncxx/v1/types/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/types/view.hpp
@@ -1,0 +1,195 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/types/view-fwd.hpp>
+
+//
+
+#include <bsoncxx/v1/detail/prelude.hpp>
+
+namespace bsoncxx {
+namespace v1 {
+namespace types {
+
+///
+/// BSON type value "64-bit Binary Floating Point".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_double {};
+
+///
+/// BSON type value "UTF-8 String".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_string {};
+
+///
+/// BSON type value "Embedded Document".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_document {};
+
+///
+/// BSON type value "Array".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_array {};
+
+///
+/// BSON type value "Binary Data".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_binary {};
+
+///
+/// BSON type value "Undefined (Value)".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_undefined {};
+
+///
+/// BSON type value "ObjectID".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_oid {};
+
+///
+/// BSON type value "Boolean".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_bool {};
+
+///
+/// BSON type value "UTC Datetime".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_date {};
+
+///
+/// BSON type value "Null Value".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_null {};
+
+///
+/// BSON type value "Regular Expression".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_regex {};
+
+///
+/// BSON type value "DBPointer".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_dbpointer {};
+
+///
+/// BSON type value "JavaScript Code".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_code {};
+
+///
+/// BSON type value "Symbol".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_symbol {};
+
+///
+/// BSON type value "JavaScript Code With Scope".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_codewscope {};
+
+///
+/// BSON type value "32-bit Integer".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_int32 {};
+
+///
+/// BSON type value "Timestamp".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_timestamp {};
+
+///
+/// BSON type value "64-bit Integer".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_int64 {};
+
+///
+/// BSON type value "Decimal128".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_decimal128 {};
+
+///
+/// BSON type value "Max Key".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_maxkey {};
+
+///
+/// BSON type value "Min Key".
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+struct b_minkey {};
+
+///
+/// A non-owning, read-only union of BSON type values.
+///
+/// @note This class only represents the **value** of a BSON element without its key.
+/// @ref bsoncxx::v1::element::view represents a BSON element including its key.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+class view {};
+
+} // namespace types
+} // namespace v1
+} // namespace bsoncxx
+
+#include <bsoncxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides non-owning, read-only entities representing a BSON type value.
+///
+/// @note A "BSON type value" refers to the value of a BSON element without its key.
+///

--- a/src/bsoncxx/lib/CMakeLists.txt
+++ b/src/bsoncxx/lib/CMakeLists.txt
@@ -42,11 +42,22 @@ set(bsoncxx_sources_v_noabi
 )
 
 set(bsoncxx_sources_v1
+    bsoncxx/v1/array/value.cpp
+    bsoncxx/v1/array/view.cpp
     bsoncxx/v1/config/config.cpp
     bsoncxx/v1/config/export.cpp
     bsoncxx/v1/config/version.cpp
+    bsoncxx/v1/decimal128.cpp
     bsoncxx/v1/detail/postlude.cpp
     bsoncxx/v1/detail/prelude.cpp
+    bsoncxx/v1/document/value.cpp
+    bsoncxx/v1/document/view.cpp
+    bsoncxx/v1/element/view.cpp
+    bsoncxx/v1/exception.cpp
+    bsoncxx/v1/oid.cpp
+    bsoncxx/v1/types/id.cpp
+    bsoncxx/v1/types/value.cpp
+    bsoncxx/v1/types/view.cpp
 )
 
 list(APPEND bsoncxx_sources

--- a/src/bsoncxx/lib/bsoncxx/v1/array/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/array/value.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/array/value.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/array/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/array/view.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/array/view.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/decimal128.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/decimal128.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/decimal128.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/document/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/document/value.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/document/value.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/document/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/document/view.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/document/view.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/element/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/element/view.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/element/view.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/exception.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/exception.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/exception.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/oid.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/oid.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/oid.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/types/id.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/types/id.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/types/id.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/types/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/types/value.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/types/value.hpp>

--- a/src/bsoncxx/lib/bsoncxx/v1/types/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/types/view.cpp
@@ -1,0 +1,15 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/types/view.hpp>


### PR DESCRIPTION
Resolves CXX-3231. Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1336.

As initially attempted in https://github.com/mongodb/mongo-cxx-driver/pull/1336, this PR is a "lightweight" preview of the bsoncxx v1 interface, file structure, and corresponding API documentation. Relevant details from https://github.com/mongodb/mongo-cxx-driver/pull/1336 are copied here for locality and updated with latest changes.

---

- Relative Changelog (v_noabi -> v1):
    - Additional Features:
        - X macros over BSON types and subtypes: `BSONCXX_V1_TYPES_XMACRO` and `BSONCXX_V1_BINARY_SUBTYPES_XMACRO`.
        - `bsoncxx::v1::error` for user-facing error conditions. This will be elaborated in greater detail in the followup "interfaces" PR.
    -  Changed Features:
        - Classes `types::bson_value::view` (v_noabi) and `types::bson_value::value` (v_noabi) are now `types::view` (v1) and `types::value` (v1).
        - Enumerators `type` (v_noabi) and `binary_sub_type` are now `types::id` (v1) and `types::binary_subtype` (v1). A type alias for both will be provided in the `v_noabi` namespace to assist with incremental upgrades.
        - Classes `document::element` (v_noabi) and `array::element` (v_noabi) are now represented by a single class `element::view`. Type aliases for all three will be provided in the `v_noabi` namespace to assist with incremental upgrades.
        - The exception class `exception` is now provided by `exception.hpp` (v1) rather than `exception/exception.hpp` (v_noabi) to be consistent with its namespace scope.
    - Removed Features:
        - `enums/*.hpp`: replaced by new X macros.
        - `exception/error_code.hpp`: folded into `exception.hpp` (v1) and replaced by component-specific error codes.
        - `string::to_string`: supported by the explicit conversion operator in `stdx::string_view`.
        - `view_or_value`: see [CXX-1827](https://jira.mongodb.org/browse/CXX-1827).
    - Skipped Features (to be implemented after the initial stable ABI release):
        - BSON builders (basic, json, list, stream).
        - BSON binary vector API.
        - BSON validators.
- Absolute Changelog (v_noabi):
    - None.

---

Details and rationale:

- `element::view` (and `element::value`)
    - Motivated by [feedback](https://github.com/mongodb/mongo-cxx-driver/pull/1336/files/97c0756cc5bcb7315c8630c671547d2b8d896835#diff-adb5fa7b90cb63b2a1176a35b8ac7ad8ad112e19ce163a2744cac8fad3f748c3) concerning the confusing terminology regarding "views", "values", and "elements".
    - Component structure is now completely symmetric:
        - `array`: `view` + `value`.
        - `document`: `view` + `value`.
        - `element`: `view` (+ `value`).
        - `types`: `view` + `value`.
    - The design space for `element::value` is left open as an owning equivalent to `element::view` and a possible successor to `builder::basic::kvp` (v_noabi) as part of the potential redesign of BSON builders.
- `types::view` and `types::value`:
    - mirrors the "non-owning, read-only" vs. "owning" relationship established by `document` and `array` class types.
    - all "BSON type"-related entities are now declared under the `types` (v1) namespace (avoiding the `type` vs. `types` confusion):
        - `id`: a "BSON type" or "BSON type id", formerly `type`.
        - `binary_subtype`: a "BSON binary subtype", formerly `binary_sub_type`.
        - `b_*`: "BSON type values" (the value of a BSON element without a key).
        - `view`: a non-owning, read-only union of BSON type values.
        - `value`: an owning union of BSON type values.
- `error` and `exception`:
    - The `error` namespace will contain declarations for error code enumerations and corresponding error categories which describe component-specific errors which may be thrown by the `v1` interface.
    - The `source` and `type` error conditions are expected to be the primary means by which users programmatically inspect the cause of thrown errors. This will be elaborated in greater detail in the upcoming "interfaces" PR.
    - The error code enumerations for individual components are not forward-declared due to dubious value (it is unlikely that users will be handling component-specific error codes without already including the corresponding component interface header). These will be introduced in the upcoming "interfaces" PR.
    - Users are expected to eventually handle exceptions from both `v_noabi` and `v1` namespaces by catching `std::system_error` instead of ABI-specific exception types. The `v_noabi` API will continue to throw `v_noabi::exception` even if the underlying implementation is refactored to use `v1` API for backward compatibility.