### PR TITLE
Update Clang 18 -> Clang 19 for rhel95 distro

### DIFF
--- a/.evergreen/config_generator/components/abi_stability.py
+++ b/.evergreen/config_generator/components/abi_stability.py
@@ -147,7 +147,7 @@ def generate_tasks():
         if func is Abidiff:
             distro_name = 'ubuntu2204'  # Clang 12, libabigail is not available on RHEL distros.
         else:
-            distro_name = 'rhel95'  # Clang 18.
+            distro_name = 'rhel95'  # Clang 19.
 
         distro = find_large_distro(distro_name)
 

--- a/.evergreen/config_generator/components/compile_only.py
+++ b/.evergreen/config_generator/components/compile_only.py
@@ -18,16 +18,16 @@ TAG = 'compile-only'
 MATRIX = [
     # C++ standard and compiler coverage
 
-    ('rhel80',     'clang',    [11, 17, 20,   ]), # Clang  7.0 (max: C++20)
-    ('ubuntu2004', 'clang-10', [11, 17, 20,   ]), # Clang 10.0 (max: C++20)
-    ('rhel84',     'clang',    [11, 17, 20,   ]), # Clang 11.0 (max: C++20)
-    ('ubuntu2204', 'clang-12', [11, 17, 20, 23]), # Clang 12.0 (max: C++23)
-    ('rhel90',     'clang',    [11, 17, 20, 23]), # Clang 13.0 (max: C++23)
-    ('rhel91',     'clang',    [11, 17, 20, 23]), # Clang 14.0 (max: C++23)
-    ('rhel92',     'clang',    [11, 17, 20, 23]), # Clang 15.0 (max: C++23)
-    ('rhel93',     'clang',    [11, 17, 20, 23]), # Clang 16.0 (max: C++23)
-    ('rhel94',     'clang',    [11, 17, 20, 23]), # Clang 17.0 (max: C++23)
-    ('rhel95',     'clang',    [11, 17, 20, 23]), # Clang 18.0 (max: C++23)
+    ('rhel80',     'clang',    [11, 17, 20,   ]), # Clang  7 (max: C++20)
+    ('ubuntu2004', 'clang-10', [11, 17, 20,   ]), # Clang 10 (max: C++20)
+    ('rhel84',     'clang',    [11, 17, 20,   ]), # Clang 11 (max: C++20)
+    ('ubuntu2204', 'clang-12', [11, 17, 20, 23]), # Clang 12 (max: C++23)
+    ('rhel90',     'clang',    [11, 17, 20, 23]), # Clang 13 (max: C++23)
+    ('rhel91',     'clang',    [11, 17, 20, 23]), # Clang 14 (max: C++23)
+    ('rhel92',     'clang',    [11, 17, 20, 23]), # Clang 15 (max: C++23)
+    ('rhel93',     'clang',    [11, 17, 20, 23]), # Clang 16 (max: C++23)
+    ('rhel94',     'clang',    [11, 17, 20, 23]), # Clang 17 (max: C++23)
+    ('rhel95',     'clang',    [11, 17, 20, 23]), # Clang 19 (max: C++23)
 
     ('rhel7.9',    'gcc',    [11, 14,       ]), # GCC  4.8 (max: C++14)
     ('rhel80',     'gcc',    [11, 17, 20,   ]), # GCC  8.2 (max: C++20)

--- a/.evergreen/scripts/abi-stability-setup.sh
+++ b/.evergreen/scripts/abi-stability-setup.sh
@@ -67,9 +67,9 @@ mkdir -p "${working_dir}/install"
 # For latest Clang versions supporting recent C++ standards.
 export CC CXX
 case "${distro_id:?}" in
-rhel9*)
-  CC="clang-18"
-  CXX="clang++-18"
+rhel95)
+  CC="clang-19"
+  CXX="clang++-19"
   ;;
 ubuntu22*)
   CC="clang-12"


### PR DESCRIPTION
Fixes the `abi-prohibited-symbols-*` tasks which expect Clang 18 to be available on the `rhel95` distro. However, the `rhel95` distro image was recently updated to provide Clang 19 instead. Verified by [this patch](https://spruce.mongodb.com/version/686eab8edfbd34000795ae0d/).