### PR TITLE
CXX-3446 add read_concern to replace options classes

### DIFF
--- a/src/mongocxx/include/mongocxx/v1/replace_one_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/replace_one_options.hpp
@@ -135,7 +135,7 @@ class replace_one_options {
     ///
     /// Set the "readConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(replace_one_options&) read_concern(v1::read_concern wc);
+    MONGOCXX_ABI_EXPORT_CDECL(replace_one_options&) read_concern(v1::read_concern rc);
 
     ///
     /// Return the current "readConcern" field.

--- a/src/mongocxx/include/mongocxx/v1/replace_one_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/replace_one_options.hpp
@@ -26,6 +26,7 @@
 #include <bsoncxx/v1/types/view-fwd.hpp>
 
 #include <mongocxx/v1/hint-fwd.hpp>
+#include <mongocxx/v1/read_concern-fwd.hpp>
 #include <mongocxx/v1/write_concern-fwd.hpp>
 
 #include <bsoncxx/v1/stdx/optional.hpp>
@@ -44,6 +45,7 @@ namespace v1 {
 /// - `comment`
 /// - `hint`
 /// - `let`
+/// - `read_concern` ("readConcern")
 /// - `sort`
 /// - `upsert`
 /// - `write_concern` ("writeConcern")
@@ -129,6 +131,16 @@ class replace_one_options {
     /// Return the current "upsert" field.
     ///
     MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bool>) upsert() const;
+
+    ///
+    /// Set the "readConcern" field.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(replace_one_options&) read_concern(v1::read_concern wc);
+
+    ///
+    /// Return the current "readConcern" field.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<v1::read_concern>) read_concern() const;
 
     ///
     /// Set the "writeConcern" field.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace.hpp
@@ -117,7 +117,7 @@ class replace {
     ///   Whether or not to bypass document validation
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     replace& bypass_document_validation(bool bypass_document_validation) {
@@ -141,7 +141,7 @@ class replace {
     ///   The new collation.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -178,7 +178,7 @@ class replace {
     ///   is not found.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     replace& upsert(bool upsert) {
@@ -233,7 +233,7 @@ class replace {
     ///   The new write_concern
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -267,7 +267,7 @@ class replace {
     ///   Object representing the index to use.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     replace& hint(v_noabi::hint index_hint) {
@@ -291,7 +291,7 @@ class replace {
     ///   The new let option.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     replace& let(bsoncxx::v_noabi::document::view_or_value let) {
@@ -331,7 +331,7 @@ class replace {
     ///   The new comment option.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     replace& comment(bsoncxx::v_noabi::types::bson_value::view_or_value comment) {

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/replace.hpp
@@ -33,6 +33,7 @@
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
 
 #include <mongocxx/hint.hpp>
+#include <mongocxx/read_concern.hpp>
 #include <mongocxx/write_concern.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -75,6 +76,10 @@ class replace {
 
         if (_upsert) {
             ret.upsert(*_upsert);
+        }
+
+        if (_read_concern) {
+            ret.read_concern(to_v1(*_read_concern));
         }
 
         if (_write_concern) {
@@ -188,6 +193,37 @@ class replace {
     ///
     bsoncxx::v_noabi::stdx::optional<bool> const& upsert() const {
         return _upsert;
+    }
+
+    ///
+    /// Sets the read_concern for this operation.
+    ///
+    /// @param rc
+    ///   The new read_concern
+    ///
+    /// @return
+    ///   A reference to the object on which this member function is being called. This facilitates
+    ///   method chaining.
+    ///
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/read-concern/
+    ///
+    replace& read_concern(v_noabi::read_concern rc) {
+        _read_concern = std::move(rc);
+        return *this;
+    }
+
+    ///
+    /// The current read_concern for this operation.
+    ///
+    /// @return
+    ///   The current read_concern
+    ///
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/read-concern/
+    ///
+    bsoncxx::v_noabi::stdx::optional<v_noabi::read_concern> const& read_concern() const {
+        return _read_concern;
     }
 
     ///
@@ -317,6 +353,7 @@ class replace {
     bsoncxx::v_noabi::stdx::optional<bool> _bypass_document_validation;
     bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::view_or_value> _collation;
     bsoncxx::v_noabi::stdx::optional<bool> _upsert;
+    bsoncxx::v_noabi::stdx::optional<v_noabi::read_concern> _read_concern;
     bsoncxx::v_noabi::stdx::optional<v_noabi::write_concern> _write_concern;
     bsoncxx::v_noabi::stdx::optional<v_noabi::hint> _hint;
     bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::view_or_value> _let;

--- a/src/mongocxx/lib/mongocxx/v1/collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/collection.cpp
@@ -411,6 +411,10 @@ void append_to(v1::insert_one_options const& opts, scoped_bson& doc) {
 }
 
 void append_to(v1::replace_one_options const& opts, scoped_bson& doc) {
+    if (auto const& opt = v1::replace_one_options::internal::read_concern(opts)) {
+        doc += scoped_bson{BCON_NEW("readConcern", BCON_DOCUMENT(scoped_bson{opt->to_document()}.bson()))};
+    }
+
     if (auto const& opt = v1::replace_one_options::internal::write_concern(opts)) {
         doc += scoped_bson{BCON_NEW("writeConcern", BCON_DOCUMENT(scoped_bson{opt->to_document()}.bson()))};
     }

--- a/src/mongocxx/lib/mongocxx/v1/replace_one_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/replace_one_options.cpp
@@ -20,6 +20,7 @@
 #include <bsoncxx/v1/stdx/optional.hpp>
 
 #include <mongocxx/v1/hint.hpp>
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
 #include <bsoncxx/v1/types/value.hh>
@@ -34,6 +35,7 @@ class replace_one_options::impl {
     bsoncxx::v1::stdx::optional<bool> _bypass_document_validation;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> _collation;
     bsoncxx::v1::stdx::optional<bool> _upsert;
+    bsoncxx::v1::stdx::optional<v1::read_concern> _read_concern;
     bsoncxx::v1::stdx::optional<v1::write_concern> _write_concern;
     bsoncxx::v1::stdx::optional<v1::hint> _hint;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> _let;
@@ -119,6 +121,15 @@ bsoncxx::v1::stdx::optional<bool> replace_one_options::upsert() const {
     return impl::with(this)->_upsert;
 }
 
+replace_one_options& replace_one_options::read_concern(v1::read_concern wc) {
+    impl::with(this)->_read_concern = std::move(wc);
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern> replace_one_options::read_concern() const {
+    return impl::with(this)->_read_concern;
+}
+
 replace_one_options& replace_one_options::write_concern(v1::write_concern wc) {
     impl::with(this)->_write_concern = std::move(wc);
     return *this;
@@ -169,6 +180,11 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> const& replace_one_opt
     return impl::with(self)._collation;
 }
 
+bsoncxx::v1::stdx::optional<v1::read_concern> const& replace_one_options::internal::read_concern(
+    replace_one_options const& self) {
+    return impl::with(self)._read_concern;
+}
+
 bsoncxx::v1::stdx::optional<v1::write_concern> const& replace_one_options::internal::write_concern(
     replace_one_options const& self) {
     return impl::with(self)._write_concern;
@@ -196,6 +212,10 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> const& replace_one_option
 bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& replace_one_options::internal::collation(
     replace_one_options& self) {
     return impl::with(self)._collation;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern>& replace_one_options::internal::read_concern(replace_one_options& self) {
+    return impl::with(self)._read_concern;
 }
 
 bsoncxx::v1::stdx::optional<v1::write_concern>& replace_one_options::internal::write_concern(

--- a/src/mongocxx/lib/mongocxx/v1/replace_one_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/replace_one_options.cpp
@@ -121,8 +121,8 @@ bsoncxx::v1::stdx::optional<bool> replace_one_options::upsert() const {
     return impl::with(this)->_upsert;
 }
 
-replace_one_options& replace_one_options::read_concern(v1::read_concern wc) {
-    impl::with(this)->_read_concern = std::move(wc);
+replace_one_options& replace_one_options::read_concern(v1::read_concern rc) {
+    impl::with(this)->_read_concern = std::move(rc);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/replace_one_options.hh
+++ b/src/mongocxx/lib/mongocxx/v1/replace_one_options.hh
@@ -22,6 +22,7 @@
 #include <bsoncxx/v1/types/value-fwd.hpp>
 
 #include <mongocxx/v1/hint-fwd.hpp>
+#include <mongocxx/v1/read_concern-fwd.hpp>
 #include <mongocxx/v1/write_concern-fwd.hpp>
 
 #include <bsoncxx/v1/stdx/optional.hpp>
@@ -32,6 +33,7 @@ namespace v1 {
 class replace_one_options::internal {
    public:
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> const& collation(replace_one_options const& self);
+    static bsoncxx::v1::stdx::optional<v1::read_concern> const& read_concern(replace_one_options const& self);
     static bsoncxx::v1::stdx::optional<v1::write_concern> const& write_concern(replace_one_options const& self);
     static bsoncxx::v1::stdx::optional<v1::hint> const& hint(replace_one_options const& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> const& let(replace_one_options const& self);
@@ -39,6 +41,7 @@ class replace_one_options::internal {
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> const& comment(replace_one_options const& self);
 
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& collation(replace_one_options& self);
+    static bsoncxx::v1::stdx::optional<v1::read_concern>& read_concern(replace_one_options& self);
     static bsoncxx::v1::stdx::optional<v1::write_concern>& write_concern(replace_one_options& self);
     static bsoncxx::v1::stdx::optional<v1::hint>& hint(replace_one_options& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& let(replace_one_options& self);

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
@@ -396,6 +396,10 @@ void append_to(v_noabi::options::insert const& opts, scoped_bson& doc) {
 }
 
 void append_to(v_noabi::options::replace const& opts, scoped_bson& doc) {
+    if (auto const& opt = opts.read_concern()) {
+        doc += scoped_bson{BCON_NEW("readConcern", BCON_DOCUMENT(to_scoped_bson(opt->to_document()).bson()))};
+    }
+
     if (auto const& opt = opts.write_concern()) {
         doc += scoped_bson{BCON_NEW("writeConcern", BCON_DOCUMENT(to_scoped_bson(opt->to_document()).bson()))};
     }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/replace.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/replace.cpp
@@ -35,6 +35,7 @@ replace::replace(v1::replace_one_options opts)
           return {};
       }()},
       _upsert{opts.upsert()},
+      _read_concern{std::move(v1::replace_one_options::internal::read_concern(opts))},
       _write_concern{std::move(v1::replace_one_options::internal::write_concern(opts))},
       _hint{std::move(v1::replace_one_options::internal::hint(opts))},
       _let{[&]() -> decltype(_let) {

--- a/src/mongocxx/test/v1/replace_one_options.cpp
+++ b/src/mongocxx/test/v1/replace_one_options.cpp
@@ -17,6 +17,7 @@
 //
 
 #include <mongocxx/v1/hint.hpp>
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
 #include <bsoncxx/test/v1/array/value.hh>
@@ -80,6 +81,7 @@ TEST_CASE("default", "[mongocxx][v1][replace_one_options]") {
     CHECK_FALSE(opts.bypass_document_validation().has_value());
     CHECK_FALSE(opts.collation().has_value());
     CHECK_FALSE(opts.upsert().has_value());
+    CHECK_FALSE(opts.read_concern().has_value());
     CHECK_FALSE(opts.write_concern().has_value());
     CHECK_FALSE(opts.hint().has_value());
     CHECK_FALSE(opts.let().has_value());
@@ -106,6 +108,17 @@ TEST_CASE("upsert", "[mongocxx][v1][replace_one_options]") {
     auto const v = GENERATE(false, true);
 
     CHECK(replace_one_options{}.upsert(v).upsert() == v);
+}
+
+TEST_CASE("read_concern", "[mongocxx][v1][replace_one_options]") {
+    using T = v1::read_concern;
+
+    auto const v = GENERATE(values({
+        T{},
+        T{}.acknowledge_level(T::level::k_majority),
+    }));
+
+    CHECK(replace_one_options{}.read_concern(v).read_concern() == v);
 }
 
 TEST_CASE("write_concern", "[mongocxx][v1][replace_one_options]") {

--- a/src/mongocxx/test/v_noabi/options/replace.cpp
+++ b/src/mongocxx/test/v_noabi/options/replace.cpp
@@ -150,6 +150,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][replace]") {
             CHECK(to.collation().value() == collation->view());
             CHECK(to.upsert() == *upsert);
             CHECK(to.read_concern() == *read_concern);
+            CHECK(to.write_concern() == *write_concern);
             CHECK(to.hint().value().to_value() == hint->to_value());
             CHECK(to.let().value() == let->view());
             CHECK(to.sort().value() == sort->view());
@@ -159,6 +160,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][replace]") {
             CHECK_FALSE(to.collation().has_value());
             CHECK_FALSE(to.upsert().has_value());
             CHECK_FALSE(to.read_concern().has_value());
+            CHECK_FALSE(to.write_concern().has_value());
             CHECK_FALSE(to.hint().has_value());
             CHECK_FALSE(to.let().has_value());
             CHECK_FALSE(to.sort().has_value());

--- a/src/mongocxx/test/v_noabi/options/replace.cpp
+++ b/src/mongocxx/test/v_noabi/options/replace.cpp
@@ -17,6 +17,7 @@
 //
 
 #include <mongocxx/v1/hint.hpp>
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
 #include <bsoncxx/test/v1/document/value.hh>
@@ -30,6 +31,7 @@
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
 
+#include <mongocxx/read_concern.hpp>
 #include <mongocxx/write_concern.hpp>
 
 #include <bsoncxx/test/catch.hh>
@@ -49,6 +51,7 @@ TEST_CASE("replace opts", "[replace][option]") {
     CHECK_OPTIONAL_ARGUMENT(repl, bypass_document_validation, true);
     CHECK_OPTIONAL_ARGUMENT(repl, collation, collation.view());
     CHECK_OPTIONAL_ARGUMENT(repl, upsert, true);
+    CHECK_OPTIONAL_ARGUMENT(repl, read_concern, read_concern{});
     CHECK_OPTIONAL_ARGUMENT(repl, write_concern, write_concern{});
 }
 } // namespace
@@ -63,6 +66,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][replace]") {
     bsoncxx::v1::stdx::optional<bool> bypass_document_validation;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> collation;
     bsoncxx::v1::stdx::optional<bool> upsert;
+    bsoncxx::v1::stdx::optional<v1::read_concern> read_concern;
     bsoncxx::v1::stdx::optional<v1::write_concern> write_concern;
     bsoncxx::v1::stdx::optional<v1::hint> hint;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> let;
@@ -73,6 +77,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][replace]") {
         bypass_document_validation.emplace();
         collation.emplace();
         upsert.emplace();
+        read_concern.emplace();
         write_concern.emplace();
         hint.emplace("hint");
         let.emplace();
@@ -90,6 +95,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][replace]") {
             from.bypass_document_validation(*bypass_document_validation);
             from.collation(*collation);
             from.upsert(*upsert);
+            from.read_concern(*read_concern);
             from.write_concern(*write_concern);
             from.hint(*hint);
             from.let(*let);
@@ -103,6 +109,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][replace]") {
             CHECK(to.bypass_document_validation() == *bypass_document_validation);
             CHECK(to.collation().value() == collation->view());
             CHECK(to.upsert() == *upsert);
+            CHECK(to.read_concern() == *read_concern);
             CHECK(to.write_concern() == *write_concern);
             CHECK(to.hint().value().to_value() == hint->to_value());
             CHECK(to.let().value() == let->view());
@@ -112,6 +119,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][replace]") {
             CHECK_FALSE(to.bypass_document_validation().has_value());
             CHECK_FALSE(to.collation().has_value());
             CHECK_FALSE(to.upsert().has_value());
+            CHECK_FALSE(to.read_concern().has_value());
             CHECK_FALSE(to.write_concern().has_value());
             CHECK_FALSE(to.hint().has_value());
             CHECK_FALSE(to.let().has_value());
@@ -127,6 +135,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][replace]") {
             from.bypass_document_validation(*bypass_document_validation);
             from.collation(from_v1(collation->view()));
             from.upsert(*upsert);
+            from.read_concern(*read_concern);
             from.write_concern(*write_concern);
             from.hint(*hint);
             from.let(from_v1(let->view()));
@@ -140,7 +149,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][replace]") {
             CHECK(to.bypass_document_validation() == *bypass_document_validation);
             CHECK(to.collation().value() == collation->view());
             CHECK(to.upsert() == *upsert);
-            CHECK(to.write_concern() == *write_concern);
+            CHECK(to.read_concern() == *read_concern);
             CHECK(to.hint().value().to_value() == hint->to_value());
             CHECK(to.let().value() == let->view());
             CHECK(to.sort().value() == sort->view());
@@ -149,7 +158,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][replace]") {
             CHECK_FALSE(to.bypass_document_validation().has_value());
             CHECK_FALSE(to.collation().has_value());
             CHECK_FALSE(to.upsert().has_value());
-            CHECK_FALSE(to.write_concern().has_value());
+            CHECK_FALSE(to.read_concern().has_value());
             CHECK_FALSE(to.hint().has_value());
             CHECK_FALSE(to.let().has_value());
             CHECK_FALSE(to.sort().has_value());


### PR DESCRIPTION
**Related Ticket:** [CXX-3446](https://jira.mongodb.org/browse/CXX-3446)

## Summary
This PR addresses [CXX-3446](https://jira.mongodb.org/browse/CXX-3446), a subtask of [CXX-1748](https://jira.mongodb.org/browse/CXX-1748), which tracks `read_concern` support for individual operations. It introduces support for setting `read_concern` on `v1::replace_one_options`, and `v_noabi::options::replace`. Previously, unlike `write_concern`, `read_concern` could not be set per operation. This change aligns the API with the existing behaviour for write concerns.

## Tests
Added unit tests for `read_concern` in:
  - `v1/replace_one_options.cpp`
  - `v_noabi/options/replace.cpp`