### PR TITLE
CXX-3450 add read_concern to findOneAnd* options classes

### DIFF
--- a/src/mongocxx/include/mongocxx/v1/find_one_and_delete_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/find_one_and_delete_options.hpp
@@ -26,6 +26,7 @@
 #include <bsoncxx/v1/types/view-fwd.hpp>
 
 #include <mongocxx/v1/hint-fwd.hpp>
+#include <mongocxx/v1/read_concern-fwd.hpp>
 #include <mongocxx/v1/write_concern-fwd.hpp>
 
 #include <bsoncxx/v1/stdx/optional.hpp>
@@ -47,6 +48,7 @@ namespace v1 {
 /// - `let`
 /// - `max_time` ("maxTimeMS")
 /// - `projection`
+/// - `read_concern` ("readConcern")
 /// - `sort`
 /// - `write_concern` ("writeConcern")
 ///
@@ -142,6 +144,16 @@ class find_one_and_delete_options {
     /// Return the current "sort" field.
     ///
     MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view>) sort() const;
+
+    ///
+    /// Set the "readConcern" field.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete_options&) read_concern(v1::read_concern read_concern);
+
+    ///
+    /// Return the current "readConcern" field.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<v1::read_concern>) read_concern() const;
 
     ///
     /// Set the "writeConcern" field.

--- a/src/mongocxx/include/mongocxx/v1/find_one_and_replace_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/find_one_and_replace_options.hpp
@@ -27,6 +27,7 @@
 
 #include <mongocxx/v1/hint-fwd.hpp>
 #include <mongocxx/v1/return_document-fwd.hpp>
+#include <mongocxx/v1/read_concern-fwd.hpp>
 #include <mongocxx/v1/write_concern-fwd.hpp>
 
 #include <bsoncxx/v1/stdx/optional.hpp>
@@ -49,6 +50,7 @@ namespace v1 {
 /// - `let`
 /// - `max_time` ("maxTimeMS")
 /// - `projection`
+/// - `read_concern` ("readConcern")
 /// - `return_document` ("returnDocument")
 /// - `sort`
 /// - `upsert`
@@ -207,6 +209,16 @@ class find_one_and_replace_options {
     /// Return the current "upsert" field.
     ///
     MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bool>) upsert() const;
+
+    ///
+    /// Set the "readConcern" field.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) read_concern(v1::read_concern read_concern);
+
+    ///
+    /// Return the current "readConcern" field.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<v1::read_concern>) read_concern() const;
 
     ///
     /// Set the "writeConcern" field.

--- a/src/mongocxx/include/mongocxx/v1/find_one_and_replace_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/find_one_and_replace_options.hpp
@@ -26,8 +26,8 @@
 #include <bsoncxx/v1/types/view-fwd.hpp>
 
 #include <mongocxx/v1/hint-fwd.hpp>
-#include <mongocxx/v1/return_document-fwd.hpp>
 #include <mongocxx/v1/read_concern-fwd.hpp>
+#include <mongocxx/v1/return_document-fwd.hpp>
 #include <mongocxx/v1/write_concern-fwd.hpp>
 
 #include <bsoncxx/v1/stdx/optional.hpp>

--- a/src/mongocxx/include/mongocxx/v1/find_one_and_update_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/find_one_and_update_options.hpp
@@ -29,6 +29,7 @@
 
 #include <mongocxx/v1/hint-fwd.hpp>
 #include <mongocxx/v1/return_document-fwd.hpp>
+#include <mongocxx/v1/read_concern-fwd.hpp>
 #include <mongocxx/v1/write_concern-fwd.hpp>
 
 #include <bsoncxx/v1/stdx/optional.hpp>
@@ -52,6 +53,7 @@ namespace v1 {
 /// - `let`
 /// - `max_time` ("maxTimeMS")
 /// - `projection`
+/// - `read_concern` ("readConcern")
 /// - `return_document` ("returnDocument")
 /// - `sort`
 /// - `upsert`
@@ -209,6 +211,16 @@ class find_one_and_update_options {
     /// Return the current "upsert" field.
     ///
     MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bool>) upsert() const;
+
+    ///
+    /// Set the "readConcern" field.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) read_concern(v1::read_concern read_concern);
+
+    ///
+    /// Return the current "readConcern" field.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<v1::read_concern>) read_concern() const;
 
     ///
     /// Set the "writeConcern" field.

--- a/src/mongocxx/include/mongocxx/v1/find_one_and_update_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/find_one_and_update_options.hpp
@@ -28,8 +28,8 @@
 #include <bsoncxx/v1/types/view-fwd.hpp>
 
 #include <mongocxx/v1/hint-fwd.hpp>
-#include <mongocxx/v1/return_document-fwd.hpp>
 #include <mongocxx/v1/read_concern-fwd.hpp>
+#include <mongocxx/v1/return_document-fwd.hpp>
 #include <mongocxx/v1/write_concern-fwd.hpp>
 
 #include <bsoncxx/v1/stdx/optional.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.hpp
@@ -34,6 +34,7 @@
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
 
 #include <mongocxx/hint.hpp>
+#include <mongocxx/read_concern.hpp>
 #include <mongocxx/write_concern.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -80,6 +81,10 @@ class find_one_and_delete {
 
         if (_ordering) {
             ret.sort(bsoncxx::v1::document::value{to_v1(_ordering->view())});
+        }
+
+        if (_read_concern) {
+            ret.read_concern(to_v1(*_read_concern));
         }
 
         if (_write_concern) {
@@ -225,6 +230,37 @@ class find_one_and_delete {
     }
 
     ///
+    /// Sets the read concern for this operation.
+    ///
+    /// @param read_concern
+    ///   Object representing the read concern.
+    ///
+    /// @return
+    ///   A reference to the object on which this member function is being called. This facilitates
+    ///   method chaining.
+    ///
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    ///
+    find_one_and_delete& read_concern(v_noabi::read_concern read_concern) {
+        _read_concern = std::move(read_concern);
+        return *this;
+    }
+
+    ///
+    /// Gets the current read concern.
+    ///
+    /// @return
+    ///   The current read concern.
+    ///
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    ///
+    bsoncxx::v_noabi::stdx::optional<v_noabi::read_concern> const& read_concern() const {
+        return _read_concern;
+    }
+
+    ///
     /// Sets the write concern for this operation.
     ///
     /// @param write_concern
@@ -337,6 +373,7 @@ class find_one_and_delete {
     bsoncxx::v_noabi::stdx::optional<std::chrono::milliseconds> _max_time;
     bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::view_or_value> _projection;
     bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::view_or_value> _ordering;
+    bsoncxx::v_noabi::stdx::optional<v_noabi::read_concern> _read_concern;
     bsoncxx::v_noabi::stdx::optional<v_noabi::write_concern> _write_concern;
     bsoncxx::v_noabi::stdx::optional<v_noabi::hint> _hint;
     bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::view_or_value> _let;

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.hpp
@@ -112,7 +112,7 @@ class find_one_and_delete {
     ///   The new collation.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -143,7 +143,7 @@ class find_one_and_delete {
     ///   The max amount of running time (in milliseconds).
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -173,7 +173,7 @@ class find_one_and_delete {
     ///   The projection document.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -206,7 +206,7 @@ class find_one_and_delete {
     ///   Document describing the order of the documents to be returned.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -267,7 +267,7 @@ class find_one_and_delete {
     ///   Object representing the write concern.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -301,7 +301,7 @@ class find_one_and_delete {
     ///   Object representing the index to use.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     find_one_and_delete& hint(v_noabi::hint index_hint) {
@@ -325,7 +325,7 @@ class find_one_and_delete {
     ///   The new let option.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     find_one_and_delete& let(bsoncxx::v_noabi::document::view_or_value let) {
@@ -350,7 +350,7 @@ class find_one_and_delete {
     ///   The new comment option.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     find_one_and_delete& comment(bsoncxx::v_noabi::types::bson_value::view_or_value comment) {

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.hpp
@@ -125,7 +125,7 @@ class find_one_and_replace {
     ///   The new collation.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -160,7 +160,7 @@ class find_one_and_replace {
     ///   Whether or not to bypass document validation.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -193,7 +193,7 @@ class find_one_and_replace {
     ///   Object representing the index to use.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     find_one_and_replace& hint(v_noabi::hint index_hint) {
@@ -217,7 +217,7 @@ class find_one_and_replace {
     ///   The new let option.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     find_one_and_replace& let(bsoncxx::v_noabi::document::view_or_value let) {
@@ -242,7 +242,7 @@ class find_one_and_replace {
     ///   The new comment option.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     find_one_and_replace& comment(bsoncxx::v_noabi::types::bson_value::view_or_value comment) {
@@ -267,7 +267,7 @@ class find_one_and_replace {
     ///   The max amount of time (in milliseconds).
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -297,7 +297,7 @@ class find_one_and_replace {
     ///   The projection document.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -328,7 +328,7 @@ class find_one_and_replace {
     ///   Version of document to return, either original or replaced.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -363,7 +363,7 @@ class find_one_and_replace {
     ///   Document describing the order of the documents to be returned.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -395,7 +395,7 @@ class find_one_and_replace {
     ///   Whether or not to perform an upsert.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -425,7 +425,7 @@ class find_one_and_replace {
     ///   Object representing the read concern.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -456,7 +456,7 @@ class find_one_and_replace {
     ///   Object representing the write concern.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.hpp
@@ -35,6 +35,7 @@
 
 #include <mongocxx/hint.hpp>
 #include <mongocxx/options/find_one_common_options.hpp>
+#include <mongocxx/read_concern.hpp>
 #include <mongocxx/write_concern.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -105,6 +106,10 @@ class find_one_and_replace {
 
         if (_upsert) {
             ret.upsert(*_upsert);
+        }
+
+        if (_read_concern) {
+            ret.read_concern(to_v1(*_read_concern));
         }
 
         if (_write_concern) {
@@ -414,6 +419,37 @@ class find_one_and_replace {
     }
 
     ///
+    /// Sets the read concern for this operation.
+    ///
+    /// @param read_concern
+    ///   Object representing the read concern.
+    ///
+    /// @return
+    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   method chaining.
+    ///
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    ///
+    find_one_and_replace& read_concern(v_noabi::read_concern read_concern) {
+        _read_concern = std::move(read_concern);
+        return *this;
+    }
+
+    ///
+    /// Gets the current read concern.
+    ///
+    /// @return
+    ///   The current read concern.
+    ///
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    ///
+    bsoncxx::v_noabi::stdx::optional<v_noabi::read_concern> const& read_concern() const {
+        return _read_concern;
+    }
+
+    ///
     /// Sets the write concern for this operation.
     ///
     /// @param write_concern
@@ -455,6 +491,7 @@ class find_one_and_replace {
     bsoncxx::v_noabi::stdx::optional<v_noabi::options::return_document> _return_document;
     bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::view_or_value> _ordering;
     bsoncxx::v_noabi::stdx::optional<bool> _upsert;
+    bsoncxx::v_noabi::stdx::optional<v_noabi::read_concern> _read_concern;
     bsoncxx::v_noabi::stdx::optional<v_noabi::write_concern> _write_concern;
 };
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update.hpp
@@ -132,7 +132,7 @@ class find_one_and_update {
     ///   The new collation.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -167,7 +167,7 @@ class find_one_and_update {
     ///   Whether or not to bypass document validation.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -201,7 +201,7 @@ class find_one_and_update {
     ///   Object representing the index to use.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     find_one_and_update& hint(v_noabi::hint index_hint) {
@@ -225,7 +225,7 @@ class find_one_and_update {
     ///   The new let option.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     find_one_and_update& let(bsoncxx::v_noabi::document::view_or_value let) {
@@ -250,7 +250,7 @@ class find_one_and_update {
     ///   The new comment option.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     find_one_and_update& comment(bsoncxx::v_noabi::types::bson_value::view_or_value comment) {
@@ -275,7 +275,7 @@ class find_one_and_update {
     ///   The max amount of time (in milliseconds).
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -305,7 +305,7 @@ class find_one_and_update {
     ///   The projection document.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -336,7 +336,7 @@ class find_one_and_update {
     ///   Version of document to return, either original or updated.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -371,7 +371,7 @@ class find_one_and_update {
     ///   Document describing the order of the documents to be returned.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -403,7 +403,7 @@ class find_one_and_update {
     ///   Whether or not to perform an upsert.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -464,7 +464,7 @@ class find_one_and_update {
     ///   Object representing the write concern.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -495,7 +495,7 @@ class find_one_and_update {
     ///   Array representing filters determining which array elements to modify.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/find_one_and_update.hpp
@@ -38,6 +38,7 @@
 
 #include <mongocxx/hint.hpp>
 #include <mongocxx/options/find_one_common_options.hpp>
+#include <mongocxx/read_concern.hpp>
 #include <mongocxx/write_concern.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -108,6 +109,10 @@ class find_one_and_update {
 
         if (_upsert) {
             ret.upsert(*_upsert);
+        }
+
+        if (_read_concern) {
+            ret.read_concern(to_v1(*_read_concern));
         }
 
         if (_write_concern) {
@@ -422,6 +427,37 @@ class find_one_and_update {
     }
 
     ///
+    /// Sets the read concern for this operation.
+    ///
+    /// @param read_concern
+    ///   Object representing the read concern.
+    ///
+    /// @return
+    ///   A reference to the object on which this member function is being called. This facilitates
+    ///   method chaining.
+    ///
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    ///
+    find_one_and_update& read_concern(v_noabi::read_concern read_concern) {
+        _read_concern = std::move(read_concern);
+        return *this;
+    }
+
+    ///
+    /// Gets the current read concern.
+    ///
+    /// @return
+    ///   The current read concern.
+    ///
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    ///
+    bsoncxx::v_noabi::stdx::optional<v_noabi::read_concern> const& read_concern() const {
+        return _read_concern;
+    }
+
+    ///
     /// Sets the write concern for this operation.
     ///
     /// @param write_concern
@@ -494,6 +530,7 @@ class find_one_and_update {
     bsoncxx::v_noabi::stdx::optional<v_noabi::options::return_document> _return_document;
     bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::view_or_value> _ordering;
     bsoncxx::v_noabi::stdx::optional<bool> _upsert;
+    bsoncxx::v_noabi::stdx::optional<v_noabi::read_concern> _read_concern;
     bsoncxx::v_noabi::stdx::optional<v_noabi::write_concern> _write_concern;
     bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::array::view_or_value> _array_filters;
 };

--- a/src/mongocxx/lib/mongocxx/v1/collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/collection.cpp
@@ -681,6 +681,10 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> find_and_modify_impl(
     {
         scoped_bson extra;
 
+        if (auto const& opt = Options::internal::read_concern(options)) {
+            extra += scoped_bson{BCON_NEW("readConcern", BCON_DOCUMENT(scoped_bson{opt->to_document()}.bson()))};
+        }
+
         if (auto const& opt = Options::internal::write_concern(options)) {
             extra += scoped_bson{BCON_NEW("writeConcern", BCON_DOCUMENT(scoped_bson{opt->to_document()}.bson()))};
         }

--- a/src/mongocxx/lib/mongocxx/v1/find_one_and_delete_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/find_one_and_delete_options.cpp
@@ -21,6 +21,7 @@
 #include <bsoncxx/v1/types/value.hpp>
 
 #include <mongocxx/v1/hint.hpp>
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
 #include <chrono>
@@ -36,6 +37,7 @@ class find_one_and_delete_options::impl {
     bsoncxx::v1::stdx::optional<std::chrono::milliseconds> _max_time;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> _projection;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> _sort;
+    bsoncxx::v1::stdx::optional<v1::read_concern> _read_concern;
     bsoncxx::v1::stdx::optional<v1::write_concern> _write_concern;
     bsoncxx::v1::stdx::optional<v1::hint> _hint;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> _let;
@@ -130,6 +132,15 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> find_one_and_delete_opt
     return impl::with(this)->_sort;
 }
 
+find_one_and_delete_options& find_one_and_delete_options::read_concern(v1::read_concern read_concern) {
+    impl::with(this)->_read_concern = std::move(read_concern);
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern> find_one_and_delete_options::read_concern() const {
+    return impl::with(this)->_read_concern;
+}
+
 find_one_and_delete_options& find_one_and_delete_options::write_concern(v1::write_concern write_concern) {
     impl::with(this)->_write_concern = std::move(write_concern);
     return *this;
@@ -181,6 +192,11 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> const& find_one_and_de
     return impl::with(self)._sort;
 }
 
+bsoncxx::v1::stdx::optional<v1::read_concern> const& find_one_and_delete_options::internal::read_concern(
+    find_one_and_delete_options const& self) {
+    return impl::with(self)._read_concern;
+}
+
 bsoncxx::v1::stdx::optional<v1::write_concern> const& find_one_and_delete_options::internal::write_concern(
     find_one_and_delete_options const& self) {
     return impl::with(self)._write_concern;
@@ -214,6 +230,11 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& find_one_and_delete_o
 bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& find_one_and_delete_options::internal::sort(
     find_one_and_delete_options& self) {
     return impl::with(self)._sort;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern>& find_one_and_delete_options::internal::read_concern(
+    find_one_and_delete_options& self) {
+    return impl::with(self)._read_concern;
 }
 
 bsoncxx::v1::stdx::optional<v1::write_concern>& find_one_and_delete_options::internal::write_concern(

--- a/src/mongocxx/lib/mongocxx/v1/find_one_and_delete_options.hh
+++ b/src/mongocxx/lib/mongocxx/v1/find_one_and_delete_options.hh
@@ -22,6 +22,7 @@
 #include <bsoncxx/v1/types/value-fwd.hpp>
 
 #include <mongocxx/v1/hint-fwd.hpp>
+#include <mongocxx/v1/read_concern-fwd.hpp>
 #include <mongocxx/v1/write_concern-fwd.hpp>
 
 #include <bsoncxx/v1/stdx/optional.hpp>
@@ -37,6 +38,7 @@ class find_one_and_delete_options::internal {
         find_one_and_delete_options const& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> const& sort(
         find_one_and_delete_options const& self);
+    static bsoncxx::v1::stdx::optional<v1::read_concern> const& read_concern(find_one_and_delete_options const& self);
     static bsoncxx::v1::stdx::optional<v1::write_concern> const& write_concern(find_one_and_delete_options const& self);
     static bsoncxx::v1::stdx::optional<v1::hint> const& hint(find_one_and_delete_options const& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> const& let(
@@ -47,6 +49,7 @@ class find_one_and_delete_options::internal {
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& collation(find_one_and_delete_options& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& projection(find_one_and_delete_options& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& sort(find_one_and_delete_options& self);
+    static bsoncxx::v1::stdx::optional<v1::read_concern>& read_concern(find_one_and_delete_options& self);
     static bsoncxx::v1::stdx::optional<v1::write_concern>& write_concern(find_one_and_delete_options& self);
     static bsoncxx::v1::stdx::optional<v1::hint>& hint(find_one_and_delete_options& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& let(find_one_and_delete_options& self);

--- a/src/mongocxx/lib/mongocxx/v1/find_one_and_replace_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/find_one_and_replace_options.cpp
@@ -22,6 +22,7 @@
 
 #include <mongocxx/v1/hint.hpp>
 #include <mongocxx/v1/return_document.hpp>
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
 #include <chrono>
@@ -43,6 +44,7 @@ class find_one_and_replace_options::impl {
     bsoncxx::v1::stdx::optional<v1::return_document> _return_document;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> _sort;
     bsoncxx::v1::stdx::optional<bool> _upsert;
+    bsoncxx::v1::stdx::optional<v1::read_concern> _read_concern;
     bsoncxx::v1::stdx::optional<v1::write_concern> _write_concern;
 
     static impl const& with(find_one_and_replace_options const& self) {
@@ -189,6 +191,15 @@ bsoncxx::v1::stdx::optional<bool> find_one_and_replace_options::upsert() const {
     return impl::with(this)->_upsert;
 }
 
+find_one_and_replace_options& find_one_and_replace_options::read_concern(v1::read_concern read_concern) {
+    impl::with(this)->_read_concern = std::move(read_concern);
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern> find_one_and_replace_options::read_concern() const {
+    return impl::with(this)->_read_concern;
+}
+
 find_one_and_replace_options& find_one_and_replace_options::write_concern(v1::write_concern write_concern) {
     impl::with(this)->_write_concern = std::move(write_concern);
     return *this;
@@ -228,6 +239,11 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> const& find_one_and_re
     return impl::with(self)._sort;
 }
 
+bsoncxx::v1::stdx::optional<v1::read_concern> const& find_one_and_replace_options::internal::read_concern(
+    find_one_and_replace_options const& self) {
+    return impl::with(self)._read_concern;
+}
+
 bsoncxx::v1::stdx::optional<v1::write_concern> const& find_one_and_replace_options::internal::write_concern(
     find_one_and_replace_options const& self) {
     return impl::with(self)._write_concern;
@@ -261,6 +277,11 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& find_one_and_replace_
 bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& find_one_and_replace_options::internal::sort(
     find_one_and_replace_options& self) {
     return impl::with(self)._sort;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern>& find_one_and_replace_options::internal::read_concern(
+    find_one_and_replace_options& self) {
+    return impl::with(self)._read_concern;
 }
 
 bsoncxx::v1::stdx::optional<v1::write_concern>& find_one_and_replace_options::internal::write_concern(

--- a/src/mongocxx/lib/mongocxx/v1/find_one_and_replace_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/find_one_and_replace_options.cpp
@@ -21,8 +21,8 @@
 #include <bsoncxx/v1/types/value.hpp>
 
 #include <mongocxx/v1/hint.hpp>
-#include <mongocxx/v1/return_document.hpp>
 #include <mongocxx/v1/read_concern.hpp>
+#include <mongocxx/v1/return_document.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
 #include <chrono>

--- a/src/mongocxx/lib/mongocxx/v1/find_one_and_replace_options.hh
+++ b/src/mongocxx/lib/mongocxx/v1/find_one_and_replace_options.hh
@@ -43,8 +43,7 @@ class find_one_and_replace_options::internal {
         find_one_and_replace_options const& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> const& sort(
         find_one_and_replace_options const& self);
-    static bsoncxx::v1::stdx::optional<v1::read_concern> const& read_concern(
-        find_one_and_replace_options const& self);
+    static bsoncxx::v1::stdx::optional<v1::read_concern> const& read_concern(find_one_and_replace_options const& self);
     static bsoncxx::v1::stdx::optional<v1::write_concern> const& write_concern(
         find_one_and_replace_options const& self);
 

--- a/src/mongocxx/lib/mongocxx/v1/find_one_and_replace_options.hh
+++ b/src/mongocxx/lib/mongocxx/v1/find_one_and_replace_options.hh
@@ -22,6 +22,7 @@
 #include <bsoncxx/v1/types/value-fwd.hpp>
 
 #include <mongocxx/v1/hint-fwd.hpp>
+#include <mongocxx/v1/read_concern-fwd.hpp>
 #include <mongocxx/v1/write_concern-fwd.hpp>
 
 #include <bsoncxx/v1/stdx/optional.hpp>
@@ -42,6 +43,8 @@ class find_one_and_replace_options::internal {
         find_one_and_replace_options const& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> const& sort(
         find_one_and_replace_options const& self);
+    static bsoncxx::v1::stdx::optional<v1::read_concern> const& read_concern(
+        find_one_and_replace_options const& self);
     static bsoncxx::v1::stdx::optional<v1::write_concern> const& write_concern(
         find_one_and_replace_options const& self);
 
@@ -51,6 +54,7 @@ class find_one_and_replace_options::internal {
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value>& comment(find_one_and_replace_options& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& projection(find_one_and_replace_options& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& sort(find_one_and_replace_options& self);
+    static bsoncxx::v1::stdx::optional<v1::read_concern>& read_concern(find_one_and_replace_options& self);
     static bsoncxx::v1::stdx::optional<v1::write_concern>& write_concern(find_one_and_replace_options& self);
 };
 

--- a/src/mongocxx/lib/mongocxx/v1/find_one_and_update_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/find_one_and_update_options.cpp
@@ -23,6 +23,7 @@
 
 #include <mongocxx/v1/hint.hpp>
 #include <mongocxx/v1/return_document.hpp>
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
 #include <chrono>
@@ -44,6 +45,7 @@ class find_one_and_update_options::impl {
     bsoncxx::v1::stdx::optional<v1::return_document> _return_document;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> _sort;
     bsoncxx::v1::stdx::optional<bool> _upsert;
+    bsoncxx::v1::stdx::optional<v1::read_concern> _read_concern;
     bsoncxx::v1::stdx::optional<v1::write_concern> _write_concern;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::array::value> _array_filters;
 
@@ -190,6 +192,15 @@ bsoncxx::v1::stdx::optional<bool> find_one_and_update_options::upsert() const {
     return impl::with(this)->_upsert;
 }
 
+find_one_and_update_options& find_one_and_update_options::read_concern(v1::read_concern read_concern) {
+    impl::with(this)->_read_concern = std::move(read_concern);
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern> find_one_and_update_options::read_concern() const {
+    return impl::with(this)->_read_concern;
+}
+
 find_one_and_update_options& find_one_and_update_options::write_concern(v1::write_concern write_concern) {
     impl::with(this)->_write_concern = std::move(write_concern);
     return *this;
@@ -238,6 +249,11 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> const& find_one_and_up
     return impl::with(self)._sort;
 }
 
+bsoncxx::v1::stdx::optional<v1::read_concern> const& find_one_and_update_options::internal::read_concern(
+    find_one_and_update_options const& self) {
+    return impl::with(self)._read_concern;
+}
+
 bsoncxx::v1::stdx::optional<v1::write_concern> const& find_one_and_update_options::internal::write_concern(
     find_one_and_update_options const& self) {
     return impl::with(self)._write_concern;
@@ -275,6 +291,11 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& find_one_and_update_o
 bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& find_one_and_update_options::internal::sort(
     find_one_and_update_options& self) {
     return impl::with(self)._sort;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern>& find_one_and_update_options::internal::read_concern(
+    find_one_and_update_options& self) {
+    return impl::with(self)._read_concern;
 }
 
 bsoncxx::v1::stdx::optional<v1::write_concern>& find_one_and_update_options::internal::write_concern(

--- a/src/mongocxx/lib/mongocxx/v1/find_one_and_update_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/find_one_and_update_options.cpp
@@ -22,8 +22,8 @@
 #include <bsoncxx/v1/types/value.hpp>
 
 #include <mongocxx/v1/hint.hpp>
-#include <mongocxx/v1/return_document.hpp>
 #include <mongocxx/v1/read_concern.hpp>
+#include <mongocxx/v1/return_document.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
 #include <chrono>

--- a/src/mongocxx/lib/mongocxx/v1/find_one_and_update_options.hh
+++ b/src/mongocxx/lib/mongocxx/v1/find_one_and_update_options.hh
@@ -23,6 +23,7 @@
 #include <bsoncxx/v1/types/value-fwd.hpp>
 
 #include <mongocxx/v1/hint-fwd.hpp>
+#include <mongocxx/v1/read_concern-fwd.hpp>
 #include <mongocxx/v1/write_concern-fwd.hpp>
 
 #include <bsoncxx/v1/stdx/optional.hpp>
@@ -43,6 +44,7 @@ class find_one_and_update_options::internal {
         find_one_and_update_options const& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> const& sort(
         find_one_and_update_options const& self);
+    static bsoncxx::v1::stdx::optional<v1::read_concern> const& read_concern(find_one_and_update_options const& self);
     static bsoncxx::v1::stdx::optional<v1::write_concern> const& write_concern(find_one_and_update_options const& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::array::value> const& array_filters(
         find_one_and_update_options const& self);
@@ -53,6 +55,7 @@ class find_one_and_update_options::internal {
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value>& comment(find_one_and_update_options& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& projection(find_one_and_update_options& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& sort(find_one_and_update_options& self);
+    static bsoncxx::v1::stdx::optional<v1::read_concern>& read_concern(find_one_and_update_options& self);
     static bsoncxx::v1::stdx::optional<v1::write_concern>& write_concern(find_one_and_update_options& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::array::value>& array_filters(find_one_and_update_options& self);
 };

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
@@ -660,10 +660,6 @@ bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::value> find_and_mod
         scoped_bson extra;
 
         if (auto const& opt = options.read_concern()) {
-            if (!opt->is_acknowledged() && options.collation()) {
-                throw v_noabi::logic_error{v_noabi::error_code::k_invalid_parameter};
-            }
-
             extra += scoped_bson{BCON_NEW("readConcern", BCON_DOCUMENT(to_scoped_bson(opt->to_document()).bson()))};
         }
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
@@ -659,6 +659,14 @@ bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::value> find_and_mod
     {
         scoped_bson extra;
 
+        if (auto const& opt = options.read_concern()) {
+            if (!opt->is_acknowledged() && options.collation()) {
+                throw v_noabi::logic_error{v_noabi::error_code::k_invalid_parameter};
+            }
+
+            extra += scoped_bson{BCON_NEW("readConcern", BCON_DOCUMENT(to_scoped_bson(opt->to_document()).bson()))};
+        }
+
         if (auto const& opt = options.write_concern()) {
             if (!opt->is_acknowledged() && options.collation()) {
                 throw v_noabi::logic_error{v_noabi::error_code::k_invalid_parameter};

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find_one_and_delete.cpp
@@ -46,6 +46,7 @@ find_one_and_delete::find_one_and_delete(v1::find_one_and_delete_options opts)
           }
           return {};
       }()},
+      _read_concern{std::move(v1::find_one_and_delete_options::internal::read_concern(opts))},
       _write_concern{std::move(v1::find_one_and_delete_options::internal::write_concern(opts))},
       _hint{std::move(v1::find_one_and_delete_options::internal::hint(opts))},
       _let{[&]() -> decltype(_let) {

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find_one_and_replace.cpp
@@ -57,6 +57,7 @@ find_one_and_replace::find_one_and_replace(v1::find_one_and_replace_options opts
           return {};
       }()},
       _upsert{opts.upsert()},
+      _read_concern{std::move(v1::find_one_and_replace_options::internal::read_concern(opts))},
       _write_concern{std::move(v1::find_one_and_replace_options::internal::write_concern(opts))} {}
 
 } // namespace options

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find_one_and_update.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/find_one_and_update.cpp
@@ -58,6 +58,7 @@ find_one_and_update::find_one_and_update(v1::find_one_and_update_options opts)
           return {};
       }()},
       _upsert{opts.upsert()},
+      _read_concern{std::move(v1::find_one_and_update_options::internal::read_concern(opts))},
       _write_concern{std::move(v1::find_one_and_update_options::internal::write_concern(opts))},
       _array_filters{[&]() -> decltype(_array_filters) {
           if (auto& opt = v1::find_one_and_update_options::internal::array_filters(opts)) {

--- a/src/mongocxx/test/v1/find_one_and_delete_options.cpp
+++ b/src/mongocxx/test/v1/find_one_and_delete_options.cpp
@@ -17,6 +17,7 @@
 //
 
 #include <mongocxx/v1/hint.hpp>
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
 #include <bsoncxx/test/v1/array/value.hh>
@@ -82,6 +83,7 @@ TEST_CASE("default", "[mongocxx][v1][find_one_and_delete_options]") {
     CHECK_FALSE(opts.max_time().has_value());
     CHECK_FALSE(opts.projection().has_value());
     CHECK_FALSE(opts.sort().has_value());
+    CHECK_FALSE(opts.read_concern().has_value());
     CHECK_FALSE(opts.write_concern().has_value());
     CHECK_FALSE(opts.hint().has_value());
     CHECK_FALSE(opts.let().has_value());
@@ -127,6 +129,17 @@ TEST_CASE("sort", "[mongocxx][v1][find_one_and_delete_options]") {
     }));
 
     CHECK(find_one_and_delete_options{}.sort(v.value()).sort() == v.view());
+}
+
+TEST_CASE("read_concern", "[mongocxx][v1][find_one_and_delete_options]") {
+    using T = v1::read_concern;
+
+    auto const v = GENERATE(values({
+        T{},
+        T{}.acknowledge_level(T::level::k_majority),
+    }));
+
+    CHECK(find_one_and_delete_options{}.read_concern(v).read_concern() == v);
 }
 
 TEST_CASE("write_concern", "[mongocxx][v1][find_one_and_delete_options]") {

--- a/src/mongocxx/test/v1/find_one_and_replace_options.cpp
+++ b/src/mongocxx/test/v1/find_one_and_replace_options.cpp
@@ -17,6 +17,7 @@
 //
 
 #include <mongocxx/v1/hint.hpp>
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/return_document.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
@@ -89,6 +90,7 @@ TEST_CASE("default", "[mongocxx][v1][find_one_and_replace_options]") {
     CHECK_FALSE(opts.return_document().has_value());
     CHECK_FALSE(opts.sort().has_value());
     CHECK_FALSE(opts.upsert().has_value());
+    CHECK_FALSE(opts.read_concern().has_value());
     CHECK_FALSE(opts.write_concern().has_value());
 }
 
@@ -181,6 +183,17 @@ TEST_CASE("upsert", "[mongocxx][v1][find_one_and_replace_options]") {
     auto const v = GENERATE(false, true);
 
     CHECK(find_one_and_replace_options{}.upsert(v).upsert() == v);
+}
+
+TEST_CASE("read_concern", "[mongocxx][v1][find_one_and_replace_options]") {
+    using T = v1::read_concern;
+
+    auto const v = GENERATE(values({
+        T{},
+        T{}.acknowledge_level(T::level::k_majority),
+    }));
+
+    CHECK(find_one_and_replace_options{}.read_concern(v).read_concern() == v);
 }
 
 TEST_CASE("write_concern", "[mongocxx][v1][find_one_and_replace_options]") {

--- a/src/mongocxx/test/v1/find_one_and_update_options.cpp
+++ b/src/mongocxx/test/v1/find_one_and_update_options.cpp
@@ -17,6 +17,7 @@
 //
 
 #include <mongocxx/v1/hint.hpp>
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/return_document.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
@@ -89,6 +90,7 @@ TEST_CASE("default", "[mongocxx][v1][find_one_and_update_options]") {
     CHECK_FALSE(opts.return_document().has_value());
     CHECK_FALSE(opts.sort().has_value());
     CHECK_FALSE(opts.upsert().has_value());
+    CHECK_FALSE(opts.read_concern().has_value());
     CHECK_FALSE(opts.write_concern().has_value());
     CHECK_FALSE(opts.array_filters().has_value());
 }
@@ -182,6 +184,17 @@ TEST_CASE("upsert", "[mongocxx][v1][find_one_and_update_options]") {
     auto const v = GENERATE(false, true);
 
     CHECK(find_one_and_update_options{}.upsert(v).upsert() == v);
+}
+
+TEST_CASE("read_concern", "[mongocxx][v1][find_one_and_update_options]") {
+    using T = v1::read_concern;
+
+    auto const v = GENERATE(values({
+        T{},
+        T{}.acknowledge_level(T::level::k_majority),
+    }));
+
+    CHECK(find_one_and_update_options{}.read_concern(v).read_concern() == v);
 }
 
 TEST_CASE("write_concern", "[mongocxx][v1][find_one_and_update_options]") {

--- a/src/mongocxx/test/v_noabi/options/find_one_and_delete.cpp
+++ b/src/mongocxx/test/v_noabi/options/find_one_and_delete.cpp
@@ -17,6 +17,7 @@
 //
 
 #include <mongocxx/v1/hint.hpp>
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
 #include <bsoncxx/test/v1/document/value.hh>
@@ -68,6 +69,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_delete]") {
     bsoncxx::v1::stdx::optional<std::chrono::milliseconds> max_time;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> projection;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> ordering;
+    bsoncxx::v1::stdx::optional<v1::read_concern> read_concern;
     bsoncxx::v1::stdx::optional<v1::write_concern> write_concern;
     bsoncxx::v1::stdx::optional<v1::hint> hint;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> let;
@@ -78,6 +80,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_delete]") {
         max_time.emplace();
         projection.emplace();
         ordering.emplace();
+        read_concern.emplace();
         write_concern.emplace();
         hint.emplace("hint");
         let.emplace();
@@ -95,6 +98,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_delete]") {
             from.max_time(*max_time);
             from.projection(*projection);
             from.sort(*ordering);
+            from.read_concern(*read_concern);
             from.write_concern(*write_concern);
             from.hint(*hint);
             from.let(*let);
@@ -108,6 +112,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_delete]") {
             CHECK(to.max_time() == *max_time);
             CHECK(to.projection().value() == projection->view());
             CHECK(to.sort().value() == ordering->view());
+            CHECK(to.read_concern() == *read_concern);
             CHECK(to.write_concern() == *write_concern);
             CHECK(to.hint().value().to_value() == hint->to_value());
             CHECK(to.let().value() == let->view());
@@ -117,6 +122,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_delete]") {
             CHECK_FALSE(to.max_time().has_value());
             CHECK_FALSE(to.projection().has_value());
             CHECK_FALSE(to.sort().has_value());
+            CHECK_FALSE(to.read_concern().has_value());
             CHECK_FALSE(to.write_concern().has_value());
             CHECK_FALSE(to.hint().has_value());
             CHECK_FALSE(to.let().has_value());
@@ -132,6 +138,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_delete]") {
             from.max_time(*max_time);
             from.projection(from_v1(projection->view()));
             from.sort(from_v1(ordering->view()));
+            from.read_concern(*read_concern);
             from.write_concern(*write_concern);
             from.hint(*hint);
             from.let(from_v1(let->view()));
@@ -145,6 +152,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_delete]") {
             CHECK(to.max_time() == *max_time);
             CHECK(to.projection().value() == projection->view());
             CHECK(to.sort().value() == ordering->view());
+            CHECK(to.read_concern() == *read_concern);
             CHECK(to.write_concern() == *write_concern);
             CHECK(to.hint().value().to_value() == hint->to_value());
             CHECK(to.let().value() == let->view());
@@ -154,6 +162,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_delete]") {
             CHECK_FALSE(to.max_time().has_value());
             CHECK_FALSE(to.projection().has_value());
             CHECK_FALSE(to.sort().has_value());
+            CHECK_FALSE(to.read_concern().has_value());
             CHECK_FALSE(to.write_concern().has_value());
             CHECK_FALSE(to.hint().has_value());
             CHECK_FALSE(to.let().has_value());

--- a/src/mongocxx/test/v_noabi/options/find_one_and_replace.cpp
+++ b/src/mongocxx/test/v_noabi/options/find_one_and_replace.cpp
@@ -17,8 +17,8 @@
 //
 
 #include <mongocxx/v1/hint.hpp>
-#include <mongocxx/v1/return_document.hpp>
 #include <mongocxx/v1/read_concern.hpp>
+#include <mongocxx/v1/return_document.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
 #include <bsoncxx/test/v1/document/value.hh>

--- a/src/mongocxx/test/v_noabi/options/find_one_and_replace.cpp
+++ b/src/mongocxx/test/v_noabi/options/find_one_and_replace.cpp
@@ -18,6 +18,7 @@
 
 #include <mongocxx/v1/hint.hpp>
 #include <mongocxx/v1/return_document.hpp>
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
 #include <bsoncxx/test/v1/document/value.hh>
@@ -79,6 +80,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_replace]") {
     bsoncxx::v1::stdx::optional<v1::return_document> return_document;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> ordering;
     bsoncxx::v1::stdx::optional<bool> upsert;
+    bsoncxx::v1::stdx::optional<v1::read_concern> read_concern;
     bsoncxx::v1::stdx::optional<v1::write_concern> write_concern;
 
     if (has_value) {
@@ -92,6 +94,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_replace]") {
         return_document.emplace();
         ordering.emplace();
         upsert.emplace();
+        read_concern.emplace();
         write_concern.emplace();
     }
 
@@ -112,6 +115,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_replace]") {
             from.return_document(*return_document);
             from.sort(*ordering);
             from.upsert(*upsert);
+            from.read_concern(*read_concern);
             from.write_concern(*write_concern);
         }
 
@@ -128,6 +132,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_replace]") {
             CHECK(to.return_document() == *return_document);
             CHECK(to.sort().value() == ordering->view());
             CHECK(to.upsert() == *upsert);
+            CHECK(to.read_concern() == *read_concern);
             CHECK(to.write_concern() == *write_concern);
         } else {
             CHECK_FALSE(to.bypass_document_validation().has_value());
@@ -140,6 +145,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_replace]") {
             CHECK_FALSE(to.return_document().has_value());
             CHECK_FALSE(to.sort().has_value());
             CHECK_FALSE(to.upsert().has_value());
+            CHECK_FALSE(to.read_concern().has_value());
             CHECK_FALSE(to.write_concern().has_value());
         }
     }
@@ -158,6 +164,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_replace]") {
             from.return_document(*return_document);
             from.sort(from_v1(ordering->view()));
             from.upsert(*upsert);
+            from.read_concern(*read_concern);
             from.write_concern(*write_concern);
         }
 
@@ -174,6 +181,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_replace]") {
             CHECK(to.return_document() == *return_document);
             CHECK(to.sort().value() == ordering->view());
             CHECK(to.upsert() == *upsert);
+            CHECK(to.read_concern() == *read_concern);
             CHECK(to.write_concern() == *write_concern);
         } else {
             CHECK_FALSE(to.bypass_document_validation().has_value());
@@ -186,6 +194,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_replace]") {
             CHECK_FALSE(to.return_document().has_value());
             CHECK_FALSE(to.sort().has_value());
             CHECK_FALSE(to.upsert().has_value());
+            CHECK_FALSE(to.read_concern().has_value());
             CHECK_FALSE(to.write_concern().has_value());
         }
     }

--- a/src/mongocxx/test/v_noabi/options/find_one_and_update.cpp
+++ b/src/mongocxx/test/v_noabi/options/find_one_and_update.cpp
@@ -17,6 +17,7 @@
 //
 
 #include <mongocxx/v1/hint.hpp>
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/return_document.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
@@ -84,6 +85,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_update]") {
     bsoncxx::v1::stdx::optional<v1::return_document> return_document;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> ordering;
     bsoncxx::v1::stdx::optional<bool> upsert;
+    bsoncxx::v1::stdx::optional<v1::read_concern> read_concern;
     bsoncxx::v1::stdx::optional<v1::write_concern> write_concern;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::array::value> array_filters;
 
@@ -98,6 +100,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_update]") {
         return_document.emplace();
         ordering.emplace();
         upsert.emplace();
+        read_concern.emplace();
         write_concern.emplace();
         array_filters.emplace();
     }
@@ -119,6 +122,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_update]") {
             from.return_document(*return_document);
             from.sort(*ordering);
             from.upsert(*upsert);
+            from.read_concern(*read_concern);
             from.write_concern(*write_concern);
             from.array_filters(*array_filters);
         }
@@ -136,6 +140,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_update]") {
             CHECK(to.return_document() == *return_document);
             CHECK(to.sort().value() == ordering->view());
             CHECK(to.upsert() == *upsert);
+            CHECK(to.read_concern() == *read_concern);
             CHECK(to.write_concern() == *write_concern);
             CHECK(to.array_filters().value() == array_filters->view());
         } else {
@@ -149,6 +154,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_update]") {
             CHECK_FALSE(to.return_document().has_value());
             CHECK_FALSE(to.sort().has_value());
             CHECK_FALSE(to.upsert().has_value());
+            CHECK_FALSE(to.read_concern().has_value());
             CHECK_FALSE(to.write_concern().has_value());
             CHECK_FALSE(to.array_filters().has_value());
         }
@@ -168,6 +174,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_update]") {
             from.return_document(*return_document);
             from.sort(from_v1(ordering->view()));
             from.upsert(*upsert);
+            from.read_concern(*read_concern);
             from.write_concern(*write_concern);
             from.array_filters(from_v1(array_filters->view()));
         }
@@ -185,6 +192,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_update]") {
             CHECK(to.return_document() == *return_document);
             CHECK(to.sort().value() == ordering->view());
             CHECK(to.upsert() == *upsert);
+            CHECK(to.read_concern() == *read_concern);
             CHECK(to.write_concern() == *write_concern);
             CHECK(to.array_filters().value() == array_filters->view());
         } else {
@@ -198,6 +206,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][find_one_and_update]") {
             CHECK_FALSE(to.return_document().has_value());
             CHECK_FALSE(to.sort().has_value());
             CHECK_FALSE(to.upsert().has_value());
+            CHECK_FALSE(to.read_concern().has_value());
             CHECK_FALSE(to.write_concern().has_value());
             CHECK_FALSE(to.array_filters().has_value());
         }


### PR DESCRIPTION
**Related Ticket:** [CXX-3450](https://jira.mongodb.org/browse/CXX-3450)

## Summary
This PR addresses [CXX-3450](https://jira.mongodb.org/browse/CXX-3450), a subtask of [CXX-1748](https://jira.mongodb.org/browse/CXX-1748), which tracks `read_concern` support for individual operations. It introduces support for setting `read_concern` on the following:
- `v1::find_one_and_delete_options`
- `v1::find_one_and_replace_options`
- `v1::find_one_and_update_options`
- `v_noabi::options::find_one_and_delete`
- `v_noabi::options::find_one_and_replace`
- `v_noabi::options::find_one_and_update`

Previously, unlike `write_concern`, `read_concern` could not be set per operation. This change aligns the API with the existing behaviour for write concerns.

## Tests
Added unit tests for `read_concern` in:
- `v1/find_one_and_delete_options.cpp`
- `v1/find_one_and_replace_options.cpp`
- `v1/find_one_and_update_options.cpp`
- `v_noabi/options/find_one_and_delete.cpp`
- `v_noabi/options/find_one_and_replace.cpp`
- `v_noabi/options/find_one_and_update.cpp`