### PR TITLE
Update index test case for forward-compatibility with server 8.3

### DIFF
--- a/src/mongocxx/test/index_view.cpp
+++ b/src/mongocxx/test/index_view.cpp
@@ -371,7 +371,7 @@ TEST_CASE("drop_one", "[index_view]") {
         REQUIRE(std::distance(cursor.begin(), cursor.end()) == 1);
 
         // SERVER-90152: "dropIndex should be idempotent"
-        if (!test_util::server_version_is_at_least("8.3")) {
+        if (!test_util::newer_than("8.3")) {
             REQUIRE_THROWS_AS(indexes.drop_one("foo"), operation_exception);
         }
     }

--- a/src/mongocxx/test/index_view.cpp
+++ b/src/mongocxx/test/index_view.cpp
@@ -370,7 +370,10 @@ TEST_CASE("drop_one", "[index_view]") {
         auto cursor = indexes.list();
         REQUIRE(std::distance(cursor.begin(), cursor.end()) == 1);
 
-        REQUIRE_THROWS_AS(indexes.drop_one("foo"), operation_exception);
+        // SERVER-90152: "dropIndex should be idempotent"
+        if (!test_util::server_version_is_at_least("8.3")) {
+            REQUIRE_THROWS_AS(indexes.drop_one("foo"), operation_exception);
+        }
     }
 }
 


### PR DESCRIPTION
Cherry-pick c39093aa699431dd954cce4b8e617ebcb4e41d37 to fix failing tests on latest servers.

Verified with this Evergreen patch: https://spruce.mongodb.com/version/68b74a62241a92000755fd12

Intended to help fix tests on the release branch ahead of the upcoming 4.1.2 release.