### PR TITLE
Update release instructions and related scripts

### DIFF
--- a/.evergreen/scripts/install-c-driver.sh
+++ b/.evergreen/scripts/install-c-driver.sh
@@ -3,6 +3,9 @@
 set -o errexit
 set -o pipefail
 
+declare script_dir
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 declare -r mongoc_version="${mongoc_version:-"${mongoc_version_minimum:?"missing mongoc version"}"}"
 : "${mongoc_version:?}"
 
@@ -30,7 +33,7 @@ mkdir "${mongoc_dir}"
 curl -sS -o mongo-c-driver.tar.gz -L "https://api.github.com/repos/mongodb/mongo-c-driver/tarball/${mongoc_version}"
 tar xzf mongo-c-driver.tar.gz --directory "${mongoc_dir}" --strip-components=1
 
-. mongo-cxx-driver/.evergreen/scripts/install-build-tools.sh
+. "${script_dir:?}/install-build-tools.sh"
 install_build_tools
 
 # Default CMake generator to use if not already provided.

--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -168,6 +168,8 @@ def release(
     auth_jira = JIRA(jira_options, token_auth=jira_token)
 
     github_token = read_github_creds(github_token_file)
+    if not github_token:
+        sys.exit(1)
     auth_gh = Github(auth=Auth.Token(github_token))
 
     if not is_valid_remote(remote):

--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -206,7 +206,7 @@ def release(
         click.echo('Tag {} does not point to HEAD...exiting!'.format(release_tag), err=True)
         sys.exit(1)
 
-    is_pre_release = check_pre_release(release_tag)
+    is_pre_release = is_pre_release_tag(release_tag)
 
     if not quiet:
         found_msg = 'Found release tag {}'.format(release_tag)
@@ -413,13 +413,14 @@ def release_tag_points_to_head(release_tag):
     return tag_commit == repo.head.commit
 
 
-def check_pre_release(tag_name):
+def is_pre_release_tag(tag_name):
     """
-    Check the given tag to determine if it is a release tag, that is, whether it
-    is of the form rX.Y.Z.  Tags that do not match (e.g., because they are
-    suffixed with someting like -beta# or -rc#) are considered pre-release tags.
-    Note that this assumes that the tag name has been validated to ensure that
-    it starts with something like rX.Y.Z and nothing else.
+    Return true when the given (valid) release tag is a pre-release tag.
+
+    A pre-release tag must contain "extra" labels delimited by a '-':
+    - Normal:      r3.9.0
+    - Pre-release: r3.9.0-rc0, r3.9.0-extra, etc.
+    - Invalid:     r3.9.0-, r3.9.0.extra, r3.9.0extra, etc.
     """
 
     match = RELEASE_TAG_RE.fullmatch(tag_name)

--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -422,9 +422,8 @@ def check_pre_release(tag_name):
     it starts with something like rX.Y.Z and nothing else.
     """
 
-    release_re = re.compile('^r[0-9]+\\.[0-9]+\\.[0-9]+$')
-
-    return not bool(release_re.match(tag_name))
+    match = RELEASE_TAG_RE.fullmatch(tag_name)
+    return bool(match and match.group('verpre'))
 
 
 def ensure_c_driver(c_driver_build_ref, with_c_driver, quiet):

--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -48,7 +48,7 @@ import textwrap
 
 import click  # pip install Click
 from git import Repo  # pip install GitPython
-from github import Github  # pip install PyGithub
+from github import Auth, Github  # pip install PyGithub
 from jira import JIRA  # pip install jira
 from looseversion import LooseVersion
 
@@ -121,6 +121,11 @@ ISSUE_TYPE_ID = {
     help='Send release announcement draft output to the specified file',
 )
 @click.option(
+    '--allow-unreleased-changelog-entry',
+    is_flag=True,
+    help='Permit an [Unreleased] tag in the CHANGELOG version header',
+)
+@click.option(
     '--dry-run',
     '-n',
     is_flag=True,
@@ -139,6 +144,7 @@ def release(
     jira_token_file,
     github_token_file,
     allow_open_issues,
+    allow_unreleased_changelog_entry,
     remote,
     c_driver_build_ref,
     with_c_driver,
@@ -162,7 +168,7 @@ def release(
     auth_jira = JIRA(jira_options, token_auth=jira_token)
 
     github_token = read_github_creds(github_token_file)
-    auth_gh = Github(github_token)
+    auth_gh = Github(auth=Auth.Token(github_token))
 
     if not is_valid_remote(remote):
         click.echo(
@@ -242,7 +248,7 @@ def release(
 
     with open('CHANGELOG.md', 'r') as changelog:
         changelog_contents = changelog.read()
-    release_notes_text = generate_release_notes(release_version, changelog_contents)
+    release_notes_text = generate_release_notes(release_version, changelog_contents, allow_unreleased_changelog_entry)
 
     gh_repo = auth_gh.get_repo('mongodb/mongo-cxx-driver')
     gh_release_dict = get_github_releases(gh_repo)
@@ -414,7 +420,7 @@ def check_pre_release(tag_name):
     it starts with something like rX.Y.Z and nothing else.
     """
 
-    release_re = re.compile('^r[0-9]+\\.[0-9]+\\.[0-9]+')
+    release_re = re.compile('^r[0-9]+\\.[0-9]+\\.[0-9]+$')
 
     return not bool(release_re.match(tag_name))
 
@@ -552,7 +558,9 @@ def all_issues_closed(issues):
     return True
 
 
-def generate_release_notes(release_version: str, changelog_contents: str) -> str:
+def generate_release_notes(
+    release_version: str, changelog_contents: str, allow_unreleased_changelog_entry: bool = False
+) -> str:
     lines = []
     adding_to_lines = False
     for line in changelog_contents.splitlines(keepends=True):
@@ -563,16 +571,15 @@ def generate_release_notes(release_version: str, changelog_contents: str) -> str
             if matched_version == release_version:
                 # Found matching version.
                 extra = match.group(2)
-                if extra != '':
+                if extra != '' and not (allow_unreleased_changelog_entry and extra == '[Unreleased]'):
                     raise click.ClickException(
                         'Unexpected extra characters in CHANGELOG: {}. Is the CHANGELOG updated?'.format(extra)
                     )
                 if adding_to_lines:
                     raise click.ClickException(
                         'Unexpected second changelog entry matching version: {}: {}'.format(
-                            matched_version, release_version
-                        ),
-                        line,
+                            matched_version, line.rstrip()
+                        )
                     )
                 # Begin adding lines to `lines` list.
                 adding_to_lines = True

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -139,7 +139,7 @@ Run a patch build which executes the `sbom` task and download the "Augmented SBO
 
 ```bash
 # Ensure `-p` matches the correct Evergreen project for the current branch!
-evergreen patch -y -p mongo-cxx-driver -t all -v sbom -f
+evergreen patch -y -p mongo-cxx-driver -t sbom -v sbom -f -u
 ```
 
 Commit the updated SBOM documents if there are any substantial changes.
@@ -159,6 +159,10 @@ Download the "Augmented SBOM (Updated)" file from the latest EVG commit build in
 Inspect the list of projects in the latest report for the `mongodb/mongo-cxx-driver` target in [Snyk](https://app.snyk.io/org/dev-prod/).
 
 Deactivate any projects that will not be relevant in the upcoming release. Remove any projects that are not relevant to the current release.
+
+> [!TIP]
+> Use the "Project Origin" filter and select "github" and/or "cli" to exclude noise from deactivated and unsupported OCI
+> container images.
 
 ### Check Jira
 
@@ -209,6 +213,8 @@ git checkout releases/vX.Y
 
 In `etc/apidocmenu.md`, update the list of versions under "Driver Documentation By Version" and the table under "Driver Development Status" with a new entry corresponding to this release.
 
+Update `README.md` and sync the "Driver Development Status" table with the updated table from `etc/apidocmenu.md`.
+
 Update `CHANGELOG.md` with a summary of important changes in this release. Consult the list of related Jira tickets (updated ealier) as well as the list of commits since the last release.
 
 Remove the `[Unreleased]` tag from the relevant patch release section, e.g. for release `1.2.3`:
@@ -224,11 +230,11 @@ Remove the `[Unreleased]` tag from the relevant patch release section, e.g. for 
 
 ```
 
-Commit and push the updates to `etc/apidocmenu.md` and `CHANGELOG.md` to `releases/vX.Y` (a PR is not required):
+Commit and push the updates to `etc/apidocmenu.md`, `CHANGELOG.md`, and `README.md` to `releases/vX.Y` (a PR is not required):
 
 ```bash
 git commit -m 'Update CHANGELOG for X.Y.Z'
-git push upstream releases/vX.Y
+git push -u upstream releases/vX.Y
 ```
 
 #### ... for a Non-Patch Release
@@ -241,6 +247,8 @@ git checkout -b pre-release-changes upstream/master
 ```
 
 In `etc/apidocmenu.md`, update the list of versions under "Driver Documentation By Version" and the table under "Driver Development Status" with a new entry corresponding to this release.
+
+Update `README.md` and sync the "Driver Development Status" table with the updated table from `etc/apidocmenu.md`.
 
 Update `CHANGELOG.md` with a summary of important changes in this release. Consult the list of related Jira tickets (updated earlier) as well as the list of commits since the last release.
 
@@ -260,7 +268,7 @@ Remove the `[Unreleased]` tag from the relevant non-patch release section, e.g. 
 > [!IMPORTANT]
 > If there are entries under an unreleased patch release section with the old minor release number, move the entries into this release's section and remove the unreleased patch release section. For example, for a `1.3.0` minor release, move entries from `1.2.3 [Unreleased]` to `1.3.0` and remove `1.2.3 [Unreleased]`. Due to cherry-picking, a non-patch release should always (already) contain the changes targeting a patch release with a prior minor version number. (This is analogous to updating the fix version of Jira tickets, as done earlier.)
 
-Commit the updates to `etc/apidocmenu.md` and `CHANGELOG.md`.
+Commit the updates to `etc/apidocmenu.md`, `CHANGELOG.md`, and `README.md`.
 
 ```bash
 git commit -m 'Update CHANGELOG for X.Y.Z'
@@ -292,7 +300,7 @@ Create and activate a fresh Python 3 virtual environment with required packages 
 
 ```bash
 # Outside the mongo-cxx-driver-release directory!
-export UV_PROJECT_ENVIRONMENT="$HOME/mongo-cxx-driver-release-venv"
+export UV_PROJECT_ENVIRONMENT="$(mktemp -d)"
 
 # Install required packages into a new virtual environment.
 uv sync --frozen --group apidocs --group make_release
@@ -347,6 +355,7 @@ follows:
 
 - Use `--dry-run` to prevent unrecoverable effects.
 - Use `--skip-release-tag` to skip creating the release tag when it already exists.
+- Use `--allow-unreleased-changelog-entry` to skip errors when an `[Unreleased]` exists in the changelog.
 - If building the C driver fails, use an existing C driver build (ensure it is
   the right version) with `--with-c-driver /path/to/c-driver/install`.
 - Use `--skip-distcheck` to bypass time consuming checks when building the
@@ -383,13 +392,11 @@ Click the "..." next to the relevant version and select "Release".
 
 ### Update GitHub Webhook
 
-For a non-patch release, update the [Github Webhook](https://wiki.corp.mongodb.com/display/INTX/Githook) to include the new branch.
+For a non-patch release, request a team member with the Admin role to update the [Github Webhook](https://wiki.corp.mongodb.com/display/INTX/Githook) to include the new branch:
 
-Navigate to the [Webhook Settings](https://github.com/mongodb/mongo-cxx-driver/settings/hooks)
-
-Click `Edit` on the hook for `https://githook.mongodb.com/`.
-
-Add the new release branch to the `Payload URL`. Remove unmaintained release branches.
+- Navigate to the [Webhook Settings](https://github.com/mongodb/mongo-cxx-driver/settings/hooks)
+- Click `Edit` on the hook for `https://githook.mongodb.com/`.
+- Add the new release branch to the `Payload URL`. Remove unmaintained release branches.
 
 ### Update releases/stable
 
@@ -428,7 +435,7 @@ Push the new branch to the remote repository:
 git push upstream releases/vX.Y
 ```
 
-The new branch should be continuously tested on Evergreen. Update the "Display Name" and "Branch Name" of the [mongo-cxx-driver-latest-release Evergreen project](https://spruce.mongodb.com/project/mongo-cxx-driver-latest-release/settings/general) to refer to the new release branch.
+The new branch should be continuously tested on Evergreen. Update the "Display Name" and "Branch Name" of the [mongo-cxx-driver-latest-release Evergreen project](https://spruce.mongodb.com/project/mongo-cxx-driver-latest-release/settings/general) to refer to the new release branch. Trigger a "Force Repotracker Run" (under General Settings > Project Flags > Repotracker Settings) so the waterfall is updated with the new branch's commit history.
 
 ### Update SBOM serial number
 
@@ -445,16 +452,28 @@ podman run -it --rm -v "$(pwd):/pwd" 901841024863.dkr.ecr.us-east-1.amazonaws.co
   update --refresh --generate-new-serial-number -p "/pwd/etc/purls.txt" -i "/pwd/etc/cyclonedx.sbom.json" -o "/pwd/etc/cyclonedx.sbom.json"
 ```
 
-Update `etc/augmented.sbom.json` by running a patch build which executes the `sbom` task as described above in [SBOM Lite](#sbom-lite).
+Update `etc/augmented.sbom.json` by running a patch build which executes the `sbom` task as described above in [SBOM Lite](#sbom-lite):
 
-Commit and push these changes to the `releases/vX.Y` branch.
+```bash
+evergreen patch -y -p mongo-cxx-driver-latest-release -t sbom -v sbom -f -u
+```
+
+Commit and push these changes to the `releases/vX.Y` branch:
+
+```bash
+git commit -m "Update SBOM serial number"
+```
 
 ### Update Snyk
 
 > [!IMPORTANT]
 > Run the Snyk commands in a fresh clone of the post-release repository to avoid existing build and release artifacts from affecting Snyk.
 
-Checkout the new release tag.
+Checkout the new release tag in a clean repository:
+
+```bash
+git clone --revision rX.Y.Z https://github.com/mongodb/mongo-cxx-driver.git
+```
 
 Configure and build the CXX Driver (do not reuse an existing C Driver installation; use the auto-downloaded C Driver sources instead):
 
@@ -477,7 +496,7 @@ snyk auth "${SNYK_API_TOKEN:?}"
 
 # Verify third party dependency sources listed in etc/purls.txt are detected by Snyk.
 # If not, see: https://support.snyk.io/hc/en-us/requests/new
-# Use --exclude=extras until CXX-3042 is resolved
+# Use --exclude=extras until CXX-3062 is resolved
 snyk_args=(
   --org=dev-prod
   --remote-repo-url=https://github.com/mongodb/mongo-cxx-driver/
@@ -494,6 +513,9 @@ snyk monitor "${snyk_args[@]:?}"
 
 Verify the new Snyk target reference is present in the [Snyk project targets list](https://app.snyk.io/org/dev-prod/projects?groupBy=targets&before&after&searchQuery=mongo-cxx-driver&sortBy=highest+severity&filters[Show]=&filters[Integrations]=cli&filters[CollectionIds]=) for `mongodb/mongo-cxx-driver`.
 
+> [!NOTE]
+> The mongo-cxx-driver project itself will likely show up as a dependency. Ignore this entry.
+
 ### Post-Release Changes
 
 Create and checkout a new branch `post-release-changes` relative to `master` to contain documentation updates following the new release:
@@ -508,10 +530,6 @@ This branch will be used to create a PR later.
 > [!IMPORTANT]
 > Make sure the `post-release-changes` branch is created on `master`, not `rX.Y.Z` or `releases/vX.Y`!
 
-For a patch release, in `etc/apidocmenu.md`, update the list of versions under "Driver Documentation By Version" and the table under "Driver Development Status" with a new entry corresponding to this release.
-
-In `README.md`, sync the "Driver Development Status" table with the updated table from `etc/apidocmenu.md`.
-
 Update `etc/cyclonedx.sbom.json` with a new unique serial number for the next upcoming non-patch release (e.g. for `1.4.0` following the release of `1.3.0`):
 
 ```bash
@@ -521,12 +539,13 @@ podman pull 901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/
 # Output: "... writing sbom to file"
 podman run -it --rm -v "$(pwd):/pwd" 901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/silkbomb:2.0 \
   update --refresh --generate-new-serial-number -p "/pwd/etc/purls.txt" -i "/pwd/etc/cyclonedx.sbom.json" -o "/pwd/etc/cyclonedx.sbom.json"
-
-git add etc/cyclonedx.sbom.json
-git commit -m "update SBOM serial number"
 ```
 
-Update `etc/augmented.sbom.json` by running a patch build which executes the `sbom` task as described above in [SBOM Lite](#sbom-lite).
+Update `etc/augmented.sbom.json` by running a patch build which executes the `sbom` task as described above in [SBOM Lite](#sbom-lite):
+
+```
+evergreen patch -y -p mongo-cxx-driver -t sbom -v sbom -u
+```
 
 Commit these changes to the `post-release-changes` branch:
 
@@ -573,21 +592,21 @@ git commit -am "Prepare to generate rX.Y.Z release documentation"
 Ensure `doxygen` and `hugo` are locally installed and up-to-date.
 
 ```bash
-command -V doxygen hugo
+command -V doxygen hugo rsync
 ```
 
 > [!IMPORTANT]
 > The required Doxygen version is defined in `etc/generate-latest-apidocs.sh` as `$DOXYGEN_VERSION_REQUIRED`. If not already present, download the required version from [Doxygen Releases](https://www.doxygen.nl/download.html). Use the `DOXYGEN_BINARY` environment variable to override the default `doxygen` command with a path to a specific Doxygen binary.
 
-Run `git clean -dfx` to restore the repository to a clean state.
+Clone a clean copy of the repository.
 
-> [!WARNING]
-> Do NOT run `git clean -dfx` in your local development repository, as it may delete your local development files present in the repository (even if normally ignored by git)! Only run this in the command in the separate repository being used for this release!
+> [!TIP]
+> Clone a local filesystem repository via `git clone /path/to/local/repo` for better performance.
 
-Configure CMake using `build` as the binary directory. Leave all other configuration variables as their default.
+Configure CMake using `build` as the binary directory. Leave all configuration variables as their default (but `CMAKE_PREFIX_PATH` may be used to reuse an existing C driver libraries).
 
 ```bash
-cmake -S . -B build
+cmake -B build
 ```
 
 Test generating both Hugo and Doxygen docs locally by building the `docs` target:
@@ -668,6 +687,9 @@ Set `<lastmod>` for both the new entry and the `/current` sitemap entry to the c
 ...
 ```
 
+> [!NOTE]
+> Only the "current" and latest release entries should have a `<priority>` tag set to `1.0`.
+
 Commit and push these change to the `gh-pages` branch:
 
 ```bash
@@ -701,7 +723,13 @@ Add a section for the next patch release, e.g. following a `1.2.3` release:
 ## 1.2.2 <!-- Prior release. -->
 ```
 
-Commit the changes to the `releases/vX.Y` branch and push the branch to the remote repository (a PR is not required for this step).
+Commit the changes to the `releases/vX.Y` branch:
+
+```bash
+git commit -m 'Add changelog entry for the next patch release'
+```
+
+Push the branch to the remote repository (a PR is not required for this step).
 
 Checkout the `post-release-changes` branch.
 
@@ -744,7 +772,13 @@ Add a section for the next patch release, e.g. following a `1.2.0` release:
 ## 1.1.0 <!-- Prior release. -->
 ```
 
-Commit the changes to the `releases/vX.Y` branch and push the branch to the remote repository (a PR is not required for this step).
+Commit the changes to the `releases/vX.Y` branch:
+
+```bash
+git commit -m 'Add changelog entry for the next minor release'
+```
+
+Push the branch to the remote repository (a PR is not required for this step).
 
 Checkout the `post-release-changes` branch.
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -544,7 +544,7 @@ podman run -it --rm -v "$(pwd):/pwd" 901841024863.dkr.ecr.us-east-1.amazonaws.co
 Update `etc/augmented.sbom.json` by running a patch build which executes the `sbom` task as described above in [SBOM Lite](#sbom-lite):
 
 ```
-evergreen patch -y -p mongo-cxx-driver -t sbom -v sbom -u
+evergreen patch -y -p mongo-cxx-driver -t sbom -v sbom -f -u
 ```
 
 Commit these changes to the `post-release-changes` branch:

--- a/etc/test_make_release.py
+++ b/etc/test_make_release.py
@@ -5,61 +5,114 @@ import click
 
 import make_release
 
+# Changelog entries for the 3.9.0 release.
+CHANGELOG_ENTRIES = textwrap.dedent("""\
+- Add CMake option `MONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX` (default is `TRUE`
+    for backwards-compatibility).
+- Add API to manage Atlas Search Indexes.
+""")
+
+
+# The expected release notes generated for the 3.9.0 release.
+EXPECTED_RELEASE_NOTES = f"""\
+## Added
+
+{CHANGELOG_ENTRIES}
+See the [full list of changes in Jira](https://jira.mongodb.org/issues/?jql=project%20%3D%20CXX%20AND%20fixVersion%20%3D%203.9.0).
+
+## Feedback
+To report a bug or request a feature, please open a ticket in the MongoDB issue management tool Jira:
+
+- [Create an account](https://jira.mongodb.org) and login.
+- Navigate to the [CXX project](https://jira.mongodb.org/browse/CXX)
+- Click `Create`.
+
+## Signature Verification
+Release artifacts may be verified by using the accompanying detached signature (.asc) and the cpp-driver public key obtained from https://pgp.mongodb.com.
+"""
+
+
+# The CHANGELOG.md file containing multiple release entries, including the 3.9.0 release.
+def make_changelog(version_suffix: str) -> str:
+    return f"""\
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 3.9.0{version_suffix}
+
+### Added
+
+{CHANGELOG_ENTRIES}
+## 3.8.0
+
+### Fixed
+
+- Fix foo.
+"""
+
+
+# The official 3.9.0 changelog.
+CHANGELOG = make_changelog('')
+
+# The unreleased 3.9.0 changelog.
+CHANGELOG_UNRELEASED = make_changelog(' [Unreleased]')
+
+# Duplicate release entry check.
+CHANGELOG_DUPLICATE_VERSION = textwrap.dedent("""
+## 3.9.0
+
+### Added
+
+- Add something.
+
+## 3.9.0
+
+### Fixed
+
+- Fix something.
+
+## 3.8.0
+
+### Fixed
+
+- Fix foo.
+""").lstrip()
+
 
 class TestMakeRelease(unittest.TestCase):
-    def test_generate_release_notes(self):
-        # Test can generate.
-        changelog = textwrap.dedent("""
-        # Changelog
+    def test_success(self):
+        got = make_release.generate_release_notes('3.9.0', CHANGELOG)
+        self.assertEqual(got, EXPECTED_RELEASE_NOTES)
 
-        All notable changes to this project will be documented in this file.
-
-        The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-        and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-        ## 3.9.0
-
-        ### Added
-
-        - Add CMake option `MONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX` (default is `TRUE`
-          for backwards-compatibility).
-        - Add API to manage Atlas Search Indexes.
-                                    
-        ## 3.8.0
-
-        ### Fixed
-
-        - Fix foo.
-        """).lstrip()
-        expected_release_notes = textwrap.dedent("""
-        ## Added
-
-        - Add CMake option `MONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX` (default is `TRUE`
-          for backwards-compatibility).
-        - Add API to manage Atlas Search Indexes.
-
-        See the [full list of changes in Jira](https://jira.mongodb.org/issues/?jql=project%20%3D%20CXX%20AND%20fixVersion%20%3D%203.9.0).
-
-        ## Feedback
-        To report a bug or request a feature, please open a ticket in the MongoDB issue management tool Jira:
-
-        - [Create an account](https://jira.mongodb.org) and login.
-        - Navigate to the [CXX project](https://jira.mongodb.org/browse/CXX)
-        - Click `Create`.
-        """).lstrip()
-
-        got = make_release.generate_release_notes('3.9.0', changelog)
-        self.assertEqual(got, expected_release_notes)
-
-        # Test exception occurs if CHANGELOG includes extra characters in title.
+    def test_raises_when_version_not_found(self):
         with self.assertRaises(click.ClickException) as ctx:
-            make_release.generate_release_notes('3.9.0', '## 3.9.0 [Unreleased]')
+            make_release.generate_release_notes('4.0.0', CHANGELOG)
+        self.assertIn('Failed to find', str(ctx.exception.message))
+
+    def test_raises_on_unexpected_extra_characters(self):
+        with self.assertRaises(click.ClickException) as ctx:
+            make_release.generate_release_notes('3.9.0', CHANGELOG_UNRELEASED)
         self.assertIn('Unexpected extra characters', str(ctx.exception.message))
 
-        # Test exception occurs if CHANGELOG does not include matching entry.
+    def test_allows_unreleased_tag(self):
+        got = make_release.generate_release_notes('3.9.0', CHANGELOG_UNRELEASED, allow_unreleased_changelog_entry=True)
+        self.assertEqual(got, EXPECTED_RELEASE_NOTES)
+
+    def test_allows_unreleased_tag_only(self):
         with self.assertRaises(click.ClickException) as ctx:
-            make_release.generate_release_notes('3.9.0', '## 3.8.0')
-        self.assertIn('Failed to find', str(ctx.exception.message))
+            make_release.generate_release_notes(
+                '3.9.0', make_changelog(' extra'), allow_unreleased_changelog_entry=True
+            )
+        self.assertIn('Unexpected extra characters', str(ctx.exception.message))
+
+    def test_raises_on_duplicate_version_entry(self):
+        with self.assertRaises(click.ClickException) as ctx:
+            make_release.generate_release_notes('3.9.0', CHANGELOG_DUPLICATE_VERSION)
+        self.assertIn('Unexpected second changelog entry', str(ctx.exception.message))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Followup to the 4.3.0 release. Fixes and improves release instructions and relevant scripts.

 ---

Fixes and improvements to `make_release.py` include:

- Adding support for a `--allow-unreleased-changelog-entry` to support pre-release dry-runs against the unmodified CHANGELOG.
- Fix a PyGithub deprecation warning which suggests using `Auth.Token(token)` instead of the old `login_or_token` positional argument.
- Fix the `check_pre_release()` regex to match against the _entire_ tag name (add the end-of-line `$` anchor), not just against a potential-prefix.
- Fix an out-of-place `line` argument when constructing the error message thrown by the duplicate version check.

Fixes and improvements to `test_make_release.py` include:

- Refactored assertions into fine-grained test cases.
- Refactored changelog contents into constant variables to separate test logic from setup and inputs.

Fixes and improvements to release instructions include:

- Move the "Driver Development Status" table update step for `README.md` from "Post-Release Steps" into "Release Steps" so the updated table is included in the release tag.
- Replace the dangerous `git clean -dfx` command and hardcoded paths with temporary directories and "clean repository" instructions.
- Fixed `install-build-tools.sh` so it is not sensitive to the current working directory (exposed by the tmpdir/clean repo changes above).
- Updated reference to CXX-3042 (duplicate) and replaced it with CXX-3062 (successor) in Snyk `--exclude=extras` instructions.
- Added `rsync` to list of required commands prior to Hugo page deployment.
- Updated sitemap update instructions to account for `<priority>` tags (only applicable to the current and latest API doc versions, not older versions).
- Tweaked the GitHub Webhook instructions to account for stricter repository permissions (Admins only).
- Added and updated various commands and examples to improve the flow of instructions.