### PR TITLE
DEVPROD-20053 - Remove perf.send from latest release branch

### DIFF
--- a/.evergreen/config_generator/components/benchmarks.py
+++ b/.evergreen/config_generator/components/benchmarks.py
@@ -26,14 +26,11 @@ class RunBenchmarks(Function):
             working_dir='mongo-cxx-driver',
             script='build/benchmark/microbenchmarks all',
         ),
-
-        BuiltInCommand(
-            command='perf.send',
-            type=EvgCommandType.SYSTEM,
-            params={
-                'name': 'perf',
-                'file': 'mongo-cxx-driver/results.json',
-            }
+        bash_exec(
+            command_type=EvgCommandType.SYSTEM,
+            working_dir='mongo-cxx-driver',
+            script='.evergreen/scripts/send-perf-data.sh',
+            include_expansions_in_env=['project_id', 'version_id', 'build_variant', 'parsed_order_id', 'task_name', 'task_id', 'execution', 'requester', 'revision_order_id'],
         ),
     ]
 

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -142,11 +142,23 @@ functions:
         args:
           - -c
           - build/benchmark/microbenchmarks all
-    - command: perf.send
+    - command: subprocess.exec
       type: system
       params:
-        name: perf
-        file: mongo-cxx-driver/results.json
+        binary: bash
+        working_dir: mongo-cxx-driver
+        include_expansions_in_env:
+          - project_id
+          - version_id
+          - build_variant
+          - task_name
+          - task_id
+          - execution
+          - requester
+          - revision_order_id
+        args:
+          - -c
+          - .evergreen/scripts/send-perf-data.sh
   build-package-debian:
     - command: subprocess.exec
       type: test

--- a/.evergreen/scripts/send-perf-data.sh
+++ b/.evergreen/scripts/send-perf-data.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+# We use the requester expansion to determine whether the data is from a mainline evergreen run or not
+if [ "${requester}" == "commit" ]; then
+    is_mainline=true
+else
+    is_mainline=false
+fi
+
+# Parse the username out of the order_id. Patches append the username. The raw perf results end point does not need the other information.
+parsed_order_id=$(echo "${revision_order_id}" | awk -F'_' '{print $NF}')
+
+response=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X 'POST' \
+    "https://performance-monitoring-api.corp.mongodb.com/raw_perf_results/cedar_report?project=${project_id}&version=${version_id}&variant=${build_variant}&order=${parsed_order_id}&task_name=${task_name}&task_id=${task_id}&execution=${execution}&mainline=${is_mainline}" \
+    -H 'accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -d @results.json)
+http_status=$(echo "$response" | grep "HTTP_STATUS" | awk -F':' '{print $2}')
+response_body=$(echo "$response" | sed '/HTTP_STATUS/d')
+# We want to throw an error if the data was not successfully submitted
+if [ "$http_status" -ne 200 ]; then
+    echo "Error: Received HTTP status $http_status"
+    echo "Response Body: $response_body"
+    exit 1
+fi
+echo "Response Body: $response_body"
+echo "HTTP Status: $http_status"


### PR DESCRIPTION
The perf.send command is no longer being maintained and will be decommissioned soon. Users can now submit performance data using the "raw_perf_results" end point provided by the performance-monitoring-api. This PR migrates the latest release project over to that API.