### PR TITLE
CXX-3287 assume role before `pull-mongohouse-image.sh`

### DIFF
--- a/.evergreen/config_generator/components/mongohouse.py
+++ b/.evergreen/config_generator/components/mongohouse.py
@@ -17,18 +17,22 @@ TAG = 'mongohouse'
 
 class BuildMongohouse(Function):
     name = 'build_mongohouse'
-    commands = bash_exec(
-        command_type=EvgCommandType.SETUP,
-        script='''\
-            if [ ! -d "drivers-evergreen-tools" ]; then
-                git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git
-            fi
-            cd drivers-evergreen-tools
-            export DRIVERS_TOOLS=$(pwd)
+    commands = [
+        ec2_assume_role (role_arn='${aws_test_secrets_role}'),
+        bash_exec(
+            include_expansions_in_env=["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"],
+            command_type=EvgCommandType.SETUP,
+            script='''\
+                if [ ! -d "drivers-evergreen-tools" ]; then
+                    git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git
+                fi
+                cd drivers-evergreen-tools
+                export DRIVERS_TOOLS=$(pwd)
 
-            .evergreen/atlas_data_lake/pull-mongohouse-image.sh
-        '''
-    )
+                .evergreen/atlas_data_lake/pull-mongohouse-image.sh
+            '''
+        )
+    ]
 
 
 class RunMongohouse(Function):

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -201,20 +201,27 @@ functions:
         permissions: public-read
         remote_file: mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/rpm-packages.tar.gz
   build_mongohouse:
-    command: subprocess.exec
-    type: setup
-    params:
-      binary: bash
-      args:
-        - -c
-        - |
-          if [ ! -d "drivers-evergreen-tools" ]; then
-              git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git
-          fi
-          cd drivers-evergreen-tools
-          export DRIVERS_TOOLS=$(pwd)
+    - command: ec2.assume_role
+      params:
+        role_arn: ${aws_test_secrets_role}
+    - command: subprocess.exec
+      type: setup
+      params:
+        binary: bash
+        include_expansions_in_env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+        args:
+          - -c
+          - |
+            if [ ! -d "drivers-evergreen-tools" ]; then
+                git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git
+            fi
+            cd drivers-evergreen-tools
+            export DRIVERS_TOOLS=$(pwd)
 
-          .evergreen/atlas_data_lake/pull-mongohouse-image.sh
+            .evergreen/atlas_data_lake/pull-mongohouse-image.sh
   check augmented sbom:
     - command: ec2.assume_role
       type: setup


### PR DESCRIPTION
See DRIVERS-3188. Use `ec2.assume_role` to fix failing [test_mongohouse](https://spruce.mongodb.com/task/mongo_cxx_driver_mongohouse_test_mongohouse_b5264f290678449f0bde768de7ea64149b95328a_25_05_28_20_02_09/logs?execution=0) task:

```
An error occurred (AccessDenied) when calling the AssumeRole operation
```

Tested with this [patch build](https://spruce.mongodb.com/version/6838a3a876c89e000795b746).

The `aws_test_secrets_role` variable was added to the [Evergreen variables](https://spruce.mongodb.com/project/64f76a9057e85af0e130fd04/settings/variables) for the repo.


