### PR TITLE
Fix test coverage of index drop options

### DIFF
--- a/src/mongocxx/test/v1/indexes.cpp
+++ b/src/mongocxx/test/v1/indexes.cpp
@@ -690,11 +690,11 @@ void test_drop_index_options() {
 } // namespace
 
 TEST_CASE("DropIndexOptions", "[mongocxx][v1][indexes][drop_one_options]") {
-    test_drop_index_options<indexes::create_one_options>();
+    test_drop_index_options<indexes::drop_one_options>();
 }
 
 TEST_CASE("DropIndexOptions", "[mongocxx][v1][indexes][drop_all_options]") {
-    test_drop_index_options<indexes::create_many_options>();
+    test_drop_index_options<indexes::drop_all_options>();
 }
 
 TEST_CASE("batch_size", "[mongocxx][v1][indexes][list_options]") {


### PR DESCRIPTION
Identified during review of [#1620](/mongodb/mongo-cxx-driver/pull/1620): due to copy-paste error, the drop test cases were incorrectly passing create option classes as template arguments, thus failing to test coverage of the drop option classes as intended. Applying this fix revealed no latent issues.