### PR TITLE
Generate EVG configuration with ASAN_SYMBOLIZER_PATH

### DIFF
--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -654,6 +654,7 @@ functions:
       binary: bash
       working_dir: mongo-cxx-driver
       include_expansions_in_env:
+        - ASAN_SYMBOLIZER_PATH
         - build_type
         - CRYPT_SHARED_LIB_PATH
         - cse_aws_access_key_id

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -13863,6 +13863,7 @@ tasks:
       - func: run_kms_servers
       - func: test
         vars:
+          ASAN_SYMBOLIZER_PATH: /opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           MONGOCXX_TEST_TOPOLOGY: replica
           TEST_WITH_ASAN: "ON"
           TEST_WITH_CSFLE: "ON"
@@ -13896,6 +13897,7 @@ tasks:
       - func: run_kms_servers
       - func: test
         vars:
+          ASAN_SYMBOLIZER_PATH: /opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           MONGOCXX_TEST_TOPOLOGY: sharded
           TEST_WITH_ASAN: "ON"
           TEST_WITH_CSFLE: "ON"
@@ -13928,6 +13930,7 @@ tasks:
       - func: run_kms_servers
       - func: test
         vars:
+          ASAN_SYMBOLIZER_PATH: /opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           MONGOCXX_TEST_TOPOLOGY: single
           TEST_WITH_ASAN: "ON"
           TEST_WITH_CSFLE: "ON"
@@ -13961,6 +13964,7 @@ tasks:
       - func: run_kms_servers
       - func: test
         vars:
+          ASAN_SYMBOLIZER_PATH: /opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           MONGOCXX_TEST_TOPOLOGY: replica
           TEST_WITH_ASAN: "ON"
           TEST_WITH_CSFLE: "ON"
@@ -13994,6 +13998,7 @@ tasks:
       - func: run_kms_servers
       - func: test
         vars:
+          ASAN_SYMBOLIZER_PATH: /opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           MONGOCXX_TEST_TOPOLOGY: sharded
           TEST_WITH_ASAN: "ON"
           TEST_WITH_CSFLE: "ON"
@@ -14026,6 +14031,7 @@ tasks:
       - func: run_kms_servers
       - func: test
         vars:
+          ASAN_SYMBOLIZER_PATH: /opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           MONGOCXX_TEST_TOPOLOGY: single
           TEST_WITH_ASAN: "ON"
           TEST_WITH_CSFLE: "ON"
@@ -14059,6 +14065,7 @@ tasks:
       - func: run_kms_servers
       - func: test
         vars:
+          ASAN_SYMBOLIZER_PATH: /opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           MONGOCXX_TEST_TOPOLOGY: replica
           TEST_WITH_ASAN: "ON"
           TEST_WITH_CSFLE: "ON"
@@ -14092,6 +14099,7 @@ tasks:
       - func: run_kms_servers
       - func: test
         vars:
+          ASAN_SYMBOLIZER_PATH: /opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           MONGOCXX_TEST_TOPOLOGY: sharded
           TEST_WITH_ASAN: "ON"
           TEST_WITH_CSFLE: "ON"
@@ -14124,6 +14132,7 @@ tasks:
       - func: run_kms_servers
       - func: test
         vars:
+          ASAN_SYMBOLIZER_PATH: /opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           MONGOCXX_TEST_TOPOLOGY: single
           TEST_WITH_ASAN: "ON"
           TEST_WITH_CSFLE: "ON"
@@ -14157,6 +14166,7 @@ tasks:
       - func: run_kms_servers
       - func: test
         vars:
+          ASAN_SYMBOLIZER_PATH: /opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           MONGOCXX_TEST_TOPOLOGY: replica
           TEST_WITH_CSFLE: "ON"
           TEST_WITH_UBSAN: "ON"
@@ -14190,6 +14200,7 @@ tasks:
       - func: run_kms_servers
       - func: test
         vars:
+          ASAN_SYMBOLIZER_PATH: /opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           MONGOCXX_TEST_TOPOLOGY: sharded
           TEST_WITH_CSFLE: "ON"
           TEST_WITH_UBSAN: "ON"
@@ -14222,6 +14233,7 @@ tasks:
       - func: run_kms_servers
       - func: test
         vars:
+          ASAN_SYMBOLIZER_PATH: /opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           MONGOCXX_TEST_TOPOLOGY: single
           TEST_WITH_CSFLE: "ON"
           TEST_WITH_UBSAN: "ON"
@@ -14255,6 +14267,7 @@ tasks:
       - func: run_kms_servers
       - func: test
         vars:
+          ASAN_SYMBOLIZER_PATH: /opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           MONGOCXX_TEST_TOPOLOGY: replica
           TEST_WITH_CSFLE: "ON"
           TEST_WITH_UBSAN: "ON"
@@ -14288,6 +14301,7 @@ tasks:
       - func: run_kms_servers
       - func: test
         vars:
+          ASAN_SYMBOLIZER_PATH: /opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           MONGOCXX_TEST_TOPOLOGY: sharded
           TEST_WITH_CSFLE: "ON"
           TEST_WITH_UBSAN: "ON"
@@ -14320,6 +14334,7 @@ tasks:
       - func: run_kms_servers
       - func: test
         vars:
+          ASAN_SYMBOLIZER_PATH: /opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           MONGOCXX_TEST_TOPOLOGY: single
           TEST_WITH_CSFLE: "ON"
           TEST_WITH_UBSAN: "ON"
@@ -14353,6 +14368,7 @@ tasks:
       - func: run_kms_servers
       - func: test
         vars:
+          ASAN_SYMBOLIZER_PATH: /opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           MONGOCXX_TEST_TOPOLOGY: replica
           TEST_WITH_CSFLE: "ON"
           TEST_WITH_UBSAN: "ON"
@@ -14386,6 +14402,7 @@ tasks:
       - func: run_kms_servers
       - func: test
         vars:
+          ASAN_SYMBOLIZER_PATH: /opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           MONGOCXX_TEST_TOPOLOGY: sharded
           TEST_WITH_CSFLE: "ON"
           TEST_WITH_UBSAN: "ON"
@@ -14418,6 +14435,7 @@ tasks:
       - func: run_kms_servers
       - func: test
         vars:
+          ASAN_SYMBOLIZER_PATH: /opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           MONGOCXX_TEST_TOPOLOGY: single
           TEST_WITH_CSFLE: "ON"
           TEST_WITH_UBSAN: "ON"


### PR DESCRIPTION
https://github.com/mongodb/mongo-cxx-driver/pull/1446 did not include corresponding changes to generated configs. (Perhaps we should add an EVG task to detect this...)