### PR TITLE
Update index test case for forward-compatibility with server 8.3

### DIFF
--- a/src/mongocxx/test/v_noabi/index_view.cpp
+++ b/src/mongocxx/test/v_noabi/index_view.cpp
@@ -359,7 +359,10 @@ TEST_CASE("drop_one", "[index_view]") {
         auto cursor = indexes.list();
         REQUIRE(std::distance(cursor.begin(), cursor.end()) == 1);
 
-        REQUIRE_THROWS_AS(indexes.drop_one("foo"), operation_exception);
+        // SERVER-90152: "dropIndex should be idempotent"
+        if (!server_version_is_at_least("8.3")) {
+            REQUIRE_THROWS_AS(indexes.drop_one("foo"), operation_exception);
+        }
     }
 }
 


### PR DESCRIPTION
Avoid task failures against the latest server (8.3.0-alpha0) due to [SERVER-90152](https://jira.mongodb.org/browse/SERVER-90152).