### PR TITLE
CXX-3300 update build-from-source minimum supported compiler versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 ### Changed
 
 - CMake 3.16.0 or newer is required when `ENABLE_TESTS=ON` for compatibility with the updated Catch2 library version (3.7.0 -> 3.8.1).
+- Minimum supported compiler versions to build from source are updated to the following:
+  - GCC 8.1 (from GCC 4.8.2).
+    - Users on RHEL 7 may consult Red Hat's ["Hello World - installing GCC on RHEL 7"](https://developers.redhat.com/HW/gcc-RHEL-7#) or ["How to install GCC 8 and Clang/LLVM 6 on Red Hat Enterprise Linux 7"](https://developers.redhat.com/blog/2019/03/05/yum-install-gcc-8-clang-6#) for instructions on how to obtain GCC 8 or newer.
+  - Clang 3.8 (from Clang 3.5).
+  - Apple Clang 13.1 with Xcode 13.4.1 (from Apple Clang 5.1 with Xcode 5.1).
+  - MSVC 19.0.24210 with Visual Studio 2015 Update 3 (from MSVC 19.0.23506 with Visual Studio 2015 Update 1).
 
 ## 4.1.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,20 +25,32 @@ set(CMAKE_MODULE_PATH
 option(BUILD_TESTING "When ENABLE_TESTS=ON, include test targets in the \"all\" target")
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.8.2")
-        message(FATAL_ERROR "Insufficient GCC version - GCC 4.8.2+ required")
+    # https://gcc.gnu.org/onlinedocs/libstdc++/manual/status.html
+    # https://gcc.gnu.org/projects/cxx-status.html
+    # https://gcc.gnu.org/releases.html
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8.1")
+        message(FATAL_ERROR "GCC 8.1 or newer is required")
     endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.0.23506")
-        message(FATAL_ERROR "Insufficient Microsoft Visual C++ version - MSVC 2015 Update 1+ required")
+    # https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering
+    # https://learn.microsoft.com/en-us/cpp/overview/compiler-versions
+    # https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.0.24210")
+        message(FATAL_ERROR "Visual Studio 13 2015 Update 3 or newer is required")
     endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.1")
-        message(FATAL_ERROR "Insufficient Apple clang version - XCode 5.1+ required")
+    # https://developer.apple.com/xcode/cpp/
+    # https://en.wikipedia.org/wiki/Xcode#Version_comparison_table
+    # https://trac.macports.org/wiki/XcodeVersionInfo
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "13.1")
+        message(FATAL_ERROR "Xcode 13.4.1 or newer is required")
     endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "3.5")
-        message(FATAL_ERROR "Insufficient clang version - clang 3.5+ required")
+    # https://releases.llvm.org/
+    # https://clang.llvm.org/cxx_status.html
+    # https://libcxx.llvm.org/#c-standards-conformance
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "3.8")
+        message(FATAL_ERROR "Clang 3.8 or newer is required")
     endif()
 else()
     message(WARNING "Unknown compiler... recklessly proceeding without a version check")


### PR DESCRIPTION
## Summary

This PR proposes updating our minimum compiler version requirements:

- GCC 4.8.2 -> GCC 8.1
- Clang 3.5 -> Clang 3.8
- Apple Clang 5.1 -> Apple Clang 13.3
- MSVC 19.0.23506 (VS 2015 Update 1) -> MSVC 19.0.24210 (VS 2015 Update 3)

> [!IMPORTANT]
> This PR only affects the _build from source_ requirements. These do not apply to users compiling or linking against our libraries; the requirements are not inherited by package config files, prebuilt libraries, or headers.

> [!NOTE]
> This PR is focused only on compiler support for the C++11 standard. Newer standards are not in scope. Other features or improvements such as debugging, diagnostics, platform compatibility, and performance are not in scope.

## Background

The [current](https://github.com/mongodb/mongo-cxx-driver/blob/f88307a20866a359a9a3fe620ad3882ff03dbbcd/CMakeLists.txt#L27-L45) minimum compiler version requirements have not been substantially updated since their introduction [in Jan 2016](https://github.com/mongodb/mongo-cxx-driver/commit/4d21b2df37f8a215438e46bf158f02f6581e4880) ([CXX-807](https://jira.mongodb.org/browse/CXX-807)) for the initial v3.0 release. They are long overdue for an update given changes to supported platforms and environments, EVG task coverage, C++ standard support by compilers, and the evolution of the codebase since these values were initially set.

The current state of minimum supported compiler versions are as follows.

### GCC 4.8.2 (October 2013)

This GCC version "contains experimental support for the second ISO C++ standard (2011)", "most of which have been implemented in an experimental C++11 mode". Notably missing features include:

- "Rvalue references for `*this`" despite [current usage](https://github.com/mongodb/mongo-cxx-driver/blob/bcfb268ec0d77e69908ea7b06dae1cca452c362c/src/bsoncxx/include/bsoncxx/v1/stdx/optional.hpp#L302-L309).
    - First seen: [January 2015](https://github.com/eramongodb/mongo-cxx-driver/blob/e736c885508e79c14b21ebb9f3f629ba48c3cac4/src/stdx/optional.hpp#L274) in `src/stdx/optional.hpp`.
- "Generalized attributes" despite [current usage](https://github.com/eramongodb/mongo-cxx-driver/blob/bcfb268ec0d77e69908ea7b06dae1cca452c362c/src/bsoncxx/include/bsoncxx/v1/stdx/optional.hpp#L91-L100).
    - First seen (tests only): [June 2020](https://github.com/eramongodb/mongo-cxx-driver/blob/55241d71e3c1b00bbb91186a6df6341d39f3c34f/src/third_party/catch/include/catch.hpp#L3848) in `src/third_party/catch/include/catch.hpp`.
    - First seen (library code): [February 2024](https://github.com/eramongodb/mongo-cxx-driver/blob/e21084eb26568ec4db799fe472e7b1adcbde26c8/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/optional.hpp#L70) in `src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/stdx/optional.hpp`.
- "Alignment support" despite [prior usage](https://github.com/eramongodb/mongo-cxx-driver/blob/0ca160d436bbb2cd08e65ff303947b3b2150dbe1/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/builder/core.cpp#L66) (removed by https://github.com/eramongodb/mongo-cxx-driver/commit/197e279e7237238f922b3b939d51fa1cc0ce0a23).
    - First seen: [Janurary 2015](https://github.com/eramongodb/mongo-cxx-driver/blob/fe429b58ffe6e887841940991886affc336781d4/src/bson/util/stack.hpp#L68) in `src/bson/util/stack.hpp`.

In short, GCC 4.8 does not fully support the C++11 standard. Compatibility with GCC 4.8, including dealing with numerous compiler bugs, have repeatedly caused pain over the years (plenty just for the C++ Driver, but also for libmongocrypt and the C Driver).

### Clang 3.5 (September 2014)

According to [C++ Support in Clang](https://clang.llvm.org/cxx_status.html#cxx11), "Clang 3.3 and later implement all of the ISO C++ 2011 standard." There is not much to say here: there is no notable issues with this compiler version.

### Apple Clang 5.1 (March 2014)

The Apple Clang compiler version number only [_roughly_](https://trac.macports.org/wiki/XcodeVersionInfo) corresponds to the Xcode version number. Additionally, the correspondance between Apple Clang and equivalent Clang/LLVM versions are also only roughly correlated, e.g. Apple Clang 5.1 corresponds to Clang 5.1, but uses LLVM 3.4. C++11 conformance documentation per release is [lacking](https://developer.apple.com/xcode/cpp/#c++11). The best we can do is assume support is consistent with the corresponding Clang version.

> [!TIP]
> "Apple Clang" is the compiler (+ toolchain). Xcode is the IDE that provides Apple Clang.

### MSVC 19.0.23506 (November 2015)

This version number corresponds to Visual Studio 2015 Update 1. The format is as reported by CMake's [`CMAKE_(C|CXX)_COMPILER_VERSION`](https://github.com/Kitware/CMake/blob/v3.15.0/Modules/Compiler/MSVC-DetermineCompiler.cmake) variable, derived from the [`_MSC_FULL_VER`](https://learn.microsoft.com/en-us/cpp/overview/compiler-versions) preprocessor macro. For clarity, the corresponding Visual Studio release version which (first) provides the given MSVC version will be mentioned alongside the MSVC version.

"Expression SFINAE" and "two-phase name lookup" are not supported until MSVC 19.14 (Visual Studio 2017). Tracking instances of these features in our codebase is difficult, but there are many cases of VS 2015 interfering with supposedly well-formed code (e.g. as far back as [Jan 2016](https://github.com/mongodb/mongo-cxx-driver/commit/025ebb2df0)). All other "C++03/11 Core language features" are labled as "Supported" since VS 2015. However, there are numerous conformance issues which are only toggled by the [`/permissive-`](https://learn.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance) flag, which is _not_ enabled by either `CMAKE_CXX_STANDARD_REQUIRED=ON` or `CMAKE_CXX_EXTENSIONS=OFF` ([cmake/cmake#17068](https://gitlab.kitware.com/cmake/cmake/-/issues/17068)). The set of [`/Zc:`](https://learn.microsoft.com/en-us/cpp/build/reference/zc-conformance) flags which are applied by default without `/permissive-` (which toggles _all_ of them) varies across MSVC releases.

> [!TIP]
> "Microsoft Visual C++" (MSVC) is the compiler (+ toolchain). "Visual Studio" is the IDE that provides MSVC.

> [!NOTE]
> We do not currently document or enforce minimum compatibility requirements for the ["Windows SDK"](https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_VERSION.html) or ["Platform Toolset"](https://cmake.org/cmake/help/latest/variable/CMAKE_VS_PLATFORM_TOOLSET_VERSION.html). However, the toolset version is included in the [ABI tag suffix](https://github.com/mongodb/mongo-cxx-driver/blob/f88307a20866a359a9a3fe620ad3882ff03dbbcd/cmake/BsoncxxUtil.cmake#L86-L89) when built with MSVC.

### Current Compilation Coverage

The lowest compiler versions (per CMake output) currently tested by our EVG config are:

- GCC 4.8.5 (June 2015) on `rhel7.9-latest`.
- Clang 7.0.1 (Sep 2023) on `rhel80`.
- Apple Clang 15.0.0 (Sep 2023) on `macos-14-arm64`.
- MSVC: 19.0.24223 ([March 2019](https://support.microsoft.com/en-us/topic/march-26-2019-kb4490481-os-build-17763-402-c323e5c1-d524-dbdb-04a0-c3b5c8c8f2fd)) on `windows-vsCurrent`.

## Proposal

This PR proposes updating our minimum compiler version requirements to better match our actual requirements, to avoid continued backward compatibility support with long-unsupported compiler versions, and to hopefully help pave the way to refine our documentation for supported targets by specifying compiler version rather than specific operating system release versions (e.g. RHEL 7, Ubuntu 20.04, etc.). Support for specific operating systems would continue to (indirectly) inform our minimum supported compiler versions (e.g. see below concerning GCC on RHEL 7).

The proposed minimum compiler versions are as follows.

### GCC 8.1 (May 2018)

The ["C++ Standards Support in GCC"](https://gcc.gnu.org/projects/cxx-status.html#cxx11) page states:

> GCC 4.8.1 was the first feature-complete implementation of the 2011 C++ standard, previously known as C++0x.

and the libstdc++ doc's ["Implementation Status"](https://gcc.gnu.org/onlinedocs/libstdc++/manual/status.html#status.iso.2011) section states:

> GCC 5.1 was the first release with non-experimental C++11 support, so the API and ABI of features added in C++11 is only stable since that release.

However, [GCC 5 release notes](https://gcc.gnu.org/onlinedocs/gcc-5.4.0/gcc/Standards.html#Standards) state:

>  C++11 contains several changes to the C++ language, most of which have been implemented in **an experimental C++11 mode** in GCC.

> [!NOTE]
> As an aside, GCC 5 satisfies the C Driver's C99 conformance requirement:
>
> > GCC has substantially complete support for this standard version; see http://gcc.gnu.org/c99status.html for details.

GCC 6 is the first release whose [notes](https://gcc.gnu.org/onlinedocs/gcc-6.1.0/gcc/Standards.html#Standards) declare full support for the C++11 standard:

> C++11 contains several changes to the C++ language, **all of which have been implemented** in GCC.

Therefore, GCC 6 is the minimum compiler version which fully satisfies our [long-standing](https://github.com/mongodb/mongo-cxx-driver/commit/3991de721d48ec6aa70262c31d59f4529991d957) C++11 or newer requirement. However, this PR proposes going further and raising the minimum to GCC 8 instead. RHEL also bumped their default provided toolchain from GCC 4.8 on RHEL 7 straight to GCC 8 on RHEL 8. For comparison with other Linux distros we currently support, Ubuntu 20.04 LTS provides GCC 9 [by default](https://documentation.ubuntu.com/ubuntu-for-developers/reference/availability/gcc/) (but GCC 8 is also [available](https://launchpad.net/ubuntu/+source/gcc-8)) and Debian 10 provides GCC 8 [by default](https://packages.debian.org/buster/gcc).

> [!TIP]
> GCC uses a versioning scheme where X.0 is reserved for development and X.1 is the first minor version for the public release. Therefore, GCC 8.1 is the first official GCC 8 release version; there is no GCC 8.0. LLVM also started using this versioning scheme beginning with Clang 18.1.

The oldest particular operating system we currently need to continue supporting (per Drivers Maintainability & Compatibility Policy) is RHEL 7, which distributes GCC 4.8.x:

- [RHEL 7 Docs: "10. Compiler and Tools"](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/7/html/7.0_release_notes/chap-red_hat_enterprise_linux-7.0_release_notes-compiler_and_tools)
- [RHEL Knowledgebase: "What gcc versions are available in Red Hat Enterprise Linux?"](https://access.redhat.com/solutions/19458)
- [RHEL Customer Portal: "Product Life Cycle of Red Hat Software Collections for Red Hat Enterprise Linux 7"](https://access.redhat.com/support/policy/updates/rhscl-rhel7)

However, MongoDB Server's support for RHEL 7 concerns the use of _prebuilt binaries_ which _target_ the operating system's environment. It is not support for _building_ the server from source on RHEL 7 as a _host_. On the other hand, the C++ Driver's support for RHEL 7 currently requires being able to build on RHEL 7 as a host, as we do not yet support a strategy for prebuilt binary distribution or cross-compilation.

Therefore, rather than continuing to support GCC 4.8 due to RHEL 7 compatibility, this PR proposes that we instead require users who build the C++ Driver libraries from source on RHEL 7 to install a "Red Hat Developer Toolset" (DTS) which provides a sufficiently recent GCC compiler version that satisfies our minimum requirements. According to multiple official Red Hat articles , the ability to install GCC 8 on RHEL 7 via DTS is an expected workflow:

- ["Hello World - installing GCC on RHEL 7"](https://developers.redhat.com/HW/gcc-RHEL-7) (Feb 2019)
- ["How to install GCC 8 and Clang/LLVM 6 on Red Hat Enterprise Linux 7 "](https://developers.redhat.com/blog/2019/03/05/yum-install-gcc-8-clang-6) (Mar 2019)
- ["Developer Toolset 8.1 and GCC 8.3 now available for Red Hat Enterprise Linux 7"](https://developers.redhat.com/blog/2019/06/20/developer-toolset-8-1-and-gcc-8-3-now-available-for-red-hat-enterprise-linux-7) (Jun 2019)

> [!NOTE]
> Red Hat Developer Toolsets (e.g. `devtoolset-N`) are EOL. The latest version, DTS 12, was "retired" in June 2024. They have been succeeded by ["GCC Toolsets"](https://catalog.redhat.com/software/containers/rhel8/gcc-toolset-13-toolchain/6467657ba2c025a6e86d2e2e) (e.g. `gcc-toolset-N-toolchain`) which are distributed via [Red Hat Software Collections](https://developers.redhat.com/products/red-hat-software-collections/overview) (RHSCL).

> [!NOTE]
> The Linux Kernel [recently](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=dee264c16a6334dcdbea5c186f5ff35f98b1df42) (May 2025) updated their own minimum required compiler version from GCC 5 to GCC 8. The minimum was raised from GCC 4.9 to GCC 5 in [Sep 2021](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=316346243be6df12799c0b64b788e06bad97c30b). GCC 4.8 was dropped in [July 2020](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=6ec4476ac82512f09c94aff5972654b70f3772b2) with this particularly notable remark:
>
> > The latest (in a long string) of reasons for minimum compiler version
upgrades was commit 5435f73d5c4a ("efi/x86: Fix build with gcc 4"). Ard points out that RHEL 7 uses gcc-4.8, but the people who stay back on old RHEL versions persumably also don't build their own kernels anyway. And maybe they should cross-built or just have a little side affair with a newer compiler?

### Clang 3.8 (March 2016)

Although Clang 3.5 seems to fully support the C++11, I would like to propose raising it to 3.8 anyways for the following reasons:

- libc++ 3.8 is the oldest release for which I can find [doc pages](https://releases.llvm.org/3.8.0/projects/libcxx/docs/index.html) which state "C++11 Support: Complete".
- Clang 3.8 includes some [minor C++11 conformance improvements](https://releases.llvm.org/3.9.0/tools/clang/docs/ReleaseNotes.html#id1).

Even though our current compilation task coverage only goes back as far as Clang 7.0, I do not think we need to raise the minimum requirement to exactly match our current coverage for this case. Therefore, I think Clang 3.8 is a reasonable interim requirement. That being said, if we want to raise the Clang version to one that is comparable to GCC 8 w.r.t. recency, Red Hat suggests [Clang 6](https://developers.redhat.com/blog/2019/03/05/yum-install-gcc-8-clang-6#) (March 2018) may be a good pick.

> [!NOTE]
> Clang 5.0 is the [last release](https://releases.llvm.org/5.0.0/tools/clang/docs/ReleaseNotes.html) which defaults to `-std=gnu++98` (changed to `-std=gnu++14` in Clang 6.0) and the first release to fully support the C++17 standard. (When the minimum required C++ standard is raised to C++17, this would be the corresponding minimum required Clang version.)

### Apple Clang 13.1 (October 2021)

To match the Clang 3.8 requirement, the minimum required equivalent version would be Apple Clang 4.5 (Xcode 4.5 on Mac OS X 10.7). However, we [deprecated](https://github.com/mongodb/mongo-cxx-driver/commit/c609e3e05a60c8011e3e7d31adb61b4c568049eb) support for MacOS 12 and older in the 4.1.0 release ([CXX-3194](https://jira.mongodb.org/browse/CXX-3194)). This means the oldest Apple Clang version we actually _need_ to support is really Apple Clang 13.1.6 (with Xcode 13.4.1 on MacOS 13), which corresponds to Clang 13.1.6 (with LLVM 13.0). This minimum requirement should suffice for now until we drop support for MacOS 13 as well after it reaches EOL. Upgrading from Xcode 5.1 to Xcode 13 will include [several](https://developer.apple.com/documentation/xcode-release-notes/) C++11 conformance improvements.

> [!NOTE]
> Xcode 13 is apparently too old to be worth mentioning under "Other Xcode versions" in their [Xcode versions list](https://developer.apple.com/support/xcode/). The [release notes](https://developer.apple.com/documentation/xcode-release-notes/) page only goes back as far as Xcode 10.0.

### MSVC 19.0.24210 (June 2016)

This corresponds to "Visual Studio 2015 Update 3", the latest and last release for Visual Studio 2015. This is just an interim update before we drop support for VS 2015 entirely with [CXX-3215](https://jira.mongodb.org/browse/CXX-3215) (EOL on Oct 2025). The bump from Update 1 to Update 3 includes:

- [Update 2](https://mongodb.slack.com/archives/GMY98JS86/p1749227566827219):
    - "Enhanced support" for C++11.
    - "More than 300 compiler bugs" fixed.
    - Full implementation of C++11 relative to N4567 (Nov 2015).
- [Update 3](https://learn.microsoft.com/en-us/visualstudio/releasenotes/vs2015-update3-vs): 
    - Some C++11 conformance improvements (trivial copy/move ctors, `std::is_convertible`).

The next bump would be up to MSVC 19.10.25017 (Visual Studio 2017 v15.0). Aside from some improvements to expression SFINAE and two-phase name lookup in MSVC 19.14 (VS 2017 v15.7), I do not think there any need to raise the minimum any higher until the minimum required C++ standard is raised to C++14 or newer.
