### PR TITLE
Update bsoncxx validation examples for CDRIVER-5710 and CDRIVER-6017

### DIFF
--- a/.evergreen/config_generator/components/funcs/install_c_driver.py
+++ b/.evergreen/config_generator/components/funcs/install_c_driver.py
@@ -14,7 +14,7 @@ from typing import Mapping
 # Only MONGOC_DOWNLOAD_VERSION needs to be updated when pinning to an unreleased commit.
 # If pinning to an unreleased commit, create a "Blocked" JIRA ticket with
 # a "depends on" link to the appropriate C Driver version release ticket.
-MONGOC_VERSION_MINIMUM = '2.0.0'
+MONGOC_VERSION_MINIMUM = '2.0.2'
 
 
 class InstallCDriver(Function):

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -443,7 +443,7 @@ functions:
       type: setup
       params:
         updates:
-          - { key: mongoc_version_minimum, value: 2.0.0 }
+          - { key: mongoc_version_minimum, value: 2.0.2 }
     - command: subprocess.exec
       type: setup
       params:

--- a/examples/api/bsoncxx/examples/validation/basic_usage.cpp
+++ b/examples/api/bsoncxx/examples/validation/basic_usage.cpp
@@ -61,8 +61,8 @@ void example() {
 
         EXPECT(bsoncxx::validate(data, length) == bsoncxx::validate(data, length, options, &offset));
 
-        // Not set when valid.
-        EXPECT(offset == 123u);
+        // Set to 0 when valid.
+        EXPECT(offset == 0u);
     }
 }
 // [Example]

--- a/examples/api/bsoncxx/examples/validation/validator.cpp
+++ b/examples/api/bsoncxx/examples/validation/validator.cpp
@@ -77,8 +77,8 @@ void example(std::uint8_t const* bytes, std::size_t length) {
 
         EXPECT(!bsoncxx::validate(bytes, length, options, &offset));
 
-        // Offset of `"$numberInt": "123"` relative to start of the sub-document. (CDRIVER-5710)
-        EXPECT(offset == 4u);
+        // Offset of `"$numberInt": "123"` relative to start of the document.
+        EXPECT(offset == 31u);
     }
 }
 // [Example]


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/2026 which addressed CDRIVER-5710 and CDRIVER-6017. The changes in https://github.com/mongodb/mongo-c-driver/commit/d184525513e5bf21f30810c00d6b0094aac8b00c affect a few in the C++ Driver which demonstrate use of `bsoncxx::v_noabi::validate()` including the expected error offsets. Because the offsets are now changed/fixed, these examples need to be updated to run successfully.

This PR bumps the C Driver version on Evergreen to 2.0.2 for testing only. It does not bump the minimum required C Driver version for downstream users. We can also raise the minimum required C Driver version for downstream users if that is preferable (CXX-3302), but I do not think it is necessary at this time.

Alternatively we can defer applying this PR until the minimum required C Driver version for downstream users is bumped instead (e.g. when C Driver 2.1.0 is released).