### PR TITLE
CXX-3193 add changelog entry dropping macOS 11 and macOS 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 - Support for MongoDB Server 4.2.
   - See: [MongoDB Software Lifecycle Schedules](https://www.mongodb.com/legal/support-policy/lifecycles).
   - See: [MongoDB C Driver 2.1.0 Release Notes](https://github.com/mongodb/mongo-c-driver/releases/tag/2.1.0).
+- Support for macOS 11 and macOS 12 (deprecated in 4.1.0).
 
 ## 4.1.1
 


### PR DESCRIPTION
Resolves CXX-3193. Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1293 and https://github.com/mongodb/mongo-cxx-driver/pull/1328. Support for macOS 11 and macOS 12 were deprecated in the 4.1.0 release; this PR officially declares support is removed in the upcoming 4.2.0 release. The prior PRs already updated the EVG configuration accordingly. (Oddly, we seem to have completely skipped macOS 13 task coverage...? Which is probably okay, given limited macOS host availability.)