### PR TITLE
CXX-3449 add read_concern to index options classes

### DIFF
--- a/src/mongocxx/include/mongocxx/v1/indexes.hpp
+++ b/src/mongocxx/include/mongocxx/v1/indexes.hpp
@@ -25,6 +25,7 @@
 
 #include <mongocxx/v1/client_session-fwd.hpp>
 #include <mongocxx/v1/cursor-fwd.hpp>
+#include <mongocxx/v1/read_concern-fwd.hpp>
 #include <mongocxx/v1/write_concern-fwd.hpp>
 
 #include <bsoncxx/v1/document/value.hpp>
@@ -430,6 +431,7 @@ class indexes {
     /// - `comment`
     /// - `commit_quorum` ("commitQuorum")
     /// - `max_time` ("maxTimeMS")
+    /// - `read_concern` ("readConcern")
     /// - `write_concern` ("writeConcern")
     ///
     class create_one_options {
@@ -512,6 +514,16 @@ class indexes {
         MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<std::chrono::milliseconds>) max_time() const;
 
         ///
+        /// Set the "readConcern" field.
+        ///
+        MONGOCXX_ABI_EXPORT_CDECL(create_one_options&) read_concern(v1::read_concern v);
+
+        ///
+        /// Return the current "readConcern" field.
+        ///
+        MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<v1::read_concern>) read_concern() const;
+
+        ///
         /// Set the "writeConcern" field.
         ///
         MONGOCXX_ABI_EXPORT_CDECL(create_one_options&) write_concern(v1::write_concern v);
@@ -531,6 +543,7 @@ class indexes {
     /// - `comment`
     /// - `commit_quorum` ("commitQuorum")
     /// - `max_time` ("maxTimeMS")
+    /// - `read_concern` ("readConcern")
     /// - `write_concern` ("writeConcern")
     ///
     class create_many_options {
@@ -612,6 +625,16 @@ class indexes {
         MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<std::chrono::milliseconds>) max_time() const;
 
         ///
+        /// Set the "readConcern" field.
+        ///
+        MONGOCXX_ABI_EXPORT_CDECL(create_many_options&) read_concern(v1::read_concern v);
+
+        ///
+        /// Return the current "readConcern" field.
+        ///
+        MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<v1::read_concern>) read_concern() const;
+
+        ///
         /// Set the "writeConcern" field.
         ///
         MONGOCXX_ABI_EXPORT_CDECL(create_many_options&) write_concern(v1::write_concern v);
@@ -630,6 +653,7 @@ class indexes {
     /// Supported fields include:
     /// - `comment`
     /// - `max_time` ("maxTimeMS")
+    /// - `read_concern` ("readConcern")
     /// - `write_concern` ("writeConcern")
     ///
     class drop_one_options {
@@ -701,6 +725,16 @@ class indexes {
         MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<std::chrono::milliseconds>) max_time() const;
 
         ///
+        /// Set the "readConcern" field.
+        ///
+        MONGOCXX_ABI_EXPORT_CDECL(drop_one_options&) read_concern(v1::read_concern v);
+
+        ///
+        /// Return the current "readConcern" field.
+        ///
+        MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<v1::read_concern>) read_concern() const;
+
+        ///
         /// Set the "writeConcern" field.
         ///
         MONGOCXX_ABI_EXPORT_CDECL(drop_one_options&) write_concern(v1::write_concern v);
@@ -719,6 +753,7 @@ class indexes {
     /// Supported fields include:
     /// - `comment`
     /// - `max_time` ("maxTimeMS")
+    /// - `read_concern` ("readConcern")
     /// - `write_concern` ("writeConcern")
     ///
     class drop_all_options {
@@ -788,6 +823,16 @@ class indexes {
         /// Return the current "maxTimeMS" field.
         ///
         MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<std::chrono::milliseconds>) max_time() const;
+
+        ///
+        /// Set the "readConcern" field.
+        ///
+        MONGOCXX_ABI_EXPORT_CDECL(drop_all_options&) read_concern(v1::read_concern v);
+
+        ///
+        /// Return the current "readConcern" field.
+        ///
+        MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<v1::read_concern>) read_concern() const;
 
         ///
         /// Set the "writeConcern" field.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view.hpp
@@ -122,7 +122,7 @@ class index_view {
     ///   The max amount of time (in milliseconds).
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -184,7 +184,7 @@ class index_view {
     ///   Object representing the write concern.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/index_view.hpp
@@ -31,6 +31,7 @@
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/stdx/optional.hpp>
 
+#include <mongocxx/read_concern.hpp>
 #include <mongocxx/write_concern.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -72,6 +73,10 @@ class index_view {
             ret.max_time(*_max_time);
         }
 
+        if (_read_concern) {
+            ret.read_concern(to_v1(*_read_concern));
+        }
+
         if (_write_concern) {
             ret.write_concern(to_v1(*_write_concern));
         }
@@ -91,6 +96,10 @@ class index_view {
 
         if (_max_time) {
             ret.max_time(*_max_time);
+        }
+
+        if (_read_concern) {
+            ret.read_concern(to_v1(*_read_concern));
         }
 
         if (_write_concern) {
@@ -135,6 +144,37 @@ class index_view {
     ///
     bsoncxx::v_noabi::stdx::optional<std::chrono::milliseconds> const& max_time() const {
         return _max_time;
+    }
+
+    ///
+    /// Sets the read concern for this operation.
+    ///
+    /// @param read_concern
+    ///   Object representing the read concern.
+    ///
+    /// @return
+    ///   A reference to the object on which this member function is being called. This facilitates
+    ///   method chaining.
+    ///
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    ///
+    index_view& read_concern(v_noabi::read_concern read_concern) {
+        _read_concern = std::move(read_concern);
+        return *this;
+    }
+
+    ///
+    /// Gets the current read concern.
+    ///
+    /// @return
+    ///   The current read concern.
+    ///
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+    ///
+    bsoncxx::v_noabi::stdx::optional<v_noabi::read_concern> const& read_concern() const {
+        return _read_concern;
     }
 
     ///
@@ -223,6 +263,7 @@ class index_view {
 
    private:
     bsoncxx::v_noabi::stdx::optional<std::chrono::milliseconds> _max_time;
+    bsoncxx::v_noabi::stdx::optional<v_noabi::read_concern> _read_concern;
     bsoncxx::v_noabi::stdx::optional<v_noabi::write_concern> _write_concern;
     bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::value> _commit_quorum;
 };

--- a/src/mongocxx/lib/mongocxx/v1/indexes.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/indexes.cpp
@@ -27,6 +27,7 @@
 #include <mongocxx/v1/client_session.hh>
 #include <mongocxx/v1/cursor.hh>
 #include <mongocxx/v1/exception.hh>
+#include <mongocxx/v1/read_concern.hh>
 #include <mongocxx/v1/write_concern.hh>
 
 #include <chrono>
@@ -157,6 +158,7 @@ class create_index_options_impl {
     bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> _comment;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> _commit_quorum;
     bsoncxx::v1::stdx::optional<std::chrono::milliseconds> _max_time;
+    bsoncxx::v1::stdx::optional<v1::read_concern> _read_concern;
     bsoncxx::v1::stdx::optional<v1::write_concern> _write_concern;
 
     static create_index_options_impl* with(void* ptr) {
@@ -174,6 +176,10 @@ void append_create_to(CreateIndexOptions const& opts, scoped_bson& doc) {
         doc += scoped_bson{BCON_NEW("maxTimeMS", BCON_INT64(std::int64_t{opt->count()}))};
     }
 
+    if (auto const& opt = CreateIndexOptions::internal::read_concern(opts)) {
+        doc += scoped_bson{BCON_NEW("readConcern", BCON_DOCUMENT(scoped_bson{opt->to_document()}.bson()))};
+    }
+
     if (auto const& opt = CreateIndexOptions::internal::write_concern(opts)) {
         doc += scoped_bson{BCON_NEW("writeConcern", BCON_DOCUMENT(scoped_bson{opt->to_document()}.bson()))};
     }
@@ -183,6 +189,7 @@ class drop_index_options_impl {
    public:
     bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> _comment;
     bsoncxx::v1::stdx::optional<std::chrono::milliseconds> _max_time;
+    bsoncxx::v1::stdx::optional<v1::read_concern> _read_concern;
     bsoncxx::v1::stdx::optional<v1::write_concern> _write_concern;
 
     static drop_index_options_impl* with(void* ptr) {
@@ -198,6 +205,10 @@ void append_drop_to(DropIndexOptions const& opts, scoped_bson& doc) {
 
     if (auto const& opt = opts.max_time()) {
         doc += scoped_bson{BCON_NEW("maxTimeMS", BCON_INT64(std::int64_t{opt->count()}))};
+    }
+
+    if (auto const& opt = DropIndexOptions::internal::read_concern(opts)) {
+        doc += scoped_bson{BCON_NEW("readConcern", BCON_DOCUMENT(scoped_bson{opt->to_document()}.bson()))};
     }
 
     if (auto const& opt = DropIndexOptions::internal::write_concern(opts)) {
@@ -949,6 +960,11 @@ indexes::create_one_options& indexes::create_one_options::max_time(std::chrono::
     return *this;
 }
 
+indexes::create_one_options& indexes::create_one_options::read_concern(v1::read_concern v) {
+    create_index_options_impl::with(_impl)->_read_concern = std::move(v);
+    return *this;
+}
+
 indexes::create_one_options& indexes::create_one_options::write_concern(v1::write_concern v) {
     create_index_options_impl::with(_impl)->_write_concern = std::move(v);
     return *this;
@@ -964,6 +980,10 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> indexes::create_one_opt
 
 bsoncxx::v1::stdx::optional<std::chrono::milliseconds> indexes::create_one_options::max_time() const {
     return create_index_options_impl::with(_impl)->_max_time;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern> indexes::create_one_options::read_concern() const {
+    return create_index_options_impl::with(_impl)->_read_concern;
 }
 
 bsoncxx::v1::stdx::optional<v1::write_concern> indexes::create_one_options::write_concern() const {
@@ -1018,6 +1038,11 @@ indexes::create_many_options& indexes::create_many_options::max_time(std::chrono
     return *this;
 }
 
+indexes::create_many_options& indexes::create_many_options::read_concern(v1::read_concern v) {
+    create_index_options_impl::with(_impl)->_read_concern = std::move(v);
+    return *this;
+}
+
 indexes::create_many_options& indexes::create_many_options::write_concern(v1::write_concern v) {
     create_index_options_impl::with(_impl)->_write_concern = std::move(v);
     return *this;
@@ -1033,6 +1058,10 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> indexes::create_many_op
 
 bsoncxx::v1::stdx::optional<std::chrono::milliseconds> indexes::create_many_options::max_time() const {
     return create_index_options_impl::with(_impl)->_max_time;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern> indexes::create_many_options::read_concern() const {
+    return create_index_options_impl::with(_impl)->_read_concern;
 }
 
 bsoncxx::v1::stdx::optional<v1::write_concern> indexes::create_many_options::write_concern() const {
@@ -1088,6 +1117,15 @@ indexes::drop_one_options& indexes::drop_one_options::max_time(std::chrono::mill
 
 bsoncxx::v1::stdx::optional<std::chrono::milliseconds> indexes::drop_one_options::max_time() const {
     return drop_index_options_impl::with(_impl)->_max_time;
+}
+
+indexes::drop_one_options& indexes::drop_one_options::read_concern(v1::read_concern v) {
+    drop_index_options_impl::with(_impl)->_read_concern = std::move(v);
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern> indexes::drop_one_options::read_concern() const {
+    return drop_index_options_impl::with(_impl)->_read_concern;
 }
 
 indexes::drop_one_options& indexes::drop_one_options::write_concern(v1::write_concern v) {
@@ -1148,6 +1186,15 @@ indexes::drop_all_options& indexes::drop_all_options::max_time(std::chrono::mill
 
 bsoncxx::v1::stdx::optional<std::chrono::milliseconds> indexes::drop_all_options::max_time() const {
     return drop_index_options_impl::with(_impl)->_max_time;
+}
+
+indexes::drop_all_options& indexes::drop_all_options::read_concern(v1::read_concern v) {
+    drop_index_options_impl::with(_impl)->_read_concern = std::move(v);
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern> indexes::drop_all_options::read_concern() const {
+    return drop_index_options_impl::with(_impl)->_read_concern;
 }
 
 indexes::drop_all_options& indexes::drop_all_options::write_concern(v1::write_concern v) {
@@ -1318,6 +1365,11 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> const& indexes::create
     return create_index_options_impl::with(self._impl)->_commit_quorum;
 }
 
+bsoncxx::v1::stdx::optional<v1::read_concern> const& indexes::create_one_options::internal::read_concern(
+    create_one_options const& self) {
+    return create_index_options_impl::with(self._impl)->_read_concern;
+}
+
 bsoncxx::v1::stdx::optional<v1::write_concern> const& indexes::create_one_options::internal::write_concern(
     create_one_options const& self) {
     return create_index_options_impl::with(self._impl)->_write_concern;
@@ -1331,6 +1383,11 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value>& indexes::create_one_opti
 bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& indexes::create_one_options::internal::commit_quorum(
     create_one_options& self) {
     return create_index_options_impl::with(self._impl)->_commit_quorum;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern>& indexes::create_one_options::internal::read_concern(
+    create_one_options& self) {
+    return create_index_options_impl::with(self._impl)->_read_concern;
 }
 
 bsoncxx::v1::stdx::optional<v1::write_concern>& indexes::create_one_options::internal::write_concern(
@@ -1348,6 +1405,11 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> const& indexes::create
     return create_index_options_impl::with(self._impl)->_commit_quorum;
 }
 
+bsoncxx::v1::stdx::optional<v1::read_concern> const& indexes::create_many_options::internal::read_concern(
+    create_many_options const& self) {
+    return create_index_options_impl::with(self._impl)->_read_concern;
+}
+
 bsoncxx::v1::stdx::optional<v1::write_concern> const& indexes::create_many_options::internal::write_concern(
     create_many_options const& self) {
     return create_index_options_impl::with(self._impl)->_write_concern;
@@ -1363,6 +1425,11 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& indexes::create_many_
     return create_index_options_impl::with(self._impl)->_commit_quorum;
 }
 
+bsoncxx::v1::stdx::optional<v1::read_concern>& indexes::create_many_options::internal::read_concern(
+    create_many_options& self) {
+    return create_index_options_impl::with(self._impl)->_read_concern;
+}
+
 bsoncxx::v1::stdx::optional<v1::write_concern>& indexes::create_many_options::internal::write_concern(
     create_many_options& self) {
     return create_index_options_impl::with(self._impl)->_write_concern;
@@ -1371,6 +1438,11 @@ bsoncxx::v1::stdx::optional<v1::write_concern>& indexes::create_many_options::in
 bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> const& indexes::drop_one_options::internal::comment(
     drop_one_options const& self) {
     return drop_index_options_impl::with(self._impl)->_comment;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern> const& indexes::drop_one_options::internal::read_concern(
+    drop_one_options const& self) {
+    return drop_index_options_impl::with(self._impl)->_read_concern;
 }
 
 bsoncxx::v1::stdx::optional<v1::write_concern> const& indexes::drop_one_options::internal::write_concern(
@@ -1383,6 +1455,11 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value>& indexes::drop_one_option
     return drop_index_options_impl::with(self._impl)->_comment;
 }
 
+bsoncxx::v1::stdx::optional<v1::read_concern>& indexes::drop_one_options::internal::read_concern(
+    drop_one_options& self) {
+    return drop_index_options_impl::with(self._impl)->_read_concern;
+}
+
 bsoncxx::v1::stdx::optional<v1::write_concern>& indexes::drop_one_options::internal::write_concern(
     drop_one_options& self) {
     return drop_index_options_impl::with(self._impl)->_write_concern;
@@ -1393,6 +1470,11 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> const& indexes::drop_all_
     return drop_index_options_impl::with(self._impl)->_comment;
 }
 
+bsoncxx::v1::stdx::optional<v1::read_concern> const& indexes::drop_all_options::internal::read_concern(
+    drop_all_options const& self) {
+    return drop_index_options_impl::with(self._impl)->_read_concern;
+}
+
 bsoncxx::v1::stdx::optional<v1::write_concern> const& indexes::drop_all_options::internal::write_concern(
     drop_all_options const& self) {
     return drop_index_options_impl::with(self._impl)->_write_concern;
@@ -1401,6 +1483,11 @@ bsoncxx::v1::stdx::optional<v1::write_concern> const& indexes::drop_all_options:
 bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value>& indexes::drop_all_options::internal::comment(
     drop_all_options& self) {
     return drop_index_options_impl::with(self._impl)->_comment;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern>& indexes::drop_all_options::internal::read_concern(
+    drop_all_options& self) {
+    return drop_index_options_impl::with(self._impl)->_read_concern;
 }
 
 bsoncxx::v1::stdx::optional<v1::write_concern>& indexes::drop_all_options::internal::write_concern(

--- a/src/mongocxx/lib/mongocxx/v1/indexes.hh
+++ b/src/mongocxx/lib/mongocxx/v1/indexes.hh
@@ -21,6 +21,7 @@
 #include <bsoncxx/v1/document/value-fwd.hpp>
 #include <bsoncxx/v1/types/value-fwd.hpp>
 
+#include <mongocxx/v1/read_concern-fwd.hpp>
 #include <mongocxx/v1/write_concern-fwd.hpp>
 
 #include <bsoncxx/v1/stdx/optional.hpp>
@@ -66,10 +67,12 @@ class indexes::create_one_options::internal {
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> const& comment(create_one_options const& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> const& commit_quorum(
         create_one_options const& self);
+    static bsoncxx::v1::stdx::optional<v1::read_concern> const& read_concern(create_one_options const& self);
     static bsoncxx::v1::stdx::optional<v1::write_concern> const& write_concern(create_one_options const& self);
 
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value>& comment(create_one_options& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& commit_quorum(create_one_options& self);
+    static bsoncxx::v1::stdx::optional<v1::read_concern>& read_concern(create_one_options& self);
     static bsoncxx::v1::stdx::optional<v1::write_concern>& write_concern(create_one_options& self);
 };
 
@@ -78,28 +81,34 @@ class indexes::create_many_options::internal {
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> const& comment(create_many_options const& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> const& commit_quorum(
         create_many_options const& self);
+    static bsoncxx::v1::stdx::optional<v1::read_concern> const& read_concern(create_many_options const& self);
     static bsoncxx::v1::stdx::optional<v1::write_concern> const& write_concern(create_many_options const& self);
 
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value>& comment(create_many_options& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& commit_quorum(create_many_options& self);
+    static bsoncxx::v1::stdx::optional<v1::read_concern>& read_concern(create_many_options& self);
     static bsoncxx::v1::stdx::optional<v1::write_concern>& write_concern(create_many_options& self);
 };
 
 class indexes::drop_one_options::internal {
    public:
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> const& comment(drop_one_options const& self);
+    static bsoncxx::v1::stdx::optional<v1::read_concern> const& read_concern(drop_one_options const& self);
     static bsoncxx::v1::stdx::optional<v1::write_concern> const& write_concern(drop_one_options const& self);
 
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value>& comment(drop_one_options& self);
+    static bsoncxx::v1::stdx::optional<v1::read_concern>& read_concern(drop_one_options& self);
     static bsoncxx::v1::stdx::optional<v1::write_concern>& write_concern(drop_one_options& self);
 };
 
 class indexes::drop_all_options::internal {
    public:
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> const& comment(drop_all_options const& self);
+    static bsoncxx::v1::stdx::optional<v1::read_concern> const& read_concern(drop_all_options const& self);
     static bsoncxx::v1::stdx::optional<v1::write_concern> const& write_concern(drop_all_options const& self);
 
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value>& comment(drop_all_options& self);
+    static bsoncxx::v1::stdx::optional<v1::read_concern>& read_concern(drop_all_options& self);
     static bsoncxx::v1::stdx::optional<v1::write_concern>& write_concern(drop_all_options& self);
 };
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/index_view.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/index_view.cpp
@@ -83,6 +83,10 @@ void append_create_to(CreateIndexOptions const& opts, scoped_bson& doc) {
         doc += scoped_bson{BCON_NEW("maxTimeMS", BCON_INT64(std::int64_t{opt->count()}))};
     }
 
+    if (auto const& opt = opts.read_concern()) {
+        doc += scoped_bson{BCON_NEW("readConcern", BCON_DOCUMENT(to_scoped_bson(opt->to_document()).bson()))};
+    }
+
     if (auto const& opt = opts.write_concern()) {
         doc += scoped_bson{BCON_NEW("writeConcern", BCON_DOCUMENT(to_scoped_bson(opt->to_document()).bson()))};
     }
@@ -92,6 +96,10 @@ template <typename DropIndexOptions>
 void append_drop_to(DropIndexOptions const& opts, scoped_bson& doc) {
     if (auto const& opt = opts.max_time()) {
         doc += scoped_bson{BCON_NEW("maxTimeMS", BCON_INT64(std::int64_t{opt->count()}))};
+    }
+
+    if (auto const& opt = opts.read_concern()) {
+        doc += scoped_bson{BCON_NEW("readConcern", BCON_DOCUMENT(to_scoped_bson(opt->to_document()).bson()))};
     }
 
     if (auto const& opt = opts.write_concern()) {

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/index_view.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/index_view.cpp
@@ -45,6 +45,7 @@ index_view::index_view(v1::indexes::create_one_options opts)
 index_view::index_view(v1::indexes::create_many_options opts)
     : _max_time(opts.max_time()),
       _read_concern{std::move(v1::indexes::create_many_options::internal::read_concern(opts))},
+      _write_concern{std::move(v1::indexes::create_many_options::internal::write_concern(opts))},
       _commit_quorum{[&]() -> decltype(_commit_quorum) {
           if (auto& opt = v1::indexes::create_many_options::internal::commit_quorum(opts)) {
               return bsoncxx::v_noabi::from_v1(std::move(*opt));

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/index_view.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/index_view.cpp
@@ -33,6 +33,7 @@ namespace options {
 
 index_view::index_view(v1::indexes::create_one_options opts)
     : _max_time(opts.max_time()),
+      _read_concern{std::move(v1::indexes::create_one_options::internal::read_concern(opts))},
       _write_concern{std::move(v1::indexes::create_one_options::internal::write_concern(opts))},
       _commit_quorum{[&]() -> decltype(_commit_quorum) {
           if (auto& opt = v1::indexes::create_one_options::internal::commit_quorum(opts)) {
@@ -43,7 +44,7 @@ index_view::index_view(v1::indexes::create_one_options opts)
 
 index_view::index_view(v1::indexes::create_many_options opts)
     : _max_time(opts.max_time()),
-      _write_concern{std::move(v1::indexes::create_many_options::internal::write_concern(opts))},
+      _read_concern{std::move(v1::indexes::create_many_options::internal::read_concern(opts))},
       _commit_quorum{[&]() -> decltype(_commit_quorum) {
           if (auto& opt = v1::indexes::create_many_options::internal::commit_quorum(opts)) {
               return bsoncxx::v_noabi::from_v1(std::move(*opt));

--- a/src/mongocxx/test/v1/indexes.cpp
+++ b/src/mongocxx/test/v1/indexes.cpp
@@ -17,6 +17,7 @@
 //
 
 #include <mongocxx/v1/exception.hpp>
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
 #include <bsoncxx/test/v1/types/value.hh>
@@ -458,6 +459,7 @@ TEST_CASE("default", "[mongocxx][v1][indexes][create_one_options]") {
     CHECK_FALSE(opts.comment().has_value());
     CHECK_FALSE(opts.commit_quorum().has_value());
     CHECK_FALSE(opts.max_time().has_value());
+    CHECK_FALSE(opts.read_concern().has_value());
     CHECK_FALSE(opts.write_concern().has_value());
 }
 
@@ -467,6 +469,7 @@ TEST_CASE("default", "[mongocxx][v1][indexes][create_many_options]") {
     CHECK_FALSE(opts.comment().has_value());
     CHECK_FALSE(opts.commit_quorum().has_value());
     CHECK_FALSE(opts.max_time().has_value());
+    CHECK_FALSE(opts.read_concern().has_value());
     CHECK_FALSE(opts.write_concern().has_value());
 }
 
@@ -475,6 +478,7 @@ TEST_CASE("default", "[mongocxx][v1][indexes][drop_one_options]") {
 
     CHECK_FALSE(opts.comment().has_value());
     CHECK_FALSE(opts.max_time().has_value());
+    CHECK_FALSE(opts.read_concern().has_value());
     CHECK_FALSE(opts.write_concern().has_value());
 }
 
@@ -483,6 +487,7 @@ TEST_CASE("default", "[mongocxx][v1][indexes][drop_all_options]") {
 
     CHECK_FALSE(opts.comment().has_value());
     CHECK_FALSE(opts.max_time().has_value());
+    CHECK_FALSE(opts.read_concern().has_value());
     CHECK_FALSE(opts.write_concern().has_value());
 }
 
@@ -627,6 +632,17 @@ void test_create_index_options() {
         CHECK(CreateIndexOptions{}.max_time(v).max_time() == v);
     }
 
+    SECTION("read_concern") {
+        using T = v1::read_concern;
+
+        auto const v = GENERATE(values({
+            T{},
+            T{}.acknowledge_level(T::level::k_majority),
+        }));
+
+        CHECK(CreateIndexOptions{}.read_concern(v).read_concern() == v);
+    }
+
     SECTION("write_concern") {
         using T = v1::write_concern;
 
@@ -672,6 +688,17 @@ void test_drop_index_options() {
         auto const v = GENERATE(as<std::chrono::milliseconds>(), 0, 1);
 
         CHECK(DropIndexOptions{}.max_time(v).max_time() == v);
+    }
+
+    SECTION("read_concern") {
+        using T = v1::read_concern;
+
+        auto const v = GENERATE(values({
+            T{},
+            T{}.acknowledge_level(T::level::k_majority),
+        }));
+
+        CHECK(DropIndexOptions{}.read_concern(v).read_concern() == v);
     }
 
     SECTION("write_concern") {

--- a/src/mongocxx/test/v_noabi/options/index_view.cpp
+++ b/src/mongocxx/test/v_noabi/options/index_view.cpp
@@ -16,6 +16,7 @@
 
 //
 
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/write_concern.hpp>
 
 #include <bsoncxx/test/v1/document/value.hh>
@@ -35,11 +36,13 @@ void test_create_options() {
     auto const has_value = GENERATE(false, true);
 
     bsoncxx::v1::stdx::optional<std::chrono::milliseconds> max_time;
+    bsoncxx::v1::stdx::optional<v1::read_concern> read_concern;
     bsoncxx::v1::stdx::optional<v1::write_concern> write_concern;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> commit_quorum;
 
     if (has_value) {
         max_time.emplace();
+        read_concern.emplace();
         write_concern.emplace();
         commit_quorum.emplace();
     }
@@ -56,6 +59,7 @@ void test_create_options() {
 
         if (has_value) {
             from.max_time(*max_time);
+            from.read_concern(*read_concern);
             from.write_concern(*write_concern);
             from.commit_quorum(*commit_quorum);
         }
@@ -64,10 +68,12 @@ void test_create_options() {
 
         if (has_value) {
             CHECK(to.max_time() == max_time);
+            CHECK(to.read_concern() == read_concern);
             CHECK(to.write_concern() == write_concern);
             CHECK(to.commit_quorum().value().view() == commit_quorum->view());
         } else {
             CHECK_FALSE(to.max_time().has_value());
+            CHECK_FALSE(to.read_concern().has_value());
             CHECK_FALSE(to.write_concern().has_value());
             CHECK_FALSE(to.commit_quorum().has_value());
         }


### PR DESCRIPTION
**Related Ticket:** [CXX-3449](https://jira.mongodb.org/browse/CXX-3449)

## Summary
This PR addresses [CXX-3449](https://jira.mongodb.org/browse/CXX-3449), a subtask of [CXX-1748](https://jira.mongodb.org/browse/CXX-1748), which tracks `read_concern` support for individual operations. It introduces support for setting `read_concern` on the following:
- `v1::indexes`
- `v_noabi::options::index_view`

Previously, unlike `write_concern`, `read_concern` could not be set per operation. This change aligns the API with the existing behaviour for write concerns.

## Tests
Added unit tests for `read_concern` in:
- `v1/indexes.cpp`
- `v_noabi/options/index_view.cpp`