### PR TITLE
CXX-3325 condition fix on GCC version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 ### Fixed
 
 - `storage_engine() const` in `mongocxx::v_noabi::options::index` is correctly exported using mongocxx export macros instead of bsoncxx export macros.
+- Fix `-Wdeprecated-literal-operator` warning.
 
 ## 4.1.1
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/json.hpp
@@ -82,7 +82,11 @@ BSONCXX_ABI_EXPORT_CDECL(document::value) from_json(stdx::string_view json);
 ///
 /// @throws bsoncxx::v_noabi::exception with error details if the conversion failed.
 ///
+#if defined(__GNUC__) && (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ <= 8)) && !defined(__clang__)
+BSONCXX_ABI_EXPORT_CDECL(document::value) operator"" _bson(char const* json, size_t len);
+#else
 BSONCXX_ABI_EXPORT_CDECL(document::value) operator""_bson(char const* json, size_t len);
+#endif // GCC <= 4.8
 
 } // namespace v_noabi
 } // namespace bsoncxx
@@ -92,7 +96,11 @@ namespace bsoncxx {
 using ::bsoncxx::v_noabi::from_json;
 using ::bsoncxx::v_noabi::to_json;
 
+#if defined(__GNUC__) && (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ <= 8)) && !defined(__clang__)
+using ::bsoncxx::v_noabi::operator"" _bson;
+#else
 using ::bsoncxx::v_noabi::operator""_bson;
+#endif // GCC <= 4.8
 
 } // namespace bsoncxx
 

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/json.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/json.cpp
@@ -107,7 +107,11 @@ document::value from_json(stdx::string_view json) {
     return document::value{buf, length, bson_free_deleter};
 }
 
+#if defined(__GNUC__) && (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ <= 8)) && !defined(__clang__)
+document::value operator"" _bson(char const* str, size_t len) {
+#else
 document::value operator""_bson(char const* str, size_t len) {
+#endif // GCC <= 4.8
     return from_json(stdx::string_view{str, len});
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/mongo-cxx-driver/pull/1441. Quoting the PR description:

> following #1415, GCC 4.8 is no longer within our range of supported (minimum required) compilers.

However, GCC 4.8 is still supported on the v4.1 release branch. Therefore, the fix is conditioned on GCC 4.8. This is needed for the 4.1.2 release.

Fixes failing RHEL 7.6 tasks: https://spruce.mongodb.com/version/68b7661dc208c10007ea47f3