### PR TITLE
CXX-3451 add read_concern to count options classes

### DIFF
--- a/src/mongocxx/include/mongocxx/v1/count_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/count_options.hpp
@@ -26,6 +26,7 @@
 #include <bsoncxx/v1/types/view-fwd.hpp>
 
 #include <mongocxx/v1/hint-fwd.hpp>
+#include <mongocxx/v1/read_concern-fwd.hpp>
 #include <mongocxx/v1/read_preference-fwd.hpp>
 
 #include <bsoncxx/v1/stdx/optional.hpp>
@@ -47,6 +48,7 @@ namespace v1 {
 /// - `hint`
 /// - `limit`
 /// - `max_time` ("maxTimeMS")
+/// - `read_concern` ("readConcern")
 /// - `read_preference` ("readPreference")
 /// - `skip`
 ///
@@ -161,6 +163,16 @@ class count_options {
     /// Return the current "skip" field.
     ///
     MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<std::int64_t>) skip() const;
+
+    ///
+    /// Set the "readConcern" field.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(count_options&) read_concern(v1::read_concern rc);
+
+    ///
+    /// Return the current "readConcern" field.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<v1::read_concern>) read_concern() const;
 
     ///
     /// Set the "readPreference" field.

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count.hpp
@@ -35,6 +35,7 @@
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
 
 #include <mongocxx/hint.hpp>
+#include <mongocxx/read_concern.hpp>
 #include <mongocxx/read_preference.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -105,7 +106,7 @@ class count {
     ///   The new collation.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -136,7 +137,7 @@ class count {
     ///   Object representing the index to use.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -166,7 +167,7 @@ class count {
     ///   The new comment option.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -196,7 +197,7 @@ class count {
     ///  The max number of documents to count.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -226,7 +227,7 @@ class count {
     ///   The max amount of time (in milliseconds).
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -256,7 +257,7 @@ class count {
     ///   The number of documents to skip.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -286,7 +287,7 @@ class count {
     ///   The new read_preference.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -309,6 +310,37 @@ class count {
         return _read_preference;
     }
 
+    ///
+    /// Sets the read_concern for this operation.
+    ///
+    /// @param rc
+    ///   The new read_concern.
+    ///
+    /// @return
+    ///   A reference to the object on which this member function is being called. This facilitates
+    ///   method chaining.
+    ///
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/read-concern/
+    ///
+    count& read_concern(v_noabi::read_concern rc) {
+        _read_concern = std::move(rc);
+        return *this;
+    }
+
+    ///
+    /// The current read_concern for this operation.
+    ///
+    /// @return
+    ///   The current read_concern.
+    ///
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/read-concern/
+    ///
+    bsoncxx::v_noabi::stdx::optional<v_noabi::read_concern> const& read_concern() const {
+        return _read_concern;
+    }
+
    private:
     bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::view_or_value> _collation;
     bsoncxx::v_noabi::stdx::optional<v_noabi::hint> _hint;
@@ -317,6 +349,7 @@ class count {
     bsoncxx::v_noabi::stdx::optional<std::chrono::milliseconds> _max_time;
     bsoncxx::v_noabi::stdx::optional<std::int64_t> _skip;
     bsoncxx::v_noabi::stdx::optional<v_noabi::read_preference> _read_preference;
+    bsoncxx::v_noabi::stdx::optional<v_noabi::read_concern> _read_concern;
 };
 
 } // namespace options

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/count.hpp
@@ -96,6 +96,10 @@ class count {
             ret.read_preference(to_v1(*_read_preference));
         }
 
+        if (_read_concern) {
+            ret.read_concern(to_v1(*_read_concern));
+        }
+
         return ret;
     }
 

--- a/src/mongocxx/lib/mongocxx/v1/collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/collection.cpp
@@ -220,6 +220,10 @@ void append_to(v1::count_options const& opts, scoped_bson& doc) {
         doc += scoped_bson{BCON_NEW("collation", BCON_DOCUMENT(scoped_bson_view{*opt}.bson()))};
     }
 
+    if (auto const& opt = v1::count_options::internal::read_concern(opts)) {
+        doc += scoped_bson{BCON_NEW("readConcern", BCON_DOCUMENT(scoped_bson{opt->to_document()}.bson()))};
+    }
+
     if (auto const& opt = opts.max_time()) {
         doc += scoped_bson{BCON_NEW("maxTimeMS", BCON_INT64(std::int64_t{opt->count()}))};
     }

--- a/src/mongocxx/lib/mongocxx/v1/count_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/count_options.cpp
@@ -20,6 +20,7 @@
 #include <bsoncxx/v1/stdx/optional.hpp>
 #include <bsoncxx/v1/types/view.hpp>
 
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/read_preference.hpp>
 
 #include <bsoncxx/v1/types/value.hh>
@@ -44,6 +45,7 @@ class count_options::impl {
     bsoncxx::v1::stdx::optional<std::chrono::milliseconds> _max_time;
     bsoncxx::v1::stdx::optional<std::int64_t> _skip;
     bsoncxx::v1::stdx::optional<v1::read_preference> _rp;
+    bsoncxx::v1::stdx::optional<v1::read_concern> _read_concern;
 
     static impl const& with(count_options const& other) {
         return *static_cast<impl const*>(other._impl);
@@ -159,6 +161,15 @@ bsoncxx::v1::stdx::optional<v1::read_preference> count_options::read_preference(
     return impl::with(this)->_rp;
 }
 
+count_options& count_options::read_concern(v1::read_concern rc) {
+    impl::with(this)->_read_concern = std::move(rc);
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern> count_options::read_concern() const {
+    return impl::with(this)->_read_concern;
+}
+
 bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> const& count_options::internal::collation(
     count_options const& self) {
     return impl::with(self)._collation;
@@ -178,6 +189,11 @@ bsoncxx::v1::stdx::optional<v1::read_preference> const& count_options::internal:
     return impl::with(self)._rp;
 }
 
+bsoncxx::v1::stdx::optional<v1::read_concern> const& count_options::internal::read_concern(
+    count_options const& self) {
+    return impl::with(self)._read_concern;
+}
+
 bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& count_options::internal::collation(count_options& self) {
     return impl::with(self)._collation;
 }
@@ -192,6 +208,10 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value>& count_options::internal:
 
 bsoncxx::v1::stdx::optional<v1::read_preference>& count_options::internal::read_preference(count_options& self) {
     return impl::with(self)._rp;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern>& count_options::internal::read_concern(count_options& self) {
+    return impl::with(self)._read_concern;
 }
 
 } // namespace v1

--- a/src/mongocxx/lib/mongocxx/v1/count_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/count_options.cpp
@@ -189,8 +189,7 @@ bsoncxx::v1::stdx::optional<v1::read_preference> const& count_options::internal:
     return impl::with(self)._rp;
 }
 
-bsoncxx::v1::stdx::optional<v1::read_concern> const& count_options::internal::read_concern(
-    count_options const& self) {
+bsoncxx::v1::stdx::optional<v1::read_concern> const& count_options::internal::read_concern(count_options const& self) {
     return impl::with(self)._read_concern;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/count_options.hh
+++ b/src/mongocxx/lib/mongocxx/v1/count_options.hh
@@ -22,6 +22,7 @@
 #include <bsoncxx/v1/types/value-fwd.hpp>
 
 #include <mongocxx/v1/hint-fwd.hpp>
+#include <mongocxx/v1/read_concern-fwd.hpp>
 #include <mongocxx/v1/read_preference-fwd.hpp>
 
 #include <bsoncxx/v1/stdx/optional.hpp>
@@ -35,11 +36,13 @@ class count_options::internal {
     static bsoncxx::v1::stdx::optional<v1::hint> const& hint(count_options const& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> const& comment(count_options const& self);
     static bsoncxx::v1::stdx::optional<v1::read_preference> const& read_preference(count_options const& self);
+    static bsoncxx::v1::stdx::optional<v1::read_concern> const& read_concern(count_options const& self);
 
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& collation(count_options& self);
     static bsoncxx::v1::stdx::optional<v1::hint>& hint(count_options& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value>& comment(count_options& self);
     static bsoncxx::v1::stdx::optional<v1::read_preference>& read_preference(count_options& self);
+    static bsoncxx::v1::stdx::optional<v1::read_concern>& read_concern(count_options& self);
 };
 
 } // namespace v1

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
@@ -232,6 +232,10 @@ void append_to(v_noabi::options::count const& opts, scoped_bson& doc) {
         doc += scoped_bson{BCON_NEW("collation", BCON_DOCUMENT(to_scoped_bson_view(*opt).bson()))};
     }
 
+    if (auto const& opt = opts.read_concern()) {
+        doc += scoped_bson{BCON_NEW("readConcern", BCON_DOCUMENT(to_scoped_bson_view(opt->to_document()).bson()))};
+    }
+
     if (auto const& opt = opts.max_time()) {
         doc += scoped_bson{BCON_NEW("maxTimeMS", BCON_INT64(std::int64_t{opt->count()}))};
     }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/count.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/count.cpp
@@ -38,7 +38,8 @@ count::count(v1::count_options opts)
       _limit{opts.limit()},
       _max_time{opts.max_time()},
       _skip{opts.skip()},
-      _read_preference{std::move(v1::count_options::internal::read_preference(opts))} {}
+      _read_preference{std::move(v1::count_options::internal::read_preference(opts))},
+      _read_concern{std::move(v1::count_options::internal::read_concern(opts))} {}
 
 } // namespace options
 } // namespace v_noabi

--- a/src/mongocxx/test/v1/count_options.cpp
+++ b/src/mongocxx/test/v1/count_options.cpp
@@ -175,7 +175,7 @@ TEST_CASE("read_concern", "[mongocxx][v1][count_options]") {
     auto const v = GENERATE(values({
         T{},
         T{}.acknowledge_level(T::level::k_majority),
-    })); 
+    }));
 
     CHECK(count_options{}.read_concern(v).read_concern() == v);
 }

--- a/src/mongocxx/test/v1/count_options.cpp
+++ b/src/mongocxx/test/v1/count_options.cpp
@@ -17,6 +17,7 @@
 //
 
 #include <mongocxx/v1/hint.hpp>
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/read_preference.hpp>
 
 #include <bsoncxx/test/v1/types/value.hh>
@@ -83,6 +84,7 @@ TEST_CASE("default", "[mongocxx][v1][count_options]") {
     CHECK_FALSE(opts.max_time().has_value());
     CHECK_FALSE(opts.skip().has_value());
     CHECK_FALSE(opts.read_preference().has_value());
+    CHECK_FALSE(opts.read_concern().has_value());
 }
 
 TEST_CASE("collation", "[mongocxx][v1][count_options]") {
@@ -165,6 +167,17 @@ TEST_CASE("read_preference", "[mongocxx][v1][count_options]") {
     }));
 
     CHECK(count_options{}.read_preference(v).read_preference() == v);
+}
+
+TEST_CASE("read_concern", "[mongocxx][v1][count_options]") {
+    using T = v1::read_concern;
+
+    auto const v = GENERATE(values({
+        T{},
+        T{}.acknowledge_level(T::level::k_majority),
+    })); 
+
+    CHECK(count_options{}.read_concern(v).read_concern() == v);
 }
 
 } // namespace v1

--- a/src/mongocxx/test/v_noabi/options/count.cpp
+++ b/src/mongocxx/test/v_noabi/options/count.cpp
@@ -17,6 +17,7 @@
 //
 
 #include <mongocxx/v1/hint.hpp>
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/read_preference.hpp>
 
 #include <bsoncxx/test/v1/document/value.hh>
@@ -34,6 +35,7 @@
 #include <bsoncxx/document/view_or_value.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
 
+#include <mongocxx/read_concern.hpp>
 #include <mongocxx/read_preference.hpp>
 
 #include <bsoncxx/test/catch.hh>
@@ -57,6 +59,7 @@ TEST_CASE("count", "[count][option]") {
     CHECK_OPTIONAL_ARGUMENT(cnt, max_time, std::chrono::milliseconds{1000});
     CHECK_OPTIONAL_ARGUMENT(cnt, read_preference, read_preference{});
     CHECK_OPTIONAL_ARGUMENT(cnt, skip, 3);
+    CHECK_OPTIONAL_ARGUMENT(cnt, read_concern, read_concern{});
 }
 
 } // namespace
@@ -76,6 +79,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][count]") {
     bsoncxx::v1::stdx::optional<std::chrono::milliseconds> max_time;
     bsoncxx::v1::stdx::optional<std::int64_t> skip;
     bsoncxx::v1::stdx::optional<v1::read_preference> read_preference;
+    bsoncxx::v1::stdx::optional<v1::read_concern> read_concern;
 
     if (has_value) {
         collation.emplace();
@@ -85,6 +89,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][count]") {
         max_time.emplace();
         skip.emplace();
         read_preference.emplace();
+        read_concern.emplace();
     }
 
     using v_noabi = v_noabi::options::count;
@@ -101,6 +106,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][count]") {
             from.max_time(*max_time);
             from.skip(*skip);
             from.read_preference(*read_preference);
+            from.read_concern(*read_concern);
         }
 
         v_noabi const to{from};
@@ -113,6 +119,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][count]") {
             CHECK(to.max_time() == *max_time);
             CHECK(to.skip() == *skip);
             CHECK(to.read_preference() == *read_preference);
+            CHECK(to.read_concern() == *read_concern);
         } else {
             CHECK_FALSE(to.collation().has_value());
             CHECK_FALSE(to.hint().has_value());
@@ -121,6 +128,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][count]") {
             CHECK_FALSE(to.max_time().has_value());
             CHECK_FALSE(to.skip().has_value());
             CHECK_FALSE(to.read_preference().has_value());
+            CHECK_FALSE(to.read_concern().has_value());
         }
     }
 
@@ -135,6 +143,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][count]") {
             from.max_time(*max_time);
             from.skip(*skip);
             from.read_preference(*read_preference);
+            from.read_concern(*read_concern);
         }
 
         v1 const to{from};
@@ -147,6 +156,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][count]") {
             CHECK(to.max_time() == *max_time);
             CHECK(to.skip() == *skip);
             CHECK(to.read_preference() == *read_preference);
+            CHECK(to.read_concern() == *read_concern);
         } else {
             CHECK_FALSE(to.collation().has_value());
             CHECK_FALSE(to.hint().has_value());
@@ -155,6 +165,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][count]") {
             CHECK_FALSE(to.max_time().has_value());
             CHECK_FALSE(to.skip().has_value());
             CHECK_FALSE(to.read_preference().has_value());
+            CHECK_FALSE(to.read_concern().has_value());
         }
     }
 }


### PR DESCRIPTION
**Related Ticket:** [CXX-3451](https://jira.mongodb.org/browse/CXX-3451)

## Summary
This PR addresses [CXX-3451](https://jira.mongodb.org/browse/CXX-3451), a subtask of [CXX-1748](https://jira.mongodb.org/browse/CXX-1748), which tracks `read_concern` support for individual operations. It introduces support for setting `read_concern` on the following:
- `v1::count_options`
- `v_noabi::options::count`

Previously, unlike `write_concern`, `read_concern` could not be set per operation. This change aligns the API with the existing behaviour for write concerns.

## Tests
Added unit tests for `read_concern` in:
- `v1/count_options.cpp`
- `v_noabi/options/count.cpp`