### PR TITLE
CXX-3288 do not initialize ENABLE_TESTS with the auto-downloaded C Driver

### DIFF
--- a/.evergreen/config_generator/components/macro_guards.py
+++ b/.evergreen/config_generator/components/macro_guards.py
@@ -47,8 +47,8 @@ def tasks():
                     Compile.call(
                         build_type='Debug',
                         compiler=compiler,
-                        vars={'COMPILE_MACRO_GUARD_TESTS': 'ON'},
-                    )
+                        vars={'COMPILE_MACRO_GUARD_TESTS': 'ON', 'ENABLE_TESTS': 'ON'},
+                    ),
                 ],
             )
         )

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -14187,6 +14187,7 @@ tasks:
       - func: compile
         vars:
           COMPILE_MACRO_GUARD_TESTS: "ON"
+          ENABLE_TESTS: "ON"
           build_type: Debug
   - name: macro-guards-rhel80-clang
     run_on: rhel80-large
@@ -14198,6 +14199,7 @@ tasks:
       - func: compile
         vars:
           COMPILE_MACRO_GUARD_TESTS: "ON"
+          ENABLE_TESTS: "ON"
           build_type: Debug
           cc_compiler: clang
           cxx_compiler: clang++
@@ -14211,6 +14213,7 @@ tasks:
       - func: compile
         vars:
           COMPILE_MACRO_GUARD_TESTS: "ON"
+          ENABLE_TESTS: "ON"
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ## 4.1.1 [Unreleased]
 
-<!-- Will contain entries for the next patch release. -->
+### Fixed
+
+- CMake option `ENABLE_TESTS` (`OFF` by default) is no longer overwritten by the auto-downloaded C Driver (`ON` by default) during CMake configuration.
 
 ## 4.1.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,8 +49,6 @@ set(BSON_REQUIRED_VERSION 2.0.0)
 set(MONGOC_REQUIRED_VERSION 2.0.0)
 set(MONGOC_DOWNLOAD_VERSION 2.0.0)
 
-include(FetchMongoC)
-
 # All of our target compilers support the deprecated
 # attribute. Normally, we would just let the GenerateExportHeader
 # subsystem do this via configure check, but there appears to be a
@@ -320,6 +318,8 @@ endif()
 if(ENABLE_TESTS)
     enable_testing()
 endif()
+
+include(FetchMongoC)
 
 add_subdirectory(src)
 


### PR DESCRIPTION
Cherry-picks https://github.com/mongodb/mongo-cxx-driver/pull/1404 onto the `releases/v4.1` branch targeting a 4.1.1 patch release as a bugfix.