### PR TITLE
Support JIRA epic status in release issues

### DIFF
--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -551,7 +551,10 @@ def all_issues_closed(issues):
         click.echo(msg, err=True)
 
         def open_filter(x):
-            return x.fields.status.name != 'Closed'
+            return x.fields.status.name not in {
+                'Closed',  # Normal issues.
+                'Development Complete',  # Epics.
+            }
 
         open_issues = [i.key for i in filter(open_filter, issues)]
         click.echo('{}'.format(', '.join(open_issues)), err=True)


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1623. Epics may be listed in release versions alongside "normal" JIRA issues when they are given a fix version. Unlike normal issues, the "status" field for an epic is set to "Development Complete", not "Closed".