### PR TITLE
CXX-3468 Update C driver to 2.3.0

### DIFF
--- a/.evergreen/config_generator/components/funcs/install_c_driver.py
+++ b/.evergreen/config_generator/components/funcs/install_c_driver.py
@@ -12,7 +12,7 @@ from config_generator.etc.utils import bash_exec
 # - the default value of --c-driver-build-ref in etc/make_release.py
 # If pinning to an unreleased commit, create a "Blocked" JIRA ticket with
 # a "depends on" link to the appropriate C Driver version release ticket.
-MONGOC_VERSION_MINIMUM = '2.2.3'
+MONGOC_VERSION_MINIMUM = '2.3.0'
 
 
 class InstallCDriver(Function):

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -391,7 +391,7 @@ functions:
       type: setup
       params:
         updates:
-          - { key: mongoc_version_minimum, value: 2.2.3 }
+          - { key: mongoc_version_minimum, value: 2.3.0 }
     - command: subprocess.exec
       type: setup
       params:

--- a/.evergreen/scripts/install-c-driver.sh
+++ b/.evergreen/scripts/install-c-driver.sh
@@ -106,6 +106,9 @@ if [[ "${SKIP_INSTALL_LIBMONGOCRYPT:-}" != "1" ]]; then
       exit 1
     }
   else
+    # Unset CC / CXX variables if set to the empty string. Avoids an error in libmongocrypt building Ninja from source.
+    [ -z "${CC:-}" ] && unset CC
+    [ -z "${CXX:-}" ] && unset CXX
     "${mongoc_dir}/.evergreen/scripts/compile-libmongocrypt.sh" "$(command -v cmake)" "${mongoc_idir}" "${mongoc_install_idir}"
   fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 - Support for Visual Studio 2015 (EOL since Oct 2025). Use Visual Studio 2017 or newer.
 
+### Changed
+
+- Bump the minimum required C Driver version to [2.3.0](https://github.com/mongodb/mongo-c-driver/releases/tag/2.3.0).
+
 ## 4.2.0
 
 > [!IMPORTANT]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,9 +62,9 @@ else()
 endif()
 
 # Also update etc/purls.txt.
-set(BSON_REQUIRED_VERSION 2.2.3)
-set(MONGOC_REQUIRED_VERSION 2.2.3)
-set(MONGOC_DOWNLOAD_VERSION 2.2.3)
+set(BSON_REQUIRED_VERSION 2.3.0)
+set(MONGOC_REQUIRED_VERSION 2.3.0)
+set(MONGOC_DOWNLOAD_VERSION 2.3.0)
 
 # All of our target compilers support the deprecated
 # attribute. Normally, we would just let the GenerateExportHeader

--- a/etc/augmented.sbom.json
+++ b/etc/augmented.sbom.json
@@ -1,16 +1,16 @@
 {
   "components": [
     {
-      "bom-ref": "pkg:github/mongodb/mongo-c-driver@2.2.3",
+      "bom-ref": "pkg:github/mongodb/mongo-c-driver@2.3.0",
       "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://github.com/mongodb/mongo-c-driver/archive/2.2.3.tar.gz"
+          "url": "https://github.com/mongodb/mongo-c-driver/archive/2.3.0.tar.gz"
         },
         {
           "type": "website",
-          "url": "https://github.com/mongodb/mongo-c-driver/tree/2.2.3"
+          "url": "https://github.com/mongodb/mongo-c-driver/tree/2.3.0"
         }
       ],
       "group": "mongodb",
@@ -22,18 +22,18 @@
         }
       ],
       "name": "mongo-c-driver",
-      "purl": "pkg:github/mongodb/mongo-c-driver@2.2.3",
+      "purl": "pkg:github/mongodb/mongo-c-driver@2.3.0",
       "type": "library",
-      "version": "2.2.3"
+      "version": "2.3.0"
     }
   ],
   "dependencies": [
     {
-      "ref": "pkg:github/mongodb/mongo-c-driver@2.2.3"
+      "ref": "pkg:github/mongodb/mongo-c-driver@2.3.0"
     }
   ],
   "metadata": {
-    "timestamp": "2026-03-24T13:40:23.249424+00:00",
+    "timestamp": "2026-04-17T12:29:34.470425+00:00",
     "tools": [
       {
         "externalReferences": [

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -1,16 +1,16 @@
 {
   "components": [
     {
-      "bom-ref": "pkg:github/mongodb/mongo-c-driver@2.2.3",
+      "bom-ref": "pkg:github/mongodb/mongo-c-driver@2.3.0",
       "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://github.com/mongodb/mongo-c-driver/archive/2.2.3.tar.gz"
+          "url": "https://github.com/mongodb/mongo-c-driver/archive/2.3.0.tar.gz"
         },
         {
           "type": "website",
-          "url": "https://github.com/mongodb/mongo-c-driver/tree/2.2.3"
+          "url": "https://github.com/mongodb/mongo-c-driver/tree/2.3.0"
         }
       ],
       "group": "mongodb",
@@ -22,18 +22,18 @@
         }
       ],
       "name": "mongo-c-driver",
-      "purl": "pkg:github/mongodb/mongo-c-driver@2.2.3",
+      "purl": "pkg:github/mongodb/mongo-c-driver@2.3.0",
       "type": "library",
-      "version": "2.2.3"
+      "version": "2.3.0"
     }
   ],
   "dependencies": [
     {
-      "ref": "pkg:github/mongodb/mongo-c-driver@2.2.3"
+      "ref": "pkg:github/mongodb/mongo-c-driver@2.3.0"
     }
   ],
   "metadata": {
-    "timestamp": "2026-03-24T13:40:23.249424+00:00",
+    "timestamp": "2026-04-17T12:29:34.470425+00:00",
     "tools": [
       {
         "externalReferences": [

--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -100,7 +100,7 @@ ISSUE_TYPE_ID = {
 )
 @click.option(
     '--c-driver-build-ref',
-    default='2.2.3',
+    default='2.3.0',
     show_default=True,
     help='When building the C driver, build at this Git reference',
 )

--- a/etc/purls.txt
+++ b/etc/purls.txt
@@ -6,4 +6,4 @@
 # re-generate the SBOM JSON file!
 
 # bson and mongoc may be obtained via cmake/FetchMongoC.cmake.
-pkg:github/mongodb/mongo-c-driver@2.2.3
+pkg:github/mongodb/mongo-c-driver@2.3.0

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/builder/core.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/builder/core.cpp
@@ -209,7 +209,7 @@ class core::impl {
 
         frame(bson_t* parent, char const* key, std::int32_t len, bool is_array) : is_array(is_array), parent(parent) {
             if (is_array) {
-                if (!bson_append_array_begin(parent, key, len, &bson)) {
+                if (!bson_append_array_unsafe_begin(parent, key, len, &bson)) {
                     throw v_noabi::exception{v_noabi::error_code::k_cannot_begin_appending_array};
                 }
             } else {


### PR DESCRIPTION
[skip ci] Evergreen: https://spruce.corp.mongodb.com/version/69e264af28087200071b1df3

# Summary

Update required and downloaded C driver versions to 2.3.0.

# Motivation

Needed for client backpressure support for upcoming 4.3.0 release.

# Details

A workaround to unset `CC` and `CXX` is to address a [task failure](https://spruce.corp.mongodb.com/task/mongo_cxx_driver_integration_matrix_linux_integration_rhel8_arm64_latest_debug_static_cxx17_csfle_7.0_single_patch_1b6a599f9745078d029ec05fee7eadab85c69ccc_69e22a306a49890007fca487_26_04_17_12_40_19/logs?execution=0) building libmongocrypt from source:

```
bootstrapping ninja...
when running:   -MMD [...]
```

The log suggests the compiler evaluated to an empty string. I expect this is due to CC / CXX [expansions](https://github.com/mongodb/mongo-cxx-driver/blob/1b6a599f9745078d029ec05fee7eadab85c69ccc/.evergreen/generated_configs/functions.yml#L301-L303) set to an empty string for variants that do not set them explicitly.

libmongocrypt [pins to Ninja 1.8.2](https://github.com/mongodb/libmongocrypt/blob/9b72f0c5dc04a117491377bd5d5a7e2bd56f67aa/.evergreen/ensure-ninja.sh#L7-L8), and builds from source on arm64 hosts. This may be improved by having libmongocrypt support a caller setting a path to a known Ninja, but I kept it simple (as it might overlap with MONGOCRYPT-872).


A call to the now-deprecated `bson_append_array_begin` is replaced with the equivalent `bson_append_array_unsafe_begin`. I briefly considered migrating to `bson_array_builder_t`, but I expect the builder is generating correct array keys and would only be complicated by managing both a `bson_t` and `bson_array_builder_t`.
