### PR TITLE
CXX-3439 Add `maxAdaptiveRetries` and `enableOverloadRetargeting` URI fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 - Bump the minimum required C Driver version to [2.3.0](https://github.com/mongodb/mongo-c-driver/releases/tag/2.3.0).
 
+### Added
+
+- Added support for [MongoDB's Intelligent Workload Management (IWM)](https://www.mongodb.com/docs/atlas/intelligent-workload-management/) and ingress connection rate limiting features. The driver now gracefully handles write-blocking scenarios and optimizes connection establishment during high-load conditions to maintain application availability.
+    - Supported on all commands.
+    - Custom application retry logic may need to be adjusted to avoid retrying too long.
+    - Upgrade is recommended to avoid impacts of server changes related to overload errors.
+        - If not upgrading, custom application retry logic may need to be adjusted to handle higher rates of overload errors.
+    - Add URI option `maxAdaptiveRetries` to configure the maximum number of retries for operations that fail with a `SystemOverloadedError` (default: `2`).
+    - Add URI option `enableOverloadRetargeting` to control whether retries of `SystemOverloadedError` will attempt to use a different server (default: `false`).
+
 ## 4.2.0
 
 > [!IMPORTANT]

--- a/src/mongocxx/include/mongocxx/v1/uri.hpp
+++ b/src/mongocxx/include/mongocxx/v1/uri.hpp
@@ -60,10 +60,12 @@ namespace v1 {
 /// - `connect_timeout_ms` ("connectTimeoutMS")
 /// - `database`
 /// - `direct_connection` ("directConnection")
+/// - `enable_overload_retargeting` ("enableOverloadRetargeting")
 /// - `heartbeat_frequency_ms` ("heartbeatFrequencyMS")
 /// - `hosts`
 /// - `local_threshold_ms` ("localThresholdMS")
 /// - `max_pool_size` ("maxPoolSize")
+/// - `max_adaptive_retries` ("maxAdaptiveRetries")
 /// - `password`
 /// - `read_concern` ("readConcern")
 /// - `read_preference` ("readPreference")
@@ -274,6 +276,16 @@ class uri {
     /// Return the "localThresholdMS" option.
     ///
     MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<std::int32_t>) local_threshold_ms() const;
+
+    ///
+    /// Return the "maxAdaptiveRetries" option.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<std::int32_t>) max_adaptive_retries() const;
+
+    ///
+    /// Return the "enableOverloadRetargeting" option.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bool>) enable_overload_retargeting() const;
 
     ///
     /// Return the "maxPoolSize" option.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/uri.hpp
@@ -344,6 +344,24 @@ class uri {
     }
 
     ///
+    /// Returns the value of the option "maxAdaptiveRetries" if present in the uri.
+    ///
+    /// @return An optional std::int32_t
+    ///
+    bsoncxx::v_noabi::stdx::optional<std::int32_t> max_adaptive_retries() const {
+        return _uri.max_adaptive_retries();
+    }
+
+    ///
+    /// Returns the value of the option "enableOverloadRetargeting" if present in the uri.
+    ///
+    /// @return An optional bool
+    ///
+    bsoncxx::v_noabi::stdx::optional<bool> enable_overload_retargeting() const {
+        return _uri.enable_overload_retargeting();
+    }
+
+    ///
     /// Returns the value of the option "maxPoolSize" if present in the uri.
     ///
     /// @return An optional std::int32_t

--- a/src/mongocxx/lib/mongocxx/v1/uri.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/uri.cpp
@@ -268,10 +268,6 @@ bsoncxx::v1::stdx::optional<bool> uri::direct_connection() const {
     return get_field<bool>(to_mongoc(_impl), MONGOC_URI_DIRECTCONNECTION);
 }
 
-bsoncxx::v1::stdx::optional<bool> uri::enable_overload_retargeting() const {
-    return get_field<bool>(to_mongoc(_impl), MONGOC_URI_ENABLEOVERLOADRETARGETING);
-}
-
 bsoncxx::v1::stdx::optional<std::int32_t> uri::heartbeat_frequency_ms() const {
     return get_field<std::int32_t>(to_mongoc(_impl), MONGOC_URI_HEARTBEATFREQUENCYMS);
 }
@@ -282,6 +278,10 @@ bsoncxx::v1::stdx::optional<std::int32_t> uri::local_threshold_ms() const {
 
 bsoncxx::v1::stdx::optional<std::int32_t> uri::max_adaptive_retries() const {
     return get_field<std::int32_t>(to_mongoc(_impl), MONGOC_URI_MAXADAPTIVERETRIES);
+}
+
+bsoncxx::v1::stdx::optional<bool> uri::enable_overload_retargeting() const {
+    return get_field<bool>(to_mongoc(_impl), MONGOC_URI_ENABLEOVERLOADRETARGETING);
 }
 
 bsoncxx::v1::stdx::optional<std::int32_t> uri::max_pool_size() const {

--- a/src/mongocxx/lib/mongocxx/v1/uri.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/uri.cpp
@@ -276,6 +276,14 @@ bsoncxx::v1::stdx::optional<std::int32_t> uri::local_threshold_ms() const {
     return get_field<std::int32_t>(to_mongoc(_impl), MONGOC_URI_LOCALTHRESHOLDMS);
 }
 
+bsoncxx::v1::stdx::optional<std::int32_t> uri::max_adaptive_retries() const {
+    return get_field<std::int32_t>(to_mongoc(_impl), MONGOC_URI_MAXADAPTIVERETRIES);
+}
+
+bsoncxx::v1::stdx::optional<bool> uri::enable_overload_retargeting() const {
+    return get_field<bool>(to_mongoc(_impl), MONGOC_URI_ENABLEOVERLOADRETARGETING);
+}
+
 bsoncxx::v1::stdx::optional<std::int32_t> uri::max_pool_size() const {
     return get_field<std::int32_t>(to_mongoc(_impl), MONGOC_URI_MAXPOOLSIZE);
 }

--- a/src/mongocxx/lib/mongocxx/v1/uri.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/uri.cpp
@@ -268,6 +268,10 @@ bsoncxx::v1::stdx::optional<bool> uri::direct_connection() const {
     return get_field<bool>(to_mongoc(_impl), MONGOC_URI_DIRECTCONNECTION);
 }
 
+bsoncxx::v1::stdx::optional<bool> uri::enable_overload_retargeting() const {
+    return get_field<bool>(to_mongoc(_impl), MONGOC_URI_ENABLEOVERLOADRETARGETING);
+}
+
 bsoncxx::v1::stdx::optional<std::int32_t> uri::heartbeat_frequency_ms() const {
     return get_field<std::int32_t>(to_mongoc(_impl), MONGOC_URI_HEARTBEATFREQUENCYMS);
 }
@@ -278,10 +282,6 @@ bsoncxx::v1::stdx::optional<std::int32_t> uri::local_threshold_ms() const {
 
 bsoncxx::v1::stdx::optional<std::int32_t> uri::max_adaptive_retries() const {
     return get_field<std::int32_t>(to_mongoc(_impl), MONGOC_URI_MAXADAPTIVERETRIES);
-}
-
-bsoncxx::v1::stdx::optional<bool> uri::enable_overload_retargeting() const {
-    return get_field<bool>(to_mongoc(_impl), MONGOC_URI_ENABLEOVERLOADRETARGETING);
 }
 
 bsoncxx::v1::stdx::optional<std::int32_t> uri::max_pool_size() const {

--- a/src/mongocxx/test/v1/uri.cpp
+++ b/src/mongocxx/test/v1/uri.cpp
@@ -647,6 +647,10 @@ TEST_CASE("direct_connection", "[mongocxx][v1][uri]") {
     test_option_bool(&uri::direct_connection, MONGOC_URI_DIRECTCONNECTION);
 }
 
+TEST_CASE("enable_overload_retargeting", "[mongocxx][v1][uri]") {
+    test_option_bool(&uri::enable_overload_retargeting, MONGOC_URI_ENABLEOVERLOADRETARGETING);
+}
+
 TEST_CASE("heartbeat_frequency_ms", "[mongocxx][v1][uri]") {
     test_option_int32(&uri::heartbeat_frequency_ms, MONGOC_URI_HEARTBEATFREQUENCYMS);
 }
@@ -657,10 +661,6 @@ TEST_CASE("local_threshold_ms", "[mongocxx][v1][uri]") {
 
 TEST_CASE("max_adaptive_retries", "[mongocxx][v1][uri]") {
     test_option_int32(&uri::max_adaptive_retries, MONGOC_URI_MAXADAPTIVERETRIES);
-}
-
-TEST_CASE("enable_overload_retargeting", "[mongocxx][v1][uri]") {
-    test_option_bool(&uri::enable_overload_retargeting, MONGOC_URI_ENABLEOVERLOADRETARGETING);
 }
 
 TEST_CASE("max_pool_size", "[mongocxx][v1][uri]") {

--- a/src/mongocxx/test/v1/uri.cpp
+++ b/src/mongocxx/test/v1/uri.cpp
@@ -402,6 +402,8 @@ TEST_CASE("default", "[mongocxx][v1][uri]") {
     CHECK_FALSE(opts.direct_connection().has_value());
     CHECK_FALSE(opts.heartbeat_frequency_ms().has_value());
     CHECK_FALSE(opts.local_threshold_ms().has_value());
+    CHECK_FALSE(opts.max_adaptive_retries().has_value());
+    CHECK_FALSE(opts.enable_overload_retargeting().has_value());
     CHECK_FALSE(opts.max_pool_size().has_value());
     CHECK_FALSE(opts.retry_reads().has_value());
     CHECK_FALSE(opts.retry_writes().has_value());
@@ -651,6 +653,14 @@ TEST_CASE("heartbeat_frequency_ms", "[mongocxx][v1][uri]") {
 
 TEST_CASE("local_threshold_ms", "[mongocxx][v1][uri]") {
     test_option_int32(&uri::local_threshold_ms, MONGOC_URI_LOCALTHRESHOLDMS);
+}
+
+TEST_CASE("max_adaptive_retries", "[mongocxx][v1][uri]") {
+    test_option_int32(&uri::max_adaptive_retries, MONGOC_URI_MAXADAPTIVERETRIES);
+}
+
+TEST_CASE("enable_overload_retargeting", "[mongocxx][v1][uri]") {
+    test_option_bool(&uri::enable_overload_retargeting, MONGOC_URI_ENABLEOVERLOADRETARGETING);
 }
 
 TEST_CASE("max_pool_size", "[mongocxx][v1][uri]") {

--- a/src/mongocxx/test/v1/uri.cpp
+++ b/src/mongocxx/test/v1/uri.cpp
@@ -647,10 +647,6 @@ TEST_CASE("direct_connection", "[mongocxx][v1][uri]") {
     test_option_bool(&uri::direct_connection, MONGOC_URI_DIRECTCONNECTION);
 }
 
-TEST_CASE("enable_overload_retargeting", "[mongocxx][v1][uri]") {
-    test_option_bool(&uri::enable_overload_retargeting, MONGOC_URI_ENABLEOVERLOADRETARGETING);
-}
-
 TEST_CASE("heartbeat_frequency_ms", "[mongocxx][v1][uri]") {
     test_option_int32(&uri::heartbeat_frequency_ms, MONGOC_URI_HEARTBEATFREQUENCYMS);
 }
@@ -661,6 +657,10 @@ TEST_CASE("local_threshold_ms", "[mongocxx][v1][uri]") {
 
 TEST_CASE("max_adaptive_retries", "[mongocxx][v1][uri]") {
     test_option_int32(&uri::max_adaptive_retries, MONGOC_URI_MAXADAPTIVERETRIES);
+}
+
+TEST_CASE("enable_overload_retargeting", "[mongocxx][v1][uri]") {
+    test_option_bool(&uri::enable_overload_retargeting, MONGOC_URI_ENABLEOVERLOADRETARGETING);
 }
 
 TEST_CASE("max_pool_size", "[mongocxx][v1][uri]") {

--- a/src/mongocxx/test/v_noabi/uri.cpp
+++ b/src/mongocxx/test/v_noabi/uri.cpp
@@ -227,6 +227,68 @@ TEST_CASE("uri::local_threshold_ms()", "[uri]") {
     _test_int32_option("localThresholdMS", [](mongocxx::uri& uri) { return uri.local_threshold_ms(); });
 }
 
+TEST_CASE("uri::max_adaptive_retries()", "[uri]") {
+    // As-if, _test_int32_options(), but does not error on invalid values.
+    {
+        /* Not present. */
+        mongocxx::uri uri{"mongodb://host/"};
+        REQUIRE(!uri.max_adaptive_retries());
+
+        /* Present. */
+        uri = mongocxx::uri{"mongodb://host/?maxAdaptiveRetries=1234"};
+        REQUIRE(uri.max_adaptive_retries());
+        REQUIRE(1234 == *uri.max_adaptive_retries());
+
+        uri = mongocxx::uri{"mongodb://host/?maxAdaptiveRetries=0"};
+        REQUIRE(uri.max_adaptive_retries());
+        REQUIRE(0 == *uri.max_adaptive_retries());
+
+        /* Present but empty. libmongoc considers it unset. */
+        uri = mongocxx::uri{"mongodb://host/?maxAdaptiveRetries=&tls=true"};
+        REQUIRE(!uri.max_adaptive_retries());
+
+        /* Present, but wrong type. **NOT** an error. */
+        REQUIRE_NOTHROW(uri = mongocxx::uri{"mongodb://host/?maxAdaptiveRetries=abc"});
+        REQUIRE_FALSE(uri.max_adaptive_retries().has_value());
+    }
+}
+
+TEST_CASE("uri::enable_overload_retargeting()", "[uri]") {
+    // As-if, _test_bool_option(), but does not error on invalid values.
+    {
+        /* Not present. */
+        mongocxx::uri uri{"mongodb://host/"};
+        REQUIRE(!uri.enable_overload_retargeting());
+
+        /* Present. */
+        uri = mongocxx::uri{"mongodb://host/?enableOverloadRetargeting=true"};
+        REQUIRE(uri.enable_overload_retargeting());
+        REQUIRE(true == *uri.enable_overload_retargeting());
+
+        /* Present, but false. */
+        uri = mongocxx::uri{"mongodb://host/?enableOverloadRetargeting=false"};
+        REQUIRE(uri.enable_overload_retargeting());
+        REQUIRE(false == *uri.enable_overload_retargeting());
+
+        /* Present but empty. libmongoc considers it unset. */
+        uri = mongocxx::uri{"mongodb://host/?enableOverloadRetargeting="};
+        REQUIRE(!uri.enable_overload_retargeting());
+
+        /* Present, but valid numeric. */
+        uri = mongocxx::uri{"mongodb://host/?enableOverloadRetargeting=1"};
+        REQUIRE(uri.enable_overload_retargeting());
+        REQUIRE(true == *uri.enable_overload_retargeting());
+
+        /* Present, but invalid numeric. **NOT** an error. */
+        REQUIRE_NOTHROW(uri = mongocxx::uri{"mongodb://host/?enableOverloadRetargeting=2"});
+        REQUIRE_FALSE(uri.enable_overload_retargeting().has_value());
+
+        /* Present, but wrong type. **NOT** an error. */
+        REQUIRE_NOTHROW(uri = mongocxx::uri{"mongodb://host/?enableOverloadRetargeting=lol"});
+        REQUIRE_FALSE(uri.enable_overload_retargeting().has_value());
+    }
+}
+
 TEST_CASE("uri::max_pool_size()", "[uri]") {
     _test_int32_option("maxPoolSize", [](mongocxx::uri& uri) { return uri.max_pool_size(); });
 }


### PR DESCRIPTION
Resolves CXX-3439 (CXX-3328) as followup to CDRIVER-6274 (CDRIVER-6073) and CXX-3468.

Because most changes required by the relevant JIRA issues pertain to internal (C driver) behavior or tests which the C++ driver does not implement (due to redundancy or due to blocked-on status), the only meaningful changes required for the C++ driver is extending support for querying URI options (read-only API) to include the new "maxAdaptiveRetries" and "enableOverloadRetargeting" fields.

Extending test coverage to account for these two options reveal inconsistent handling of invalid values relative to other int32 and bool fields following https://github.com/mongodb/mongo-c-driver/pull/2269#discussion_r3081069742, where `mongoc_uri_get_option_as_int32()` is deliberately unused to avoid `0`-special-casing, but also demoted the behavior of invalid values from "error" to "warn and ignore". This manifests as the unexpected absence of exceptions throw by the URI constructor(s) relative to the `_test_int32_options()` and `_test_bool_options()` test helper functions (discrepancies marked with "**NOT** an error" comments for clarity).