### PR TITLE
CXX-3288 do not initialize ENABLE_TESTS with the auto-downloaded C Driver

### DIFF
--- a/.evergreen/config_generator/components/macro_guards.py
+++ b/.evergreen/config_generator/components/macro_guards.py
@@ -47,8 +47,8 @@ def tasks():
                     Compile.call(
                         build_type='Debug',
                         compiler=compiler,
-                        vars={'COMPILE_MACRO_GUARD_TESTS': 'ON'},
-                    )
+                        vars={'COMPILE_MACRO_GUARD_TESTS': 'ON', 'ENABLE_TESTS': 'ON'},
+                    ),
                 ],
             )
         )

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -14187,6 +14187,7 @@ tasks:
       - func: compile
         vars:
           COMPILE_MACRO_GUARD_TESTS: "ON"
+          ENABLE_TESTS: "ON"
           build_type: Debug
   - name: macro-guards-rhel80-clang
     run_on: rhel80-large
@@ -14198,6 +14199,7 @@ tasks:
       - func: compile
         vars:
           COMPILE_MACRO_GUARD_TESTS: "ON"
+          ENABLE_TESTS: "ON"
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
@@ -14211,6 +14213,7 @@ tasks:
       - func: compile
         vars:
           COMPILE_MACRO_GUARD_TESTS: "ON"
+          ENABLE_TESTS: "ON"
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ## 4.2.0 [Unreleased]
 
-<!-- Will contain entries for the next minor release. -->
+### Fixed
+
+- CMake option `ENABLE_TESTS` (`OFF` by default) is no longer overwritten by the auto-downloaded C Driver (`ON` by default) during CMake configuration.
 
 ## 4.1.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,8 +49,6 @@ set(BSON_REQUIRED_VERSION 2.0.0)
 set(MONGOC_REQUIRED_VERSION 2.0.0)
 set(MONGOC_DOWNLOAD_VERSION 2.0.0)
 
-include(FetchMongoC)
-
 # All of our target compilers support the deprecated
 # attribute. Normally, we would just let the GenerateExportHeader
 # subsystem do this via configure check, but there appears to be a
@@ -320,6 +318,8 @@ endif()
 if(ENABLE_TESTS)
     enable_testing()
 endif()
+
+include(FetchMongoC)
 
 add_subdirectory(src)
 


### PR DESCRIPTION
Resolves CXX-3288. Split from https://github.com/mongodb/mongo-cxx-driver/pull/1403.

This PR delays the call to `include(FetchMongoC)` until _after_ all top-level cache variables have been initialized (notably, including the `ENABLE_TESTS` option) to avoid the C Driver's own cache variable initialization taking priority over the C++ Driver when conditionally importing the auto-downloaded C Driver via `add_subdirectory()`.

---

The auto-downloaded C Driver is observed to overwrite the default value (OFF) of the C++ Driver's `ENABLE_TESTS` cache variable with its own default (ON):

```
$ cmake -B local-build -LA
...
-- Required MongoDB C Driver libraries not found via find_package()
-- MongoDB C Driver library sources will be downloaded from GitHub
-- Downloading and configuring MongoDB C Driver 2.0.0...
...
-- Downloading Catch2... (!?)
...
-- Downloading Catch2... done.
...
ENABLE_TESTS:BOOL=ON (!?)
```

According to CMake documentation, `set()` [shouldn't](https://cmake.org/cmake/help/latest/command/set.html) overwrite an existing cache variable:

> Since cache entries are meant to provide user-settable values this does not overwrite existing cache entries by default. Use the `FORCE` option to overwrite existing entries.

The C++ Driver defines `ENABLE_TESTS` via [`option()`](https://github.com/mongodb/mongo-cxx-driver/blob/5edf0963b9dee8cc1d5c77f080c9467f87f26e63/CMakeLists.txt#L313), which creates a cache variable:

> In CMake project mode, a boolean cache variable is created with the option value.

However, the C++ Driver does so [long after](https://github.com/mongodb/mongo-cxx-driver/blob/5edf0963b9dee8cc1d5c77f080c9467f87f26e63/CMakeLists.txt#L52) the C Driver has already been imported via `include(FetchMongoC)`. This means the C Driver's `ENABLE_TESTS` cache variable initialization via `set(CACHE)` has priority over the C++ Driver's call to `option()` which is therefore ignored:

```
25  | option(BUILD_TESTING "When ENABLE_TESTS=ON, include test targets in the \"all\" target")
    .
52  | include(FetchMongoC) # Initializes the ENABLE_TESTS cache variable with "ON".
    .
313 | option(ENABLE_TESTS "Enable building test targets." OFF) # Too late!
    .
320 | if(ENABLE_TESTS)
321 |     enable_testing()
322 | endif()
323 |
324 | add_subdirectory(src) # Sees ENABLE_TESTS=ON -> calls include(FetchCatch2).
```

To fix this bug, this PR moves the `include(FetchMongoC)` to come _after_ `option(ENABLE_TESTS)` (and other top-level cache variables) and just before `add_subdirectory(src)` (where C Driver targets are required).