### PR TITLE
Apply post-r4.1.1 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
   - Apple Clang 13.1 with Xcode 13.4.1 (from Apple Clang 5.1 with Xcode 5.1).
   - MSVC 19.0.24210 with Visual Studio 2015 Update 3 (from MSVC 19.0.23506 with Visual Studio 2015 Update 1).
 
+## 4.1.1
+
+### Fixed
+
+- CMake option `ENABLE_TESTS` (`OFF` by default) is no longer overwritten by the auto-downloaded C Driver (`ON` by default) during CMake configuration.
+- Static pkg-config files are updated to depend on the static (not shared) libbson / libmongoc packages.
+- Fix build if macros `GCC`/`GNU`/`Clang`/`MSVC` are already defined.
+
+
 ## 4.1.0
 
 ### Fixed

--- a/Doxyfile
+++ b/Doxyfile
@@ -1602,7 +1602,7 @@ TOC_EXPAND             = NO
 # protocol see https://www.sitemaps.org
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-SITEMAP_URL            = https://mongocxx.org/api/mongocxx-4.1.0/
+SITEMAP_URL            = https://mongocxx.org/api/mongocxx-4.1.1/
 
 # If the GENERATE_QHP tag is set to YES and both QHP_NAMESPACE and
 # QHP_VIRTUAL_FOLDER are set, an additional index file will be generated that

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ git clone -b releases/stable https://github.com/mongodb/mongo-cxx-driver.git
 | Version     | ABI Stability   | Development Stability       | Development Status |
 | :---------: | :-------------: | :-------------------------: | :----------------: |
 | master      | N/A             | _Do not use in production!_ | Active             |
-| 4.1.0       | None            | Ready for Use               | Bug Fixes Only     |
+| 4.1.1       | None            | Ready for Use               | Bug Fixes Only     |
+| 4.1.0       | None            | Ready for Use               | Not Supported      |
 | 4.0.0       | None            | Ready for Use               | Not Supported      |
 | 3.11.0      | None            | Ready for Use               | Bug Fixes Only     |
 | 3.10.2      | None            | Ready for Use               | Not Supported      |

--- a/etc/apidocmenu.md
+++ b/etc/apidocmenu.md
@@ -2,7 +2,7 @@
 
 ## Driver Documentation By Version
 
-[4.1.0](../mongocxx-4.1.0) | [4.0.0](../mongocxx-4.0.0) | [3.11.0](../mongocxx-3.11.0) | [3.10.2](../mongocxx-3.10.2) | [3.10.1](../mongocxx-3.10.1) | [3.10.0](../mongocxx-3.10.0) | [3.9.0](../mongocxx-3.9.0) | [3.8.1](../mongocxx-3.8.1) | [3.8.0](../mongocxx-3.8.0) | [3.7.2](../mongocxx-3.7.2) | [3.7.1](../mongocxx-3.7.1) | [3.7.0](../mongocxx-3.7.0) | [3.6.7](../mongocxx-3.6.7) | [3.6.6](../mongocxx-3.6.6) | [3.6.5](../mongocxx-3.6.5) | [3.6.4](../mongocxx-3.6.4) | [3.6.3](../mongocxx-3.6.3) | [3.6.2](../mongocxx-3.6.2) | [3.6.1](../mongocxx-3.6.1) | [3.6.0](../mongocxx-3.6.0) | [3.5.1](../mongocxx-3.5.1) | [3.5.0](../mongocxx-3.5.0) | [3.4.2](../mongocxx-3.4.2) | [3.4.1](../mongocxx-3.4.1) | [3.4.0](../mongocxx-3.4.0) | [3.3.2](../mongocxx-3.3.2) | [3.3.1](../mongocxx-3.3.1) | [3.3.0](../mongocxx-3.3.0) | [3.2.1](../mongocxx-3.2.1) | [3.2.0](../mongocxx-3.2.0) | [3.1.4](../mongocxx-3.1.4/) | [3.1.3](../mongocxx-3.1.3/) | [3.1.2](../mongocxx-3.1.2/) | [3.1.1](../mongocxx-3.1.1/) | [3.1.0](../mongocxx-3.1.0/) | [3.0.3](../mongocxx-3.0.3/) | [3.0.2](../mongocxx-3.0.2/) | [3.0.1](../mongocxx-3.0.1/) | [3.0.0](../mongocxx-3.0.0/)
+[4.1.1](../mongocxx-4.1.1) | [4.1.0](../mongocxx-4.1.0) | [4.0.0](../mongocxx-4.0.0) | [3.11.0](../mongocxx-3.11.0) | [3.10.2](../mongocxx-3.10.2) | [3.10.1](../mongocxx-3.10.1) | [3.10.0](../mongocxx-3.10.0) | [3.9.0](../mongocxx-3.9.0) | [3.8.1](../mongocxx-3.8.1) | [3.8.0](../mongocxx-3.8.0) | [3.7.2](../mongocxx-3.7.2) | [3.7.1](../mongocxx-3.7.1) | [3.7.0](../mongocxx-3.7.0) | [3.6.7](../mongocxx-3.6.7) | [3.6.6](../mongocxx-3.6.6) | [3.6.5](../mongocxx-3.6.5) | [3.6.4](../mongocxx-3.6.4) | [3.6.3](../mongocxx-3.6.3) | [3.6.2](../mongocxx-3.6.2) | [3.6.1](../mongocxx-3.6.1) | [3.6.0](../mongocxx-3.6.0) | [3.5.1](../mongocxx-3.5.1) | [3.5.0](../mongocxx-3.5.0) | [3.4.2](../mongocxx-3.4.2) | [3.4.1](../mongocxx-3.4.1) | [3.4.0](../mongocxx-3.4.0) | [3.3.2](../mongocxx-3.3.2) | [3.3.1](../mongocxx-3.3.1) | [3.3.0](../mongocxx-3.3.0) | [3.2.1](../mongocxx-3.2.1) | [3.2.0](../mongocxx-3.2.0) | [3.1.4](../mongocxx-3.1.4/) | [3.1.3](../mongocxx-3.1.3/) | [3.1.2](../mongocxx-3.1.2/) | [3.1.1](../mongocxx-3.1.1/) | [3.1.0](../mongocxx-3.1.0/) | [3.0.3](../mongocxx-3.0.3/) | [3.0.2](../mongocxx-3.0.2/) | [3.0.1](../mongocxx-3.0.1/) | [3.0.0](../mongocxx-3.0.0/)
 
 ## Driver Development Status
 
@@ -12,7 +12,8 @@
 | Version     | ABI Stability   | Development Stability       | Development Status |
 | :---------: | :-------------: | :-------------------------: | :----------------: |
 | master      | N/A             | _Do not use in production!_ | Active             |
-| 4.1.0       | None            | Ready for Use               | Bug Fixes Only     |
+| 4.1.1       | None            | Ready for Use               | Bug Fixes Only     |
+| 4.1.0       | None            | Ready for Use               | Not Supported      |
 | 4.0.0       | None            | Ready for Use               | Not Supported      |
 | 3.11.0      | None            | Ready for Use               | Bug Fixes Only     |
 | 3.10.2      | None            | Ready for Use               | Not Supported      |

--- a/etc/augmented.sbom.json
+++ b/etc/augmented.sbom.json
@@ -33,7 +33,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2025-06-12T17:36:20.890153+00:00",
+    "timestamp": "2025-07-01T14:54:54.875217+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -76,7 +76,7 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:c1c87561-6868-46b2-9e0c-d2f7f3bdf028",
+  "serialNumber": "urn:uuid:f6bad0a4-0ad0-4f8f-afce-5aae6a7d8a0f",
   "version": 1,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -33,7 +33,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2025-06-12T17:36:20.890153+00:00",
+    "timestamp": "2025-07-01T14:54:54.875217+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -76,7 +76,7 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:c1c87561-6868-46b2-9e0c-d2f7f3bdf028",
+  "serialNumber": "urn:uuid:f6bad0a4-0ad0-4f8f-afce-5aae6a7d8a0f",
   "version": 1,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",

--- a/etc/generate-latest-apidocs.sh
+++ b/etc/generate-latest-apidocs.sh
@@ -10,7 +10,7 @@
 set -o errexit
 set -o pipefail
 
-LATEST_VERSION="4.1.0"
+LATEST_VERSION="4.1.1"
 DOXYGEN_VERSION_REQUIRED="1.13.2"
 
 # Permit using a custom Doxygen binary.


### PR DESCRIPTION
Applying changes following [release steps](https://github.com/mongodb/mongo-cxx-driver/blob/93fa969ada72f89639e95c76214a634357cab793/etc/releasing.md#merge-post-release-changes) after r4.1.1 release.