### PR TITLE
Update Invalid URI test for CDRIVER-5983

### DIFF
--- a/src/mongocxx/test/v_noabi/uri.cpp
+++ b/src/mongocxx/test/v_noabi/uri.cpp
@@ -72,7 +72,8 @@ TEST_CASE("URI", "[uri]") {
         } catch (mongocxx::logic_error const& e) {
             REQUIRE(e.code() == mongocxx::error_code::k_invalid_uri);
 
-            std::string invalid_schema = "Invalid URI Schema, expecting 'mongodb://' or 'mongodb+srv://': ";
+            std::string invalid_schema =
+                "Invalid URI scheme \"mongo://\". Expected one of \"mongodb://\" or \"mongodb+srv://\": ";
 
             REQUIRE(e.what() == invalid_schema + e.code().message());
         }

--- a/src/mongocxx/test/v_noabi/uri.cpp
+++ b/src/mongocxx/test/v_noabi/uri.cpp
@@ -72,8 +72,7 @@ TEST_CASE("URI", "[uri]") {
         } catch (mongocxx::logic_error const& e) {
             REQUIRE(e.code() == mongocxx::error_code::k_invalid_uri);
 
-            std::string invalid_schema =
-                "Invalid URI scheme \"mongo://\". Expected one of \"mongodb://\" or \"mongodb+srv://\": ";
+            std::string invalid_schema = "Invalid URI Schema, expecting 'mongodb://' or 'mongodb+srv://': ";
 
             REQUIRE(e.what() == invalid_schema + e.code().message());
         }


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/2047 which modified the error message for an invalid URI connection scheme.