### PR TITLE
Address miscellaneous Clang warnings

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v1/detail/type_traits.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/detail/type_traits.hpp
@@ -479,6 +479,8 @@ struct is_equality_comparable : decltype(is_equality_comparable_f<L, R>(0)) {};
 template <typename L, typename R>
 std::false_type is_partially_ordered_with_f(rank<0>);
 
+BSONCXX_PRIVATE_WARNINGS_PUSH();
+BSONCXX_PRIVATE_WARNINGS_DISABLE(Clang("-Wordered-compare-function-pointers"));
 template <typename L, typename R>
 auto is_partially_ordered_with_f(rank<1>) -> true_t<
     decltype(std::declval<L const&>() > std::declval<R const&>()),
@@ -489,6 +491,7 @@ auto is_partially_ordered_with_f(rank<1>) -> true_t<
     decltype(std::declval<R const&>() > std::declval<L const&>()),
     decltype(std::declval<R const&>() <= std::declval<L const&>()),
     decltype(std::declval<R const&>() >= std::declval<L const&>())>;
+BSONCXX_PRIVATE_WARNINGS_POP();
 
 template <typename T, typename U>
 struct is_partially_ordered_with : decltype(is_partially_ordered_with_f<T, U>(rank<1>{})) {};

--- a/src/bsoncxx/test/v1/stdx/optional.test.cpp
+++ b/src/bsoncxx/test/v1/stdx/optional.test.cpp
@@ -16,7 +16,9 @@
 
 //
 
+#include <bsoncxx/v1/detail/compare.hpp>
 #include <bsoncxx/v1/detail/macros.hpp>
+#include <bsoncxx/v1/detail/type_traits.hpp>
 
 #include <bsoncxx/test/v1/stdx/string_view.hh>
 
@@ -25,9 +27,6 @@
 #include <mutex>
 #include <string>
 #include <type_traits>
-
-#include <bsoncxx/stdx/operators.hpp>
-#include <bsoncxx/stdx/type_traits.hpp>
 
 #include <bsoncxx/private/make_unique.hh>
 
@@ -654,11 +653,14 @@ TEST_CASE("Optional: Hashing") {
     CHECK_VS2017(hashit(c) == hashit(a));
 }
 
+BSONCXX_PRIVATE_WARNINGS_PUSH();
+BSONCXX_PRIVATE_WARNINGS_DISABLE(Clang("-Wunneeded-member-function"));
 struct in_place_convertible {
     bool constructed_from_in_place = false;
     in_place_convertible() = default;
     in_place_convertible(bsoncxx::v1::stdx::in_place_t) : constructed_from_in_place(true) {}
 };
+BSONCXX_PRIVATE_WARNINGS_POP();
 
 TEST_CASE("optional<T> conversions") {
     // Some stdlib implementations do not forbid this ctor correctly.

--- a/src/bsoncxx/test/v1/stdx/type_traits.test.cpp
+++ b/src/bsoncxx/test/v1/stdx/type_traits.test.cpp
@@ -1,9 +1,25 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bsoncxx/v1/detail/type_traits.hpp>
+
+//
+
 #include <string>
 #include <type_traits>
 
-#include <bsoncxx/stdx/type_traits.hpp>
-
-#include <bsoncxx/test/catch.hh>
+#include <bsoncxx/test/system_error.hh>
 
 // We declare variables that are only used for compilation checking
 BSONCXX_PRIVATE_WARNINGS_DISABLE(GNU("-Wunused"));

--- a/src/mongocxx/lib/mongocxx/private/mongoc_error.hh
+++ b/src/mongocxx/lib/mongocxx/private/mongoc_error.hh
@@ -52,12 +52,12 @@ inline void make_generic_bson_error(bson_error_t* error) {
 }
 
 template <typename exception_type>
-void throw_exception(::bson_error_t const& error) {
+[[noreturn]] void throw_exception(::bson_error_t const& error) {
     throw exception_type{make_error_code(error), error.message};
 }
 
 template <typename exception_type>
-void throw_exception(bsoncxx::v_noabi::document::value raw_server_error, ::bson_error_t const& error) {
+[[noreturn]] void throw_exception(bsoncxx::v_noabi::document::value raw_server_error, ::bson_error_t const& error) {
     throw exception_type{make_error_code(error), std::move(raw_server_error), error.message};
 }
 

--- a/src/mongocxx/test/spec/gridfs.cpp
+++ b/src/mongocxx/test/spec/gridfs.cpp
@@ -89,7 +89,7 @@ bsoncxx::stdx::optional<test_util::item_t> transform_hex(test_util::item_t pair,
         return {pair};
     }
 
-    std::basic_string<std::uint8_t> bytes = test_util::convert_hex_string_to_bytes(data["$hex"].get_string().value);
+    std::vector<std::uint8_t> bytes = test_util::convert_hex_string_to_bytes(data["$hex"].get_string().value);
     types::b_binary binary_data = {binary_sub_type::k_binary, static_cast<std::uint32_t>(bytes.size()), bytes.data()};
 
     context->append(binary_data);
@@ -230,7 +230,7 @@ void test_download(database db, gridfs::bucket bucket, document::view operation,
     // string>" }, which needs to be converted to an array of bytes.
     REQUIRE(result["$hex"]);
     std::string hex = bsoncxx::string::to_string(result["$hex"].get_string().value);
-    std::basic_string<std::uint8_t> expected = test_util::convert_hex_string_to_bytes(hex);
+    std::vector<std::uint8_t> expected = test_util::convert_hex_string_to_bytes(hex);
 
     REQUIRE(actual_size == expected.size());
 
@@ -267,7 +267,7 @@ void test_upload(database db, gridfs::bucket bucket, document::view operation, d
 
     REQUIRE(source["$hex"]);
     std::string hex = bsoncxx::string::to_string(source["$hex"].get_string().value);
-    std::basic_string<std::uint8_t> source_bytes = test_util::convert_hex_string_to_bytes(hex);
+    std::vector<std::uint8_t> source_bytes = test_util::convert_hex_string_to_bytes(hex);
 
     uploader.write(source_bytes.data(), source_bytes.size());
     result::gridfs::upload upload_result = uploader.close();

--- a/src/mongocxx/test/spec/unified_tests/assert.cpp
+++ b/src/mongocxx/test/spec/unified_tests/assert.cpp
@@ -162,7 +162,7 @@ void special_operator(types::bson_value::view actual, document::view expected, e
         REQUIRE(actual.type() == bsoncxx::type::k_binary);
 
         auto expected_bytes = test_util::convert_hex_string_to_bytes(op.get_value().get_string());
-        decltype(expected_bytes) actual_bytes(actual.get_binary().bytes, actual.get_binary().size);
+        decltype(expected_bytes) actual_bytes(actual.get_binary().bytes, actual.get_binary().bytes + actual.get_binary().size);
 
         REQUIRE(actual_bytes == expected_bytes);
     } else {

--- a/src/mongocxx/test/v_noabi/client_helpers.cpp
+++ b/src/mongocxx/test/v_noabi/client_helpers.cpp
@@ -236,8 +236,8 @@ bool newer_than(std::string version) {
     return (compare_versions(server_version, version) >= 0);
 }
 
-std::basic_string<std::uint8_t> convert_hex_string_to_bytes(bsoncxx::stdx::string_view hex) {
-    std::basic_string<std::uint8_t> bytes;
+std::vector<std::uint8_t> convert_hex_string_to_bytes(bsoncxx::stdx::string_view hex) {
+    std::vector<std::uint8_t> bytes;
 
     // Convert each pair of hexadecimal digits into a number and store it in the array.
     for (std::size_t i = 0; i < hex.size(); i += 2) {

--- a/src/mongocxx/test/v_noabi/client_helpers.hh
+++ b/src/mongocxx/test/v_noabi/client_helpers.hh
@@ -18,6 +18,7 @@
 #include <functional>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <bsoncxx/builder/basic/array.hpp>
 #include <bsoncxx/document/element.hpp>
@@ -63,7 +64,7 @@ bool newer_than(std::string version);
 // This function assumes that `hex` has an even length and that all characters in the string are
 // valid hexadecimal digits.
 //
-std::basic_string<std::uint8_t> convert_hex_string_to_bytes(bsoncxx::stdx::string_view hex);
+std::vector<std::uint8_t> convert_hex_string_to_bytes(bsoncxx::stdx::string_view hex);
 
 //
 // Adds server API options to passed-in options if MONGODB_API_VERSION


### PR DESCRIPTION
Some changes to address warnings encountered/discovered during ongoing reviews for CXX-2745. Cherry-picked onto a separate branch for standalone review.

---

The `stdx` test components are updated to explicitly include v1 headers for consistency with other v1 components (which in general should not include v_noabi headers).

---

When `T` given `bsoncxx::v1::stdx::optional<T>` is a function pointer (e.g. `T = void (*)(std::uint8_t)`), Clang may emit the following warning (abbreviated):

```
warning: ordered comparison of function pointers ('void (*)(unsigned char *)' and 'void (*)(unsigned char *)') [-Wordered-compare-function-pointers]
  484 |     decltype(std::declval<L const&>() > std::declval<R const&>()),
      |              ~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~
note: ...
note: while substituting deduced template arguments into function template 'impl' [with L = Catch::Decomposer, R = bsoncxx::v1::stdx::optional<void (*)(unsigned char *)>]
  161 |     DEFOP(<=);
      |     ^
note: ...
note: while substituting deduced template arguments into function template 'operator<=' [with L = Catch::Decomposer, R = bsoncxx::v1::stdx::optional<void (*)(unsigned char *)>]
  493 |             CHECK(foo() == bar);
      |             ^
note: expanded from macro 'CHECK'
  134 |   #define CHECK( ... ) INTERNAL_CATCH_TEST( "CHECK", Catch::ResultDisposition::ContinueOnFailure, __VA_ARGS__ )
      |                        ^
note: expanded from macro 'INTERNAL_CATCH_TEST'
   50 |             catchAssertionHandler.handleExpr( Catch::Decomposer() <= __VA_ARGS__ ); /* NOLINT(bugprone-chained-comparison) */ \
      |                                                                   ^
```

These warnings are suppressed by disabling `-Wordered-compare-function-pointers` around the `is_partially_ordered_with_f` helper function declaration.

---

There are some instances of `std::basic_string<std::uint8_t>` in test code which are triggering the following warning:

```
warning: 'char_traits<unsigned char>' is deprecated: char_traits<T> for T not equal to char, wchar_t, char8_t, char16_t or char32_t is non-standard and is provided for a temporary period. It will be removed in LLVM 19, so please migrate off of it. [-Wdeprecated-declarations]
```

AFAICT the only motivation for using `std::basic_string<T>` instead of `std::vector<T>` is to use the the `(ptr, size)` constructor. Replaced all instances with a vector and switched to the `(ptr, ptr + size)` ctor instead.