### PR TITLE
Re-enable distros previously missing system uv binaries

### DIFF
--- a/.evergreen/config_generator/components/compile_only.py
+++ b/.evergreen/config_generator/components/compile_only.py
@@ -16,7 +16,7 @@ MATRIX = [
     # C++ standard and compiler coverage
 
     ('rhel80',     'clang',    [11, 17, 20,   ]), # Clang  7 (max: C++20)
-  # ('rhel84',     'clang',    [11, 17, 20,   ]), # Clang 11 (max: C++20) # No uv binary available.
+    ('rhel84',     'clang',    [11, 17, 20,   ]), # Clang 11 (max: C++20)
     ('ubuntu2204', 'clang-12', [11, 17, 20, 23]), # Clang 12 (max: C++23)
     ('rhel90',     'clang',    [11, 17, 20, 23]), # Clang 13 (max: C++23)
     ('rhel91',     'clang',    [11, 17, 20, 23]), # Clang 14 (max: C++23)
@@ -25,16 +25,16 @@ MATRIX = [
     ('rhel94',     'clang',    [11, 17, 20, 23]), # Clang 17 (max: C++23)
     ('rhel95',     'clang',    [11, 17, 20, 23]), # Clang 19 (max: C++23)
 
-    ('rhel7.9',    'gcc',    [11, 14,       ]), # GCC  4.8 (max: C++14)
-    ('rhel80',     'gcc',    [11, 17, 20,   ]), # GCC  8.2 (max: C++20)
-  # ('rhel84',     'gcc',    [11, 17, 20,   ]), # GCC  8.4 (max: C++20) # No uv binary available.
-  # ('debian11',   'gcc-10', [11, 17, 20,   ]), # GCC 10.2 (max: C++20) # No uv binary available.
-    ('rhel90',     'gcc',    [11, 17, 20, 23]), # GCC 11.2 (max: C++23)
-    ('rhel92',     'gcc',    [11, 17, 20, 23]), # GCC 11.3 (max: C++23)
-    ('rhel94',     'gcc',    [11, 17, 20, 23]), # GCC 11.4 (max: C++23)
-    ('rhel95',     'gcc',    [11, 17, 20, 23]), # GCC 11.5 (max: C++23)
-    ('debian12',   'gcc',    [11, 17, 20,   ]), # GCC 12.2 (max: C++23)
-    ('ubuntu2404', 'gcc-13', [11, 17, 20,   ]), # GCC 13.3 (max: C++23)
+    ('rhel7.9',         'gcc',    [11, 14,       ]), # GCC  4.8 (max: C++14)
+    ('rhel80',          'gcc',    [11, 17, 20,   ]), # GCC  8.2 (max: C++20)
+    ('rhel84',          'gcc',    [11, 17, 20,   ]), # GCC  8.4 (max: C++20)
+    ('debian11-latest', 'gcc-10', [11, 17, 20,   ]), # GCC 10.2 (max: C++20)
+    ('rhel90',          'gcc',    [11, 17, 20, 23]), # GCC 11.2 (max: C++23)
+    ('rhel92',          'gcc',    [11, 17, 20, 23]), # GCC 11.3 (max: C++23)
+    ('rhel94',          'gcc',    [11, 17, 20, 23]), # GCC 11.4 (max: C++23)
+    ('rhel95',          'gcc',    [11, 17, 20, 23]), # GCC 11.5 (max: C++23)
+    ('debian12-latest', 'gcc',    [11, 17, 20,   ]), # GCC 12.2 (max: C++23)
+    ('ubuntu2404',      'gcc-13', [11, 17, 20,   ]), # GCC 13.3 (max: C++23)
 
     ('windows-vsCurrent', 'vs2015x64', [11, 14,             'latest']), # Max: C++14
     ('windows-vsCurrent', 'vs2017x64', [11, 14, 17, 20,     'latest']), # Max: C++20

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -50,8 +50,7 @@ def ls_distro(name, **kwargs):
 
 
 DEBIAN_DISTROS = [
-    *ls_distro(name='debian11', os='debian', os_type='linux', os_ver='11'),
-    *ls_distro(name='debian12', os='debian', os_type='linux', os_ver='12'),
+    *ls_distro(name='debian11-latest', os='debian', os_type='linux', os_ver='11'),
     *ls_distro(name='debian12-latest', os='debian', os_type='linux', os_ver='latest'),
 ]
 

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -223,9 +223,66 @@ tasks:
         vars:
           CMAKE_VERSION: 3.15.0
           INSTALL_C_DRIVER: 1
-  - name: compile-only-debian12-gcc-cxx11-debug
-    run_on: debian12-large
-    tags: [compile-only, debian12, cxx11, gcc, debug]
+  - name: compile-only-debian11-latest-gcc-10-cxx11-debug
+    run_on: debian11-latest-large
+    tags: [compile-only, debian11-latest, cxx11, gcc-10, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc-10 }
+            - { key: cxx_compiler, value: g++-10 }
+      - func: setup
+      - func: install_c_driver
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          build_type: Debug
+          cc_compiler: gcc-10
+          cxx_compiler: g++-10
+  - name: compile-only-debian11-latest-gcc-10-cxx17-debug
+    run_on: debian11-latest-large
+    tags: [compile-only, debian11-latest, cxx17, gcc-10, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc-10 }
+            - { key: cxx_compiler, value: g++-10 }
+      - func: setup
+      - func: install_c_driver
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          build_type: Debug
+          cc_compiler: gcc-10
+          cxx_compiler: g++-10
+  - name: compile-only-debian11-latest-gcc-10-cxx20-debug
+    run_on: debian11-latest-large
+    tags: [compile-only, debian11-latest, cxx20, gcc-10, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc-10 }
+            - { key: cxx_compiler, value: g++-10 }
+      - func: setup
+      - func: install_c_driver
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 20
+          build_type: Debug
+          cc_compiler: gcc-10
+          cxx_compiler: g++-10
+  - name: compile-only-debian12-latest-gcc-cxx11-debug
+    run_on: debian12-latest-large
+    tags: [compile-only, debian12-latest, cxx11, gcc, debug]
     commands:
       - command: expansions.update
         params:
@@ -242,9 +299,9 @@ tasks:
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
-  - name: compile-only-debian12-gcc-cxx17-debug
-    run_on: debian12-large
-    tags: [compile-only, debian12, cxx17, gcc, debug]
+  - name: compile-only-debian12-latest-gcc-cxx17-debug
+    run_on: debian12-latest-large
+    tags: [compile-only, debian12-latest, cxx17, gcc, debug]
     commands:
       - command: expansions.update
         params:
@@ -261,9 +318,9 @@ tasks:
           build_type: Debug
           cc_compiler: gcc
           cxx_compiler: g++
-  - name: compile-only-debian12-gcc-cxx20-debug
-    run_on: debian12-large
-    tags: [compile-only, debian12, cxx20, gcc, debug]
+  - name: compile-only-debian12-latest-gcc-cxx20-debug
+    run_on: debian12-latest-large
+    tags: [compile-only, debian12-latest, cxx20, gcc, debug]
     commands:
       - command: expansions.update
         params:
@@ -542,6 +599,120 @@ tasks:
   - name: compile-only-rhel80-gcc-cxx20-debug
     run_on: rhel80-large
     tags: [compile-only, rhel80, cxx20, gcc, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc }
+            - { key: cxx_compiler, value: g++ }
+      - func: setup
+      - func: install_c_driver
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 20
+          build_type: Debug
+          cc_compiler: gcc
+          cxx_compiler: g++
+  - name: compile-only-rhel84-clang-cxx11-debug
+    run_on: rhel84-large
+    tags: [compile-only, rhel84, cxx11, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel84-clang-cxx17-debug
+    run_on: rhel84-large
+    tags: [compile-only, rhel84, cxx17, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel84-clang-cxx20-debug
+    run_on: rhel84-large
+    tags: [compile-only, rhel84, cxx20, clang, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: clang }
+            - { key: cxx_compiler, value: clang++ }
+      - func: setup
+      - func: install_c_driver
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 20
+          build_type: Debug
+          cc_compiler: clang
+          cxx_compiler: clang++
+  - name: compile-only-rhel84-gcc-cxx11-debug
+    run_on: rhel84-large
+    tags: [compile-only, rhel84, cxx11, gcc, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc }
+            - { key: cxx_compiler, value: g++ }
+      - func: setup
+      - func: install_c_driver
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          build_type: Debug
+          cc_compiler: gcc
+          cxx_compiler: g++
+  - name: compile-only-rhel84-gcc-cxx17-debug
+    run_on: rhel84-large
+    tags: [compile-only, rhel84, cxx17, gcc, debug]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+            - { key: cc_compiler, value: gcc }
+            - { key: cxx_compiler, value: g++ }
+      - func: setup
+      - func: install_c_driver
+      - func: compile
+        vars:
+          BUILD_SHARED_AND_STATIC_LIBS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          build_type: Debug
+          cc_compiler: gcc
+          cxx_compiler: g++
+  - name: compile-only-rhel84-gcc-cxx20-debug
+    run_on: rhel84-large
+    tags: [compile-only, rhel84, cxx20, gcc, debug]
     commands:
       - command: expansions.update
         params:


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1464. Following the resolution of [DEVPROD-22169](https://jira.mongodb.org/browse/DEVPROD-22169), distros previously skipped due to absence of a system `uv` binary can now be enabled, with the caveat that the `debian11` distro is [no longer being built by DevProd](https://jira.mongodb.org/browse/DEVPROD-22169?focusedCommentId=7744278&focusedId=7744278&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-7744278), so the task has been moved to `debian11-latest` as suggested by DevProd. For consistenc, `debian12` tasks have also been migrated to `debian12-latest`.