### PR TITLE
Fix documentation of v1::document::value post-move state

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v1/document/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/document/value.hpp
@@ -129,7 +129,8 @@ class value {
     /// Move construction.
     ///
     /// @par Postconditions:
-    /// - `other` is equivalent to a default-initialized value.
+    /// - `this->data() == nullptr`
+    /// - `this->get_deleter()` is in a valid but unspecified state.
     ///
     value(value&& other) noexcept = default;
 
@@ -137,7 +138,8 @@ class value {
     /// Move assignment.
     ///
     /// @par Postconditions:
-    /// - `other` is equivalent to a default-initialized value.
+    /// - `this->data() == nullptr`
+    /// - `this->get_deleter()` is in a valid but unspecified state.
     ///
     value& operator=(value&& other) noexcept = default;
 


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1412, where the documentation of post-move state for `v1::document::value` (and `v1::array::value` via `\copydoc`) was not correctly updated to account for the default initialization state being changed from "invalid" to "empty", as asserted by the (correctly updated) tests:

https://github.com/mongodb/mongo-cxx-driver/blob/91b9c64c907dd43b6fc492444b99e919a30b8934/src/bsoncxx/test/v1/document/value.cpp#L131-L139