### PR TITLE
[v4.1] CXX-3296 fix build if `GCC/GNU/Clang/MSVC` macro defined (#1409)

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v1/detail/postlude.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/detail/postlude.hpp
@@ -64,6 +64,10 @@
 #pragma pop_macro("BSONCXX_PRIVATE_WARNINGS_DISABLE")
 #pragma pop_macro("BSONCXX_PRIVATE_WARNINGS_POP")
 #pragma pop_macro("BSONCXX_PRIVATE_WARNINGS_PUSH")
+#pragma pop_macro("Clang")
+#pragma pop_macro("GCC")
+#pragma pop_macro("GNU")
+#pragma pop_macro("MSVC")
 #endif
 
 #if !defined(BSONCXX_PRIVATE_V1_INSIDE_MACRO_GUARD_SCOPE)

--- a/src/bsoncxx/include/bsoncxx/v1/detail/prelude.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/detail/prelude.hpp
@@ -102,6 +102,14 @@
 #undef BSONCXX_PRIVATE_WARNINGS_PUSH
 #pragma push_macro("BSONCXX_PRIVATE_UNREACHABLE")
 #undef BSONCXX_PRIVATE_UNREACHABLE
+#pragma push_macro("Clang") // Guard since BSONCXX_PRIVATE_WARNINGS_DISABLE(Clang(...)) assumes Clang is not defined.
+#undef Clang
+#pragma push_macro("GCC") // Guard since BSONCXX_PRIVATE_WARNINGS_DISABLE(GCC(...)) assumes GCC is not defined.
+#undef GCC
+#pragma push_macro("GNU") // Guard since BSONCXX_PRIVATE_WARNINGS_DISABLE(GNU(...)) assumes GNU is not defined.
+#undef GNU
+#pragma push_macro("MSVC") // Guard since BSONCXX_PRIVATE_WARNINGS_DISABLE(MSVC(...)) assumes MSVC is not defined.
+#undef MSVC
 #endif
 
 ///

--- a/src/bsoncxx/test/CMakeLists.txt
+++ b/src/bsoncxx/test/CMakeLists.txt
@@ -123,6 +123,10 @@ if(ENABLE_MACRO_GUARD_TESTS)
             BSONCXX_PRIVATE_WARNINGS_DISABLE_IMPL_FOR_MSVC
             BSONCXX_PRIVATE_WARNINGS_POP
             BSONCXX_PRIVATE_WARNINGS_PUSH
+            Clang
+            GCC
+            GNU
+            MSVC
 
             # bsoncxx/v1/detail/prelude.hpp
             BSONCXX_PRIVATE_V1_INSIDE_MACRO_GUARD_SCOPE


### PR DESCRIPTION
Cherry-pick of https://github.com/mongodb/mongo-cxx-driver/commit/b5264f290678449f0bde768de7ea64149b95328a to releases/v4.1 branch.