### PR TITLE
CXX-3325 address -Wdeprecated-literal-operator warnings

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
@@ -82,7 +82,7 @@ BSONCXX_ABI_EXPORT_CDECL(document::value) from_json(stdx::string_view json);
 ///
 /// @throws bsoncxx::v_noabi::exception with error details if the conversion failed.
 ///
-BSONCXX_ABI_EXPORT_CDECL(document::value) operator"" _bson(char const* json, size_t len);
+BSONCXX_ABI_EXPORT_CDECL(document::value) operator""_bson(char const* json, size_t len);
 
 } // namespace v_noabi
 } // namespace bsoncxx
@@ -92,7 +92,7 @@ namespace bsoncxx {
 using ::bsoncxx::v_noabi::from_json;
 using ::bsoncxx::v_noabi::to_json;
 
-using ::bsoncxx::v_noabi::operator"" _bson;
+using ::bsoncxx::v_noabi::operator""_bson;
 
 } // namespace bsoncxx
 

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/json.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/json.cpp
@@ -107,7 +107,7 @@ document::value from_json(stdx::string_view json) {
     return document::value{buf, length, bson_free_deleter};
 }
 
-document::value operator"" _bson(char const* str, size_t len) {
+document::value operator""_bson(char const* str, size_t len) {
     return from_json(stdx::string_view{str, len});
 }
 


### PR DESCRIPTION
Resolves CXX-3325.

The `""_bson` user-defined literal (UDL) was introduced in https://github.com/mongodb/mongo-cxx-driver/pull/724. At the time, it was declared as (ignoring export macros):

```cpp
document::value operator"" _bson(const char* str, size_t len);
```

https://github.com/mongodb/mongo-cxx-driver/pull/1066 attempted to reformat this declaration to address the `-Wdeprecated-literal-operator` warning observed with newer Clang compilers (per [Compiler Explorer](https://godbolt.org/z/dsrbhj57a), supported since Clang 17 and enabled by default since Clang 20):

```
error: identifier '_bson' preceded by whitespace in a literal operator declaration is deprecated [-Werror,-Wdeprecated-literal-operator]
```

```cpp
document::value operator""_bson(const char* json, size_t len);
```

but this had to be reverted by https://github.com/mongodb/mongo-cxx-driver/pull/1194 to restore compatibility with GCC 4.8 (which does not implement [CWG 1473](https://cplusplus.github.io/CWG/issues/1473.html), prior to which a space between `""` and _ud-suffix_ was unfortunately mandatory; see [this comment](https://github.com/mongodb/mongo-cxx-driver/pull/1194#discussion_r1725543583)):

```
error: missing space between '""' and suffix identifier document::value operator""_bson(const char* json, size_t len);
```

However, following https://github.com/mongodb/mongo-cxx-driver/pull/1415, GCC 4.8 is no longer within our range of supported (minimum required) compilers. Therefore, we can now (re-)apply the proper fix (removing the space) without further issue.

> [!IMPORTANT]
> Following https://github.com/mongodb/mongo-cxx-driver/pull/1415, users on Red Hat 7 or older are expected to use a "Red Hat Developer Toolset" (DTS) or "GCC Toolset" to obtain a sufficiently recent GCC compiler version (GCC 8.1 or newer).

> [!NOTE]
> There does not seem to be a ClangFormat option to control this behavior...?