### PR TITLE
Fix -Wunused-variable Clang warnings

### DIFF
--- a/examples/bsoncxx/view_and_value.cpp
+++ b/examples/bsoncxx/view_and_value.cpp
@@ -111,6 +111,7 @@ int EXAMPLES_CDECL main() {
         // usually we don't need to actually use a switch statement, because we can also
         // get a variant 'value' that can hold any BSON type.
         types::bson_value::view doc_ele_val{doc_ele.get_value()};
+        (void)doc_ele_val;
     }
 
     // If we want to search for an element we can use operator[]

--- a/src/mongocxx/test/spec/mongohouse.cpp
+++ b/src/mongocxx/test/spec/mongohouse.cpp
@@ -138,7 +138,7 @@ void test_kill_cursors() {
 
             auto cursors_killed_elem = event["command_succeeded_event"]["reply"]["cursorsKilled"];
             auto cursors_killed_val = cursors_killed_elem.get_value();
-            auto cursors_killed_arr = cursors_killed_elem.get_array();
+            auto cursors_killed_arr = cursors_killed_val.get_array();
             auto cursors_killed = cursors_killed_arr.value;
 
             if (std::find(cursors_killed.cbegin(), cursors_killed.cend(), cursor_id_val.view()) !=


### PR DESCRIPTION
Minor PR addressing some stray unused variable warnings with Clang.