### PR TITLE
Partially revert "CXX-2120 handle nonexistent document fields (#984)"

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/element.hpp
@@ -80,8 +80,6 @@ class element : private document::element {
     friend ::bsoncxx::v_noabi::array::view;
 
     explicit element(std::uint8_t const* raw, std::uint32_t length, std::uint32_t offset, std::uint32_t keylen);
-
-    explicit element(stdx::string_view const key);
 };
 
 ///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp
@@ -357,9 +357,6 @@ class element {
     ///
     explicit element(std::uint8_t const* raw, std::uint32_t length, std::uint32_t offset, std::uint32_t keylen);
 
-    // Construct an invalid element with a key. Useful for exceptions.
-    explicit element(stdx::string_view const key);
-
     friend ::bsoncxx::v_noabi::array::element;
     friend ::bsoncxx::v_noabi::document::view;
 
@@ -367,10 +364,6 @@ class element {
     std::uint32_t _length;
     std::uint32_t _offset;
     std::uint32_t _keylen;
-    // _key will only exist when a caller attempts to find a key in the BSON but is unsuccessful.
-    // The key is stored for a more helpful error message if the user tries to access the value of
-    // a key that does not exist.
-    stdx::optional<stdx::string_view> _key;
 };
 
 ///

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/element.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/element.cpp
@@ -26,8 +26,6 @@ element::element() : document::element() {}
 element::element(std::uint8_t const* raw, std::uint32_t length, std::uint32_t offset, std::uint32_t keylen)
     : document::element(raw, length, offset, keylen) {}
 
-element::element(stdx::string_view const key) : document::element(key) {}
-
 bool operator==(element const& elem, types::bson_value::view const& v) {
     return elem.get_value() == v;
 }

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/view.cpp
@@ -115,15 +115,15 @@ view::const_iterator view::find(std::uint32_t i) const {
     bson_iter_t iter;
 
     if (!bson_init_static(&b, data(), length())) {
-        return const_iterator(element(key.c_str()));
+        return const_iterator();
     }
 
     if (!bson_iter_init(&iter, &b)) {
-        return const_iterator(element(key.c_str()));
+        return const_iterator();
     }
 
     if (!bson_iter_init_find(&iter, &b, key.c_str())) {
-        return const_iterator(element(key.c_str()));
+        return const_iterator();
     }
 
     return const_iterator(

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/element.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/element.cpp
@@ -44,8 +44,6 @@ element::element() : element(nullptr, 0, 0, 0) {}
 element::element(std::uint8_t const* raw, std::uint32_t length, std::uint32_t offset, std::uint32_t keylen)
     : _raw(raw), _length(length), _offset(offset), _keylen(keylen) {}
 
-element::element(stdx::string_view const key) : _raw(nullptr), _length(0), _offset(0), _keylen(0), _key(key) {}
-
 std::uint8_t const* element::raw() const {
     return _raw;
 }
@@ -64,9 +62,7 @@ std::uint32_t element::keylen() const {
 bsoncxx::v_noabi::type element::type() const {
     if (_raw == nullptr) {
         throw bsoncxx::v_noabi::exception{
-            error_code::k_unset_element,
-            "cannot return the type of uninitialized element" +
-                std::string(_key ? " with key \"" + std::string(_key.value().data()) + "\"" : "")};
+            error_code::k_unset_element, "cannot return the type of uninitialized element"};
     }
 
     BSONCXX_CITER;
@@ -76,9 +72,7 @@ bsoncxx::v_noabi::type element::type() const {
 stdx::string_view element::key() const {
     if (_raw == nullptr) {
         throw bsoncxx::v_noabi::exception{
-            error_code::k_unset_element,
-            "cannot return the key from an uninitialized element" +
-                std::string(_key ? " with key \"" + std::string(_key.value().data()) + "\"" : "")};
+            error_code::k_unset_element, "cannot return the key from an uninitialized element"};
     }
 
     BSONCXX_CITER;
@@ -88,16 +82,14 @@ stdx::string_view element::key() const {
     return stdx::string_view{key};
 }
 
-#define BSONCXX_ENUM(name, val)                                                                         \
-    types::b_##name element::get_##name() const {                                                       \
-        if (_raw == nullptr) {                                                                          \
-            throw bsoncxx::v_noabi::exception{                                                          \
-                error_code::k_unset_element,                                                            \
-                "cannot get " #name " from an uninitialized element" +                                  \
-                    std::string(_key ? " with key \"" + std::string(_key.value().data()) + "\"" : "")}; \
-        }                                                                                               \
-        types::bson_value::view v{_raw, _length, _offset, _keylen};                                     \
-        return v.get_##name();                                                                          \
+#define BSONCXX_ENUM(name, val)                                                                     \
+    types::b_##name element::get_##name() const {                                                   \
+        if (_raw == nullptr) {                                                                      \
+            throw bsoncxx::v_noabi::exception{                                                      \
+                error_code::k_unset_element, "cannot get " #name " from an uninitialized element"}; \
+        }                                                                                           \
+        types::bson_value::view v{_raw, _length, _offset, _keylen};                                 \
+        return v.get_##name();                                                                      \
     }
 #include <bsoncxx/enums/type.hpp>
 #undef BSONCXX_ENUM

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/view.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/view.cpp
@@ -111,8 +111,7 @@ view::const_iterator view::end() const {
 view::const_iterator view::find(stdx::string_view key) const {
     bson_t b;
     if (!bson_init_static(&b, _data, _length)) {
-        // return invalid element with key to provide more helpful exception message.
-        return const_iterator(element(key));
+        return const_iterator();
     }
 
     bson_iter_t iter;
@@ -132,8 +131,7 @@ view::const_iterator view::find(stdx::string_view key) const {
 
     if (!bson_iter_init_find_w_len(&iter, &b, key.data(), static_cast<int>(key.size()))) {
         // returning `cend()` returns an element without a key or value.
-        // return invalid element with key to provide more helpful exception
-        return const_iterator(element(key));
+        return const_iterator();
     }
 
     return const_iterator(

--- a/src/bsoncxx/test/v_noabi/bson_types.cpp
+++ b/src/bsoncxx/test/v_noabi/bson_types.cpp
@@ -372,15 +372,11 @@ TEST_CASE("document uninitialized element throws exceptions", "") {
     REQUIRE_THROWS_WITH(
         doc["doesnotexist"].get_string().value,
 
-        Catch::Matchers::ContainsSubstring(
-            "cannot get string from an uninitialized element with key "
-            "\"doesnotexist\": unset document::element"));
+        Catch::Matchers::Equals("cannot get string from an uninitialized element: unset document::element"));
 
     REQUIRE_THROWS_WITH(
         doc["alsodoesnotexist"].get_value(),
-        Catch::Matchers::ContainsSubstring(
-            "cannot return the type of uninitialized element with key "
-            "\"alsodoesnotexist\": unset document::element"));
+        Catch::Matchers::Equals("cannot return the type of uninitialized element: unset document::element"));
 
     // Ensure a non-existing element evaluates to false.
     REQUIRE(!doc["doesnotexist"]);
@@ -389,9 +385,7 @@ TEST_CASE("document uninitialized element throws exceptions", "") {
     // Ensure getting a key from a non-existing element results in an exception.
     REQUIRE_THROWS_WITH(
         doc["doesnotexist"].key(),
-        Catch::Matchers::ContainsSubstring(
-            "cannot return the key from an uninitialized element with key "
-            "\"doesnotexist\": unset document::element"));
+        Catch::Matchers::Equals("cannot return the key from an uninitialized element: unset document::element"));
 }
 
 TEST_CASE("array uninitialized element throws exceptions", "") {
@@ -401,9 +395,7 @@ TEST_CASE("array uninitialized element throws exceptions", "") {
 
     REQUIRE_THROWS_WITH(
         arr.view()[3].get_string().value,
-        Catch::Matchers::ContainsSubstring(
-            "cannot get string from an uninitialized element with key "
-            "\"3\": unset document::element"));
+        Catch::Matchers::Equals("cannot get string from an uninitialized element: unset document::element"));
     // Ensure a non-existing element evaluates to false.
     REQUIRE(!arr.view()[3]);
     // Ensure finding a non-existing element results in an end iterator.
@@ -411,8 +403,7 @@ TEST_CASE("array uninitialized element throws exceptions", "") {
     // Ensure getting a key from a non-existing element results in an exception.
     REQUIRE_THROWS_WITH(
         arr.view()[3].key(),
-        Catch::Matchers::ContainsSubstring(
-            "cannot return the key from an uninitialized element with key "
-            "\"3\": unset document::element"));
+        Catch::Matchers::Equals("cannot return the key from an uninitialized element: unset document::element"));
 }
+
 } // namespace


### PR DESCRIPTION
A small precursor change to CXX-3234 which partially reverts https://github.com/mongodb/mongo-cxx-driver/pull/984 in advance of the upcoming v_noabi refactor, which will adopt v1's ["last known element key"](https://github.com/mongodb/mongo-cxx-driver/blob/63f8ecd3a800f8919a3008dcd2d5a70210fd2b98/src/bsoncxx/lib/bsoncxx/v1/element/view.cpp#L173-L184) behavior instead.

---

> [!NOTE]
> The CXX-2120 implementation is private API whose resulting (undocumented) behavior is the format of error messages, which we do not (want to) consider part of stable API compatibility requirements (although this intention is not explicitly documented by our [API Versioning](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/api-abi-versioning/api-versioning/) policy... it should really be documented in a yet-to-be-written "Compatibility Guidelines" document). Therefore, this change in behavior is not considered to be an API breaking change.

As noted by comments in prior PRs ([here](https://github.com/mongodb/mongo-cxx-driver/pull/1412#discussion_r2112814791) and [here](https://github.com/mongodb/mongo-cxx-driver/pull/1430#discussion_r2237728139)), v1 implements an alternative approach to CXX-2120 which is not prone to dangling issues caused by the [internal string view](https://github.com/mongodb/mongo-cxx-driver/blob/63f8ecd3a800f8919a3008dcd2d5a70210fd2b98/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/element.hpp#L373). Although (hopefully) unlikely, this dangling issue can be demonstrated by the following code:

```cpp
// Current API behavior:
bsoncxx::document::value doc = bsoncxx::from_json(R"({"x": 1})");

// Intended behavior: improved exception messages.
try {
  auto type = doc["y"].type();
} catch (bsoncxx::exception const& ex) {
  CHECK_THAT( // Lookup key is present. :)
    ex.what(),
    Catch::Matchers::ContainsSubstring(R"("y")")
  );
}

// Problem: behavior is not extended to `element` access.
try {
  auto type = doc["x"]["y"].type();
} catch (bsoncxx::exception const& ex) {
  CHECK_THAT( // Neither 'x' nor 'y' are present. :(
    ex.what(),
    !Catch::Matchers::ContainsSubstring(R"("x")") && !Catch::Matchers::ContainsSubstring(R"("y")")
  );
}

// Problem: element object may be long-lived (by design).
{
  auto y = doc[std::string("y")]; // Undocumented internal long-term storage as stdx::string_view.
  //           ^~~~~~~~~~~~~~~~   // Temporary object!

  // AddressSanitizer: stack-use-after-scope
  //     # 0 in strlen
  //     # ...
  //     # 2 in std::string::string(char const*)
  //     # 3 in bsoncxx::v_noabi::document::element::type() const
  //     # ...
  CHECK_THROWS(y.type());
}
```

Due to this potential dangling issue (+ the `optional<T>`'s impact on `element`'s otherwise semitrivialty), this PR reverts these changes in advance of upcoming changes as part of CXX-3234 which will adopt v1's "last known element key" behavior instead:

```cpp
// API behavior following CXX-3234:
bsoncxx::document::value doc = bsoncxx::from_json(R"({"x": 1})");

try {
  auto type = doc["y"].type();
} catch (bsoncxx::exception const& ex) {
  CHECK_THAT( // Unfortunately no lookup key... :(
    ex.what(),
    !Catch::Matchers::ContainsSubstring(R"("y")")
  );
}

try {
  auto type = doc["x"]["y"].type();
} catch (bsoncxx::exception const& ex) {
  CHECK_THAT( // ... but does have "last known element key" instead. :)
    ex.what(),
    Catch::Matchers::ContainsSubstring(R"("x")")
  );
}

{
  auto y = doc[std::string("y")]; // No internal reference semantics to the key argument.
  CHECK_THROWS(y.type()); // OK: no undefined behavior.
}
```

The five `ContainsSubstring()` assertions modified by this PR will be modified once more by the CXX-3234 PR. These will be the _only_ assertion modifications made by CXX-3234: there will be no other observable change in v_noabi behavior.