### PR TITLE
CXX-3325 address -Wdeprecated-literal-operator warnings (#1441)

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
@@ -82,7 +82,7 @@ BSONCXX_ABI_EXPORT_CDECL(document::value) from_json(stdx::string_view json);
 ///
 /// @throws bsoncxx::v_noabi::exception with error details if the conversion failed.
 ///
-BSONCXX_ABI_EXPORT_CDECL(document::value) operator"" _bson(char const* json, size_t len);
+BSONCXX_ABI_EXPORT_CDECL(document::value) operator""_bson(char const* json, size_t len);
 
 } // namespace v_noabi
 } // namespace bsoncxx
@@ -92,7 +92,7 @@ namespace bsoncxx {
 using ::bsoncxx::v_noabi::from_json;
 using ::bsoncxx::v_noabi::to_json;
 
-using ::bsoncxx::v_noabi::operator"" _bson;
+using ::bsoncxx::v_noabi::operator""_bson;
 
 } // namespace bsoncxx
 

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/json.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/json.cpp
@@ -107,7 +107,7 @@ document::value from_json(stdx::string_view json) {
     return document::value{buf, length, bson_free_deleter};
 }
 
-document::value operator"" _bson(char const* str, size_t len) {
+document::value operator""_bson(char const* str, size_t len) {
     return from_json(stdx::string_view{str, len});
 }
 


### PR DESCRIPTION
Cherry-picks https://github.com/mongodb/mongo-cxx-driver/pull/1441 onto the `releases/v4.1` branch to target the upcoming 4.1.2 patch release for Clang 20+ forward compatibility.