### PR TITLE
CXX-3320 migrate instance and logger to mongocxx::v1

### DIFF
--- a/.evergreen/scripts/test.sh
+++ b/.evergreen/scripts/test.sh
@@ -289,8 +289,25 @@ else
     command -V valgrind
     valgrind --version
     run_test() {
+      valgrind_args=(
+        "--leak-check=full"
+        "--track-origins=yes"
+        "--num-callers=50"
+        "--error-exitcode=1"
+        "--error-limit=no"
+        "--read-var-info=yes"
+        "--suppressions=../etc/memcheck.suppressions"
+      )
+
+      # Prevent mongocxx::test::subprocess termination from confusing valgrind.
+      if [[ "${1:?}" =~ test_instance ]]; then
+        valgrind_args+=(
+          "--trace-children=no"
+        )
+      fi
+
       echo "Running ${1:?}..."
-      valgrind --leak-check=full --track-origins=yes --num-callers=50 --error-exitcode=1 --error-limit=no --read-var-info=yes --suppressions=../etc/memcheck.suppressions "${1:?}" "${test_args[@]:?}" || return
+      valgrind "${1:?}" "${test_args[@]:?}" || return
       echo "Running ${1:?}... done."
     }
   fi
@@ -304,7 +321,6 @@ else
   run_test ./src/mongocxx/test/test_command_monitoring_specs
   run_test ./src/mongocxx/test/test_instance
   run_test ./src/mongocxx/test/test_transactions_specs
-  run_test ./src/mongocxx/test/test_logging
   run_test ./src/mongocxx/test/test_retryable_reads_specs
   run_test ./src/mongocxx/test/test_read_write_concern_specs
   run_test ./src/mongocxx/test/test_unified_format_specs

--- a/src/mongocxx/include/mongocxx/v1/exception.hpp
+++ b/src/mongocxx/include/mongocxx/v1/exception.hpp
@@ -20,6 +20,13 @@
 
 #include <mongocxx/v1/detail/prelude.hpp>
 
+#include <bsoncxx/v1/detail/macros.hpp>
+
+#include <mongocxx/v1/config/export.hpp>
+
+#include <system_error>
+#include <type_traits>
+
 namespace mongocxx {
 namespace v1 {
 
@@ -28,14 +35,60 @@ namespace v1 {
 ///
 /// @attention This feature is experimental! It is not ready for use!
 ///
-enum class source_errc {};
+enum class source_errc {
+    zero,       ///< Zero.
+    mongocxx,   ///< From the mongocxx library.
+    mongoc,     ///< From the mongoc library.
+    mongocrypt, ///< From the mongocrypt library.
+    server,     ///< From the MongoDB server.
+};
+
+///
+/// The error category for @ref mongocxx::v1::source_errc.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+MONGOCXX_ABI_EXPORT_CDECL(std::error_category const&) source_error_category();
+
+///
+/// Support implicit conversion to `std::error_condition`.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+inline std::error_condition make_error_condition(source_errc code) {
+    return {static_cast<int>(code), v1::source_error_category()};
+}
 
 ///
 /// Enumeration identifying the type (cause) of a @ref mongocxx::v1 error.
 ///
 /// @attention This feature is experimental! It is not ready for use!
 ///
-enum class type_errc {};
+enum class type_errc {
+    zero,             ///< Zero.
+    invalid_argument, ///< An invalid argument passed to the throwing function.
+    runtime_error,    ///< An erroneous condition was detected at runtime.
+};
+
+///
+/// The error category for @ref mongocxx::v1::type_errc.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+MONGOCXX_ABI_EXPORT_CDECL(std::error_category const&) type_error_category();
+
+///
+/// Support implicit conversion to `std::error_condition`.
+///
+/// @attention This feature is experimental! It is not ready for use!
+///
+inline std::error_condition make_error_condition(type_errc code) {
+    return {static_cast<int>(code), v1::type_error_category()};
+}
+
+BSONCXX_PRIVATE_WARNINGS_PUSH();
+BSONCXX_PRIVATE_WARNINGS_DISABLE(MSVC(4251));
+BSONCXX_PRIVATE_WARNINGS_DISABLE(MSVC(4275));
 
 ///
 /// Base class for all exceptions thrown by @ref mongocxx::v1.
@@ -45,10 +98,32 @@ enum class type_errc {};
 ///
 /// @attention This feature is experimental! It is not ready for use!
 ///
-class exception {};
+class exception : public std::system_error {
+   public:
+    ~exception() override;
+
+    exception(exception&&) noexcept = default;
+    exception& operator=(exception&&) noexcept = default;
+    exception(exception const&) = default;
+    exception& operator=(exception const&) = default;
+
+    using std::system_error::system_error;
+};
+
+BSONCXX_PRIVATE_WARNINGS_POP();
 
 } // namespace v1
 } // namespace mongocxx
+
+namespace std {
+
+template <>
+struct is_error_condition_enum<mongocxx::v1::source_errc> : true_type {};
+
+template <>
+struct is_error_condition_enum<mongocxx::v1::type_errc> : true_type {};
+
+} // namespace std
 
 #include <mongocxx/v1/detail/postlude.hpp>
 

--- a/src/mongocxx/include/mongocxx/v1/instance.hpp
+++ b/src/mongocxx/include/mongocxx/v1/instance.hpp
@@ -20,6 +20,14 @@
 
 #include <mongocxx/v1/detail/prelude.hpp>
 
+#include <mongocxx/v1/logger-fwd.hpp>
+
+#include <mongocxx/v1/config/export.hpp>
+
+#include <memory>
+#include <system_error>
+#include <type_traits>
+
 namespace mongocxx {
 namespace v1 {
 
@@ -50,14 +58,134 @@ namespace v1 {
 /// @par Special exemptions
 /// Only the following API are permitted to be used outside the lifetime of an instance object:
 /// - @ref mongocxx::v1::logger
+/// - @ref mongocxx::v1::default_logger
 ///
 /// @see
 /// - [Initialization and Cleanup (mongoc)](https://mongoc.org/libmongoc/current/init-cleanup.html)
 ///
-class instance {};
+class instance {
+   private:
+    class impl;
+    std::unique_ptr<impl> _impl;
+
+   public:
+    ///
+    /// Cleanup the mongocxx (and mongoc) library.
+    ///
+    /// Calls [`mongoc_init()`](https://mongoc.org/libmongoc/current/mongoc_cleanup.html).
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL() ~instance();
+
+    ///
+    /// This class is not moveable.
+    ///
+    instance(instance&&) = delete;
+
+    ///
+    /// This class is not moveable.
+    ///
+    instance& operator=(instance&&) = delete;
+
+    ///
+    /// This class is not copyable.
+    ///
+    instance(instance const&) = delete;
+
+    ///
+    /// This class is not copyable.
+    ///
+    instance& operator=(instance const&) = delete;
+
+    ///
+    /// Initialize the mongoc library with unstructured log messages disabled.
+    ///
+    /// Calls [`mongoc_init()`](https://mongoc.org/libmongoc/current/mongoc_init.html) after disabling unstructured
+    /// log messages by calling `mongoc_log_set_handler(nullptr, nullptr)`.
+    ///
+    /// @important To use mongoc's default log message handler, construct this object with
+    /// @ref instance(v1::default_logger tag) instead.
+    ///
+    /// @throws mongocxx::v1::exception with @ref mongocxx::v1::instance::errc::multiple_instances if an `instance`
+    /// object has already been created.
+    ///
+    /// @see
+    /// - [Custom Log Handlers (mongoc)](https://mongoc.org/libmongoc/current/unstructured_log.html#custom-log-handlers)
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL() instance();
+
+    ///
+    /// Initialize the mongoc library with the custom unstructured log message handler.
+    ///
+    /// Calls [`mongoc_init`](https://mongoc.org/libmongoc/current/mongoc_init.html) after registering the custom
+    /// unstructured log handler by calling `mongoc_log_set_handler()`.
+    ///
+    /// @param handler Disable unstructured logging when null.
+    ///
+    /// @throws mongocxx::v1::exception with @ref mongocxx::v1::instance::errc::multiple_instances if an `instance`
+    /// object has already been created.
+    ///
+    /// @see
+    /// - [Custom Log Handlers (mongoc)](https://mongoc.org/libmongoc/current/unstructured_log.html#custom-log-handlers)
+    ///
+    explicit MONGOCXX_ABI_EXPORT_CDECL() instance(std::unique_ptr<v1::logger> handler);
+
+    ///
+    /// Initialize the mongoc library with its default unstructured log handler.
+    ///
+    /// Calls [`mongoc_init`](https://mongoc.org/libmongoc/current/mongoc_init.html) without registering any custom
+    /// unstructured log handler.
+    ///
+    /// @param tag Unused: only for overload resolution.
+    ///
+    /// @throws mongocxx::v1::exception with @ref mongocxx::v1::instance::errc::multiple_instances if an `instance`
+    /// object has already been created.
+    ///
+    explicit MONGOCXX_ABI_EXPORT_CDECL() instance(v1::default_logger tag);
+
+    ///
+    /// Equivalent to @ref instance(std::unique_ptr<v1::logger> handler) when `handler == nullptr`.
+    ///
+    /// @see
+    /// - [Custom Log Handlers (mongoc)](https://mongoc.org/libmongoc/current/unstructured_log.html#custom-log-handlers)
+    ///
+    explicit MONGOCXX_ABI_EXPORT_CDECL() instance(std::nullptr_t);
+
+    ///
+    /// Errors codes which may be returned by @ref mongocxx::v1::instance.
+    ///
+    /// @attention This feature is experimental! It is not ready for use!
+    ///
+    enum class errc {
+        zero,               ///< Zero.
+        multiple_instances, ///< Cannot construct multiple instance objects in a given process.
+    };
+
+    ///
+    /// The error category for @ref mongocxx::v1::instance::errc.
+    ///
+    /// @attention This feature is experimental! It is not ready for use!
+    ///
+    static MONGOCXX_ABI_EXPORT_CDECL(std::error_category const&) error_category();
+
+    ///
+    /// Support implicit conversion to `std::error_code`.
+    ///
+    /// @attention This feature is experimental! It is not ready for use!
+    ///
+    friend std::error_code make_error_code(errc v) {
+        return {static_cast<int>(v), error_category()};
+    }
+};
 
 } // namespace v1
 } // namespace mongocxx
+
+namespace std {
+
+template <>
+struct is_error_code_enum<mongocxx::v1::instance::errc> : true_type {};
+
+} // namespace std
 
 #include <mongocxx/v1/detail/postlude.hpp>
 

--- a/src/mongocxx/include/mongocxx/v1/logger.hpp
+++ b/src/mongocxx/include/mongocxx/v1/logger.hpp
@@ -20,6 +20,11 @@
 
 #include <mongocxx/v1/detail/prelude.hpp>
 
+#include <bsoncxx/v1/detail/macros.hpp>
+#include <bsoncxx/v1/stdx/string_view.hpp>
+
+#include <mongocxx/v1/config/export.hpp>
+
 namespace mongocxx {
 namespace v1 {
 
@@ -28,7 +33,21 @@ namespace v1 {
 ///
 /// @attention This feature is experimental! It is not ready for use!
 ///
-enum class log_level {};
+enum class log_level {
+    k_error,    ///< MONGOC_LOG_LEVEL_ERROR
+    k_critical, ///< MONGOC_LOG_LEVEL_CRITICAL
+    k_warning,  ///< MONGOC_LOG_LEVEL_WARNING
+    k_message,  ///< MONGOC_LOG_LEVEL_MESSAGE
+    k_info,     ///< MONGOC_LOG_LEVEL_INFO
+    k_debug,    ///< MONGOC_LOG_LEVEL_DEBUG
+    k_trace,    ///< MONGOC_LOG_LEVEL_TRACE
+};
+
+MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::string_view) to_string(log_level level);
+
+BSONCXX_PRIVATE_WARNINGS_PUSH();
+BSONCXX_PRIVATE_WARNINGS_DISABLE(MSVC(4251));
+BSONCXX_PRIVATE_WARNINGS_DISABLE(MSVC(4275));
 
 ///
 /// The interface for an unstructured log message handler.
@@ -37,7 +56,60 @@ enum class log_level {};
 ///
 /// @attention This feature is experimental! It is not ready for use!
 ///
-class logger {};
+class logger {
+   public:
+    ///
+    /// Destructor.
+    ///
+    virtual ~logger();
+
+    ///
+    /// Move constructor.
+    ///
+    logger(logger&&) = default;
+
+    ///
+    /// Move assignment operator.
+    ///
+    logger& operator=(logger&&) = default;
+
+    ///
+    /// Copy constructor.
+    ///
+    logger(logger const&) = default;
+
+    ///
+    /// Copy assignment operator.
+    ///
+    logger& operator=(logger const&) = default;
+
+    ///
+    /// Default constructor.
+    ///
+    logger() = default;
+
+    ///
+    /// Handle an unstructured log message emitted by mongoc.
+    ///
+    /// Users may override this function to implement custom log message behavior such as outputting messages to a file
+    /// or sending messages to a remote server.
+    ///
+    ///
+    ///
+    /// @param level The log level for the message being handled.
+    /// @param domain The domain of the message.
+    /// @param message The contents of the log message.
+    ///
+    /// @see
+    /// - [Custom Log handlers (mongoc)](https://mongoc.org/libmongoc/current/unstructured_log.html#custom-log-handlers)
+    ///
+    virtual void operator()(
+        log_level level,
+        bsoncxx::v1::stdx::string_view domain,
+        bsoncxx::v1::stdx::string_view message) noexcept = 0;
+};
+
+BSONCXX_PRIVATE_WARNINGS_POP();
 
 ///
 /// A tag type representing mongoc's default unstructured log handler.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/instance.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/instance.hpp
@@ -14,9 +14,14 @@
 
 #pragma once
 
+#include <mongocxx/instance-fwd.hpp>
+
+//
+
+#include <mongocxx/v1/instance.hpp>
+
 #include <memory>
 
-#include <mongocxx/instance-fwd.hpp>
 #include <mongocxx/logger-fwd.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -24,59 +29,7 @@
 namespace mongocxx {
 namespace v_noabi {
 
-///
-/// An instance of the MongoDB driver.
-///
-/// The constructor and destructor initialize and shut down the driver, respectively. Therefore, an
-/// instance must be created before using the driver and must remain alive until all other mongocxx
-/// objects are destroyed. After the instance destructor runs, the driver may not be used.
-///
-/// Exactly one instance must be created in a given program. Not constructing an instance or
-/// constructing more than one instance in a program are errors, even if the multiple instances have
-/// non-overlapping lifetimes.
-///
-/// The following is a correct example of using an instance in a program, as the instance is kept
-/// alive for as long as the driver is in use:
-///
-/// \code
-///
-/// #include <mongocxx/client.hpp>
-/// #include <mongocxx/instance.hpp>
-/// #include <mongocxx/uri.hpp>
-///
-/// int main() {
-///     mongocxx::v_noabi::instance inst{};
-///     mongocxx::v_noabi::client conn{mongocxx::v_noabi::uri{}};
-///     ...
-/// }
-///
-/// \endcode
-///
-/// An example of using instance incorrectly might look as follows:
-///
-/// \code
-///
-/// #include <mongocxx/client.hpp>
-/// #include <mongocxx/instance.hpp>
-/// #include <mongocxx/uri.hpp>
-///
-/// client get_client() {
-///     mongocxx::v_noabi::instance inst{};
-///     mongocxx::v_noabi::client conn{mongocxx::v_noabi::uri{}};
-///
-///     return client;
-/// } // ERROR! The instance is no longer alive after this function returns.
-///
-/// int main() {
-///     mongocxx::v_noabi::client conn = get_client();
-///     ...
-/// }
-///
-/// \endcode
-///
-/// For examples of more advanced usage of instance, see
-/// `examples/mongocxx/instance_management.cpp`.
-///
+/// @copydoc mongocxx::v1::instance
 class instance {
    public:
     ///
@@ -90,7 +43,7 @@ class instance {
     ///
     /// @throws mongocxx::v_noabi::logic_error if an instance already exists.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL() instance(std::unique_ptr<logger> logger);
+    MONGOCXX_ABI_EXPORT_CDECL() instance(std::unique_ptr<v_noabi::logger> logger);
 
     ///
     /// Move constructs an instance of the driver.
@@ -128,4 +81,7 @@ class instance {
 ///
 /// @file
 /// Provides @ref mongocxx::v_noabi::instance.
+///
+/// @par Includes
+/// - @ref mongocxx/v1/instance.hpp
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger-fwd.hpp
@@ -14,23 +14,29 @@
 
 #pragma once
 
+#include <mongocxx/v1/logger-fwd.hpp>
+
 #include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 namespace v_noabi {
 
-enum class log_level;
+using v1::log_level;
 
-class MONGOCXX_ABI_EXPORT logger;
+using v1::logger;
+
+using v1::default_logger;
 
 } // namespace v_noabi
 } // namespace mongocxx
 
 namespace mongocxx {
 
-using ::mongocxx::v_noabi::log_level;
+using v1::log_level;
 
-using ::mongocxx::v_noabi::logger;
+using v1::logger;
+
+using v1::default_logger;
 
 } // namespace mongocxx
 
@@ -39,4 +45,7 @@ using ::mongocxx::v_noabi::logger;
 ///
 /// @file
 /// Declares utilities related to mongocxx logging.
+///
+/// @par Includes
+/// - @ref mongocxx/v1/logger-fwd.hpp
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger.hpp
@@ -14,83 +14,31 @@
 
 #pragma once
 
-#include <memory>
-
 #include <mongocxx/logger-fwd.hpp>
 
-#include <bsoncxx/stdx/string_view.hpp>
+//
+
+#include <mongocxx/v1/logger.hpp>
 
 #include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
 namespace v_noabi {
 
-///
-/// The log level of a log message.
-///
-enum class log_level {
-    k_error,    ///< Log Level Error.
-    k_critical, ///< Log Level Critical.
-    k_warning,  ///< Log Level Warning.
-    k_message,  ///< Log Level Message.
-    k_info,     ///< Log Level Info.
-    k_debug,    ///< Log Level Debug.
-    k_trace,    ///< Log Level Trace.
-};
+using v1::log_level;
 
-///
-/// Returns a stringification of the given log level.
-///
-/// @param level
-///   The type to stringify.
-///
-/// @return a std::string representation of the type.
-///
-MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v_noabi::stdx::string_view) to_string(log_level level);
+using v1::to_string;
 
-///
-/// The interface which user-defined loggers must implement.
-///
-/// @see
-/// - @ref mongocxx::v_noabi::instance
-///
-class logger {
-   public:
-    virtual ~logger();
+using v1::logger;
 
-    logger(logger&&) = default;
-    logger& operator=(logger&&) = default;
-    logger(logger const&) = default;
-    logger& operator=(logger const&) = default;
-
-    ///
-    /// Handles a log message. User defined logger implementations may do whatever they wish when
-    /// this is called, such as log the output to a file or send it to a remote server for analysis.
-    ///
-    /// @param level
-    ///   The log level of the current log message
-    /// @param domain
-    ///   The domain of the current log message, such as 'client'
-    /// @param message
-    ///   The text of the current log message.
-    virtual void operator()(
-        log_level level,
-        bsoncxx::v_noabi::stdx::string_view domain,
-        bsoncxx::v_noabi::stdx::string_view message) noexcept = 0;
-
-   protected:
-    ///
-    /// Default constructor
-    ///
-    logger();
-};
+using v1::default_logger;
 
 } // namespace v_noabi
 } // namespace mongocxx
 
 namespace mongocxx {
 
-using ::mongocxx::v_noabi::to_string;
+using v1::to_string;
 
 } // namespace mongocxx
 
@@ -99,4 +47,7 @@ using ::mongocxx::v_noabi::to_string;
 ///
 /// @file
 /// Provides utilities related to mongocxx logging.
+///
+/// @par Includes
+/// - @ref mongocxx/v1/logger.hpp
 ///

--- a/src/mongocxx/lib/mongocxx/v1/exception.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/exception.cpp
@@ -13,3 +13,76 @@
 // limitations under the License.
 
 #include <mongocxx/v1/exception.hpp>
+
+//
+
+#include <string>
+
+#include <bsoncxx/private/immortal.hh>
+#include <bsoncxx/private/type_traits.hh>
+
+namespace mongocxx {
+namespace v1 {
+
+std::error_category const& source_error_category() {
+    class type final : public std::error_category {
+        char const* name() const noexcept override {
+            return "mongocxx::v1::source_errc";
+        }
+
+        std::string message(int v) const noexcept override {
+            using code = v1::source_errc;
+
+            switch (static_cast<code>(v)) {
+                case code::zero:
+                    return "zero";
+                case code::mongocxx:
+                    return "mongocxx";
+                case code::mongoc:
+                    return "mongoc";
+                case code::mongocrypt:
+                    return "mongocrypt";
+                case code::server:
+                    return "server";
+                default:
+                    return std::string(this->name()) + ':' + std::to_string(v);
+            }
+        }
+    };
+
+    static bsoncxx::immortal<type> const instance;
+
+    return instance.value();
+}
+
+std::error_category const& type_error_category() {
+    class type final : public std::error_category {
+        char const* name() const noexcept override {
+            return "mongocxx::v1::type_errc";
+        }
+
+        std::string message(int v) const noexcept override {
+            using code = v1::type_errc;
+
+            switch (static_cast<code>(v)) {
+                case code::zero:
+                    return "zero";
+                case code::invalid_argument:
+                    return "invalid argument";
+                case code::runtime_error:
+                    return "runtime error";
+                default:
+                    return std::string(this->name()) + ':' + std::to_string(v);
+            }
+        }
+    };
+
+    static bsoncxx::immortal<type> const instance;
+
+    return instance.value();
+}
+
+exception::~exception() = default;
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v1/instance.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/instance.cpp
@@ -13,3 +13,193 @@
 // limitations under the License.
 
 #include <mongocxx/v1/instance.hpp>
+
+//
+
+#include <mongocxx/v1/config/version.hpp>
+#include <mongocxx/v1/exception.hpp>
+#include <mongocxx/v1/logger.hpp>
+
+#include <atomic>
+#include <string>
+#include <system_error>
+#include <type_traits>
+#include <utility>
+
+#include <bsoncxx/private/immortal.hh>
+#include <bsoncxx/private/make_unique.hh>
+
+#include <mongocxx/private/config/config.hh>
+#include <mongocxx/private/mongoc.hh>
+
+namespace mongocxx {
+namespace v1 {
+
+using code = v1::instance::errc;
+
+static_assert(!std::is_move_constructible<instance>::value, "bsoncxx::v1::instance must be non-moveable");
+static_assert(!std::is_copy_constructible<instance>::value, "bsoncxx::v1::instance must be non-copyable");
+
+namespace {
+
+// 0: no instance object has been created.
+// 1: there is a single instance object.
+// 2: the single instance object has been destroyed.
+std::atomic_int instance_state{0};
+
+void custom_log_handler(
+    mongoc_log_level_t log_level,
+    char const* domain,
+    char const* message,
+    void* user_data) noexcept {
+    (*static_cast<v1::logger*>(user_data))(
+        static_cast<v1::log_level>(log_level),
+        bsoncxx::v1::stdx::string_view(domain),
+        bsoncxx::v1::stdx::string_view(message));
+}
+
+} // namespace
+
+class instance::impl {
+   public:
+    std::unique_ptr<v1::logger> _handler;
+
+    ~impl() {
+        if (_handler) {
+            libmongoc::log_set_handler(nullptr, nullptr);
+        }
+
+        libmongoc::cleanup();
+
+        instance_state.fetch_add(1, std::memory_order_release);
+    }
+
+    impl(impl&&) = delete;
+    impl& operator=(impl&&) = delete;
+    impl(impl const&) = delete;
+    impl& operator=(impl const&) = delete;
+
+    explicit impl(std::unique_ptr<v1::logger> handler) : _handler{std::move(handler)} {
+        this->init(true);
+    }
+
+    explicit impl(v1::default_logger tag) {
+        (void)tag;
+        this->init(false);
+    }
+
+   private:
+    void init(bool set_custom_handler) {
+        {
+            int expected = 0;
+
+            if (!instance_state.compare_exchange_strong(
+                    expected, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
+                throw v1::exception{code::multiple_instances};
+            }
+        }
+
+        if (set_custom_handler) {
+            if (auto ptr = _handler.get()) {
+                libmongoc::log_set_handler(&custom_log_handler, ptr);
+            } else {
+                libmongoc::log_set_handler(nullptr, nullptr);
+            }
+        }
+
+        libmongoc::init();
+
+        {
+            // Avoid /Zc:__cplusplus problems with MSVC.
+#pragma push_macro("STDCXX")
+#undef STDCXX
+#if defined(_MSVC_LANG)
+#define STDCXX BSONCXX_PRIVATE_STRINGIFY(_MSVC_LANG)
+#else
+#define STDCXX BSONCXX_PRIVATE_STRINGIFY(__cplusplus)
+#endif
+
+            // Handshake data can only be appended once (or it will return false): this is that "once".
+            // Despite the name, mongoc_handshake_data_append() *prepends* the platform string.
+            // Use " / " to delimit handshake date for mongocxx and mongoc.
+            (void)libmongoc::handshake_data_append(
+                "mongocxx",
+                MONGOCXX_VERSION_STRING,
+                "CXX=" MONGOCXX_COMPILER_ID " " MONGOCXX_COMPILER_VERSION " stdcxx=" STDCXX " / ");
+
+#pragma pop_macro("STDCXX")
+        }
+    }
+};
+
+instance::~instance() = default;
+
+instance::instance() : instance{v1::default_logger{}} {}
+
+instance::instance(std::unique_ptr<v1::logger> handler) : _impl{bsoncxx::make_unique<impl>(std::move(handler))} {}
+
+instance::instance(v1::default_logger tag) : _impl{bsoncxx::make_unique<impl>(tag)} {
+    (void)tag;
+}
+
+instance::instance(std::nullptr_t) : instance{std::unique_ptr<v1::logger>{}} {}
+
+std::error_category const& instance::error_category() {
+    class type final : public std::error_category {
+        char const* name() const noexcept override {
+            return "mongocxx::v1::instance";
+        }
+
+        std::string message(int v) const noexcept override {
+            switch (static_cast<code>(v)) {
+                case code::zero:
+                    return "zero";
+                case code::multiple_instances:
+                    return "cannot construct multiple instance objects in a given process";
+                default:
+                    return std::string(this->name()) + ':' + std::to_string(v);
+            }
+        }
+
+        bool equivalent(int v, std::error_condition const& ec) const noexcept override {
+            if (ec.category() == v1::source_error_category()) {
+                using condition = v1::source_errc;
+
+                auto const source = static_cast<condition>(ec.value());
+
+                switch (static_cast<code>(v)) {
+                    case code::multiple_instances:
+                        return source == condition::mongocxx;
+
+                    case code::zero:
+                    default:
+                        return false;
+                }
+            }
+
+            if (ec.category() == v1::type_error_category()) {
+                using condition = v1::type_errc;
+
+                auto const type = static_cast<condition>(ec.value());
+
+                switch (static_cast<code>(v)) {
+                    case code::multiple_instances:
+                        return type == condition::runtime_error;
+
+                    case code::zero:
+                    default:
+                        return false;
+                }
+            }
+
+            return false;
+        }
+    };
+
+    static bsoncxx::immortal<type> const instance;
+
+    return instance.value();
+}
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v1/logger.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/logger.cpp
@@ -13,3 +13,46 @@
 // limitations under the License.
 
 #include <mongocxx/v1/logger.hpp>
+
+//
+
+#include <bsoncxx/v1/stdx/string_view.hpp>
+
+#include <mongocxx/private/mongoc.hh>
+
+namespace mongocxx {
+namespace v1 {
+
+static_assert(static_cast<int>(log_level::k_error) == static_cast<int>(MONGOC_LOG_LEVEL_ERROR), "");
+static_assert(static_cast<int>(log_level::k_critical) == static_cast<int>(MONGOC_LOG_LEVEL_CRITICAL), "");
+static_assert(static_cast<int>(log_level::k_warning) == static_cast<int>(MONGOC_LOG_LEVEL_WARNING), "");
+static_assert(static_cast<int>(log_level::k_message) == static_cast<int>(MONGOC_LOG_LEVEL_MESSAGE), "");
+static_assert(static_cast<int>(log_level::k_info) == static_cast<int>(MONGOC_LOG_LEVEL_INFO), "");
+static_assert(static_cast<int>(log_level::k_debug) == static_cast<int>(MONGOC_LOG_LEVEL_DEBUG), "");
+static_assert(static_cast<int>(log_level::k_trace) == static_cast<int>(MONGOC_LOG_LEVEL_TRACE), "");
+
+bsoncxx::v1::stdx::string_view to_string(log_level level) {
+    switch (level) {
+        case log_level::k_error:
+            return "error";
+        case log_level::k_critical:
+            return "critical";
+        case log_level::k_warning:
+            return "warning";
+        case log_level::k_message:
+            return "message";
+        case log_level::k_info:
+            return "info";
+        case log_level::k_debug:
+            return "debug";
+        case log_level::k_trace:
+            return "trace";
+        default:
+            return "unknown";
+    }
+}
+
+logger::~logger() = default;
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/logger.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/logger.cpp
@@ -13,33 +13,3 @@
 // limitations under the License.
 
 #include <mongocxx/logger.hpp>
-
-namespace mongocxx {
-namespace v_noabi {
-
-bsoncxx::v_noabi::stdx::string_view to_string(log_level level) {
-    switch (level) {
-        case log_level::k_error:
-            return "error";
-        case log_level::k_critical:
-            return "critical";
-        case log_level::k_warning:
-            return "warning";
-        case log_level::k_message:
-            return "message";
-        case log_level::k_info:
-            return "info";
-        case log_level::k_debug:
-            return "debug";
-        case log_level::k_trace:
-            return "trace";
-        default:
-            return "unknown";
-    }
-}
-
-logger::logger() = default;
-logger::~logger() = default;
-
-} // namespace v_noabi
-} // namespace mongocxx

--- a/src/mongocxx/test/CMakeLists.txt
+++ b/src/mongocxx/test/CMakeLists.txt
@@ -94,6 +94,11 @@ set(mongocxx_test_sources_v_noabi
     v_noabi/write_concern.cpp
 )
 
+set(mongocxx_test_sources_v1
+    v1/exception.cpp
+    v1/logger.cpp
+)
+
 set(mongocxx_test_sources_spec
     spec/monitoring.cpp
     spec/operation.cpp
@@ -113,10 +118,12 @@ set(mongocxx_test_sources_extra
     spec/transactions.cpp
     spec/unified_tests/operations.cpp
     spec/unified_tests/runner.cpp
+    subprocess.cpp
     v_noabi/catch_helpers.cpp
     v_noabi/client_helpers.cpp
     v_noabi/instance.cpp
     v_noabi/logging.cpp
+    v1/instance.cpp
 )
 
 file(GLOB_RECURSE mongocxx_test_headers
@@ -132,14 +139,17 @@ add_library(spec_test_common OBJECT ${mongocxx_test_sources_spec})
 add_executable(test_driver
     ${mongocxx_test_sources_private}
     ${mongocxx_test_sources_v_noabi}
+    ${mongocxx_test_sources_v1}
     v_noabi/catch_helpers.cpp
 )
 target_link_libraries(test_driver PRIVATE spec_test_common client_helpers)
 
-add_executable(test_logging v_noabi/logging.cpp)
-target_compile_definitions(test_logging PRIVATE MONGOCXX_TEST_DISABLE_MAIN_INSTANCE)
-
-add_executable(test_instance v_noabi/instance.cpp)
+add_executable(test_instance
+    subprocess.cpp
+    v_noabi/instance.cpp
+    v_noabi/logging.cpp
+    v1/instance.cpp
+)
 target_compile_definitions(test_instance PRIVATE MONGOCXX_TEST_DISABLE_MAIN_INSTANCE)
 
 add_executable(test_crud_specs spec/crud.cpp)
@@ -202,7 +212,6 @@ set_property(
         test_driver
         test_gridfs_specs
         test_instance
-        test_logging
         test_read_write_concern_specs
         test_retryable_reads_specs
         test_transactions_specs
@@ -231,7 +240,6 @@ foreach(test_name
     driver
     gridfs_specs
     instance
-    logging
     read_write_concern_specs
     retryable_reads_specs
     transactions_specs
@@ -338,6 +346,7 @@ set_dist_list(src_mongocxx_test_DIST
     CMakeLists.txt
     ${mongocxx_test_sources_private}
     ${mongocxx_test_sources_v_noabi}
+    ${mongocxx_test_sources_v1}
     ${mongocxx_test_sources_spec}
     ${mongocxx_test_sources_extra}
     ${mongocxx_test_headers}

--- a/src/mongocxx/test/subprocess.cpp
+++ b/src/mongocxx/test/subprocess.cpp
@@ -1,0 +1,188 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/test/subprocess.hh>
+
+//
+
+#include <atomic>
+#include <iostream>
+#include <stdexcept>
+
+#include <catch2/catch_test_macros.hpp>
+
+#if !defined(_MSC_VER)
+
+#include <cstdlib>  // exit(), strsignal(), etc.
+#include <string.h> // strsignal()
+#include <unistd.h> // fork(), close(), etc.
+
+#include <catch2/catch_test_macros.hpp>
+#include <sys/wait.h> // waitpid()
+
+namespace mongocxx {
+namespace test {
+
+int subprocess(std::function<void()> fn, bool* is_signal_ptr) {
+    auto is_signal_local = false;
+    auto& is_signal = is_signal_ptr ? *is_signal_ptr : is_signal_local;
+
+    pid_t const pid = ::fork();
+
+    // Child: do nothing more than call `fn`.
+    if (pid == 0) {
+        // Use `std::exit()` and `std::terminate()` to prevent continued execution of the Catch2 test suite.
+        try {
+            fn();
+            std::exit(EXIT_SUCCESS);
+        } catch (Catch::TestFailureException) {
+            // Assertion failure already output its diagnostic message.
+            std::exit(EXIT_FAILURE);
+        } catch (Catch::TestSkipException) {
+            // SKIP() already output its diagnostic message.
+            // Don't try to propagate the "skip", just treat as equivalent to success.
+            std::exit(EXIT_SUCCESS);
+        } catch (std::exception const& ex) {
+            // Trigger output of Catch2 diagnostic messages.
+            FAIL_CHECK("uncaught exception in subprocess: " << ex.what());
+            std::exit(EXIT_FAILURE);
+        } catch (...) {
+            // Allow default termination handler to translate the unknown exception type.
+            // This should also trigger the output of Catch2 diagnostic messages.
+            std::terminate();
+        }
+    }
+
+    // Parent: wait for child and handle returned status values.
+    else {
+        int status;
+
+        int const ret = ::waitpid(pid, &status, 0);
+
+        if (WIFEXITED(status) && WEXITSTATUS(status) != EXIT_SUCCESS) {
+            UNSCOPED_INFO("subprocess exited with a non-zero exit code: " << WEXITSTATUS(status));
+            is_signal = false;
+            return WEXITSTATUS(status);
+        }
+
+        // For unexpected signals, stop immediately.
+        else if (WIFSIGNALED(status)) {
+            int const signal = WTERMSIG(status);
+            char const* const sigstr = ::strsignal(signal);
+            UNSCOPED_INFO("subprocess was killed by signal: " << signal << " (" << (sigstr ? sigstr : "") << ")");
+            is_signal = true;
+            return signal;
+        }
+
+        // We don't expect any other failure condition.
+        else {
+            REQUIRE(ret != -1);
+            return 0;
+        }
+    }
+}
+
+} // namespace test
+} // namespace mongocxx
+
+#else
+
+namespace mongocxx {
+namespace test {
+
+int subprocess(std::function<void()> fn, bool* is_signal_ptr) {
+    (void)fn;
+    (void)is_signal_ptr;
+
+    SKIP("mongocxx::test::subprocess() is not supported");
+
+    return 0; // Unused.
+}
+
+} // namespace test
+} // namespace mongocxx
+
+#endif // !defined(_MSC_VER)
+
+TEST_CASE("counter", "[mongocxx][test][subprocess]") {
+    std::atomic_int counter{0};
+
+    CHECK_SUBPROCESS([&counter] { counter.fetch_add(1); });
+    CHECK_SUBPROCESS([&counter] { counter.fetch_add(2); });
+    CHECK_SUBPROCESS([&counter] { counter.fetch_add(3); });
+
+    // State of a subprocess must not be observable by the original process.
+    REQUIRE(counter.load() == 0);
+}
+
+TEST_CASE("failure", "[mongocxx][test][subprocess]") {
+    auto is_signal = false;
+    CHECK_FALSE_SUBPROCESS([] {
+        // Try to silence noisy Catch2 output.
+        (void)::close(1); // stdout
+        (void)::close(2); // stderr
+
+        FAIL("subprocess");
+    });
+    CHECK_FALSE(is_signal);
+}
+
+TEST_CASE("skip", "[mongocxx][test][subprocess]") {
+    auto is_signal = false;
+    CHECK_SUBPROCESS([] {
+        // Try to silence noisy Catch2 output.
+        (void)::close(1); // stdout
+        (void)::close(2); // stderr
+
+        SKIP("subprocess");
+    });
+    CHECK_FALSE(is_signal);
+}
+
+TEST_CASE("exception", "[mongocxx][test][subprocess]") {
+    auto is_signal = false;
+    CHECK_FALSE_SUBPROCESS(
+        [] {
+            // Try to silence noisy Catch2 output.
+            (void)::close(1); // stdout
+            (void)::close(2); // stderr
+
+            throw std::runtime_error("subprocess");
+        },
+        &is_signal);
+    CHECK_FALSE(is_signal);
+}
+
+TEST_CASE("unknown exception", "[mongocxx][test][subprocess]") {
+#if !defined(_MSC_VER)
+    auto is_signal = false;
+    auto const ret = mongocxx::test::subprocess(
+        [] {
+            // Try to silence noisy Catch2 output.
+            (void)::close(1); // stdout
+            (void)::close(2); // stderr
+
+            throw "subprocess";
+        },
+        &is_signal);
+    CHECK(is_signal);
+    CHECK(ret != 0);
+    CHECK(ret != SIGTERM); // std::terminate()
+
+#else
+
+    CHECK_SUBPROCESS([] {});
+
+#endif // !defined(_MSC_VER)
+}

--- a/src/mongocxx/test/subprocess.hh
+++ b/src/mongocxx/test/subprocess.hh
@@ -1,0 +1,60 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/stdx/string_view.hpp>
+
+#include <functional>
+
+namespace mongocxx {
+namespace test {
+
+// Execute `fn` in a forked subprocess.
+//
+// Should be invoked directly from the body of a TEST_CASE(), not within a SECTION(). Keep it simple!
+//
+// @param fn The function to be invoked within a subprocess.
+// @param is_signal_ptr When not null, `*is_signal_ptr` is set to `true` if the return value is a signal rather than an
+// exit code.
+//
+// @returns The exit code of the subprocess (`*is_signal` is `false`) or the signal used to kill the subprocess
+// (`*is_signal` is `true`) .
+int subprocess(std::function<void()> fn, bool* is_signal_ptr = nullptr);
+
+#if !defined(_MSC_VER)
+
+#define CHECK_SUBPROCESS(...)                                    \
+    if (1) {                                                     \
+        int const ret = mongocxx::test::subprocess(__VA_ARGS__); \
+        CHECK(ret == 0);                                         \
+    } else                                                       \
+        ((void)0)
+
+#define CHECK_FALSE_SUBPROCESS(...)                              \
+    if (1) {                                                     \
+        int const ret = mongocxx::test::subprocess(__VA_ARGS__); \
+        CHECK(ret != 0);                                         \
+    } else                                                       \
+        ((void)0)
+
+#else
+
+#define CHECK_SUBPROCESS(...) SKIP("mongocxx::test::subprocess() is not supported")
+#define CHECK_FALSE_SUBPROCESS(...) SKIP("mongocxx::test::subprocess() is not supported")
+
+#endif // !defined(_MSC_VER)
+
+} // namespace test
+} // namespace mongocxx

--- a/src/mongocxx/test/v1/exception.cpp
+++ b/src/mongocxx/test/v1/exception.cpp
@@ -1,0 +1,62 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/test/v1/exception.hh>
+
+//
+
+#include <bsoncxx/test/system_error.hh>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+namespace mongocxx {
+namespace v1 {
+
+TEST_CASE("source", "[mongocxx][v1][error]") {
+    auto const& c = source_error_category();
+
+    SECTION("name") {
+        CHECK_THAT(c.name(), Catch::Matchers::Equals("mongocxx::v1::source_errc"));
+    }
+
+    SECTION("message") {
+        CHECK(c.message(-1) == "mongocxx::v1::source_errc:-1");
+        CHECK(c.message(0) == "zero");
+        CHECK(c.message(1) == "mongocxx");
+        CHECK(c.message(2) == "mongoc");
+        CHECK(c.message(3) == "mongocrypt");
+        CHECK(c.message(4) == "server");
+        CHECK(c.message(5) == "mongocxx::v1::source_errc:5");
+    }
+}
+
+TEST_CASE("type", "[mongocxx][v1][error]") {
+    auto const& c = type_error_category();
+
+    SECTION("name") {
+        CHECK_THAT(c.name(), Catch::Matchers::Equals("mongocxx::v1::type_errc"));
+    }
+
+    SECTION("message") {
+        CHECK(c.message(-1) == "mongocxx::v1::type_errc:-1");
+        CHECK(c.message(0) == "zero");
+        CHECK(c.message(1) == "invalid argument");
+        CHECK(c.message(2) == "runtime error");
+        CHECK(c.message(3) == "mongocxx::v1::type_errc:3");
+    }
+}
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/test/v1/exception.hh
+++ b/src/mongocxx/test/v1/exception.hh
@@ -14,27 +14,21 @@
 
 #pragma once
 
-#include <mongocxx/v1/detail/prelude.hpp>
+#include <mongocxx/v1/exception.hpp>
 
 //
 
-#include <mongocxx/v1/config/export.hpp>
+#include <catch2/catch_tostring.hpp>
 
-namespace mongocxx {
-namespace v1 {
+CATCH_REGISTER_ENUM(
+    mongocxx::v1::source_errc,
+    mongocxx::v1::source_errc::zero,
+    mongocxx::v1::source_errc::mongocxx,
+    mongocxx::v1::source_errc::mongoc,
+    mongocxx::v1::source_errc::mongocrypt)
 
-enum class log_level;
-
-class MONGOCXX_ABI_EXPORT logger;
-
-class default_logger;
-
-} // namespace v1
-} // namespace mongocxx
-
-#include <mongocxx/v1/detail/postlude.hpp>
-
-///
-/// @file
-/// Declares @ref mongocxx::v1::logger.
-///
+CATCH_REGISTER_ENUM(
+    mongocxx::v1::type_errc,
+    mongocxx::v1::type_errc::zero,
+    mongocxx::v1::type_errc::invalid_argument,
+    mongocxx::v1::type_errc::runtime_error)

--- a/src/mongocxx/test/v1/instance.cpp
+++ b/src/mongocxx/test/v1/instance.cpp
@@ -1,0 +1,206 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/test/v1/instance.hh>
+
+//
+
+#include <bsoncxx/v1/stdx/string_view.hpp>
+
+#include <mongocxx/test/v1/logger.hh>
+
+#include <functional>
+#include <utility>
+
+#include <bsoncxx/private/make_unique.hh>
+
+#include <mongocxx/private/mongoc.hh>
+
+#include <bsoncxx/test/stringify.hh>
+
+#include <mongocxx/test/subprocess.hh>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#if !defined(_MSC_VER)
+#include <unistd.h>
+#endif
+
+namespace mongocxx {
+namespace v1 {
+
+namespace {
+
+class custom_logger : public logger {
+   private:
+    using fn_type = std::function<void(log_level, bsoncxx::v1::stdx::string_view, bsoncxx::v1::stdx::string_view)>;
+
+    fn_type _fn;
+
+   public:
+    /* explicit(false) */ custom_logger(fn_type fn) : _fn{std::move(fn)} {}
+
+    void operator()(
+        log_level level,
+        bsoncxx::v1::stdx::string_view domain,
+        bsoncxx::v1::stdx::string_view message) noexcept override {
+        _fn(level, domain, message);
+    }
+};
+
+} // namespace
+
+TEST_CASE("logger", "[mongocxx][v1][instance]") {
+#if !defined(_MSC_VER)
+    class capture_stderr {
+       private:
+        int _pipes[2];
+        int _stderr; // stderr
+
+       public:
+        ~capture_stderr() {
+            ::dup2(_stderr, STDERR_FILENO); // Restore original stderr.
+        }
+
+        capture_stderr(capture_stderr&&) = delete;
+        capture_stderr& operator=(capture_stderr&&) = delete;
+        capture_stderr(capture_stderr const&) = delete;
+        capture_stderr& operator=(capture_stderr const&) = delete;
+
+        capture_stderr()
+            : _stderr{::dup(STDERR_FILENO)} // Save original stderr.
+        {
+            ::fflush(stderr);
+            REQUIRE(::pipe(_pipes) == 0);                    // Open redirection pipes.
+            REQUIRE(::dup2(_pipes[1], STDERR_FILENO) != -1); // Copy stderr to input pipe.
+            REQUIRE(::close(_pipes[1]) != -1);               // Close original stderr.
+
+            REQUIRE(
+                ::fcntl(_pipes[0], F_SETFL, ::fcntl(_pipes[0], F_GETFL) | O_NONBLOCK) != -1); // Do not block on read.
+        }
+
+        std::string read() {
+            std::string res;
+
+            {
+                // Capture everything up to this point.
+                // Avoid recursive macro expansion of `stderr` due to Catch expression decomposition.
+                auto const res = ::fflush(stderr);
+                REQUIRE(res == 0);
+            }
+
+            while (true) {
+                char buf[BUFSIZ];
+                auto const n = ::read(_pipes[0], buf, std::size_t{BUFSIZ - 1});
+
+                CHECKED_IF(n < 0) {
+                    REQUIRE(errno == EAGAIN); // No data left in stream.
+                    break;
+                }
+                else {
+                    res.append(buf, static_cast<std::size_t>(n));
+                }
+            }
+
+            return res;
+        }
+    };
+
+#else
+
+    class capture_stderr {
+       public:
+        std::string read() {
+            return {};
+        }
+    };
+
+#endif // !defined(_MSC_VER)
+
+    {
+        auto const test_default = [] {
+            instance i;
+
+            auto const output = [&] {
+                capture_stderr guard;
+                mongoc_log(MONGOC_LOG_LEVEL_WARNING, "mongocxx::v1::instance", "mongoc_log_default_handler");
+                return guard.read();
+            }();
+
+            CHECK_THAT(
+                output,
+                Catch::Matchers::ContainsSubstring("mongocxx::v1::instance") &&
+                    Catch::Matchers::ContainsSubstring("mongoc_log_default_handler"));
+        };
+        CHECK_SUBPROCESS(test_default);
+    }
+
+    {
+        auto const test_noop = [] {
+            instance i{nullptr};
+
+            auto const output = [&] {
+                capture_stderr guard;
+                mongoc_log(MONGOC_LOG_LEVEL_WARNING, "mongocxx::v1::instance", "SHOULD NOT BE LOGGED");
+                return guard.read();
+            }();
+
+            CHECK_THAT(
+                output,
+                !Catch::Matchers::ContainsSubstring("mongocxx::v1::instance") &&
+                    !Catch::Matchers::ContainsSubstring("SHOULD NOT BE LOGGED"));
+        };
+        CHECK_SUBPROCESS(test_noop);
+    }
+
+    {
+        auto const test_custom = [] {
+            int count = 0;
+            log_level level;
+            std::string domain;
+            std::string message;
+
+            auto const fn =
+                [&](log_level _level, bsoncxx::v1::stdx::string_view _domain, bsoncxx::v1::stdx::string_view _message) {
+                    ++count;
+                    level = _level;
+                    domain = std::string{_domain};
+                    message = std::string{_message};
+                };
+
+            instance i{bsoncxx::make_unique<custom_logger>(fn)};
+
+            mongoc_log(MONGOC_LOG_LEVEL_WARNING, "mongocxx::v1::instance", "custom_logger");
+
+            CHECK(count == 1);
+            CHECK(level == log_level::k_warning);
+            CHECK(domain == "mongocxx::v1::instance");
+            CHECK(message == "custom_logger");
+        };
+        CHECK_SUBPROCESS(test_custom);
+    }
+}
+
+TEST_CASE("stringify", "[mongocxx][test][v1][instance]") {
+    auto const test = [] {
+        instance i;
+
+        REQUIRE(bsoncxx::test::stringify(i) == "mongocxx::v1::instance");
+    };
+    CHECK_SUBPROCESS(test);
+}
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/test/v1/instance.hh
+++ b/src/mongocxx/test/v1/instance.hh
@@ -14,27 +14,19 @@
 
 #pragma once
 
-#include <mongocxx/v1/detail/prelude.hpp>
+#include <mongocxx/v1/instance.hpp>
 
 //
 
-#include <mongocxx/v1/config/export.hpp>
+#include <catch2/catch_tostring.hpp>
 
-namespace mongocxx {
-namespace v1 {
+namespace Catch {
 
-enum class log_level;
+template <>
+struct StringMaker<mongocxx::v1::instance> {
+    static std::string convert(mongocxx::v1::instance const&) {
+        return "mongocxx::v1::instance";
+    }
+};
 
-class MONGOCXX_ABI_EXPORT logger;
-
-class default_logger;
-
-} // namespace v1
-} // namespace mongocxx
-
-#include <mongocxx/v1/detail/postlude.hpp>
-
-///
-/// @file
-/// Declares @ref mongocxx::v1::logger.
-///
+} // namespace Catch

--- a/src/mongocxx/test/v1/logger.cpp
+++ b/src/mongocxx/test/v1/logger.cpp
@@ -1,0 +1,53 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/test/v1/logger.hh>
+
+//
+
+#include <bsoncxx/test/stringify.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace mongocxx {
+namespace v1 {
+
+namespace {
+
+struct custom_logger : logger {
+    void operator()(
+        log_level level,
+        bsoncxx::v1::stdx::string_view domain,
+        bsoncxx::v1::stdx::string_view message) noexcept override {
+        (void)level;
+        (void)domain;
+        (void)message;
+    }
+};
+
+} // namespace
+
+// mongocxx::v1::logger must not unnecessarily mpose special requirements on derived classes.
+static_assert(std::is_nothrow_destructible<custom_logger>::value, "");
+static_assert(std::is_nothrow_move_constructible<custom_logger>::value, "");
+static_assert(std::is_copy_constructible<custom_logger>::value, "");
+static_assert(std::is_default_constructible<custom_logger>::value, "");
+
+TEST_CASE("stringify", "[mongocxx][test][v1][logger]") {
+    // No point specializing StringMaker for abstract class mongocxx::v1::logger.
+    CHECK(bsoncxx::test::stringify(custom_logger{}) == "{?}");
+}
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/test/v1/logger.hh
+++ b/src/mongocxx/test/v1/logger.hh
@@ -14,27 +14,24 @@
 
 #pragma once
 
-#include <mongocxx/v1/detail/prelude.hpp>
+#include <mongocxx/v1/logger.hpp>
 
 //
 
-#include <mongocxx/v1/config/export.hpp>
+#include <catch2/catch_tostring.hpp>
 
-namespace mongocxx {
-namespace v1 {
+CATCH_REGISTER_ENUM(
+    mongocxx::v1::log_level,
+    mongocxx::v1::log_level::k_error,
+    mongocxx::v1::log_level::k_critical,
+    mongocxx::v1::log_level::k_warning,
+    mongocxx::v1::log_level::k_message,
+    mongocxx::v1::log_level::k_info,
+    mongocxx::v1::log_level::k_debug,
+    mongocxx::v1::log_level::k_trace)
 
-enum class log_level;
+namespace Catch {
 
-class MONGOCXX_ABI_EXPORT logger;
+// No point specializing StringMaker for abstract class mongocxx::v1::logger.
 
-class default_logger;
-
-} // namespace v1
-} // namespace mongocxx
-
-#include <mongocxx/v1/detail/postlude.hpp>
-
-///
-/// @file
-/// Declares @ref mongocxx::v1::logger.
-///
+} // namespace Catch


### PR DESCRIPTION
Related to CXX-3320. Due to the unique nature of `mongocxx::v_noabi::instance` as a global singleton-like object, this class is migrated in full from `v_noabi` to `v1` as a single, standalone PR. Related types `v_noabi::logger` and `v_noabi::exception` are also minimally migrated as part of this PR to support the `instance` class API. (The `v1::exception` class 

---

First, concerning `v_noabi::logger`: due to having no observable difference in behavior in `v1`, `v_noabi::logger` is merely a redeclaration of `v1::logger` in the `v_noabi` namespace! 🎉 This also avoids complications with trying to support compatibility between both a `v_noabi::logger` and `v1::logger` class given their polymorphic nature.

---

The `v_noabi::instance` class is not so fortunate. Its migration is complicated primary by the realization that there are two unresolvable deficiencies with the `v_noabi::instance` API:

* it does not support using the mongoc default log handler, and
* the custom log handler (if any) is registered _after_ `mongoc_init()` has already been invoked.

As mentioned by mongoc [docs](https://mongoc.org/libmongoc/current/unstructured_log.html):

> Note that in the example above `mongoc_log_set_handler()` is called before `mongoc_init().` Otherwise, some log traces could not be processed by the log handler.

That is, the initialization behavior is currently defined as follows (pseudocode):

```cpp
void v_noabi::init(mongoc_log_func_t handler) {
    mongoc_init(); // May emit log messages!

    if (handler) {
        mongoc_log_set_handler(handler); // Already initialized!
    } else {
        mongoc_log_set_handler(nullptr); // Disable log messages!
    }

    // ... handshake ...
}
```

The `v1::instance` object proposes fixing these issues as follows:

* Support a `v1::default_handler` tag type by which the user can request using the mongoc default log handler.
* Register or disable the custom log handler _before_ calling `mongoc_init()` so that all log messages are handled properly.

That is, the initialization behavior is changed to the following:

```cpp
void v1::init(mongoc_log_func_t handler) {
    v1::init::impl(handler, true); // Set a custom log handler.
}

void v1::init(default_handler tag) {
    v1::init::impl(handler, false); // Use default log handler.
}

void v1::init::impl(mongoc_log_func_t handler, bool set_custom_handler) {
    // Support using the default log handler.
    if (set_custom_handler) {
        if (handler) {
            mongoc_log_set_handler(handler); // Already initialized!
        } else {
            mongoc_log_set_handler(nullptr); // Disable log messages!
        }
    }

    mongoc_init(); // All log messages are captured.

    // ... handshake ...
}
```

For backward compatibility, `v_noabi::instance`'s custom log handler constructor preserves the "register handler after `mongoc_init()`" behavior. If we do not consider this behavior to be worth preserving (how important are log messages which may be emitted by `mongoc_init()`?), we can simplify the implementation of `v_noabi::instance`'s initialization.

The `v_noabi::instance` still supports the (deprecated) `::instance()` helper function for backward compatibility. The implementation of `::instance()` remains specific to `v_noabi`: the implementation `v1::instance` is entirely unaware of `::instance()` support. In place of the `current_instance` "sentinel" value, `v1::instance` instead utilizes a simple `std::atomic_int` counter to track and report exceptions given multiple instance objects.

---

Much of the rest of this PR involves refactors to the test suite for the `instance` and `logger` classes. The `test_logging` executable is removed in favor of grouping all `instance` object testing to `test_instance`. All other test executables can (in theory) be grouped into a single test executable without concern for "multiple instance object" exceptions.

The fork-based pattern to test `instance` objects used by the examples API runner (https://github.com/mongodb/mongo-cxx-driver/issues/1216) is repurposed here for compatibility with the Catch2 test suite as `mongocxx::test::subprocess(op)`. This helper function accepts a single `op: void()` invocable that is executed within a forked subprocess. The result of the subprocess, _including termination_, is translated into well-behaved Catch test assertions. The Catch test suite reporter is reused by the subprocess to support capturing values and evaluating assertions. However, using `SECTION()` is not supported due to non-trivial control flow, either within `op` or in the parent `TEST_CASE()`.

This enabled writing test cases asserting proper log message handling behavior, including _default_ log message handler behavior, by capturing log output emitted by the subprocess (using POSIX pipe API in the `capture_stderr` class). Note this is only supported on non-Windows platforms. Unfortunately, the use of `std::exit()` and `std::terminate()` in the subprocess confuses `valgrind`, which (understandably) reports memory leaks due to the abnormal process termination method. Therefore, leak detection in subprocesses is disabled for the `test_instance` executable using `--trace-children=no`.