### PR TITLE
Silence MSVC warnings when including <bit> pre-C++20

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v1/detail/bit.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/detail/bit.hpp
@@ -19,10 +19,10 @@
 #include <bsoncxx/v1/config/config.hpp>
 
 #if defined(__has_include)
-#if __has_include(<bit>)
+#if __has_include(<bit>) && (!defined(_MSVC_LANG) || _MSVC_LANG >= 202002L)
 // Prioritize using std::endian from C++20.
 #include <bit>
-#endif // __has_include(<bit>)
+#endif // __has_include(<bit>) && (!defined(_MSVC_LANG) || _MSVC_LANG >= 202002L)
 #elif defined(_WIN32)
 // Forward-compatibility with STL: https://github.com/microsoft/STL/blob/vs-2019-16.5/stl/inc/bit#L26
 #elif defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && defined(__ORDER_BIG_ENDIAN__)


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1412.

Addresses the following annoyingly-aggressive warning emitted by STL `<bit>` pre-C++20 despite using the `__cpp_lib_endian` feature test macro correctly ([CE](https://godbolt.org/z/GPc4n11TP)):

```
The contents of <bit> are available only with C++20 or later.
```

Conditioning on `__cplusplus >= 202002L` (C++20) is not enough due to [`/Zc:__cplusplus`](https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-170) issues somehow resulting in an even worse outcome ([CE](https://godbolt.org/z/dG3jGrTW9)):

```
error C3083: 'endian': the symbol to the left of a '::' must be a type
error C2039: 'native': is not a member of 'std'
```

Therefore, `_MSVC_LANG >= 202002L` is used instead, but only when `defined(_MSVC_LANG)` is also true, since this is an MSVC-specific issue which is not applicable to other compilers ([CE](https://godbolt.org/z/dxM5PWror)).