### PR TITLE
CXX-3445 add read_concern to insert options classes

### DIFF
--- a/src/mongocxx/include/mongocxx/v1/insert_many_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/insert_many_options.hpp
@@ -96,32 +96,32 @@ class insert_many_options {
     MONGOCXX_ABI_EXPORT_CDECL() insert_many_options();
 
     ///
-    /// Set the "bypass_document_validation" field.
+    /// Set the "bypassDocumentValidation" field.
     ///
     MONGOCXX_ABI_EXPORT_CDECL(insert_many_options&) bypass_document_validation(bool bypass_document_validation);
 
     ///
-    /// Return the current "bypass_document_validation" field.
+    /// Return the current "bypassDocumentValidation" field.
     ///
     MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bool>) bypass_document_validation() const;
 
     ///
-    /// Set the "read_concern" field.
+    /// Set the "readConcern" field.
     ///
     MONGOCXX_ABI_EXPORT_CDECL(insert_many_options&) read_concern(v1::read_concern rc);
 
     ///
-    /// Return the current "read_concern" field.
+    /// Return the current "readConcern" field.
     ///
     MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<v1::read_concern>) read_concern() const;
 
     ///
-    /// Set the "write_concern" field.
+    /// Set the "writeConcern" field.
     ///
     MONGOCXX_ABI_EXPORT_CDECL(insert_many_options&) write_concern(v1::write_concern wc);
 
     ///
-    /// Return the current "write_concern" field.
+    /// Return the current "writeConcern" field.
     ///
     MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<v1::write_concern>) write_concern() const;
 

--- a/src/mongocxx/include/mongocxx/v1/insert_many_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/insert_many_options.hpp
@@ -23,6 +23,7 @@
 #include <bsoncxx/v1/types/value-fwd.hpp>
 #include <bsoncxx/v1/types/view-fwd.hpp>
 
+#include <mongocxx/v1/read_concern-fwd.hpp>
 #include <mongocxx/v1/write_concern-fwd.hpp>
 
 #include <bsoncxx/v1/stdx/optional.hpp>
@@ -39,6 +40,7 @@ namespace v1 {
 /// - `bypass_document_validation` ("bypassDocumentValidation")
 /// - `comment`
 /// - `ordered`
+/// - `read_concern` ("readConcern")
 /// - `write_concern` ("writeConcern")
 ///
 /// @see
@@ -102,6 +104,16 @@ class insert_many_options {
     /// Return the current "bypass_document_validation" field.
     ///
     MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bool>) bypass_document_validation() const;
+
+    ///
+    /// Set the "read_concern" field.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(insert_many_options&) read_concern(v1::read_concern rc);
+
+    ///
+    /// Return the current "read_concern" field.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<v1::read_concern>) read_concern() const;
 
     ///
     /// Set the "write_concern" field.

--- a/src/mongocxx/include/mongocxx/v1/insert_one_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/insert_one_options.hpp
@@ -23,6 +23,7 @@
 #include <bsoncxx/v1/types/value-fwd.hpp>
 #include <bsoncxx/v1/types/view-fwd.hpp>
 
+#include <mongocxx/v1/read_concern-fwd.hpp>
 #include <mongocxx/v1/write_concern-fwd.hpp>
 
 #include <bsoncxx/v1/stdx/optional.hpp>
@@ -38,6 +39,7 @@ namespace v1 {
 /// Supported fields include:
 /// - `bypass_document_validation` ("bypassDocumentValidation")
 /// - `comment`
+/// - `read_concern` ("readConcern")
 /// - `write_concern` ("writeConcern")
 ///
 /// @see
@@ -101,6 +103,16 @@ class insert_one_options {
     /// Return the current "bypassDocumentValidation" field.
     ///
     MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bool>) bypass_document_validation() const;
+
+    ///
+    /// Set the "readConcern" field.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(insert_one_options&) read_concern(v1::read_concern rc);
+
+    ///
+    /// Return the current "readConcern" field.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<v1::read_concern>) read_concern() const;
 
     ///
     /// Set the "writeConcern" field.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert.hpp
@@ -133,7 +133,7 @@ class insert {
     ///   Whether or not to bypass document validation
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     insert& bypass_document_validation(bool bypass_document_validation) {
@@ -190,7 +190,7 @@ class insert {
     /// - https://www.mongodb.com/docs/manual/core/write-concern/
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     insert& write_concern(v_noabi::write_concern wc) {
@@ -222,7 +222,7 @@ class insert {
     ///   Whether or not the insert_many will be ordered.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -255,7 +255,7 @@ class insert {
     /// - https://www.mongodb.com/docs/manual/reference/command/insert/
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     insert& comment(bsoncxx::v_noabi::types::bson_value::view_or_value comment) {

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/insert.hpp
@@ -30,6 +30,7 @@
 #include <bsoncxx/types/bson_value/view.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
 
+#include <mongocxx/read_concern.hpp>
 #include <mongocxx/write_concern.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -67,6 +68,10 @@ class insert {
 
         v1::insert_many_options ret;
 
+        if (_read_concern) {
+            ret.read_concern(to_v1(*_read_concern));
+        }
+
         if (_write_concern) {
             ret.write_concern(to_v1(*_write_concern));
         }
@@ -96,6 +101,10 @@ class insert {
         using mongocxx::v_noabi::to_v1;
 
         v1::insert_one_options ret;
+
+        if (_read_concern) {
+            ret.read_concern(to_v1(*_read_concern));
+        }
 
         if (_write_concern) {
             ret.write_concern(to_v1(*_write_concern));
@@ -139,6 +148,36 @@ class insert {
     ///
     bsoncxx::v_noabi::stdx::optional<bool> const& bypass_document_validation() const {
         return _bypass_document_validation;
+    }
+
+    ///
+    /// Sets the read_concern for this operation.
+    ///
+    /// @param rc
+    ///   The new read_concern.
+    ///
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/read-concern/
+    ///
+    /// @return
+    ///   A reference to the object on which this member function is being called. This facilitates
+    ///   method chaining.
+    ///
+    insert& read_concern(v_noabi::read_concern rc) {
+        _read_concern = std::move(rc);
+        return *this;
+    }
+
+    ///
+    /// The current read_concern for this operation.
+    ///
+    /// @return The current read_concern.
+    ///
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/read-concern/
+    ///
+    bsoncxx::v_noabi::stdx::optional<v_noabi::read_concern> const& read_concern() const {
+        return _read_concern;
     }
 
     ///
@@ -237,6 +276,7 @@ class insert {
     }
 
    private:
+    bsoncxx::v_noabi::stdx::optional<v_noabi::read_concern> _read_concern;
     bsoncxx::v_noabi::stdx::optional<v_noabi::write_concern> _write_concern;
     bsoncxx::v_noabi::stdx::optional<bool> _ordered;
     bsoncxx::v_noabi::stdx::optional<bool> _bypass_document_validation;

--- a/src/mongocxx/lib/mongocxx/v1/collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/collection.cpp
@@ -391,6 +391,10 @@ void append_to(v1::insert_many_options const& opts, scoped_bson& doc) {
         doc += scoped_bson{BCON_NEW("ordered", BCON_BOOL(false))};
     }
 
+    if (auto const& opt = v1::insert_many_options::internal::read_concern(opts)) {
+        doc += scoped_bson{BCON_NEW("readConcern", BCON_DOCUMENT(scoped_bson{opt->to_document()}.bson()))};
+    }
+
     if (auto const& opt = v1::insert_many_options::internal::write_concern(opts)) {
         doc += scoped_bson{BCON_NEW("writeConcern", BCON_DOCUMENT(scoped_bson{opt->to_document()}.bson()))};
     }
@@ -401,6 +405,10 @@ void append_to(v1::insert_many_options const& opts, scoped_bson& doc) {
 }
 
 void append_to(v1::insert_one_options const& opts, scoped_bson& doc) {
+    if (auto const& opt = v1::insert_one_options::internal::read_concern(opts)) {
+        doc += scoped_bson{BCON_NEW("readConcern", BCON_DOCUMENT(scoped_bson{opt->to_document()}.bson()))};
+    }
+
     if (auto const& opt = v1::insert_one_options::internal::write_concern(opts)) {
         doc += scoped_bson{BCON_NEW("writeConcern", BCON_DOCUMENT(scoped_bson{opt->to_document()}.bson()))};
     }

--- a/src/mongocxx/lib/mongocxx/v1/insert_many_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/insert_many_options.cpp
@@ -19,6 +19,7 @@
 #include <bsoncxx/v1/stdx/optional.hpp>
 #include <bsoncxx/v1/types/value.hpp>
 
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
 #include <bsoncxx/v1/types/value.hh>
@@ -31,6 +32,7 @@ namespace v1 {
 class insert_many_options::impl {
    public:
     bsoncxx::v1::stdx::optional<bool> _bypass_document_validation;
+    bsoncxx::v1::stdx::optional<v1::read_concern> _read_concern;
     bsoncxx::v1::stdx::optional<v1::write_concern> _write_concern;
     bsoncxx::v1::stdx::optional<bool> _ordered;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> _comment;
@@ -96,6 +98,15 @@ bsoncxx::v1::stdx::optional<bool> insert_many_options::bypass_document_validatio
     return impl::with(this)->_bypass_document_validation;
 }
 
+insert_many_options& insert_many_options::read_concern(v1::read_concern rc) {
+    impl::with(this)->_read_concern = std::move(rc);
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern> insert_many_options::read_concern() const {
+    return impl::with(this)->_read_concern;
+}
+
 insert_many_options& insert_many_options::write_concern(v1::write_concern wc) {
     impl::with(this)->_write_concern = std::move(wc);
     return *this;
@@ -123,6 +134,11 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::types::view> insert_many_options::comme
     return impl::with(this)->_comment;
 }
 
+bsoncxx::v1::stdx::optional<v1::read_concern> const& insert_many_options::internal::read_concern(
+    insert_many_options const& self) {
+    return impl::with(self)._read_concern;
+}
+
 bsoncxx::v1::stdx::optional<v1::write_concern> const& insert_many_options::internal::write_concern(
     insert_many_options const& self) {
     return impl::with(self)._write_concern;
@@ -131,6 +147,11 @@ bsoncxx::v1::stdx::optional<v1::write_concern> const& insert_many_options::inter
 bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> const& insert_many_options::internal::comment(
     insert_many_options const& self) {
     return impl::with(self)._comment;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern>& insert_many_options::internal::read_concern(
+    insert_many_options& self) {
+    return impl::with(self)._read_concern;
 }
 
 bsoncxx::v1::stdx::optional<v1::write_concern>& insert_many_options::internal::write_concern(

--- a/src/mongocxx/lib/mongocxx/v1/insert_many_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/insert_many_options.cpp
@@ -149,8 +149,7 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> const& insert_many_option
     return impl::with(self)._comment;
 }
 
-bsoncxx::v1::stdx::optional<v1::read_concern>& insert_many_options::internal::read_concern(
-    insert_many_options& self) {
+bsoncxx::v1::stdx::optional<v1::read_concern>& insert_many_options::internal::read_concern(insert_many_options& self) {
     return impl::with(self)._read_concern;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/insert_many_options.hh
+++ b/src/mongocxx/lib/mongocxx/v1/insert_many_options.hh
@@ -20,6 +20,7 @@
 
 #include <bsoncxx/v1/types/value-fwd.hpp>
 
+#include <mongocxx/v1/read_concern-fwd.hpp>
 #include <mongocxx/v1/write_concern-fwd.hpp>
 
 #include <bsoncxx/v1/stdx/optional.hpp>
@@ -29,9 +30,11 @@ namespace v1 {
 
 class insert_many_options::internal {
    public:
+    static bsoncxx::v1::stdx::optional<v1::read_concern> const& read_concern(insert_many_options const& self);
     static bsoncxx::v1::stdx::optional<v1::write_concern> const& write_concern(insert_many_options const& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> const& comment(insert_many_options const& self);
 
+    static bsoncxx::v1::stdx::optional<v1::read_concern>& read_concern(insert_many_options& self);
     static bsoncxx::v1::stdx::optional<v1::write_concern>& write_concern(insert_many_options& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value>& comment(insert_many_options& self);
 };

--- a/src/mongocxx/lib/mongocxx/v1/insert_one_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/insert_one_options.cpp
@@ -18,6 +18,7 @@
 
 #include <bsoncxx/v1/stdx/optional.hpp>
 
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
 #include <bsoncxx/v1/types/value.hh>
@@ -30,6 +31,7 @@ namespace v1 {
 class insert_one_options::impl {
    public:
     bsoncxx::v1::stdx::optional<bool> _bypass_document_validation;
+    bsoncxx::v1::stdx::optional<v1::read_concern> _read_concern;
     bsoncxx::v1::stdx::optional<v1::write_concern> _write_concern;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> _comment;
 
@@ -93,6 +95,15 @@ bsoncxx::v1::stdx::optional<bool> insert_one_options::bypass_document_validation
     return impl::with(this)->_bypass_document_validation;
 }
 
+insert_one_options& insert_one_options::read_concern(v1::read_concern rc) {
+    impl::with(this)->_read_concern = std::move(rc);
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern> insert_one_options::read_concern() const {
+    return impl::with(this)->_read_concern;
+}
+
 insert_one_options& insert_one_options::write_concern(v1::write_concern wc) {
     impl::with(this)->_write_concern = std::move(wc);
     return *this;
@@ -111,6 +122,11 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::types::view> insert_one_options::commen
     return impl::with(this)->_comment;
 }
 
+bsoncxx::v1::stdx::optional<v1::read_concern> const& insert_one_options::internal::read_concern(
+    insert_one_options const& self) {
+    return impl::with(self)._read_concern;
+}
+
 bsoncxx::v1::stdx::optional<v1::write_concern> const& insert_one_options::internal::write_concern(
     insert_one_options const& self) {
     return impl::with(self)._write_concern;
@@ -119,6 +135,10 @@ bsoncxx::v1::stdx::optional<v1::write_concern> const& insert_one_options::intern
 bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> const& insert_one_options::internal::comment(
     insert_one_options const& self) {
     return impl::with(self)._comment;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern>& insert_one_options::internal::read_concern(insert_one_options& self) {
+    return impl::with(self)._read_concern;
 }
 
 bsoncxx::v1::stdx::optional<v1::write_concern>& insert_one_options::internal::write_concern(insert_one_options& self) {

--- a/src/mongocxx/lib/mongocxx/v1/insert_one_options.hh
+++ b/src/mongocxx/lib/mongocxx/v1/insert_one_options.hh
@@ -20,6 +20,7 @@
 
 #include <bsoncxx/v1/types/value-fwd.hpp>
 
+#include <mongocxx/v1/read_concern-fwd.hpp>
 #include <mongocxx/v1/write_concern-fwd.hpp>
 
 #include <bsoncxx/v1/stdx/optional.hpp>
@@ -29,9 +30,11 @@ namespace v1 {
 
 class insert_one_options::internal {
    public:
+    static bsoncxx::v1::stdx::optional<v1::read_concern> const& read_concern(insert_one_options const& self);
     static bsoncxx::v1::stdx::optional<v1::write_concern> const& write_concern(insert_one_options const& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> const& comment(insert_one_options const& self);
 
+    static bsoncxx::v1::stdx::optional<v1::read_concern>& read_concern(insert_one_options& self);
     static bsoncxx::v1::stdx::optional<v1::write_concern>& write_concern(insert_one_options& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value>& comment(insert_one_options& self);
 };

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
@@ -386,6 +386,10 @@ void append_to(v_noabi::options::find const& opts, scoped_bson& doc) {
 }
 
 void append_to(v_noabi::options::insert const& opts, scoped_bson& doc) {
+    if (auto const& opt = opts.read_concern()) {
+        doc += scoped_bson{BCON_NEW("readConcern", BCON_DOCUMENT(to_scoped_bson(opt->to_document()).bson()))};
+    }
+
     if (auto const& opt = opts.write_concern()) {
         doc += scoped_bson{BCON_NEW("writeConcern", BCON_DOCUMENT(to_scoped_bson(opt->to_document()).bson()))};
     }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/insert.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/insert.cpp
@@ -28,13 +28,15 @@ namespace v_noabi {
 namespace options {
 
 insert::insert(v1::insert_many_options opts)
-    : _write_concern{std::move(v1::insert_many_options::internal::write_concern(opts))},
+    : _read_concern{std::move(v1::insert_many_options::internal::read_concern(opts))},
+      _write_concern{std::move(v1::insert_many_options::internal::write_concern(opts))},
       _ordered{opts.ordered()},
       _bypass_document_validation{opts.bypass_document_validation()},
       _comment{std::move(v1::insert_many_options::internal::comment(opts))} {}
 
 insert::insert(v1::insert_one_options opts)
-    : _write_concern{std::move(v1::insert_one_options::internal::write_concern(opts))},
+    : _read_concern{std::move(v1::insert_one_options::internal::read_concern(opts))},
+      _write_concern{std::move(v1::insert_one_options::internal::write_concern(opts))},
       _ordered{},
       _bypass_document_validation{opts.bypass_document_validation()},
       _comment{std::move(v1::insert_one_options::internal::comment(opts))} {}

--- a/src/mongocxx/test/v1/insert_many_options.cpp
+++ b/src/mongocxx/test/v1/insert_many_options.cpp
@@ -16,6 +16,7 @@
 
 //
 
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
 #include <bsoncxx/test/v1/stdx/string_view.hh>
@@ -73,6 +74,7 @@ TEST_CASE("default", "[mongocxx][v1][insert_many_options]") {
     insert_many_options const opts;
 
     CHECK_FALSE(opts.bypass_document_validation().has_value());
+    CHECK_FALSE(opts.read_concern().has_value());
     CHECK_FALSE(opts.write_concern().has_value());
     CHECK_FALSE(opts.ordered().has_value());
     CHECK_FALSE(opts.comment().has_value());
@@ -82,6 +84,17 @@ TEST_CASE("bypass_document_validation", "[mongocxx][v1][insert_many_options]") {
     auto const v = GENERATE(false, true);
 
     CHECK(insert_many_options{}.bypass_document_validation(v).bypass_document_validation() == v);
+}
+
+TEST_CASE("read_concern", "[mongocxx][v1][insert_many_options]") {
+    using T = v1::read_concern;
+
+    auto const v = GENERATE(values({
+        T{},
+        T{}.acknowledge_level(T::level::k_majority),
+    }));
+
+    CHECK(insert_many_options{}.read_concern(v).read_concern() == v);
 }
 
 TEST_CASE("write_concern", "[mongocxx][v1][insert_many_options]") {

--- a/src/mongocxx/test/v1/insert_one_options.cpp
+++ b/src/mongocxx/test/v1/insert_one_options.cpp
@@ -16,6 +16,7 @@
 
 //
 
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
 #include <bsoncxx/test/v1/stdx/string_view.hh>
@@ -73,6 +74,7 @@ TEST_CASE("default", "[mongocxx][v1][insert_one_options]") {
     insert_one_options const opts;
 
     CHECK_FALSE(opts.bypass_document_validation().has_value());
+    CHECK_FALSE(opts.read_concern().has_value());
     CHECK_FALSE(opts.write_concern().has_value());
     CHECK_FALSE(opts.comment().has_value());
 }
@@ -81,6 +83,17 @@ TEST_CASE("bypass_document_validation", "[mongocxx][v1][insert_one_options]") {
     auto const v = GENERATE(false, true);
 
     CHECK(insert_one_options{}.bypass_document_validation(v).bypass_document_validation() == v);
+}
+
+TEST_CASE("read_concern", "[mongocxx][v1][insert_one_options]") {
+    using T = v1::read_concern;
+
+    auto const v = GENERATE(values({
+        T{},
+        T{}.acknowledge_level(T::level::k_majority),
+    }));
+
+    CHECK(insert_one_options{}.read_concern(v).read_concern() == v);
 }
 
 TEST_CASE("write_concern", "[mongocxx][v1][insert_one_options]") {

--- a/src/mongocxx/test/v_noabi/options/insert.cpp
+++ b/src/mongocxx/test/v_noabi/options/insert.cpp
@@ -16,6 +16,7 @@
 
 //
 
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
 #include <bsoncxx/test/v1/stdx/optional.hh>
@@ -25,6 +26,7 @@
 
 #include <bsoncxx/types/bson_value/view.hpp>
 
+#include <mongocxx/read_concern.hpp>
 #include <mongocxx/write_concern.hpp>
 
 #include <bsoncxx/test/catch.hh>
@@ -39,6 +41,7 @@ TEST_CASE("insert opts", "[insert][option]") {
     options::insert ins;
 
     CHECK_OPTIONAL_ARGUMENT(ins, bypass_document_validation, true);
+    CHECK_OPTIONAL_ARGUMENT(ins, read_concern, read_concern{});
     CHECK_OPTIONAL_ARGUMENT(ins, write_concern, write_concern{});
 }
 } // namespace
@@ -50,12 +53,14 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][insert]") {
 
     auto const has_value = GENERATE(false, true);
 
+    bsoncxx::v1::stdx::optional<v1::read_concern> read_concern;
     bsoncxx::v1::stdx::optional<v1::write_concern> write_concern;
     bsoncxx::v1::stdx::optional<bool> bypass_document_validation;
     bsoncxx::v1::stdx::optional<bool> ordered;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> comment;
 
     if (has_value) {
+        read_concern.emplace();
         write_concern.emplace();
         bypass_document_validation.emplace();
         ordered.emplace();
@@ -71,6 +76,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][insert]") {
             v1 from;
 
             if (has_value) {
+                from.read_concern(*read_concern);
                 from.write_concern(*write_concern);
                 from.bypass_document_validation(*bypass_document_validation);
                 from.ordered(*ordered);
@@ -80,11 +86,13 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][insert]") {
             v_noabi const to{from};
 
             if (has_value) {
+                CHECK(to.read_concern() == *read_concern);
                 CHECK(to.write_concern() == *write_concern);
                 CHECK(to.bypass_document_validation() == *bypass_document_validation);
                 CHECK(to.ordered() == *ordered);
                 CHECK(to.comment() == *comment);
             } else {
+                CHECK_FALSE(to.read_concern().has_value());
                 CHECK_FALSE(to.write_concern().has_value());
                 CHECK_FALSE(to.bypass_document_validation().has_value());
                 CHECK_FALSE(to.ordered().has_value());
@@ -98,6 +106,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][insert]") {
             v1 from;
 
             if (has_value) {
+                from.read_concern(*read_concern);
                 from.write_concern(*write_concern);
                 from.bypass_document_validation(*bypass_document_validation);
                 from.comment(*comment);
@@ -106,10 +115,12 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][insert]") {
             v_noabi const to{from};
 
             if (has_value) {
+                CHECK(to.read_concern() == *read_concern);
                 CHECK(to.write_concern() == *write_concern);
                 CHECK(to.bypass_document_validation() == *bypass_document_validation);
                 CHECK(to.comment() == *comment);
             } else {
+                CHECK_FALSE(to.read_concern().has_value());
                 CHECK_FALSE(to.write_concern().has_value());
                 CHECK_FALSE(to.bypass_document_validation().has_value());
                 CHECK_FALSE(to.comment().has_value());
@@ -124,6 +135,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][insert]") {
             v_noabi from;
 
             if (has_value) {
+                from.read_concern(*read_concern);
                 from.write_concern(*write_concern);
                 from.bypass_document_validation(*bypass_document_validation);
                 from.ordered(*ordered);
@@ -133,11 +145,13 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][insert]") {
             v1 const to{from};
 
             if (has_value) {
+                CHECK(to.read_concern() == *read_concern);
                 CHECK(to.write_concern() == *write_concern);
                 CHECK(to.bypass_document_validation() == *bypass_document_validation);
                 CHECK(to.ordered() == *ordered);
                 CHECK(to.comment() == *comment);
             } else {
+                CHECK_FALSE(to.read_concern().has_value());
                 CHECK_FALSE(to.write_concern().has_value());
                 CHECK_FALSE(to.bypass_document_validation().has_value());
                 CHECK_FALSE(to.ordered().has_value());
@@ -151,6 +165,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][insert]") {
             v_noabi from;
 
             if (has_value) {
+                from.read_concern(*read_concern);
                 from.write_concern(*write_concern);
                 from.bypass_document_validation(*bypass_document_validation);
                 from.comment(from_v1(comment->view()));
@@ -159,10 +174,12 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][insert]") {
             v1 const to{from};
 
             if (has_value) {
+                CHECK(to.read_concern() == *read_concern);
                 CHECK(to.write_concern() == *write_concern);
                 CHECK(to.bypass_document_validation() == *bypass_document_validation);
                 CHECK(to.comment() == *comment);
             } else {
+                CHECK_FALSE(to.read_concern().has_value());
                 CHECK_FALSE(to.write_concern().has_value());
                 CHECK_FALSE(to.bypass_document_validation().has_value());
                 CHECK_FALSE(to.comment().has_value());


### PR DESCRIPTION
**Related Ticket:** [CXX-3445](https://jira.mongodb.org/browse/CXX-3445)

## Summary
This PR addresses [CXX-3445](https://jira.mongodb.org/browse/CXX-3445), a subtask of [CXX-1748](https://jira.mongodb.org/browse/CXX-1748), which tracks `read_concern` support for individual operations. It introduces support for setting `read_concern` on `v1::insert_one_options`, `v1::insert_many_options`, and `v_noabi::options::insert`. Previously, unlike `write_concern`, `read_concern` could not be set per operation. This change aligns the API with the existing behaviour for write concerns.

## Tests
Added unit tests for `read_concern` in:
  - `v1/insert_one_options.cpp`
  - `v1/insert_many_options.cpp`
  - `v_noabi/options/insert.cpp`