### PR TITLE
Move ASAN workaround from mongocxx::instance to CI with bypass_dlclose

### DIFF
--- a/.evergreen/config_generator/components/funcs/test.py
+++ b/.evergreen/config_generator/components/funcs/test.py
@@ -42,6 +42,10 @@ class Test(Function):
             'UV_INSTALL_DIR',
             'VALGRIND_INSTALL_DIR',
         ],
+        env={
+            'CC': '${cc_compiler}',
+            'CXX': '${cxx_compiler}',
+        },
         working_dir='mongo-cxx-driver',
         script='.evergreen/scripts/test.sh',
     )

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -653,6 +653,9 @@ functions:
     params:
       binary: bash
       working_dir: mongo-cxx-driver
+      env:
+        CC: ${cc_compiler}
+        CXX: ${cxx_compiler}
       include_expansions_in_env:
         - ASAN_SYMBOLIZER_PATH
         - build_type

--- a/.evergreen/scripts/bypass-dlclose.sh
+++ b/.evergreen/scripts/bypass-dlclose.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# bypass_dlclose
+#
+# Usage:
+#   bypass_dlclose command args...
+#
+# Parameters:
+#   "$CC": compiler to use to compile and link the bypass_dlclose library.
+#
+# Return 0 (true) if able to create a shared library to bypass calls to dlclose.
+# Return a non-zero (false) value otherwise.
+#
+# If successful, print paths to add to LD_PRELOAD to stdout (pipe 1).
+# Otherwise, no output is printed to stdout (pipe 1).
+#
+# Diagnostic messages may be printed to stderr (pipe 2). Redirect to /dev/null
+# with `2>/dev/null` to silence these messages.
+bypass_dlclose() (
+  : "${CC:?'bypass_dlclose expects environment variable CC to be defined!'}"
+
+  declare ld_preload
+
+  {
+    declare tmp
+
+    if ! tmp="$(mktemp -d)"; then
+      echo "Could not create temporary directory for bypass_dlclose library!" 1>&2
+      return 1
+    fi
+
+    echo "int dlclose (void *handle) {(void) handle; return 0; }" \
+      >|"${tmp:?}/bypass_dlclose.c" || return
+
+    "${CC}" -o "${tmp:?}/bypass_dlclose.so" \
+      -shared "${tmp:?}/bypass_dlclose.c" || return
+
+    ld_preload="${tmp:?}/bypass_dlclose.so"
+
+    # Clang uses its own libasan.so; do not preload it!
+    if [[ "${CC:?}" =~ clang ]]; then
+      declare asan_path
+      asan_path="$(${CC:?} -print-file-name=libasan.so)" || return
+      ld_preload="${asan_path}:${ld_preload}"
+    fi
+  } 1>&2
+
+  printf "%s" "${ld_preload}"
+)

--- a/.evergreen/scripts/test.sh
+++ b/.evergreen/scripts/test.sh
@@ -101,6 +101,7 @@ fi
 export DRIVERS_TOOLS
 popd # "${working_dir:?}/../drivers-evergreen-tools"
 
+. .evergreen/scripts/bypass-dlclose.sh
 . .evergreen/scripts/install-build-tools.sh
 install_build_tools
 
@@ -275,21 +276,23 @@ else
   )
 
   run_test() {
-    echo "Running $@..."
-    "$@" "${test_args[@]:?}" || return
-    echo "Running $@... done."
+    echo "Running ${1:?}..."
+    "${1:?}" "${test_args[@]:?}" || return
+    echo "Running ${1:?}... done."
   }
 
+  declare ld_preload="${LD_PRELOAD:-}"
   if [[ "${TEST_WITH_ASAN:-}" == "ON" || "${TEST_WITH_UBSAN:-}" == "ON" ]]; then
     export ASAN_OPTIONS="detect_leaks=1"
     export UBSAN_OPTIONS="print_stacktrace=1"
+    ld_preload="$(bypass_dlclose):${ld_preload:-}"
   elif [[ "${TEST_WITH_VALGRIND:-}" == "ON" ]]; then
     command -V valgrind
     valgrind --version
     run_test() {
-      echo "Running $@..."
-      valgrind --leak-check=full --track-origins=yes --num-callers=50 --error-exitcode=1 --error-limit=no --read-var-info=yes --suppressions=../etc/memcheck.suppressions "$@" "${test_args[@]:?}" || return
-      echo "Running $@... done."
+      echo "Running ${1:?}..."
+      valgrind --leak-check=full --track-origins=yes --num-callers=50 --error-exitcode=1 --error-limit=no --read-var-info=yes --suppressions=../etc/memcheck.suppressions "${1:?}" "${test_args[@]:?}" || return
+      echo "Running ${1:?}... done."
     }
   fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
   - Clang 3.8 (from Clang 3.5).
   - Apple Clang 13.1 with Xcode 13.4.1 (from Apple Clang 5.1 with Xcode 5.1).
   - MSVC 19.0.24210 with Visual Studio 2015 Update 3 (from MSVC 19.0.23506 with Visual Studio 2015 Update 1).
+- `mongocxx::v_noabi::instance::~instance()` no longer skips calling `mongoc_cleanup()` when compiled with ASAN enabled.
+  - See https://github.com/google/sanitizers/issues/89 for context.
 
 ### Deprecated
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/instance.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/instance.cpp
@@ -30,10 +30,6 @@
 #include <mongocxx/private/config/config.hh>
 #include <mongocxx/private/mongoc.hh>
 
-#if !defined(__has_feature)
-#define __has_feature(x) 0
-#endif
-
 namespace mongocxx {
 namespace v_noabi {
 
@@ -119,14 +115,7 @@ class instance::impl {
             libmongoc::log_set_handler(null_log_handler, nullptr);
         }
 
-// Under ASAN, we don't want to clean up libmongoc, because it causes libraries to become
-// unloaded, and then ASAN sees non-rooted allocations that it consideres leaks. These are
-// also inscrutable, because the stack refers into an unloaded library, which ASAN can't
-// report. Note that this only works if we have built mongoc so that it doesn't do its
-// unfortunate automatic invocation of 'cleanup'.
-#if !__has_feature(address_sanitizer)
         libmongoc::cleanup();
-#endif
     }
 
     impl(impl&&) noexcept = delete;


### PR DESCRIPTION
Quoting https://github.com/mongodb/mongo-c-driver/pull/1177:

> To silence unhelpful `<unknown module>` leaks, the workaround previously applied [specifically to mongcryptd](https://github.com/mongodb/mongo-c-driver/blob/21275453cd46253b9d252fdfc319c1880b3dca3a/.evergreen/run-tests.sh#L80) was generalized into a `bypass-dlclose.sh` script which wraps a provided command with `LD_PRELOAD` set appropriately. This is applied only to tests run on Evergreen; changes to the CMake configuration were deliberately avoided to prevent introducing downstream effects.

A very long time ago in https://github.com/mongodb/mongo-cxx-driver/pull/527 (Sep 2016), mongocxx implemented a workaround for this issue, but within the implementation of `instance` itself, such that the call to `mongoc_cleanup()` is _compile-time disabled_ if it detects ASAN is enabled. Note this predates the mongocryptd `dlclose` workaround mentioned above (Nov 2019). Looking at related issues (see: [google/sanitizers#89](/google/sanitizers/issues/89)), it doesn't seem like the situation has improved since.

I think we can/should move this migration into CI scripts instead for consistency with libmongocrypt and mongoc. Included a changelog entry in case this change happens to affect anyone downstream building the C++ Driver with ASAN enabled and expect this old behavior for some reason (unlikely, but just in case).