### PR TITLE
[v4.1] CXX-3663 bump downloaded C driver to 2.1.2

### DIFF
--- a/.evergreen/scripts/cmake-compat.sh
+++ b/.evergreen/scripts/cmake-compat.sh
@@ -61,13 +61,13 @@ printf " - %s\n" "${cmake_flags[@]:?}"
 "${cmake_binary:?}" -S . -B build "${cmake_flags[@]:?}"
 "${cmake_binary:?}" --build build --target install
 
-# Use generated header bson-config.h to detect installation of C Driver libraries.
-bson_config_h="$(find install -name 'bson-config.h')"
-if [[ "${INSTALL_C_DRIVER:?}" == 1 ]] && [[ -n "${bson_config_h:-}" ]]; then
-  echo "bson-config.h SHOULD NOT be present in $(pwd)/install" >&2
+# Use header bson.h to detect installation of C Driver libraries.
+bson_h="$(find install -name 'bson.h')"
+if [[ "${INSTALL_C_DRIVER:?}" == 1 ]] && [[ -n "${bson_h:-}" ]]; then
+  echo "bson.h SHOULD NOT be present in $(pwd)/install" >&2
   exit 1
 fi
-if [[ "${INSTALL_C_DRIVER:?}" != 1 ]] && [[ -z "${bson_config_h:-}" ]]; then
-  echo "bson-config.h SHOULD be present in $(pwd)/install" >&2
+if [[ "${INSTALL_C_DRIVER:?}" != 1 ]] && [[ -z "${bson_h:-}" ]]; then
+  echo "bson.h SHOULD be present in $(pwd)/install" >&2
   exit 1
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ## 4.1.4 [Unreleased]
 
-<!-- Will contain entries for next patch release -->
+### Changed
+
+- Bump the auto-downloaded C Driver version to [2.1.2](https://github.com/mongodb/mongo-c-driver/releases/tag/2.1.2).
 
 ## 4.1.3
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ endif()
 # Also update etc/purls.txt.
 set(BSON_REQUIRED_VERSION 2.0.0)
 set(MONGOC_REQUIRED_VERSION 2.0.0)
-set(MONGOC_DOWNLOAD_VERSION 2.0.2)
+set(MONGOC_DOWNLOAD_VERSION 2.1.2)
 
 # All of our target compilers support the deprecated
 # attribute. Normally, we would just let the GenerateExportHeader

--- a/etc/augmented.sbom.json
+++ b/etc/augmented.sbom.json
@@ -1,16 +1,16 @@
 {
   "components": [
     {
-      "bom-ref": "pkg:github/mongodb/mongo-c-driver@v2.1.2",
+      "bom-ref": "pkg:github/mongodb/mongo-c-driver@2.1.2",
       "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/v2.1.2.tar.gz"
+          "url": "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/2.1.2.tar.gz"
         },
         {
           "type": "website",
-          "url": "https://github.com/mongodb/mongo-c-driver/tree/v2.1.2"
+          "url": "https://github.com/mongodb/mongo-c-driver/tree/2.1.2"
         }
       ],
       "group": "mongodb",
@@ -22,18 +22,18 @@
         }
       ],
       "name": "mongo-c-driver",
-      "purl": "pkg:github/mongodb/mongo-c-driver@v2.1.2",
+      "purl": "pkg:github/mongodb/mongo-c-driver@2.1.2",
       "type": "library",
-      "version": "v2.1.2"
+      "version": "2.1.2"
     }
   ],
   "dependencies": [
     {
-      "ref": "pkg:github/mongodb/mongo-c-driver@v2.1.2"
+      "ref": "pkg:github/mongodb/mongo-c-driver@2.1.2"
     }
   ],
   "metadata": {
-    "timestamp": "2025-10-07T15:19:21.200886+00:00",
+    "timestamp": "2025-10-07T17:23:19.924947+00:00",
     "tools": [
       {
         "externalReferences": [

--- a/etc/augmented.sbom.json
+++ b/etc/augmented.sbom.json
@@ -1,16 +1,16 @@
 {
   "components": [
     {
-      "bom-ref": "pkg:github/mongodb/mongo-c-driver@v2.0.2",
+      "bom-ref": "pkg:github/mongodb/mongo-c-driver@v2.1.2",
       "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/v2.0.2.tar.gz"
+          "url": "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/v2.1.2.tar.gz"
         },
         {
           "type": "website",
-          "url": "https://github.com/mongodb/mongo-c-driver/tree/v2.0.2"
+          "url": "https://github.com/mongodb/mongo-c-driver/tree/v2.1.2"
         }
       ],
       "group": "mongodb",
@@ -22,18 +22,18 @@
         }
       ],
       "name": "mongo-c-driver",
-      "purl": "pkg:github/mongodb/mongo-c-driver@v2.0.2",
+      "purl": "pkg:github/mongodb/mongo-c-driver@v2.1.2",
       "type": "library",
-      "version": "v2.0.2"
+      "version": "v2.1.2"
     }
   ],
   "dependencies": [
     {
-      "ref": "pkg:github/mongodb/mongo-c-driver@v2.0.2"
+      "ref": "pkg:github/mongodb/mongo-c-driver@v2.1.2"
     }
   ],
   "metadata": {
-    "timestamp": "2025-09-16T15:16:51.915650+00:00",
+    "timestamp": "2025-10-07T15:19:21.200886+00:00",
     "tools": [
       {
         "externalReferences": [

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -1,16 +1,16 @@
 {
   "components": [
     {
-      "bom-ref": "pkg:github/mongodb/mongo-c-driver@v2.1.2",
+      "bom-ref": "pkg:github/mongodb/mongo-c-driver@2.1.2",
       "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/v2.1.2.tar.gz"
+          "url": "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/2.1.2.tar.gz"
         },
         {
           "type": "website",
-          "url": "https://github.com/mongodb/mongo-c-driver/tree/v2.1.2"
+          "url": "https://github.com/mongodb/mongo-c-driver/tree/2.1.2"
         }
       ],
       "group": "mongodb",
@@ -22,18 +22,18 @@
         }
       ],
       "name": "mongo-c-driver",
-      "purl": "pkg:github/mongodb/mongo-c-driver@v2.1.2",
+      "purl": "pkg:github/mongodb/mongo-c-driver@2.1.2",
       "type": "library",
-      "version": "v2.1.2"
+      "version": "2.1.2"
     }
   ],
   "dependencies": [
     {
-      "ref": "pkg:github/mongodb/mongo-c-driver@v2.1.2"
+      "ref": "pkg:github/mongodb/mongo-c-driver@2.1.2"
     }
   ],
   "metadata": {
-    "timestamp": "2025-10-07T15:19:21.200886+00:00",
+    "timestamp": "2025-10-07T17:23:19.924947+00:00",
     "tools": [
       {
         "externalReferences": [

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -1,16 +1,16 @@
 {
   "components": [
     {
-      "bom-ref": "pkg:github/mongodb/mongo-c-driver@v2.0.2",
+      "bom-ref": "pkg:github/mongodb/mongo-c-driver@v2.1.2",
       "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/v2.0.2.tar.gz"
+          "url": "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/v2.1.2.tar.gz"
         },
         {
           "type": "website",
-          "url": "https://github.com/mongodb/mongo-c-driver/tree/v2.0.2"
+          "url": "https://github.com/mongodb/mongo-c-driver/tree/v2.1.2"
         }
       ],
       "group": "mongodb",
@@ -22,18 +22,18 @@
         }
       ],
       "name": "mongo-c-driver",
-      "purl": "pkg:github/mongodb/mongo-c-driver@v2.0.2",
+      "purl": "pkg:github/mongodb/mongo-c-driver@v2.1.2",
       "type": "library",
-      "version": "v2.0.2"
+      "version": "v2.1.2"
     }
   ],
   "dependencies": [
     {
-      "ref": "pkg:github/mongodb/mongo-c-driver@v2.0.2"
+      "ref": "pkg:github/mongodb/mongo-c-driver@v2.1.2"
     }
   ],
   "metadata": {
-    "timestamp": "2025-09-16T15:16:51.915650+00:00",
+    "timestamp": "2025-10-07T15:19:21.200886+00:00",
     "tools": [
       {
         "externalReferences": [

--- a/etc/purls.txt
+++ b/etc/purls.txt
@@ -6,4 +6,4 @@
 # re-generate the SBOM JSON file!
 
 # bson and mongoc may be obtained via cmake/FetchMongoC.cmake.
-pkg:github/mongodb/mongo-c-driver@v2.1.2
+pkg:github/mongodb/mongo-c-driver@2.1.2

--- a/etc/purls.txt
+++ b/etc/purls.txt
@@ -6,4 +6,4 @@
 # re-generate the SBOM JSON file!
 
 # bson and mongoc may be obtained via cmake/FetchMongoC.cmake.
-pkg:github/mongodb/mongo-c-driver@v2.0.2
+pkg:github/mongodb/mongo-c-driver@v2.1.2


### PR DESCRIPTION
Only backports a bump to the auto-downloaded version (`MONGOC_DOWNLOAD_VERSION`) not the required version (`MONGOC_REQUIRED_VERSION`) to avoid a minor version dependency bump in a patch release.

Fixes referenced tag for C driver from `vA.B.C` to `A.B.C` (related to CXX-3364).

Some test scripts detect of a C driver install. These were updated from checking `bson-config.h` to `bson.h` to account for header renames made in CDRIVER-4153.

Tested with this patch build: https://spruce.mongodb.com/version/68e532fd024a630007afc38c