### PR TITLE
Tiny tweaks to mongocxx

### DIFF
--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -141,7 +141,7 @@ if(1)
 ///
 /// @warning For internal use only!
 ///
-        ]]
+]]
         )
         generate_export_header(${TARGET}
             BASE_NAME MONGOCXX_ABI

--- a/src/mongocxx/lib/mongocxx/private/export.hh
+++ b/src/mongocxx/lib/mongocxx/private/export.hh
@@ -16,8 +16,7 @@
 
 #include <mongocxx/v1/config/export.hpp>
 
-// See src/bsoncxx/lib/bsoncxx/private/export.hh for an explanation of
-// the purpose of this header.
+// See bsoncxx/private/export.hh.
 
 #if defined(MONGOCXX_TESTING)
 #define MONGOCXX_ABI_EXPORT_TESTING MONGOCXX_ABI_EXPORT


### PR DESCRIPTION
Some tiny drive-by improvements to mongocxx prior to upcoming v1 PRs which don't fit into any greater topic or purpose:

* Removes some trailing whitespace in mongocxx's generated `export.hpp` resulting from stray CMake indentation as part of https://github.com/mongodb/mongo-cxx-driver/pull/1301.
* Fixes a path referencing bsoncxx's `export.hh` which was relocated by https://github.com/mongodb/mongo-cxx-driver/pull/1323.