### PR TITLE
CXX-3290 fix static pkgconfig requirements (#1406)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 ### Fixed
 
 - CMake option `ENABLE_TESTS` (`OFF` by default) is no longer overwritten by the auto-downloaded C Driver (`ON` by default) during CMake configuration.
+- Static pkg-config files are updated to depend on the static (not shared) libbson / libmongoc packages.
 
 ## 4.1.0
 

--- a/examples/projects/bsoncxx/pkg-config/shared/build.sh
+++ b/examples/projects/bsoncxx/pkg-config/shared/build.sh
@@ -5,11 +5,10 @@ set -o pipefail
 
 # Sanity-check that static library macros are not set when building against the shared library.
 # Users don't need to include this section in their projects.
-(pkg-config --cflags libbsoncxx | grep -v -- -DBSONCXX_STATIC) ||
-  (
-    echo "Expected BSONCXX_STATIC to not be set" >&2
-    exit 1
-  )
+if ! pkg-config --cflags libbsoncxx | grep -v -q -- -DBSONCXX_STATIC; then
+  echo "Expected BSONCXX_STATIC to not be set" >&2
+  exit 1
+fi
 
 rm -rf build/*
 cd build

--- a/examples/projects/bsoncxx/pkg-config/static/build.sh
+++ b/examples/projects/bsoncxx/pkg-config/static/build.sh
@@ -5,11 +5,16 @@ set -o pipefail
 
 # Sanity-check that static library macros are set when building against the static library.  Users
 # don't need to include this section in their projects.
-(pkg-config --cflags libbsoncxx-static | grep -- -DBSONCXX_STATIC) ||
-  (
-    echo "Expected BSONCXX_STATIC to be set" >&2
-    exit 1
-  )
+if ! pkg-config --cflags libbsoncxx-static | grep -q -- -DBSONCXX_STATIC; then
+  echo "Expected BSONCXX_STATIC to be set" >&2
+  exit 1
+fi
+
+# Sanity-check that static libbson is required. Regression test for CXX-3290.
+if ! pkg-config --print-requires libbsoncxx-static | grep -q -- bson2-static; then
+  echo "Expected bson2-static to be required" >&2
+  exit 1
+fi
 
 rm -rf build/*
 cd build

--- a/examples/projects/mongocxx/pkg-config/shared/build.sh
+++ b/examples/projects/mongocxx/pkg-config/shared/build.sh
@@ -5,16 +5,15 @@ set -o pipefail
 
 # Sanity-check that static library macros are not set when building against the shared library.
 # Users don't need to include this section in their projects.
-(pkg-config --cflags libmongocxx | grep -v -- -DBSONCXX_STATIC) ||
-  (
-    echo "Expected BSONCXX_STATIC to not be set" >&2
-    exit 1
-  )
-(pkg-config --cflags libmongocxx | grep -v -- -DMONGOCXX_STATIC) ||
-  (
-    echo "Expected MONGOCXX_STATIC to not be set" >&2
-    exit 1
-  )
+if ! pkg-config --cflags libmongocxx | grep -v -q -- -DBSONCXX_STATIC; then
+  echo "Expected BSONCXX_STATIC to not be set" >&2
+  exit 1
+fi
+
+if ! pkg-config --cflags libmongocxx | grep -v -q -- -DMONGOCXX_STATIC; then
+  echo "Expected MONGOCXX_STATIC to not be set" >&2
+  exit 1
+fi
 
 rm -rf build/*
 cd build

--- a/examples/projects/mongocxx/pkg-config/static/build.sh
+++ b/examples/projects/mongocxx/pkg-config/static/build.sh
@@ -5,16 +5,21 @@ set -o pipefail
 
 # Sanity-check that static library macros are set when building against the static library.  Users
 # don't need to include this section in their projects.
-(pkg-config --cflags libmongocxx-static | grep -- -DBSONCXX_STATIC) ||
-  (
-    echo "Expected BSONCXX_STATIC to be set" >&2
-    exit 1
-  )
-(pkg-config --cflags libmongocxx-static | grep -- -DMONGOCXX_STATIC) ||
-  (
-    echo "Expected MONGOCXX_STATIC to be set" >&2
-    exit 1
-  )
+if ! pkg-config --cflags libmongocxx-static | grep -q -- -DBSONCXX_STATIC; then
+  echo "Expected BSONCXX_STATIC to be set" >&2
+  exit 1
+fi
+
+if ! pkg-config --cflags libmongocxx-static | grep -q -- -DMONGOCXX_STATIC; then
+  echo "Expected MONGOCXX_STATIC to be set" >&2
+  exit 1
+fi
+
+# Sanity-check that static libmongoc is required. Regression test for CXX-3290.
+if ! pkg-config --print-requires libmongocxx-static | grep -q -- mongoc2-static; then
+  echo "Expected mongoc2-static to be required" >&2
+  exit 1
+fi
 
 rm -rf build/*
 cd build

--- a/src/bsoncxx/cmake/generate-pc.cmake
+++ b/src/bsoncxx/cmake/generate-pc.cmake
@@ -26,7 +26,7 @@ if(1)
     set(requires "")
 
     if(is_static)
-        list(APPEND requires "bson2 >= ${bson_req_ver}")
+        list(APPEND requires "bson2-static >= ${bson_req_ver}")
     endif()
 
     list(JOIN requires ", " requires)

--- a/src/mongocxx/cmake/generate-pc.cmake
+++ b/src/mongocxx/cmake/generate-pc.cmake
@@ -28,7 +28,7 @@ if(1)
 
     if(is_static)
         list(APPEND requires "lib${bsoncxx_name} >= ${version}")
-        list(APPEND requires "mongoc2 >= ${mongoc_req_ver}")
+        list(APPEND requires "mongoc2-static >= ${mongoc_req_ver}")
     else()
         list(APPEND requires "lib${bsoncxx_name} >= ${version}")
     endif()


### PR DESCRIPTION
Cherry-pick of https://github.com/mongodb/mongo-cxx-driver/commit/d688b3e635ab95b8935794a5e9e8d707f7e3ec78 with added changelog entry.