### PR TITLE
doxygen: exclude std symbols

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1066,7 +1066,8 @@ EXCLUDE_PATTERNS       =
 EXCLUDE_SYMBOLS        = bsoncxx::detail \
                          bsoncxx::*::detail \
                          mongocxx::detail \
-                         mongocxx::*::detail
+                         mongocxx::*::detail \
+                         std::*
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include


### PR DESCRIPTION
Removes these entries+pages in the Doxygen class list page following https://github.com/mongodb/mongo-cxx-driver/pull/1412:

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/ebe6d41b-d853-4cf5-951f-89628335fb7e" />

We do not need to have pages for any entities declared in the `std` namespace anyways (usually documented by the associated user-defined type in our own namespaces), so the entire `std` namespace is added to the list of excluded symbols.