### PR TITLE
CXX-3312 Fix export macro for mongocxx::v_noabi::options::index::storage_engine (#1426)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ## 4.1.2 [Unreleased]
 
-<!-- Will contain entries for the next patch release. -->
+### Fixed
+
+- `storage_engine() const` in `mongocxx::v_noabi::options::index` is correctly exported using mongocxx export macros instead of bsoncxx export macros.
 
 ## 4.1.1
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index.hpp
@@ -303,7 +303,7 @@ class index {
     ///
     /// The current storage engine options.
     ///
-    BSONCXX_ABI_EXPORT_CDECL(bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::view> const&)
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::view> const&)
     storage_engine() const;
 
     ///


### PR DESCRIPTION
Cherry-picks https://github.com/mongodb/mongo-cxx-driver/pull/1426 onto `releases/v4.1` to target a 4.1.2 patch release.