### PR TITLE
CXX-3483 Avoid implementation patterns that require RTTI

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value.hpp
@@ -42,10 +42,6 @@ namespace array {
 /// should be used sparingly; array::view should be used instead wherever possible.
 ///
 class value {
-   private:
-    v1::array::value _value;
-    std::size_t _length;
-
    public:
     /// @copydoc v_noabi::document::value::deleter_type
     using deleter_type = void(BSONCXX_ABI_CDECL*)(std::uint8_t*);
@@ -53,6 +49,11 @@ class value {
     /// @copydoc v_noabi::document::value::unique_ptr_type
     using unique_ptr_type = std::unique_ptr<uint8_t[], deleter_type>;
 
+   private:
+    unique_ptr_type _data;
+    std::size_t _length{0};
+
+   public:
     /// @copydoc v_noabi::document::value::const_iterator
     using const_iterator = v_noabi::array::view::const_iterator;
 
@@ -89,7 +90,7 @@ class value {
     ///   A user provided deleter.
     ///
     value(std::uint8_t* data, std::size_t length, deleter_type deleter)
-        : _value{data, std::move(deleter)}, _length{length} {}
+        : _data{data, std::move(deleter)}, _length{length} {}
 
     ///
     /// Constructs a value from a std::unique_ptr to a buffer. The ownership
@@ -104,7 +105,7 @@ class value {
     /// @param length
     ///   The length of the document.
     ///
-    value(unique_ptr_type ptr, std::size_t length) : _value{std::move(ptr)}, _length{length} {}
+    value(unique_ptr_type ptr, std::size_t length) : _data{std::move(ptr)}, _length{length} {}
 
     ///
     /// Constructs a value from a view of an array. The data referenced
@@ -128,7 +129,7 @@ class value {
     /// @note `this->size()` is ignored.
     ///
     explicit operator v1::array::value() const& {
-        return _value;
+        return {_data.get(), _length, _data.get_deleter()};
     }
 
     ///
@@ -143,8 +144,9 @@ class value {
     /// @note `this->size()` is ignored.
     ///
     explicit operator v1::array::value() && {
+        auto const length = _length;
         _length = 0u;
-        return std::move(_value);
+        return {_data.release(), length, std::move(_data.get_deleter())};
     }
 
     ///
@@ -177,17 +179,17 @@ class value {
 
     /// @copydoc bsoncxx::v_noabi::array::view::find(std::uint32_t i) const
     const_iterator find(std::uint32_t i) const {
-        return const_iterator{*_value.view().find(i)};
+        return const_iterator{*this->view().find(i)};
     }
 
     /// @copydoc bsoncxx::v_noabi::array::view::operator[](std::uint32_t i) const
     v_noabi::document::element operator[](std::uint32_t i) const {
-        return _value.operator[](i);
+        return to_v1(this->view()).operator[](i);
     }
 
     /// @copydoc bsoncxx::v_noabi::array::view::data() const
     std::uint8_t const* data() const {
-        return _value.data();
+        return _data.get();
     }
 
     /// @copydoc bsoncxx::v_noabi::array::view::size() const
@@ -207,14 +209,14 @@ class value {
     /// empty document.
     ///
     bool empty() const {
-        return _length == 5; // Do NOT use _value.empty().
+        return _length == 5; // Do NOT use this->view().empty().
     }
 
     ///
     /// Get a view over the array owned by this value.
     ///
     v_noabi::array::view view() const noexcept {
-        return {_value.data(), _length};
+        return {_data.get(), _length};
     }
 
     ///
@@ -236,13 +238,7 @@ class value {
     /// @return A std::unique_ptr with ownership of the buffer.
     ///
     unique_ptr_type release() {
-        auto ptr = _value.release();
-
-        // Invariant: the underlying deleter type MUST be `deleter_type`.
-        auto const deleter_ptr = ptr.get_deleter().target<deleter_type>();
-
-        // Invariant: `ptr` implies `deleter_ptr`, but not the reverse.
-        return {ptr.release(), deleter_ptr ? *deleter_ptr : nullptr};
+        return std::move(_data);
     }
 
     ///
@@ -250,7 +246,7 @@ class value {
     /// This will make a copy of the passed-in view.
     ///
     void reset(v_noabi::array::view view) {
-        _value.reset(to_v1(view));
+        *this = value{view};
     }
 };
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/array/value.hpp
@@ -129,7 +129,7 @@ class value {
     /// @note `this->size()` is ignored.
     ///
     explicit operator v1::array::value() const& {
-        return {_data.get(), _length, _data.get_deleter()};
+        return v1::array::value{to_v1(this->view())};
     }
 
     ///

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
@@ -46,10 +46,6 @@ namespace document {
 /// should be used sparingly; document::view should be used instead wherever possible.
 ///
 class value {
-   private:
-    v1::document::value _value;
-    std::size_t _length;
-
    public:
     ///
     /// The type of the deleter used to free the underlying BSON binary data.
@@ -61,6 +57,11 @@ class value {
     ///
     using unique_ptr_type = std::unique_ptr<std::uint8_t[], deleter_type>;
 
+   private:
+    unique_ptr_type _data;
+    std::size_t _length{0};
+
+   public:
     /// @copydoc v_noabi::document::view::const_iterator
     using const_iterator = v_noabi::document::view::const_iterator;
 
@@ -97,7 +98,7 @@ class value {
     ///   A user provided deleter.
     ///
     value(std::uint8_t* data, std::size_t length, deleter_type deleter)
-        : _value{data, std::move(deleter)}, _length{length} {}
+        : _data{data, std::move(deleter)}, _length{length} {}
 
     ///
     /// Constructs a value from a std::unique_ptr to a buffer. The ownership
@@ -112,7 +113,7 @@ class value {
     /// @param length
     ///   The length of the document.
     ///
-    value(unique_ptr_type ptr, std::size_t length) : _value{std::move(ptr)}, _length{length} {}
+    value(unique_ptr_type ptr, std::size_t length) : _data{std::move(ptr)}, _length{length} {}
 
     ///
     /// Constructs a value from a view of a document. The data referenced
@@ -168,7 +169,7 @@ class value {
     /// @note `this->size()` is ignored.
     ///
     explicit operator v1::document::value() const& {
-        return _value;
+        return {_data.get(), _length, _data.get_deleter()};
     }
 
     ///
@@ -183,8 +184,9 @@ class value {
     /// @note `this->size()` is ignored.
     ///
     explicit operator v1::document::value() && {
+        auto const length = _length;
         _length = 0u;
-        return std::move(_value);
+        return {_data.release(), length, std::move(_data.get_deleter())};
     }
 
     ///
@@ -217,7 +219,7 @@ class value {
 
     /// @copydoc bsoncxx::v_noabi::document::view::find(bsoncxx::v1::stdx::string_view key) const
     const_iterator find(v1::stdx::string_view key) const {
-        return const_iterator{*_value.find(key)};
+        return const_iterator{*this->view().find(key)};
     }
 
     ///
@@ -231,7 +233,7 @@ class value {
     /// @return The matching element, if found, or the invalid element.
     ///
     v_noabi::document::element operator[](v1::stdx::string_view key) const {
-        return _value.operator[](key);
+        return this->view().operator[](key);
     }
 
     ///
@@ -240,7 +242,7 @@ class value {
     /// @return A pointer to the value's buffer.
     ///
     std::uint8_t const* data() const {
-        return _value.data();
+        return _data.get();
     }
 
     ///
@@ -252,12 +254,12 @@ class value {
     /// @return The length of the document, in bytes.
     ///
     std::size_t size() const {
-        return _length; // Do NOT use _value.size().
+        return _length; // Do NOT use this->view().size().
     }
 
     /// @copydoc size() const
     std::size_t length() const {
-        return _length; // Do NOT use _value.length().
+        return _length; // Do NOT use this->view().length().
     }
 
     ///
@@ -267,14 +269,14 @@ class value {
     /// empty document.
     ///
     bool empty() const {
-        return _length == 5; // Do NOT use _value.empty().
+        return _length == 5; // Do NOT use this->view().empty().
     }
 
     ///
     /// Get a view over the document owned by this value.
     ///
     v_noabi::document::view view() const noexcept {
-        return {_value.data(), _length}; // Do NOT use _value.view().
+        return {_data.get(), _length};
     }
 
     ///
@@ -324,13 +326,7 @@ class value {
     /// @return A std::unique_ptr with ownership of the buffer. If the pointer is null, the deleter may also be null.
     ///
     unique_ptr_type release() {
-        auto ptr = _value.release();
-
-        // Invariant: the underlying deleter type MUST be `deleter_type`.
-        auto const deleter_ptr = ptr.get_deleter().target<deleter_type>();
-
-        // Invariant: `ptr` implies `deleter_ptr`, but not the reverse.
-        return {ptr.release(), deleter_ptr ? *deleter_ptr : nullptr};
+        return std::move(_data);
     }
 
     ///
@@ -338,7 +334,7 @@ class value {
     /// This will make a copy of the passed-in view.
     ///
     void reset(v_noabi::document::view view) {
-        _value.reset(to_v1(view));
+        *this = value{view};
     }
 };
 

--- a/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v_noabi/bsoncxx/document/value.hpp
@@ -169,7 +169,7 @@ class value {
     /// @note `this->size()` is ignored.
     ///
     explicit operator v1::document::value() const& {
-        return {_data.get(), _length, _data.get_deleter()};
+        return v1::document::value{to_v1(this->view())};
     }
 
     ///

--- a/src/bsoncxx/lib/bsoncxx/private/macros.hh
+++ b/src/bsoncxx/lib/bsoncxx/private/macros.hh
@@ -1,0 +1,21 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#if !defined(__GXX_RTTI) && !defined(_CPPRTTI)
+#define BSONCXX_PRIVATE_NO_RTTI() true
+#else
+#define BSONCXX_PRIVATE_NO_RTTI() false
+#endif

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/array/value.cpp
@@ -18,6 +18,7 @@
 
 #include <cstring>
 
+#include <bsoncxx/private/macros.hh>
 #include <bsoncxx/private/type_traits.hh>
 
 namespace bsoncxx {
@@ -40,7 +41,7 @@ void uint8_t_deleter(std::uint8_t* ptr) {
 } // namespace
 
 value::value(v_noabi::array::view view)
-    : _value{[&]() -> unique_ptr_type {
+    : _data{[&]() -> unique_ptr_type {
           auto res = unique_ptr_type{new std::uint8_t[view.size()], uint8_t_deleter};
           std::memcpy(res.get(), view.data(), view.size());
           return res;
@@ -56,6 +57,9 @@ namespace v_noabi {
 
 // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved): ownership transfer with `v.release()`.
 v_noabi::array::value from_v1(v1::array::value&& v) {
+#if BSONCXX_PRIVATE_NO_RTTI()
+    return from_v1(static_cast<v1::array::value const&>(v));
+#else
     auto const deleter_ptr = v.get_deleter().target<v_noabi::array::value::deleter_type>();
 
     if (!deleter_ptr || *deleter_ptr == &v1::document::value::noop_deleter) {
@@ -66,6 +70,7 @@ v_noabi::array::value from_v1(v1::array::value&& v) {
     auto const deleter = *deleter_ptr;
 
     return {v.release().release(), length, deleter};
+#endif
 }
 
 } // namespace v_noabi

--- a/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/value.cpp
+++ b/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/document/value.cpp
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <utility>
 
+#include <bsoncxx/private/macros.hh>
 #include <bsoncxx/private/type_traits.hh>
 
 namespace bsoncxx {
@@ -49,7 +50,7 @@ void uint8_t_deleter(std::uint8_t* ptr) {
 } // namespace
 
 value::value(v_noabi::document::view view)
-    : _value{[&]() -> unique_ptr_type {
+    : _data{[&]() -> unique_ptr_type {
           auto res = unique_ptr_type{new std::uint8_t[view.size()], uint8_t_deleter};
           std::memcpy(res.get(), view.data(), view.size());
           return res;
@@ -65,6 +66,9 @@ namespace v_noabi {
 
 // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved): ownership transfer with `v.release()`.
 v_noabi::document::value from_v1(v1::document::value&& v) {
+#if BSONCXX_PRIVATE_NO_RTTI()
+    return from_v1(static_cast<v1::document::value const&>(v));
+#else
     auto const deleter_ptr = v.get_deleter().target<v_noabi::document::value::deleter_type>();
 
     if (!deleter_ptr || *deleter_ptr == &v1::document::value::noop_deleter) {
@@ -75,6 +79,7 @@ v_noabi::document::value from_v1(v1::document::value&& v) {
     auto const deleter = *deleter_ptr;
 
     return {v.release().release(), length, deleter};
+#endif
 }
 
 } // namespace v_noabi

--- a/src/mongocxx/include/mongocxx/v1/gridfs/downloader.hpp
+++ b/src/mongocxx/include/mongocxx/v1/gridfs/downloader.hpp
@@ -131,6 +131,7 @@ class downloader {
     /// underlying GridFS download stream was already closed.
     /// @throws mongocxx::v1::exception with @ref mongocxx::v1::gridfs::downloader::errc::corrupt_data if the
     /// GridFS file data is invalid or inconsistent.
+    /// @throws mongocxx::v1::server_error when a server-side error is encountered and a raw server error is available.
     ///
     MONGOCXX_ABI_EXPORT_CDECL(std::size_t) read(std::uint8_t* data, std::size_t length);
 

--- a/src/mongocxx/lib/mongocxx/private/scoped_bson.cpp
+++ b/src/mongocxx/lib/mongocxx/private/scoped_bson.cpp
@@ -20,6 +20,7 @@
 #include <stdexcept>
 
 #include <bsoncxx/private/bson.hh>
+#include <bsoncxx/private/macros.hh>
 
 namespace mongocxx {
 
@@ -34,8 +35,12 @@ scoped_bson& scoped_bson::operator+=(scoped_bson_view const& other) {
 
     auto const is_self_assignment = _value.data() == other.data();
     auto const is_bson_freeable = [&]() -> bool {
+#if BSONCXX_PRIVATE_NO_RTTI()
+        return false;
+#else
         auto const deleter_ptr = _value.get_deleter().target<decltype(&bson_free)>();
         return deleter_ptr && *deleter_ptr == &bson_free;
+#endif
     }();
 
     // Copy is required for strong exception safety or allocator compatibility.

--- a/src/mongocxx/lib/mongocxx/v1/client_session.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/client_session.cpp
@@ -207,6 +207,16 @@ bool with_transaction_cb_impl(mongoc_client_session_t*, void* ctx, bson_t** repl
     try {
         (*cb_ctx->fn)(*cb_ctx->self_ptr);
         return true;
+    } catch (v1::server_error const& ex) {
+        cb_ctx->eptr = std::current_exception();
+
+        // Unused by mongoc, but set anyways for consistency.
+        bson_set_error(error, 0u, static_cast<std::uint32_t>(ex.code().value()), "%s", ex.what());
+
+        // `mongoc_client_session_with_transaction` primarily implements its behavior using the `reply` document.
+        *reply = scoped_bson_view{ex.raw()}.copy();
+
+        return false;
     } catch (v1::exception const& ex) {
         cb_ctx->eptr = std::current_exception();
 
@@ -214,9 +224,7 @@ bool with_transaction_cb_impl(mongoc_client_session_t*, void* ctx, bson_t** repl
         bson_set_error(error, 0u, static_cast<std::uint32_t>(ex.code().value()), "%s", ex.what());
 
         // `mongoc_client_session_with_transaction` primarily implements its behavior using the `reply` document.
-        if (auto const ptr = dynamic_cast<v1::server_error const*>(&ex)) {
-            *reply = scoped_bson_view{ptr->raw()}.copy();
-        } else if (auto const& reply_opt = v1::exception::internal::get_reply(ex)) {
+        if (auto const& reply_opt = v1::exception::internal::get_reply(ex)) {
             *reply = scoped_bson_view{*reply_opt}.copy();
         }
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/bulk_write.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/bulk_write.cpp
@@ -17,6 +17,7 @@
 //
 
 #include <mongocxx/v1/exception.hpp>
+#include <mongocxx/v1/server_error.hpp>
 
 #include <bsoncxx/v1/types/value.hh>
 
@@ -234,6 +235,8 @@ bsoncxx::v_noabi::stdx::optional<result::bulk_write> bulk_write::execute() const
     // Backward compatibility: `execute()` is not logically const.
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     return const_cast<v1::bulk_write&>(_bulk).execute();
+} catch (v1::server_error const& ex) {
+    throw_exception<v_noabi::bulk_write_exception>(ex);
 } catch (v1::exception const& ex) {
     throw_exception<v_noabi::bulk_write_exception>(ex);
 }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/change_stream.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/change_stream.cpp
@@ -83,6 +83,9 @@ change_stream::iterator& change_stream::iterator::operator++() {
     if (_change_stream) {
         try {
             v1::change_stream::internal::advance_iterator(_change_stream->_stream);
+        } catch (v1::server_error const& ex) {
+            _change_stream->_doc = {};
+            throw_exception<v_noabi::query_exception>(ex);
         } catch (v1::exception const& ex) {
             _change_stream->_doc = {};
             throw_exception<v_noabi::query_exception>(ex);
@@ -107,6 +110,9 @@ change_stream::iterator::iterator(change_stream* change_stream, bool is_end)
         try {
             // Advance to first event on begin() to keep operator*() state-machine-free.
             v1::change_stream::internal::advance_iterator(_change_stream->_stream);
+        } catch (v1::server_error const& ex) {
+            _change_stream->_doc = {};
+            throw_exception<v_noabi::query_exception>(ex);
         } catch (v1::exception const& ex) {
             _change_stream->_doc = {};
             throw_exception<v_noabi::query_exception>(ex);

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client.cpp
@@ -16,7 +16,9 @@
 
 //
 
+#include <mongocxx/v1/detail/macros.hpp>
 #include <mongocxx/v1/exception.hpp>
+#include <mongocxx/v1/server_error.hpp>
 
 #include <mongocxx/v1/change_stream.hh>
 #include <mongocxx/v1/client.hh>
@@ -269,6 +271,8 @@ std::vector<std::string> client::list_database_names(bsoncxx::v_noabi::document:
     auto& c = const_cast<v1::client&>(check_moved_from(_client));
 
     return c.list_database_names(to_scoped_bson_view(filter).view());
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
@@ -286,6 +290,8 @@ std::vector<std::string> client::list_database_names(
     opts += scoped_bson{BCON_NEW("filter", BCON_DOCUMENT(to_scoped_bson_view(filter).bson()))};
 
     return list_database_names_impl(v1::client::internal::as_mongoc(c), opts.bson());
+} catch (v1::server_error const&) {
+    MONGOCXX_PRIVATE_UNREACHABLE; // Only client errors or `v_noabi::operation_exception`.
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client_encryption.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client_encryption.cpp
@@ -19,6 +19,7 @@
 #include <bsoncxx/v1/document/value.hpp>
 
 #include <mongocxx/v1/exception.hpp>
+#include <mongocxx/v1/server_error.hpp>
 
 #include <bsoncxx/v1/types/value.hh>
 
@@ -455,6 +456,8 @@ bsoncxx::v_noabi::document::value client_encryption::encrypt_expression(
 
 bsoncxx::v_noabi::types::value client_encryption::decrypt(bsoncxx::v_noabi::types::bson_value::view value) try {
     return _ce.decrypt(bsoncxx::v1::types::value{bsoncxx::v_noabi::to_v1(value)});
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
@@ -502,6 +505,8 @@ v_noabi::result::rewrap_many_datakey client_encryption::rewrap_many_datakey(
 v_noabi::result::delete_result client_encryption::delete_key(
     bsoncxx::v_noabi::types::bson_value::view_or_value id) try {
     return _ce.delete_key(bsoncxx::v1::types::value{bsoncxx::v_noabi::to_v1(id.view())});
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
@@ -522,11 +527,15 @@ bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::value> empty_as_nul
 bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::value> client_encryption::get_key(
     bsoncxx::v_noabi::types::bson_value::view_or_value id) try {
     return empty_as_null(_ce.get_key(bsoncxx::v1::types::value{bsoncxx::v_noabi::to_v1(id.view())}));
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
 
-v_noabi::cursor client_encryption::get_keys() try { return _ce.get_keys(); } catch (v1::exception const& ex) {
+v_noabi::cursor client_encryption::get_keys() try { return _ce.get_keys(); } catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
+} catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
 
@@ -535,6 +544,8 @@ bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::value> client_encry
     bsoncxx::v_noabi::string::view_or_value key_alt_name) try {
     return empty_as_null(
         _ce.add_key_alt_name(bsoncxx::v1::types::value{bsoncxx::v_noabi::to_v1(id.view())}, key_alt_name.view()));
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
@@ -544,6 +555,8 @@ bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::value> client_encry
     bsoncxx::v_noabi::string::view_or_value key_alt_name) try {
     return empty_as_null(
         _ce.remove_key_alt_name(bsoncxx::v1::types::value{bsoncxx::v_noabi::to_v1(id.view())}, key_alt_name.view()));
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
@@ -551,6 +564,8 @@ bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::value> client_encry
 bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::value> client_encryption::get_key_by_alt_name(
     bsoncxx::v_noabi::string::view_or_value key_alt_name) try {
     return empty_as_null(_ce.get_key_by_alt_name(key_alt_name.view()));
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client_session.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client_session.cpp
@@ -59,8 +59,8 @@ void client_session::start_transaction(
     bsoncxx::v_noabi::stdx::optional<options::transaction> const& transaction_opts) try {
     transaction_opts ? _session.start_transaction(v_noabi::options::transaction::internal::as_v1(*transaction_opts))
                      : _session.start_transaction();
-} catch (v1::server_error const&) {
-    MONGOCXX_PRIVATE_UNREACHABLE; // Only client-side errors.
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client_session.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client_session.cpp
@@ -16,6 +16,7 @@
 
 //
 
+#include <mongocxx/v1/detail/macros.hpp>
 #include <mongocxx/v1/exception.hpp>
 #include <mongocxx/v1/server_error.hpp>
 
@@ -58,15 +59,21 @@ void client_session::start_transaction(
     bsoncxx::v_noabi::stdx::optional<options::transaction> const& transaction_opts) try {
     transaction_opts ? _session.start_transaction(v_noabi::options::transaction::internal::as_v1(*transaction_opts))
                      : _session.start_transaction();
+} catch (v1::server_error const&) {
+    MONGOCXX_PRIVATE_UNREACHABLE; // Only client-side errors.
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
 
-void client_session::commit_transaction() try { _session.commit_transaction(); } catch (v1::exception const& ex) {
+void client_session::commit_transaction() try { _session.commit_transaction(); } catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
+} catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
 
-void client_session::abort_transaction() try { _session.abort_transaction(); } catch (v1::exception const& ex) {
+void client_session::abort_transaction() try { _session.abort_transaction(); } catch (v1::server_error const&) {
+    MONGOCXX_PRIVATE_UNREACHABLE; // Only client-side errors.
+} catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
 
@@ -126,6 +133,8 @@ void client_session::with_transaction(with_transaction_cb cb, v_noabi::options::
         v_noabi::throw_exception<v_noabi::operation_exception>(
             bsoncxx::v_noabi::from_v1(std::move(reply).value()), error);
     }
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex); // `ctx.eptr` may be a `v1::server_error`.
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/cursor.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/cursor.cpp
@@ -17,6 +17,7 @@
 //
 
 #include <mongocxx/v1/exception.hpp>
+#include <mongocxx/v1/server_error.hpp>
 
 #include <mongocxx/v1/cursor.hh>
 
@@ -60,6 +61,9 @@ cursor::iterator& cursor::iterator::operator++() {
     if (_cursor) {
         try {
             v1::cursor::internal::advance_iterator(_cursor->_cursor);
+        } catch (v1::server_error const& ex) {
+            _cursor->_doc = {};
+            throw_exception<v_noabi::query_exception>(ex);
         } catch (v1::exception const& ex) {
             _cursor->_doc = {};
             throw_exception<v_noabi::query_exception>(ex);
@@ -81,6 +85,9 @@ cursor::iterator::iterator(cursor* cursor) : _cursor{cursor} {
         try {
             // Advance to first event on begin() to keep operator*() state-machine-free.
             v1::cursor::internal::advance_iterator(_cursor->_cursor);
+        } catch (v1::server_error const& ex) {
+            _cursor->_doc = {};
+            throw_exception<v_noabi::query_exception>(ex);
         } catch (v1::exception const& ex) {
             _cursor->_doc = {};
             throw_exception<v_noabi::query_exception>(ex);

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/bucket.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/bucket.cpp
@@ -18,6 +18,7 @@
 #include <bsoncxx/v1/document/value.hpp>
 
 #include <mongocxx/v1/exception.hpp>
+#include <mongocxx/v1/server_error.hpp>
 
 #include <mongocxx/v1/gridfs/bucket.hh>
 #include <mongocxx/v1/gridfs/upload_result.hh>
@@ -159,6 +160,8 @@ v_noabi::gridfs::uploader bucket::open_upload_stream_with_id(
         filename,
         options.chunk_size_bytes(),
         metadata_v1);
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     rethrow_exception(ex);
 }
@@ -183,6 +186,8 @@ v_noabi::gridfs::uploader bucket::open_upload_stream_with_id(
         filename,
         options.chunk_size_bytes(),
         metadata_v1);
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     rethrow_exception(ex);
 }
@@ -217,6 +222,8 @@ void bucket::upload_from_stream_with_id(
     v_noabi::options::gridfs::upload const& options) try {
     internal::upload_from_stream_with_id_impl(
         v_noabi::to_v1(this->open_upload_stream_with_id(id, filename, options)), *source);
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     rethrow_exception(ex);
 }
@@ -229,12 +236,16 @@ void bucket::upload_from_stream_with_id(
     v_noabi::options::gridfs::upload const& options) try {
     internal::upload_from_stream_with_id_impl(
         v_noabi::to_v1(this->open_upload_stream_with_id(session, id, filename, options)), *source);
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     rethrow_exception(ex);
 }
 
 v_noabi::gridfs::downloader bucket::open_download_stream(bsoncxx::v_noabi::types::view id) try {
     return internal::open_download_stream_impl(check_moved_from(_bucket), nullptr, bsoncxx::v_noabi::to_v1(id));
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     rethrow_exception(ex);
 }
@@ -245,6 +256,8 @@ v_noabi::gridfs::downloader bucket::open_download_stream(
     auto const& session_v1 = v_noabi::client_session::internal::as_v1(session);
 
     return internal::open_download_stream_impl(check_moved_from(_bucket), &session_v1, bsoncxx::v_noabi::to_v1(id));
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     rethrow_exception(ex);
 }
@@ -252,6 +265,8 @@ v_noabi::gridfs::downloader bucket::open_download_stream(
 void bucket::download_to_stream(bsoncxx::v_noabi::types::view id, std::ostream* destination) try {
     internal::download_to_stream_impl(
         v_noabi::to_v1(this->open_download_stream(bsoncxx::v_noabi::to_v1(id))), *destination);
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     rethrow_exception(ex);
 }
@@ -269,6 +284,8 @@ void bucket::download_to_stream(
         *destination,
         static_cast<std::int64_t>(start),
         static_cast<std::int64_t>(end));
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     rethrow_exception(ex);
 }
@@ -278,6 +295,8 @@ void bucket::download_to_stream(
     bsoncxx::v_noabi::types::view id,
     std::ostream* destination) try {
     internal::download_to_stream_impl(v_noabi::to_v1(this->open_download_stream(session, id)), *destination);
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     rethrow_exception(ex);
 }
@@ -298,12 +317,16 @@ void bucket::download_to_stream(
         *destination,
         static_cast<std::int64_t>(start),
         static_cast<std::int64_t>(end));
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     rethrow_exception(ex);
 }
 
 void bucket::delete_file(bsoncxx::v_noabi::types::view id) try {
     internal::delete_file_impl(check_moved_from(_bucket), nullptr, bsoncxx::v_noabi::to_v1(id));
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     rethrow_exception(ex);
 }
@@ -312,6 +335,8 @@ void bucket::delete_file(v_noabi::client_session const& session, bsoncxx::v_noab
     auto const& session_v1 = v_noabi::client_session::internal::as_v1(session);
 
     internal::delete_file_impl(check_moved_from(_bucket), &session_v1, bsoncxx::v_noabi::to_v1(id));
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     rethrow_exception(ex);
 }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/downloader.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/downloader.cpp
@@ -18,6 +18,8 @@
 
 #include <mongocxx/v1/exception-fwd.hpp>
 
+#include <mongocxx/v1/server_error.hpp>
+
 #include <mongocxx/v1/gridfs/downloader.hh>
 
 #include <cstddef>
@@ -53,11 +55,15 @@ Downloader& check_moved_from(Downloader& downloader) {
 
 std::size_t downloader::read(std::uint8_t* buffer, std::size_t length) try {
     return check_moved_from(_downloader).read(buffer, length);
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     internal::rethrow_exception(ex);
 }
 
-void downloader::close() try { return check_moved_from(_downloader).close(); } catch (v1::exception const& ex) {
+void downloader::close() try { return check_moved_from(_downloader).close(); } catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
+} catch (v1::exception const& ex) {
     internal::rethrow_exception(ex);
 }
 
@@ -91,6 +97,8 @@ downloader downloader::internal::make(
         chunk_size,
         initial_chunk_offset,
         initial_byte_offset);
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     rethrow_exception(ex);
 }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/uploader.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/gridfs/uploader.cpp
@@ -17,6 +17,7 @@
 //
 
 #include <mongocxx/v1/exception.hpp>
+#include <mongocxx/v1/server_error.hpp>
 
 #include <mongocxx/v1/gridfs/uploader.hh>
 
@@ -62,6 +63,8 @@ Uploader& check_moved_from(Uploader& uploader) {
 
 void uploader::write(std::uint8_t const* bytes, std::size_t length) try {
     check_moved_from(_uploader).write(bytes, length);
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     internal::rethrow_exception(ex);
 }
@@ -72,6 +75,8 @@ v_noabi::result::gridfs::upload uploader::close() try {
     }
 
     return _uploader.close();
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     internal::rethrow_exception(ex);
 }
@@ -82,6 +87,8 @@ void uploader::abort() try {
     }
 
     check_moved_from(_uploader).abort();
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     internal::rethrow_exception(ex);
 }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/index_view.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/index_view.cpp
@@ -17,6 +17,7 @@
 //
 
 #include <mongocxx/v1/exception.hpp>
+#include <mongocxx/v1/server_error.hpp>
 
 #include <mongocxx/v1/indexes.hh>
 
@@ -264,6 +265,8 @@ void index_view::drop_one(bsoncxx::v_noabi::stdx::string_view name, v_noabi::opt
     append_drop_to(options, doc);
 
     v1::indexes::internal::drop_one_impl(v1::indexes::internal::get_collection(_indexes), name, doc.bson());
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     if (ex.code() == v1::indexes::errc::invalid_name) {
         throw v_noabi::logic_error{v_noabi::error_code::k_invalid_parameter};
@@ -283,6 +286,8 @@ void index_view::drop_one(
     v_noabi::client_session::internal::append_to(session, doc);
 
     v1::indexes::internal::drop_one_impl(v1::indexes::internal::get_collection(_indexes), name, doc.bson());
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     if (ex.code() == v1::indexes::errc::invalid_name) {
         throw v_noabi::logic_error{v_noabi::error_code::k_invalid_parameter};
@@ -320,6 +325,8 @@ void index_view::drop_all(v_noabi::options::index_view const& options) try {
     append_drop_to(options, doc);
 
     v1::indexes::internal::drop_all_impl(v1::indexes::internal::get_collection(_indexes), doc.bson());
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     if (ex.code() == v1::indexes::errc::invalid_name) {
         throw v_noabi::logic_error{v_noabi::error_code::k_invalid_parameter};
@@ -336,6 +343,8 @@ void index_view::drop_all(v_noabi::client_session const& session, v_noabi::optio
     v_noabi::client_session::internal::append_to(session, doc);
 
     v1::indexes::internal::drop_all_impl(v1::indexes::internal::get_collection(_indexes), doc.bson());
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     if (ex.code() == v1::indexes::errc::invalid_name) {
         throw v_noabi::logic_error{v_noabi::error_code::k_invalid_parameter};

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/instance.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/instance.cpp
@@ -16,8 +16,10 @@
 
 //
 
+#include <mongocxx/v1/detail/macros.hpp>
 #include <mongocxx/v1/exception.hpp>
 #include <mongocxx/v1/instance.hpp>
+#include <mongocxx/v1/server_error.hpp>
 
 #include <array>
 #include <atomic>
@@ -61,6 +63,8 @@ class instance::impl {
             // Cannot use `libmongoc::*` mock due to varargs.
             mongoc_log(MONGOC_LOG_LEVEL_INFO, "mongocxx", "libmongoc logging callback enabled");
         }
+    } catch (v1::server_error const&) {
+        MONGOCXX_PRIVATE_UNREACHABLE; // Only client-side errors.
     } catch (v1::exception const&) {
         throw v_noabi::logic_error{v_noabi::error_code::k_cannot_recreate_instance};
     }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/mongoc_error.hh
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/mongoc_error.hh
@@ -107,14 +107,6 @@ template <
                           ? std::error_code{ex.code().value(), v_noabi::server_error_category()}
                           : ex.code();
 
-    // Server-side error.
-    if (auto const ptr = dynamic_cast<v1::server_error const*>(&ex)) {
-        throw exception_type{
-            code,
-            bsoncxx::v_noabi::document::value{from_v1(ptr->raw())},
-            strip_ec_msg(ptr->what(), ptr->code()).c_str()};
-    }
-
     // Propagate the original mongoc reply document as the "raw server error" document.
     if (auto const& reply = v1::exception::internal::get_reply(ex)) {
         throw exception_type{code, from_v1(*reply), strip_ec_msg(ex.what(), ex.code()).c_str()};
@@ -122,6 +114,21 @@ template <
 
     // No "raw server error" document is required.
     throw exception_type{code, strip_ec_msg(ex.what(), ex.code())};
+}
+
+template <
+    typename exception_type,
+    bsoncxx::detail::enable_if_t<std::is_base_of<operation_exception, exception_type>::value>* = nullptr>
+[[noreturn]] void throw_exception(v1::server_error const& ex) {
+    using bsoncxx::v_noabi::from_v1;
+
+    // `v1::server_error_category()` -> `v_noabi::server_error_category()`.
+    auto const code = ex.code() == v1::source_errc::server
+                          ? std::error_code{ex.code().value(), v_noabi::server_error_category()}
+                          : ex.code();
+
+    throw exception_type{
+        code, bsoncxx::v_noabi::document::value{from_v1(ex.raw())}, strip_ec_msg(ex.what(), ex.code()).c_str()};
 }
 
 template <

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/index.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/index.cpp
@@ -141,11 +141,15 @@ index::operator bsoncxx::v_noabi::document::view_or_value() {
     if (_storage_engine) {
         ret += scoped_bson{BCON_NEW("storageEngine", BCON_DOCUMENT(to_scoped_bson_view(*_storage_engine).bson()))};
     } else if (_storage_options) {
-        if (auto const wt_options =
-                dynamic_cast<options::index::wiredtiger_storage_options const*>(_storage_options.get())) {
+        if (_storage_options->type() ==
+            static_cast<int>(mongoc_index_storage_opt_type_t::MONGOC_INDEX_STORAGE_OPT_WIREDTIGER)) {
+            // Invariant: no other dynamic type must satisfy the type check above.
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+            auto const wso = static_cast<options::index::wiredtiger_storage_options const*>(_storage_options.get());
+
             scoped_bson v;
 
-            if (auto const& opt = wt_options->config_string()) {
+            if (auto const& opt = wso->config_string()) {
                 v += scoped_bson{BCON_NEW(
                     "storageEngine",
                     "{",

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/pool.cpp
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <mongocxx/v1/detail/macros.hpp>
 #include <mongocxx/v1/exception.hpp>
+#include <mongocxx/v1/server_error.hpp>
 
 #include <mongocxx/pool.hh>
 
@@ -94,6 +96,8 @@ pool::pool(v_noabi::uri const& mongodb_uri, v_noabi::options::pool const& option
         }
 #endif
     }
+} catch (v1::server_error const&) {
+    MONGOCXX_PRIVATE_UNREACHABLE; // Only client errors or `v_noabi::operation_exception`.
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/search_index_view.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/search_index_view.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <mongocxx/v1/exception.hpp>
+#include <mongocxx/v1/server_error.hpp>
 
 #include <mongocxx/search_index_view.hpp>
 
@@ -172,6 +173,8 @@ v_noabi::cursor search_index_view::list(v_noabi::options::aggregate const& optio
         nullptr,
         opts_doc.bson(),
         get_read_prefs(options));
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
@@ -189,6 +192,8 @@ v_noabi::cursor search_index_view::list(
         nullptr,
         opts_doc.bson(),
         get_read_prefs(options));
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
@@ -205,6 +210,8 @@ v_noabi::cursor search_index_view::list(
         name.terminated().data(),
         opts_doc.bson(),
         get_read_prefs(options));
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
@@ -223,6 +230,8 @@ v_noabi::cursor search_index_view::list(
         name.terminated().data(),
         doc.bson(),
         get_read_prefs(options));
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
@@ -234,6 +243,8 @@ std::string search_index_view::create_one(bsoncxx::v_noabi::document::view_or_va
 
     return v1::search_indexes::internal::create_one_impl(
         v1::search_indexes::internal::get_collection(check_moved_from(_indexes)), doc.bson(), nullptr);
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
@@ -250,6 +261,8 @@ std::string search_index_view::create_one(
 
     return v1::search_indexes::internal::create_one_impl(
         v1::search_indexes::internal::get_collection(check_moved_from(_indexes)), doc.bson(), opt_doc.bson());
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
@@ -263,6 +276,8 @@ std::string search_index_view::create_one(
 
     return v1::search_indexes::internal::create_one_impl(
         v1::search_indexes::internal::get_collection(check_moved_from(_indexes)), doc.bson(), nullptr);
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
@@ -281,6 +296,8 @@ std::string search_index_view::create_one(
 
     return v1::search_indexes::internal::create_one_impl(
         v1::search_indexes::internal::get_collection(check_moved_from(_indexes)), doc.bson(), opts_doc.bson());
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
@@ -292,6 +309,8 @@ std::string search_index_view::create_one(v_noabi::search_index_model const& mod
 
     return v1::search_indexes::internal::create_one_impl(
         v1::search_indexes::internal::get_collection(check_moved_from(_indexes)), doc.bson(), nullptr);
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
@@ -307,6 +326,8 @@ std::string search_index_view::create_one(
 
     return v1::search_indexes::internal::create_one_impl(
         v1::search_indexes::internal::get_collection(check_moved_from(_indexes)), opts_doc.bson(), nullptr);
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
@@ -329,6 +350,8 @@ std::vector<std::string> search_index_view::create_many(
 void search_index_view::drop_one(bsoncxx::v_noabi::string::view_or_value name) try {
     return v1::search_indexes::internal::drop_one_impl(
         v1::search_indexes::internal::get_collection(check_moved_from(_indexes)), name.terminated().data(), nullptr);
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
@@ -344,6 +367,8 @@ void search_index_view::drop_one(
         v1::search_indexes::internal::get_collection(check_moved_from(_indexes)),
         name.terminated().data(),
         opts_doc.bson());
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
@@ -356,6 +381,8 @@ void search_index_view::update_one(
         name.terminated().data(),
         bsoncxx::v_noabi::to_v1(definition.view()),
         nullptr);
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }
@@ -373,6 +400,8 @@ void search_index_view::update_one(
         name.terminated().data(),
         bsoncxx::v_noabi::to_v1(definition.view()),
         opts_doc.bson());
+} catch (v1::server_error const& ex) {
+    v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 } catch (v1::exception const& ex) {
     v_noabi::throw_exception<v_noabi::operation_exception>(ex);
 }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/uri.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/uri.cpp
@@ -16,7 +16,9 @@
 
 //
 
+#include <mongocxx/v1/detail/macros.hpp>
 #include <mongocxx/v1/exception.hpp>
+#include <mongocxx/v1/server_error.hpp>
 
 #include <mongocxx/v1/uri.hh>
 
@@ -39,12 +41,16 @@ namespace v_noabi {
 std::string const uri::k_default_uri = "mongodb://localhost:27017";
 
 uri::uri(bsoncxx::v_noabi::string::view_or_value uri_string) try : _uri{uri_string.view()} {
+} catch (v1::server_error const&) {
+    MONGOCXX_PRIVATE_UNREACHABLE; // Only client-side errors.
 } catch (v1::exception const& ex) {
     throw v_noabi::logic_error{v_noabi::error_code::k_invalid_uri, strip_ec_msg(ex.what(), ex.code())};
 }
 
 void uri::server_selection_try_once(bool val) try {
     _uri.server_selection_try_once(val);
+} catch (v1::server_error const&) {
+    MONGOCXX_PRIVATE_UNREACHABLE; // Only client-side errors.
 } catch (v1::exception const&) {
     throw v_noabi::exception{v_noabi::error_code::k_invalid_uri, "failed to set 'serverSelectionTryOnce' option"};
 }


### PR DESCRIPTION
Resolves CXX-3483 as a quality of implementation (QoI) improvement. (This does not constitute official support for `-fno-rtti` build configurations.)

This PR contains three distinct set of changes, ordered by the size of associated diffs:

- Convert `v1::server_exception` into `v_noabi` exceptions using an independent helper function from `v1::exception`.
- Revert `v_noabi` BSON document/array representations to their former standalone `unique_ptr_type + size_t`.
- Revert WiredTiger Storage Options detection to its former type-id-based check.

The `v_noabi::throw_exception<T>(ex)` internal helper function (where `T` derives `v_noabi::operation_exception`) used a `dynamic_cast` to detect and handle `v1::server_error` exceptions. This dynamic cast is a convenience to allow `catch (v1::exception const& ex)` blocks to handle all v1 exceptions thrown by the mongocxx library. However, this convenience also (arguably) obscures the actual set of v1 exceptions which may be thrown by internal v_noabi code reusing v1 API. By separating the `v1::server_error` case into its own catch block, these potential exceptions are made more explicit. Although this requires adding a substantial amount of repetitive catch blocks, I believe the resulting explicitness is a worthwhile improvement.

This investigation also helped identify a missing API documentation entry in `v1::gridfs::downloader`, where `read()` may potentially throw a server error by cursor iteration.