### PR TITLE
CXX-1748 Fix missing CHANGELOG entry + miscellaneous fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
         - If not upgrading, custom application retry logic may need to be adjusted to handle higher rates of overload errors.
     - Add URI option `maxAdaptiveRetries` to configure the maximum number of retries for operations that fail with a `SystemOverloadedError` (default: `2`).
     - Add URI option `enableOverloadRetargeting` to control whether retries of `SystemOverloadedError` will attempt to use a different server (default: `false`).
+- Added support for the "readConcern" option field to "find" and "update" operations.
 
 ## 4.2.0
 

--- a/src/mongocxx/include/mongocxx/v1/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v1/bulk_write.hpp
@@ -390,7 +390,7 @@ class bulk_write::update_many {
     ///
     /// Initialize with the given "filter" document and "update" aggregation pipeline.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL() update_many(bsoncxx::v1::document::value filter, pipeline const& update);
+    MONGOCXX_ABI_EXPORT_CDECL() update_many(bsoncxx::v1::document::value filter, v1::pipeline const& update);
 
     ///
     /// Return the current "filter" field.

--- a/src/mongocxx/include/mongocxx/v1/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v1/bulk_write.hpp
@@ -25,6 +25,9 @@
 #include <bsoncxx/v1/types/value-fwd.hpp>
 
 #include <mongocxx/v1/hint-fwd.hpp>
+#include <mongocxx/v1/pipeline-fwd.hpp>
+#include <mongocxx/v1/read_concern-fwd.hpp>
+#include <mongocxx/v1/write_concern-fwd.hpp>
 
 #include <bsoncxx/v1/array/value.hpp>
 #include <bsoncxx/v1/document/value.hpp>
@@ -32,10 +35,6 @@
 #include <bsoncxx/v1/types/view.hpp>
 
 #include <mongocxx/v1/config/export.hpp>
-#include <mongocxx/v1/hint.hpp>
-#include <mongocxx/v1/pipeline.hpp>
-#include <mongocxx/v1/read_concern.hpp>
-#include <mongocxx/v1/write_concern.hpp>
 
 #include <cstdint>
 #include <map>

--- a/src/mongocxx/include/mongocxx/v1/collection.hpp
+++ b/src/mongocxx/include/mongocxx/v1/collection.hpp
@@ -61,6 +61,7 @@
 #include <mongocxx/v1/replace_one_options.hpp>
 #include <mongocxx/v1/update_many_options.hpp>
 #include <mongocxx/v1/update_one_options.hpp>
+#include <mongocxx/v1/write_concern.hpp>
 
 #include <cstdint>
 #include <string>

--- a/src/mongocxx/include/mongocxx/v1/collection.hpp
+++ b/src/mongocxx/include/mongocxx/v1/collection.hpp
@@ -32,7 +32,6 @@
 #include <mongocxx/v1/search_indexes-fwd.hpp>
 #include <mongocxx/v1/update_many_result-fwd.hpp>
 #include <mongocxx/v1/update_one_result-fwd.hpp>
-#include <mongocxx/v1/write_concern-fwd.hpp>
 
 #include <bsoncxx/v1/detail/type_traits.hpp>
 #include <bsoncxx/v1/document/value.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/delete.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/delete.hpp
@@ -178,7 +178,7 @@ class delete_options {
     /// @see
     /// - https://www.mongodb.com/docs/manual/reference/read-concern/
     ///
-    delete_options& read_concern(read_concern rc) {
+    delete_options& read_concern(v_noabi::read_concern rc) {
         _read_concern = std::move(rc);
         return *this;
     }
@@ -209,7 +209,7 @@ class delete_options {
     /// @see
     /// - https://www.mongodb.com/docs/manual/core/write-concern/
     ///
-    delete_options& write_concern(write_concern wc) {
+    delete_options& write_concern(v_noabi::write_concern wc) {
         _write_concern = std::move(wc);
         return *this;
     }


### PR DESCRIPTION
Some miscellaneous followups to recent PRs related to [CXX-1748](https://jira.mongodb.org/browse/CXX-1748), including adding a missing changelog entry for the "readConcern" API which landed in the 4.3.0 release (for "find" and "update"). The [release description](https://github.com/mongodb/mongo-cxx-driver/releases/tag/r4.3.0) has already been updated accordingly.