### PR TITLE
Set ASAN_SYMBOLIZER_PATH to mongodbtoolchain v4

### DIFF
--- a/.evergreen/config_generator/components/funcs/test.py
+++ b/.evergreen/config_generator/components/funcs/test.py
@@ -12,6 +12,7 @@ class Test(Function):
     commands = bash_exec(
         command_type=EvgCommandType.TEST,
         include_expansions_in_env=[
+            'ASAN_SYMBOLIZER_PATH',
             'build_type',
             'CRYPT_SHARED_LIB_PATH',  # Set by run-orchestration.sh in "start_mongod".
             'cse_aws_access_key_id',

--- a/.evergreen/config_generator/components/sanitizers.py
+++ b/.evergreen/config_generator/components/sanitizers.py
@@ -59,6 +59,7 @@ def tasks():
 
             compile_vars = {'ENABLE_TESTS': 'ON'}
             test_vars = {
+                'ASAN_SYMBOLIZER_PATH': '/opt/mongodbtoolchain/v4/bin/llvm-symbolizer',
                 'TEST_WITH_CSFLE': 'ON',
                 'MONGOCXX_TEST_TOPOLOGY': topology,
                 'example_projects_cc': cc_compiler,

--- a/.evergreen/scripts/test.sh
+++ b/.evergreen/scripts/test.sh
@@ -14,6 +14,7 @@ set -o pipefail
 : "${MONGOCXX_TEST_TOPOLOGY:?}"
 : "${UV_INSTALL_DIR:?}"
 
+: "${ASAN_SYMBOLIZER_PATH:-}"
 : "${CRYPT_SHARED_LIB_PATH:-}"
 : "${disable_slow_tests:-}"
 : "${example_projects_cc:-}"


### PR DESCRIPTION
Identified the lack of symbolization of ASAN stack traces during recent patch builds despite debug info being present.