### PR TITLE
Fix and update EVG configuration for releases/v4.1

### DIFF
--- a/.evergreen/config_generator/components/abi_stability.py
+++ b/.evergreen/config_generator/components/abi_stability.py
@@ -147,7 +147,7 @@ def generate_tasks():
         if func is Abidiff:
             distro_name = 'ubuntu2204'  # Clang 12, libabigail is not available on RHEL distros.
         else:
-            distro_name = 'rhel95'  # Clang 18.
+            distro_name = 'rhel95'  # Clang 19.
 
         distro = find_large_distro(distro_name)
 

--- a/.evergreen/config_generator/components/compile_only.py
+++ b/.evergreen/config_generator/components/compile_only.py
@@ -18,16 +18,16 @@ TAG = 'compile-only'
 MATRIX = [
     # C++ standard and compiler coverage
 
-    ('rhel80',     'clang',    [11, 17, 20,   ]), # Clang  7.0 (max: C++20)
-    ('ubuntu2004', 'clang-10', [11, 17, 20,   ]), # Clang 10.0 (max: C++20)
-    ('rhel84',     'clang',    [11, 17, 20,   ]), # Clang 11.0 (max: C++20)
-    ('ubuntu2204', 'clang-12', [11, 17, 20, 23]), # Clang 12.0 (max: C++23)
-    ('rhel90',     'clang',    [11, 17, 20, 23]), # Clang 13.0 (max: C++23)
-    ('rhel91',     'clang',    [11, 17, 20, 23]), # Clang 14.0 (max: C++23)
-    ('rhel92',     'clang',    [11, 17, 20, 23]), # Clang 15.0 (max: C++23)
-    ('rhel93',     'clang',    [11, 17, 20, 23]), # Clang 16.0 (max: C++23)
-    ('rhel94',     'clang',    [11, 17, 20, 23]), # Clang 17.0 (max: C++23)
-    ('rhel95',     'clang',    [11, 17, 20, 23]), # Clang 18.0 (max: C++23)
+    ('rhel80',     'clang',    [11, 17, 20,   ]), # Clang  7 (max: C++20)
+    ('ubuntu2004', 'clang-10', [11, 17, 20,   ]), # Clang 10 (max: C++20)
+    ('rhel84',     'clang',    [11, 17, 20,   ]), # Clang 11 (max: C++20)
+    ('ubuntu2204', 'clang-12', [11, 17, 20, 23]), # Clang 12 (max: C++23)
+    ('rhel90',     'clang',    [11, 17, 20, 23]), # Clang 13 (max: C++23)
+    ('rhel91',     'clang',    [11, 17, 20, 23]), # Clang 14 (max: C++23)
+    ('rhel92',     'clang',    [11, 17, 20, 23]), # Clang 15 (max: C++23)
+    ('rhel93',     'clang',    [11, 17, 20, 23]), # Clang 16 (max: C++23)
+    ('rhel94',     'clang',    [11, 17, 20, 23]), # Clang 17 (max: C++23)
+    ('rhel95',     'clang',    [11, 17, 20, 23]), # Clang 19 (max: C++23)
 
     ('rhel76',     'gcc',    [11, 14,       ]), # GCC  4.8 (max: C++14)
     ('rhel80',     'gcc',    [11, 17, 20,   ]), # GCC  8.2 (max: C++20)

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -200,20 +200,27 @@ functions:
         permissions: public-read
         remote_file: mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/rpm-packages.tar.gz
   build_mongohouse:
-    command: subprocess.exec
-    type: setup
-    params:
-      binary: bash
-      args:
-        - -c
-        - |
-          if [ ! -d "drivers-evergreen-tools" ]; then
-              git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git
-          fi
-          cd drivers-evergreen-tools
-          export DRIVERS_TOOLS=$(pwd)
+    - command: ec2.assume_role
+      params:
+        role_arn: ${aws_test_secrets_role}
+    - command: subprocess.exec
+      type: setup
+      params:
+        binary: bash
+        include_expansions_in_env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+        args:
+          - -c
+          - |
+            if [ ! -d "drivers-evergreen-tools" ]; then
+                git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git
+            fi
+            cd drivers-evergreen-tools
+            export DRIVERS_TOOLS=$(pwd)
 
-          .evergreen/atlas_data_lake/pull-mongohouse-image.sh
+            .evergreen/atlas_data_lake/pull-mongohouse-image.sh
   check augmented sbom:
     - command: ec2.assume_role
       type: setup

--- a/.evergreen/scripts/abi-stability-setup.sh
+++ b/.evergreen/scripts/abi-stability-setup.sh
@@ -67,9 +67,9 @@ mkdir -p "${working_dir}/install"
 # For latest Clang versions supporting recent C++ standards.
 export CC CXX
 case "${distro_id:?}" in
-rhel9*)
-  CC="clang-18"
-  CXX="clang++-18"
+rhel95*)
+  CC="clang-19"
+  CXX="clang++-19"
   ;;
 ubuntu22*)
   CC="clang-12"


### PR DESCRIPTION
Cherry-picks https://github.com/mongodb/mongo-cxx-driver/pull/1421 to address ongoing ABI Stability Check task failures on the releases/v4.1 branch.