### PR TITLE
CXX-3469: Add missing subscript operator to `bsoncxx::vector::iterators` classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 <!-- Will contain entries for the next minor release. -->
 
+### Fixed
+
+- Added missing subscript operators for class types declared in `bsoncxx::vector::iterators`.
+
 ### Deprecated
 
 - Support for Visual Studio 2015 (EOL since Oct 2025). Use Visual Studio 2017 or newer.

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/vector/iterators.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/vector/iterators.hpp
@@ -113,6 +113,10 @@ class packed_bit_element {
         return {(byte - other.byte) * 8 + (difference_type{bit} - difference_type{other.bit})};
     }
 
+    constexpr reference operator[](difference_type const& other) const noexcept {
+        return *(*this + other);
+    }
+
     /// Advance this iterator forward by the indicated number of bits
     packed_bit_element& operator+=(difference_type const& other) noexcept {
         return *this = *this + other;
@@ -235,6 +239,10 @@ class packed_bit_byte {
     /// If the two iterators do not point into the same vector, behavior is undefined.
     constexpr difference_type operator-(packed_bit_byte const& other) const noexcept {
         return {byte - other.byte};
+    }
+
+    constexpr reference operator[](difference_type const& other) const noexcept {
+        return *(*this + other);
     }
 
     /// Advance this iterator forward by the indicated number of bytes

--- a/src/bsoncxx/test/v_noabi/vector.cpp
+++ b/src/bsoncxx/test/v_noabi/vector.cpp
@@ -138,6 +138,9 @@ void iterator_operations(
     BSONCXX_PRIVATE_WARNINGS_PUSH();
     BSONCXX_PRIVATE_WARNINGS_DISABLE(GNU("-Wfloat-equal"));
 
+    CHECK(iter_copy[0] == *begin);
+    CHECK(iter_copy[1] == *(begin + 1));
+
     std::generate(begin, end, [&] { return element_unit; });
     std::for_each(begin, end, [&](auto const& value) { CHECK(value == element_unit); });
 


### PR DESCRIPTION
Observed the following compilation error when compiling against libc++ 22.1.0:

```
error: type 'bsoncxx::v_noabi::vector::iterators::packed_bit_element<unsigned char *>' does not provide a subscript operator
note: in instantiation of function template specialization 'std::sort<bsoncxx::v_noabi::vector::iterators::packed_bit_element<unsigned char *>>' [...]
note: in instantiation of function template specialization '(anonymous namespace)::iterator_operations<bsoncxx::v_noabi::vector::iterators::packed_bit_element<unsigned char *>, bool>' [...]
```

```cpp
auto vec = sbin.allocate(TestType{}, 8007u); // TestType = vector::formats::f_packed_bit
iterator_operations(vec.begin(), vec.end(), std::ptrdiff_t(vec.size()), element_unit);
    // ...
    std::sort(begin, end); // error: [...]
```

One or more improvements to the implementation of stdlib algorithms in LLVM 22.1.0 (see: [release notes](https://releases.llvm.org/22.1.0/projects/libcxx/docs/ReleaseNotes.html) and [Compiler Explorer](https://compiler-explorer.com/z/8jMvPWqhE)) appears to have exposed the absence of a subscript operator in the implementation of `bsoncxx::vector::iterators` despite its iterator category being [Cpp17RandomAccessIterator](https://timsong-cpp.github.io/cppwp/n3337/random.access.iterators).