### PR TITLE
CXX-3233 use common format for unknown error codes

### DIFF
--- a/src/bsoncxx/lib/bsoncxx/v1/exception.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v1/exception.cpp
@@ -30,10 +30,10 @@ std::error_category const& source_error_category() {
             return "bsoncxx::v1::source_errc";
         }
 
-        std::string message(int e) const noexcept override {
+        std::string message(int v) const noexcept override {
             using code = v1::source_errc;
 
-            switch (static_cast<code>(e)) {
+            switch (static_cast<code>(v)) {
                 case code::zero:
                     return "zero";
                 case code::bsoncxx:
@@ -41,7 +41,7 @@ std::error_category const& source_error_category() {
                 case code::bson:
                     return "bson";
                 default:
-                    return "unknown: " + std::to_string(e);
+                    return std::string(this->name()) + ':' + std::to_string(v);
             }
         }
     };
@@ -57,10 +57,10 @@ std::error_category const& type_error_category() {
             return "bsoncxx::v1::type_errc";
         }
 
-        std::string message(int e) const noexcept override {
+        std::string message(int v) const noexcept override {
             using code = v1::type_errc;
 
-            switch (static_cast<code>(e)) {
+            switch (static_cast<code>(v)) {
                 case code::zero:
                     return "zero";
                 case code::invalid_argument:
@@ -68,7 +68,7 @@ std::error_category const& type_error_category() {
                 case code::runtime_error:
                     return "runtime error";
                 default:
-                    return "unknown: " + std::to_string(e);
+                    return std::string(this->name()) + ':' + std::to_string(v);
             }
         }
     };

--- a/src/bsoncxx/test/v1/exception.cpp
+++ b/src/bsoncxx/test/v1/exception.cpp
@@ -31,11 +31,11 @@ TEST_CASE("source", "[bsoncxx][v1][error]") {
     }
 
     SECTION("message") {
-        CHECK(c.message(-1) == "unknown: -1");
+        CHECK(c.message(-1) == "bsoncxx::v1::source_errc:-1");
         CHECK(c.message(0) == "zero");
         CHECK(c.message(1) == "bsoncxx");
         CHECK(c.message(2) == "bson");
-        CHECK(c.message(3) == "unknown: 3");
+        CHECK(c.message(3) == "bsoncxx::v1::source_errc:3");
     }
 }
 
@@ -47,11 +47,11 @@ TEST_CASE("type", "[bsoncxx][v1][error]") {
     }
 
     SECTION("message") {
-        CHECK(c.message(-1) == "unknown: -1");
+        CHECK(c.message(-1) == "bsoncxx::v1::type_errc:-1");
         CHECK(c.message(0) == "zero");
         CHECK(c.message(1) == "invalid argument");
         CHECK(c.message(2) == "runtime error");
-        CHECK(c.message(3) == "unknown: 3");
+        CHECK(c.message(3) == "bsoncxx::v1::type_errc:3");
     }
 }
 


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1430 which [overlooked](https://github.com/mongodb/mongo-cxx-driver/pull/1430/commits/e5c7fa9b21fca3c27725aabb327f0155cc4602d9) the application of the "common format for unknown error codes" to `v1::types::source_errc` and `v1::types::types_errc`.