### PR TITLE
Fix typo in CSE skip message

### DIFF
--- a/src/mongocxx/test/v_noabi/client_helpers.hh
+++ b/src/mongocxx/test/v_noabi/client_helpers.hh
@@ -230,7 +230,7 @@ cseeos_result client_side_encryption_enabled_or_skip_impl();
             case mongocxx::test_util::cseeos_result::enable:                          \
                 break;                                                                \
             case mongocxx::test_util::cseeos_result::skip:                            \
-                SKIP("CSE environemnt variables not set");                            \
+                SKIP("CSE environment variables not set");                            \
                 break;                                                                \
             case mongocxx::test_util::cseeos_result::fail:                            \
                 FAIL("One or more CSE environment variable is missing");              \


### PR DESCRIPTION
A simple drive-by typo fix.