### PR TITLE
Migrate EVG tasks from RHEL 7.6 to RHEL 7.9

### DIFF
--- a/.evergreen/config_generator/components/compile_only.py
+++ b/.evergreen/config_generator/components/compile_only.py
@@ -29,7 +29,7 @@ MATRIX = [
     ('rhel94',     'clang',    [11, 17, 20, 23]), # Clang 17.0 (max: C++23)
     ('rhel95',     'clang',    [11, 17, 20, 23]), # Clang 18.0 (max: C++23)
 
-    ('rhel76',     'gcc',    [11, 14,       ]), # GCC  4.8 (max: C++14)
+    ('rhel7.9',    'gcc',    [11, 14,       ]), # GCC  4.8 (max: C++14)
     ('rhel80',     'gcc',    [11, 17, 20,   ]), # GCC  8.2 (max: C++20)
     ('debian10',   'gcc-8',  [11, 17, 20,   ]), # GCC  8.3 (max: C++20)
     ('rhel84',     'gcc',    [11, 17, 20,   ]), # GCC  8.4 (max: C++20)

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -61,7 +61,7 @@ MACOS_ARM64_DISTROS = [
 ]
 
 RHEL_DISTROS = [
-    *ls_distro(name='rhel76', os='rhel', os_type='linux', os_ver='7.6'),
+    *ls_distro(name='rhel7.9', os='rhel', os_type='linux', os_ver='7.9'),
     *ls_distro(name='rhel80', os='rhel', os_type='linux', os_ver='8.0'),
     *ls_distro(name='rhel84', os='rhel', os_type='linux', os_ver='8.4'),
     *ls_distro(name='rhel90', os='rhel', os_type='linux', os_ver='9.0'),

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -428,9 +428,9 @@ tasks:
           BUILD_SHARED_AND_STATIC_LIBS: "ON"
           REQUIRED_CXX_STANDARD: 17
           build_type: Debug
-  - name: compile-only-rhel76-gcc-cxx11-debug
-    run_on: rhel76-large
-    tags: [compile-only, rhel76, cxx11, gcc, debug]
+  - name: compile-only-rhel7.9-gcc-cxx11-debug
+    run_on: rhel7.9-large
+    tags: [compile-only, rhel7.9, cxx11, gcc, debug]
     commands:
       - command: expansions.update
         params:
@@ -448,9 +448,9 @@ tasks:
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
-  - name: compile-only-rhel76-gcc-cxx14-debug
-    run_on: rhel76-large
-    tags: [compile-only, rhel76, cxx14, gcc, debug]
+  - name: compile-only-rhel7.9-gcc-cxx14-debug
+    run_on: rhel7.9-large
+    tags: [compile-only, rhel7.9, cxx14, gcc, debug]
     commands:
       - command: expansions.update
         params:


### PR DESCRIPTION
Per DevProd guidance. RHEL 7.9 is the latest RHEL 7 minor release and the one which is currently recommended for use by DevProd. This distro does not significantly change the available toolchain used for compilation test coverage (still GCC 4.8.5).