### PR TITLE
CXX-3466: deprecate support for VS 2015

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 <!-- Will contain entries for the next minor release. -->
 
+### Deprecated
+
+- Support for Visual Studio 2015 (EOL since Oct 2025). Use Visual Studio 2017 or newer.
+
 ## 4.2.0
 
 > [!IMPORTANT]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         message(FATAL_ERROR "Visual Studio 13 2015 Update 3 or newer is required")
     endif()
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.10.25017")
-        message(DEPRECATION "Visual Studio 2015 is deprecated. Visual Studio 2017 version 15.0 or newer is required")
+        message(DEPRECATION "Visual Studio 2017 version 15.0 or newer will be required")
         # TODO(CXX-3215) replace DEPRECATION with:
         # message(FATAL_ERROR "Visual Studio 2017 version 15.0 or newer is required")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,11 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.0.24210")
         message(FATAL_ERROR "Visual Studio 13 2015 Update 3 or newer is required")
     endif()
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.10.25017")
+        message(DEPRECATION "Visual Studio 2015 is deprecated. Visual Studio 2017 version 15.0 or newer is required")
+        # TODO(CXX-3215) replace DEPRECATION with:
+        # message(FATAL_ERROR "Visual Studio 2017 version 15.0 or newer is required")
+    endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     # https://developer.apple.com/xcode/cpp/
     # https://en.wikipedia.org/wiki/Xcode#Version_comparison_table


### PR DESCRIPTION
CXX-3215 proposes dropping support of VS 2015. Prior to doing so, this PR proposes adding a CHANGELOG entry to document support for VS 2015 is deprecated to give users a heads up.