### PR TITLE
CXX-3352 manually remove Delighted NPS survey scripts

### DIFF
--- a/404.html
+++ b/404.html
@@ -70,10 +70,6 @@
         gtag('js', new Date());
         gtag('config', 'G-56KD6L3MDX');
     </script>
-    <script type="text/javascript">
-        !function (e, t, r, n, a) { if (!e[a]) { for (var i = e[a] = [], s = 0; s < r.length; s++) { var c = r[s]; i[c] = i[c] || function (e) { return function () { var t = Array.prototype.slice.call(arguments); i.push([e, t]) } }(c) } i.SNIPPET_VERSION = "1.0.1"; var o = t.createElement("script"); o.type = "text/javascript", o.async = !0, o.src = "https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/" + n + "/" + a + ".js"; var l = t.getElementsByTagName("script")[0]; l.parentNode.insertBefore(o, l) } }(window, document, ["survey", "reset", "config", "init", "set", "get", "event", "identify", "track", "page", "screen", "group", "alias"], "Dk30CC86ba0nATlK", "delighted");
-        delighted.survey();
-    </script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -706,13 +706,6 @@ else if (window.attachEvent) window.attachEvent('onload', async_load);
 
   gtag('config', 'G-56KD6L3MDX');
 </script>
-
-
-<script type="text/javascript">
-  !function(e,t,r,n,a){if(!e[a]){for(var i=e[a]=[],s=0;s<r.length;s++){var c=r[s];i[c]=i[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);i.push([e,t])}}(c)}i.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+n+"/"+a+".js";var l=t.getElementsByTagName("script")[0];l.parentNode.insertBefore(o,l)}}(window,document,["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],"Dk30CC86ba0nATlK","delighted");
-
-  delighted.survey();
-</script>
 </body>
 </html>
 

--- a/legacy-v1/breaking-changes/index.html
+++ b/legacy-v1/breaking-changes/index.html
@@ -857,13 +857,6 @@ else if (window.attachEvent) window.attachEvent('onload', async_load);
 
   gtag('config', 'G-56KD6L3MDX');
 </script>
-
-
-<script type="text/javascript">
-  !function(e,t,r,n,a){if(!e[a]){for(var i=e[a]=[],s=0;s<r.length;s++){var c=r[s];i[c]=i[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);i.push([e,t])}}(c)}i.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+n+"/"+a+".js";var l=t.getElementsByTagName("script")[0];l.parentNode.insertBefore(o,l)}}(window,document,["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],"Dk30CC86ba0nATlK","delighted");
-
-  delighted.survey();
-</script>
 </body>
 </html>
 

--- a/legacy-v1/configuration/index.html
+++ b/legacy-v1/configuration/index.html
@@ -893,13 +893,6 @@ else if (window.attachEvent) window.attachEvent('onload', async_load);
 
   gtag('config', 'G-56KD6L3MDX');
 </script>
-
-
-<script type="text/javascript">
-  !function(e,t,r,n,a){if(!e[a]){for(var i=e[a]=[],s=0;s<r.length;s++){var c=r[s];i[c]=i[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);i.push([e,t])}}(c)}i.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+n+"/"+a+".js";var l=t.getElementsByTagName("script")[0];l.parentNode.insertBefore(o,l)}}(window,document,["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],"Dk30CC86ba0nATlK","delighted");
-
-  delighted.survey();
-</script>
 </body>
 </html>
 

--- a/legacy-v1/index.html
+++ b/legacy-v1/index.html
@@ -754,13 +754,6 @@ else if (window.attachEvent) window.attachEvent('onload', async_load);
 
   gtag('config', 'G-56KD6L3MDX');
 </script>
-
-
-<script type="text/javascript">
-  !function(e,t,r,n,a){if(!e[a]){for(var i=e[a]=[],s=0;s<r.length;s++){var c=r[s];i[c]=i[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);i.push([e,t])}}(c)}i.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+n+"/"+a+".js";var l=t.getElementsByTagName("script")[0];l.parentNode.insertBefore(o,l)}}(window,document,["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],"Dk30CC86ba0nATlK","delighted");
-
-  delighted.survey();
-</script>
 </body>
 </html>
 

--- a/legacy-v1/installation/index.html
+++ b/legacy-v1/installation/index.html
@@ -982,13 +982,6 @@ else if (window.attachEvent) window.attachEvent('onload', async_load);
 
   gtag('config', 'G-56KD6L3MDX');
 </script>
-
-
-<script type="text/javascript">
-  !function(e,t,r,n,a){if(!e[a]){for(var i=e[a]=[],s=0;s<r.length;s++){var c=r[s];i[c]=i[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);i.push([e,t])}}(c)}i.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+n+"/"+a+".js";var l=t.getElementsByTagName("script")[0];l.parentNode.insertBefore(o,l)}}(window,document,["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],"Dk30CC86ba0nATlK","delighted");
-
-  delighted.survey();
-</script>
 </body>
 </html>
 

--- a/legacy-v1/tutorial/index.html
+++ b/legacy-v1/tutorial/index.html
@@ -903,13 +903,6 @@ else if (window.attachEvent) window.attachEvent('onload', async_load);
 
   gtag('config', 'G-56KD6L3MDX');
 </script>
-
-
-<script type="text/javascript">
-  !function(e,t,r,n,a){if(!e[a]){for(var i=e[a]=[],s=0;s<r.length;s++){var c=r[s];i[c]=i[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);i.push([e,t])}}(c)}i.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+n+"/"+a+".js";var l=t.getElementsByTagName("script")[0];l.parentNode.insertBefore(o,l)}}(window,document,["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],"Dk30CC86ba0nATlK","delighted");
-
-  delighted.survey();
-</script>
 </body>
 </html>
 

--- a/legacy-v1/working-with-bson/index.html
+++ b/legacy-v1/working-with-bson/index.html
@@ -742,13 +742,6 @@ else if (window.attachEvent) window.attachEvent('onload', async_load);
 
   gtag('config', 'G-56KD6L3MDX');
 </script>
-
-
-<script type="text/javascript">
-  !function(e,t,r,n,a){if(!e[a]){for(var i=e[a]=[],s=0;s<r.length;s++){var c=r[s];i[c]=i[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);i.push([e,t])}}(c)}i.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+n+"/"+a+".js";var l=t.getElementsByTagName("script")[0];l.parentNode.insertBefore(o,l)}}(window,document,["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],"Dk30CC86ba0nATlK","delighted");
-
-  delighted.survey();
-</script>
 </body>
 </html>
 


### PR DESCRIPTION
Companion PR to https://github.com/mongodb/mongo-cxx-driver/pull/1466. Manually removes all instances of the Delighted NPS survey script in the current page deployment.