### PR TITLE
Fix mongo-c-driver version compatibility check tests

### DIFF
--- a/src/bsoncxx/test/private/bson_version.cpp
+++ b/src/bsoncxx/test/private/bson_version.cpp
@@ -55,11 +55,15 @@ TEST_CASE("bson version numbers", "[bsoncxx][test]") {
     CHECK(bson_get_major_version() == expect[0]);
 
     CHECKED_IF(expect.size() > 1) {
-        CHECK(bson_get_minor_version() >= expect[1]);
+        auto const minor = bson_get_minor_version();
 
-        // Only when minor version number compares equal.
-        CHECKED_IF(expect.size() > 2) {
-            CHECK(bson_get_micro_version() >= expect[2]);
+        CHECK(minor >= expect[1]);
+
+        // Only compare patch version number when minor version number compares equal.
+        CHECKED_IF(minor == expect[1]) {
+            CHECKED_IF(expect.size() > 2) {
+                CHECK(bson_get_micro_version() >= expect[2]);
+            }
         }
     }
 }
@@ -89,12 +93,14 @@ TEST_CASE(
         // Minor version number.
         CHECK(actual[1] >= expect[1]);
 
-        // Only when minor version number compares equal.
-        CHECKED_IF(expect.size() > 2) {
-            REQUIRE(actual.size() > 2);
+        // Only compare patch version number when minor version number compares equal.
+        CHECKED_IF(actual[1] == expect[1]) {
+            CHECKED_IF(expect.size() > 2) {
+                REQUIRE(actual.size() > 2);
 
-            // Patch version number.
-            CHECK(actual[2] >= expect[2]);
+                // Patch version number.
+                CHECK(actual[2] >= expect[2]);
+            }
         }
     }
 }

--- a/src/mongocxx/test/private/mongoc_version.cpp
+++ b/src/mongocxx/test/private/mongoc_version.cpp
@@ -40,18 +40,20 @@ TEST_CASE("mongoc version numbers", "[mongocxx][test]") {
     CHECK(mongoc_get_major_version() == expect[0]);
 
     CHECKED_IF(expect.size() > 1) {
-        CHECK(bson_get_minor_version() >= expect[1]);
+        auto const minor = mongoc_get_minor_version();
 
-        // Only when minor version number compares equal.
-        CHECKED_IF(expect.size() > 2) {
-            CHECK(bson_get_micro_version() >= expect[2]);
+        CHECK(minor >= expect[1]);
+
+        // Only compare patch version number when minor version number compares equal.
+        CHECKED_IF(minor == expect[1]) {
+            CHECKED_IF(expect.size() > 2) {
+                CHECK(mongoc_get_micro_version() >= expect[2]);
+            }
         }
     }
 }
 
-TEST_CASE(
-    "mongoc version string"
-    "[mongocxx][test]") {
+TEST_CASE("mongoc version string", "[mongocxx][test]") {
     auto const expect_str = bsoncxx::stdx::string_view{MONGOC_REQUIRED_VERSION()};
     auto const actual_str = bsoncxx::stdx::string_view{MONGOC_VERSION_S};
 
@@ -74,12 +76,14 @@ TEST_CASE(
         // Minor version number.
         CHECK(actual[1] >= expect[1]);
 
-        // Only when minor version number compares equal.
-        CHECKED_IF(expect.size() > 2) {
-            REQUIRE(actual.size() > 2);
+        // Only compare patch version number when minor version number compares equal.
+        CHECKED_IF(actual[1] == expect[1]) {
+            CHECKED_IF(expect.size() > 2) {
+                REQUIRE(actual.size() > 2);
 
-            // Patch version number.
-            CHECK(actual[2] >= expect[2]);
+                // Patch version number.
+                CHECK(actual[2] >= expect[2]);
+            }
         }
     }
 }


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1379 and https://github.com/mongodb/mongo-cxx-driver/pull/1416.

Despite https://github.com/mongodb/mongo-cxx-driver/pull/1379 including [comments](https://github.com/mongodb/mongo-cxx-driver/blob/69c5fc2934d0dce571132aaa35dc5cafc86d62c2/src/bsoncxx/test/version.cpp#L92) implying the patch version number is only checked when the minor version numbers are equal following a [suggestion](https://github.com/mongodb/mongo-cxx-driver/pull/1379#discussion_r2045183395) describing exactly this scenario, the `CHECKED_IF` conditions do not actually do as described. This bug is exposed by https://github.com/mongodb/mongo-cxx-driver/pull/1416 (`2.1.0-dev` vs. `2.0.2`):

```
src/bsoncxx/test/private/bson_version.cpp:62: FAILED:
  CHECK( bson_get_micro_version() >= expect[2] )
with expansion:
  0 >= 2
with message:
  expect_str := "2.0.2"
```

This PR fixes the version compat test cases to _actually_ only compare the patch version numbers when the minor version numbers compare equal. The "mongoc version numbers" test case was also incorrectly calling `bson_get_micro_version` instead of `mongoc_get_micro_version`.

```
src/bsoncxx/test/private/bson_version.cpp:63: FAILED - but was ok:
  CHECKED_IF( minor == expect[1] )
with expansion:
  1 == 0
with message:
  expect_str := "2.0.2"
```