### PR TITLE
CXX-2745 add immortal.hh and type_traits.hh

### DIFF
--- a/src/bsoncxx/lib/CMakeLists.txt
+++ b/src/bsoncxx/lib/CMakeLists.txt
@@ -104,11 +104,13 @@ set_dist_list(src_bsoncxx_lib_DIST
     bsoncxx/private/convert.hh
     bsoncxx/private/export.hh
     bsoncxx/private/helpers.hh
+    bsoncxx/private/immortal.hh
     bsoncxx/private/itoa.hh
     bsoncxx/private/bson.hh
     bsoncxx/private/make_unique.hh
     bsoncxx/private/stack.hh
     bsoncxx/private/suppress_deprecation_warnings.hh
+    bsoncxx/private/type_traits.hh
     bsoncxx/private/version.hh
     bsoncxx/v_noabi/bsoncxx/types/bson_value/value.hh
     bsoncxx/v1/config/config.hpp.in

--- a/src/bsoncxx/lib/bsoncxx/private/immortal.hh
+++ b/src/bsoncxx/lib/bsoncxx/private/immortal.hh
@@ -20,6 +20,19 @@
 
 namespace bsoncxx {
 
+//
+// Used to construct an object whose destructor is never invoked (hence, "immortal").
+//
+// This is primarily to avoid generating exit-time destructors for error category objects:
+//
+// ```cpp
+// std::error_category const& name() noexcept {
+//     class type final : public std::error_category { ... };
+//     static bsoncxx::immortal<type> const instance;
+//     return instance.value();
+// }
+// ```
+//
 template <typename T>
 class immortal {
    private:

--- a/src/bsoncxx/lib/bsoncxx/private/immortal.hh
+++ b/src/bsoncxx/lib/bsoncxx/private/immortal.hh
@@ -46,7 +46,7 @@ class immortal {
     immortal& operator=(immortal const&) = delete;
 
     template <typename... Args>
-    immortal(Args&&... args) {
+    explicit immortal(Args&&... args) {
         new (_storage) T(BSONCXX_PRIVATE_FWD(args)...);
     }
 

--- a/src/bsoncxx/lib/bsoncxx/private/immortal.hh
+++ b/src/bsoncxx/lib/bsoncxx/private/immortal.hh
@@ -1,0 +1,49 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/macros.hpp>
+
+#include <new>
+
+namespace bsoncxx {
+
+template <typename T>
+class immortal {
+   private:
+    alignas(T) unsigned char _storage[sizeof(T)];
+
+   public:
+    ~immortal() = default;
+    immortal(immortal&&) = delete;
+    immortal& operator=(immortal&&) = delete;
+    immortal(immortal const&) = delete;
+    immortal& operator=(immortal const&) = delete;
+
+    template <typename... Args>
+    immortal(Args&&... args) {
+        new (_storage) T(BSONCXX_PRIVATE_FWD(args)...);
+    }
+
+    T const& value() const {
+        return *reinterpret_cast<T const*>(_storage);
+    }
+
+    T& value() {
+        return *reinterpret_cast<T*>(_storage);
+    }
+};
+
+} // namespace bsoncxx

--- a/src/bsoncxx/lib/bsoncxx/private/type_traits.hh
+++ b/src/bsoncxx/lib/bsoncxx/private/type_traits.hh
@@ -1,0 +1,78 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/detail/type_traits.hpp>
+
+namespace bsoncxx {
+
+template <typename LHS, typename RHS>
+using is_assignable_from_expr = decltype(std::declval<LHS>() = std::declval<RHS>());
+
+// Approximates the `assignable_from` concept in C++20.
+template <typename LHS, typename RHS>
+struct is_assignable_from : detail::conjunction<
+                                std::is_lvalue_reference<LHS>,
+                                std::is_same<detail::detected_t<is_assignable_from_expr, LHS, RHS>, LHS>> {};
+
+// Equivalent to `is_assignable_from` but also requires noexceptness.
+template <typename LHS, typename RHS>
+struct is_nothrow_assignable_from
+    : detail::bool_constant<
+          is_assignable_from<LHS, RHS>::value && noexcept(std::declval<LHS>() = std::declval<RHS>())> {};
+
+// Approximates the `movable` concept in C++20.
+template <typename T>
+struct is_movable : detail::conjunction<
+                        std::is_object<T>,
+                        std::is_move_constructible<T>,
+                        is_assignable_from<T&, T>,
+                        detail::is_swappable<T>> {};
+
+// Equivalent to `is_moveable` but additionally requires noexceptness.
+template <typename T>
+struct is_nothrow_moveable : detail::conjunction<
+                                 std::is_object<T>,
+                                 std::is_nothrow_move_constructible<T>,
+                                 is_nothrow_assignable_from<T&, T>,
+                                 detail::is_nothrow_swappable<T>> {};
+
+// Approximates the `copyable` concept in C++20.
+template <typename T>
+struct is_copyable : detail::conjunction<
+                         std::is_copy_constructible<T>,
+                         is_movable<T>,
+                         is_assignable_from<T&, T&>,
+                         is_assignable_from<T&, T const&>,
+                         is_assignable_from<T&, T const>> {};
+
+// Approximates the `semiregular` concept in C++20.
+template <typename T>
+struct is_semiregular : detail::conjunction<is_copyable<T>, std::is_default_constructible<T>> {};
+
+// Approximates the `regular` concept in C++20.
+template <typename T>
+struct is_regular : detail::conjunction<is_semiregular<T>, detail::is_equality_comparable<T>> {};
+
+// Equivalent to `is_trivial` without requiring trivial default constructibility.
+template <typename T>
+struct is_semitrivial : detail::conjunction<
+                            std::is_trivially_destructible<T>,
+                            std::is_trivially_move_constructible<T>,
+                            std::is_trivially_move_assignable<T>,
+                            std::is_trivially_copy_constructible<T>,
+                            std::is_trivially_copy_assignable<T>> {};
+
+} // namespace bsoncxx


### PR DESCRIPTION
Related to CXX-2745. Precursor changes to CXX-3232.

Adds two new internal bsoncxx components which are used by upcoming v1 interfaces.

---

The `bsoncxx::immortal<T>` class is used to define error category objects in a manner that avoids generating exit-time destructors (hence, "immortal") as can be diagnosed by the `-Wexit-time-destructors` Clang warning.

The pattern will look as follows:

```cpp
std::error_category const& example() {
    class type final : public std::error_category { ... };

    // The error category object instance. This is never destroyed!
    static bsoncxx::immortal<type> const instance;

    return instance.value();
}
```

---

Several new type traits are introduce to ensure consistency and correctness of v1 interfaces via static assertions. These type traits are derived from patterns observed in v_noabi interfaces and are enforced by v1 interfaces in a more rigorous manner.

The new type traits are:

- `is_semitrivial<T>`:
    - `T` is trivial to copy, move, and destroy ("like an `int`").
    - Trivial default constructibility is excluded (hence "semi") due to most types requiring non-trivial construction (to enforce class invariants) even when other special member functions are all trivial (invariants are entirely enforced by initialization).
- `is_semiregular<T>` and `is_regular<T>`:
    - `T` has value semantics ("like an `int` or `std::string`") and is (optionally) equality-comparable.
    - `is_semitrivial<T>` implies `is_semiregular<T>`.
- `is_nothrow_moveable<T>`:
    - `T` does not throw on destruction, move construction, or move assignment ("like a `std::unique_ptr<T>`").
    - This is meant to roughly approximate the requirements for [`is_nothrow_relocatable<T>` in C++26](https://wg21.link/p2786r13#is_nothrow_relocatable-trait) without misleadingly implying actual nothrow relocatability (which is complicated to accurately specify). This type trait is primarily to catch missing `noexcept` specifiers and highlight immovable types.
    - `is_semitrivial<T>` implies `is_nothrow_moveable<T>`.

All class types in bsoncxx and mongocxx are expected to (eventually) satisfy _semiregular_ and _nothrow moveable_ at a minimum to ensure consistent user-friendly behavior (e.g. `bsoncxx::v_noabi::document::value` is notably [not semiregular](https://jira.mongodb.org/browse/CXX-939)). Some types may additionally support semitrivialty. Some types may  additionally support regularity (equality comparison). If there are any circumstances where nothrow moveability is deliberately violated (potentially-throwing move operations or immovability), we should expect such instances to be highlighted with a negated static assertion ("we do something unusual here!") such as for `mongocxx::v_noabi::instance` (an immovable class type).

> [!IMPORTANT]
> Move constructors and move assignment operators which may allocate memory are still declared `noexcept`. `std::bad_alloc` exceptions are _**NOT**_ accounted for by nothrow moveability, as we do not support recovering from out-of-memory situations in either the C++ or C Driver libraries.
