### PR TITLE
CXX-3452 add read_concern to distinct options classes

### DIFF
--- a/src/mongocxx/include/mongocxx/v1/distinct_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/distinct_options.hpp
@@ -25,6 +25,7 @@
 #include <bsoncxx/v1/types/value-fwd.hpp>
 #include <bsoncxx/v1/types/view-fwd.hpp>
 
+#include <mongocxx/v1/read_concern-fwd.hpp>
 #include <mongocxx/v1/read_preference-fwd.hpp>
 
 #include <bsoncxx/v1/stdx/optional.hpp>
@@ -43,6 +44,7 @@ namespace v1 {
 /// - `collation`
 /// - `comment`
 /// - `max_time` ("maxTimeMS")
+/// - `read_concern` ("readConcern")
 /// - `read_preference` ("readPreference")
 ///
 /// @see
@@ -134,6 +136,16 @@ class distinct_options {
     /// Return the current "readPreference" field.
     ///
     MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<v1::read_preference>) read_preference() const;
+
+    ///
+    /// Set the "readConcern" field.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(distinct_options&) read_concern(v1::read_concern rc);
+
+    ///
+    /// Return the current "readConcern" field.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<v1::read_concern>) read_concern() const;
 
     class internal;
 };

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct.hpp
@@ -95,7 +95,7 @@ class distinct {
     ///   The new collation.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -126,7 +126,7 @@ class distinct {
     ///   The max amount of time (in milliseconds).
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -156,7 +156,7 @@ class distinct {
     ///   The new comment.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see
@@ -186,7 +186,7 @@ class distinct {
     ///   The new read_preference.
     ///
     /// @return
-    ///   A reference to the object on which this member function is being called.  This facilitates
+    ///   A reference to the object on which this member function is being called. This facilitates
     ///   method chaining.
     ///
     /// @see

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct.hpp
@@ -220,7 +220,7 @@ class distinct {
     ///   method chaining.
     ///
     /// @see
-    /// - https://www.mongodb.com/docs/manual/reference/read-concern/
+    /// - https://www.mongodb.com/docs/manual/reference/command/distinct/
     ///
     distinct& read_concern(v_noabi::read_concern rc) {
         _read_concern = std::move(rc);

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct.hpp
@@ -33,6 +33,7 @@
 #include <bsoncxx/types/bson_value/view.hpp>
 #include <bsoncxx/types/bson_value/view_or_value.hpp>
 
+#include <mongocxx/read_concern.hpp>
 #include <mongocxx/read_preference.hpp>
 
 #include <mongocxx/config/prelude.hpp>
@@ -78,6 +79,10 @@ class distinct {
 
         if (_read_preference) {
             ret.read_preference(to_v1(*_read_preference));
+        }
+
+        if (_read_concern) {
+            ret.read_concern(to_v1(*_read_concern));
         }
 
         return ret;
@@ -204,11 +209,42 @@ class distinct {
         return _read_preference;
     }
 
+    ///
+    /// Sets the read_concern for this operation.
+    ///
+    /// @param rc
+    ///   The new read_concern.
+    ///
+    /// @return
+    ///   A reference to the object on which this member function is being called. This facilitates
+    ///   method chaining.
+    ///
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/read-concern/
+    ///
+    distinct& read_concern(v_noabi::read_concern rc) {
+        _read_concern = std::move(rc);
+        return *this;
+    }
+
+    ///
+    /// The current read_concern for this operation.
+    ///
+    /// @return the current read_concern.
+    ///
+    /// @see
+    /// - https://www.mongodb.com/docs/manual/reference/read-concern/
+    ///
+    bsoncxx::v_noabi::stdx::optional<v_noabi::read_concern> const& read_concern() const {
+        return _read_concern;
+    }
+
    private:
     bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::view_or_value> _collation;
     bsoncxx::v_noabi::stdx::optional<std::chrono::milliseconds> _max_time;
     bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::types::bson_value::view_or_value> _comment;
     bsoncxx::v_noabi::stdx::optional<v_noabi::read_preference> _read_preference;
+    bsoncxx::v_noabi::stdx::optional<v_noabi::read_concern> _read_concern;
 };
 
 } // namespace options

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/distinct.hpp
@@ -233,7 +233,7 @@ class distinct {
     /// @return the current read_concern.
     ///
     /// @see
-    /// - https://www.mongodb.com/docs/manual/reference/read-concern/
+    /// - https://www.mongodb.com/docs/manual/reference/command/distinct/
     ///
     bsoncxx::v_noabi::stdx::optional<v_noabi::read_concern> const& read_concern() const {
         return _read_concern;

--- a/src/mongocxx/lib/mongocxx/v1/collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/collection.cpp
@@ -296,6 +296,10 @@ void append_to(v1::distinct_options const& opts, scoped_bson& doc) {
         doc += scoped_bson{BCON_NEW("collation", BCON_DOCUMENT(scoped_bson_view{*opt}.bson()))};
     }
 
+    if (auto const& opt = v1::distinct_options::internal::read_concern(opts)) {
+        doc += scoped_bson{BCON_NEW("readConcern", BCON_DOCUMENT(scoped_bson{opt->to_document()}.bson()))};
+    }
+
     if (auto const& opt = v1::distinct_options::internal::comment(opts)) {
         append_comment(*opt, doc);
     }

--- a/src/mongocxx/lib/mongocxx/v1/distinct_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/distinct_options.cpp
@@ -19,6 +19,7 @@
 #include <bsoncxx/v1/document/value.hpp>
 #include <bsoncxx/v1/stdx/optional.hpp>
 
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/read_preference.hpp>
 
 #include <bsoncxx/v1/types/value.hh>
@@ -36,6 +37,7 @@ class distinct_options::impl {
     bsoncxx::v1::stdx::optional<std::chrono::milliseconds> _max_time;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> _comment;
     bsoncxx::v1::stdx::optional<v1::read_preference> _read_preference;
+    bsoncxx::v1::stdx::optional<v1::read_concern> _read_concern;
 
     static impl const& with(distinct_options const& self) {
         return *static_cast<impl const*>(self._impl);
@@ -124,6 +126,15 @@ bsoncxx::v1::stdx::optional<v1::read_preference> distinct_options::read_preferen
     return impl::with(this)->_read_preference;
 }
 
+distinct_options& distinct_options::read_concern(v1::read_concern rc) {
+    impl::with(this)->_read_concern = std::move(rc);
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern> distinct_options::read_concern() const {
+    return impl::with(this)->_read_concern;
+}
+
 bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> const& distinct_options::internal::collation(
     distinct_options const& self) {
     return impl::with(self)._collation;
@@ -144,6 +155,11 @@ bsoncxx::v1::stdx::optional<v1::read_preference> const& distinct_options::intern
     return impl::with(self)._read_preference;
 }
 
+bsoncxx::v1::stdx::optional<v1::read_concern> const& distinct_options::internal::read_concern(
+    distinct_options const& self) {
+    return impl::with(self)._read_concern;
+}
+
 bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& distinct_options::internal::collation(
     distinct_options& self) {
     return impl::with(self)._collation;
@@ -159,6 +175,10 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value>& distinct_options::intern
 
 bsoncxx::v1::stdx::optional<v1::read_preference>& distinct_options::internal::read_preference(distinct_options& self) {
     return impl::with(self)._read_preference;
+}
+
+bsoncxx::v1::stdx::optional<v1::read_concern>& distinct_options::internal::read_concern(distinct_options& self) {
+    return impl::with(self)._read_concern;
 }
 
 } // namespace v1

--- a/src/mongocxx/lib/mongocxx/v1/distinct_options.hh
+++ b/src/mongocxx/lib/mongocxx/v1/distinct_options.hh
@@ -21,6 +21,7 @@
 #include <bsoncxx/v1/document/value-fwd.hpp>
 #include <bsoncxx/v1/types/value-fwd.hpp>
 
+#include <mongocxx/v1/read_concern-fwd.hpp>
 #include <mongocxx/v1/read_preference-fwd.hpp>
 
 #include <bsoncxx/v1/stdx/optional.hpp>
@@ -36,11 +37,13 @@ class distinct_options::internal {
     static bsoncxx::v1::stdx::optional<std::chrono::milliseconds> const& max_time(distinct_options const& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> const& comment(distinct_options const& self);
     static bsoncxx::v1::stdx::optional<v1::read_preference> const& read_preference(distinct_options const& self);
+    static bsoncxx::v1::stdx::optional<v1::read_concern> const& read_concern(distinct_options const& self);
 
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value>& collation(distinct_options& self);
     static bsoncxx::v1::stdx::optional<std::chrono::milliseconds>& max_time(distinct_options& self);
     static bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value>& comment(distinct_options& self);
     static bsoncxx::v1::stdx::optional<v1::read_preference>& read_preference(distinct_options& self);
+    static bsoncxx::v1::stdx::optional<v1::read_concern>& read_concern(distinct_options& self);
 };
 
 } // namespace v1

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
@@ -290,6 +290,10 @@ void append_to(v_noabi::options::distinct const& opts, scoped_bson& doc) {
         doc += scoped_bson{BCON_NEW("collation", BCON_DOCUMENT(to_scoped_bson_view(*opt).bson()))};
     }
 
+    if (auto const& opt = opts.read_concern()) {
+        doc += scoped_bson{BCON_NEW("readConcern", BCON_DOCUMENT(to_scoped_bson(opt->to_document()).bson()))};
+    }
+
     if (auto const& opt = opts.comment()) {
         append_comment(*opt, doc);
     }

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/distinct.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/distinct.cpp
@@ -35,8 +35,8 @@ distinct::distinct(v1::distinct_options opts)
       }()},
       _max_time{std::move(v1::distinct_options::internal::max_time(opts))},
       _comment{std::move(v1::distinct_options::internal::comment(opts))},
-      _read_concern{std::move(v1::distinct_options::internal::read_concern(opts))},
-      _read_preference{std::move(v1::distinct_options::internal::read_preference(opts))} {}
+      _read_preference{std::move(v1::distinct_options::internal::read_preference(opts))},
+      _read_concern{std::move(v1::distinct_options::internal::read_concern(opts))} {}
 
 } // namespace options
 } // namespace v_noabi

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/distinct.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/options/distinct.cpp
@@ -35,6 +35,7 @@ distinct::distinct(v1::distinct_options opts)
       }()},
       _max_time{std::move(v1::distinct_options::internal::max_time(opts))},
       _comment{std::move(v1::distinct_options::internal::comment(opts))},
+      _read_concern{std::move(v1::distinct_options::internal::read_concern(opts))},
       _read_preference{std::move(v1::distinct_options::internal::read_preference(opts))} {}
 
 } // namespace options

--- a/src/mongocxx/test/v1/distinct_options.cpp
+++ b/src/mongocxx/test/v1/distinct_options.cpp
@@ -16,6 +16,7 @@
 
 //
 
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/read_preference.hpp>
 
 #include <bsoncxx/test/v1/types/value.hh>
@@ -78,6 +79,7 @@ TEST_CASE("default", "[mongocxx][v1][distinct_options]") {
     CHECK_FALSE(opts.max_time().has_value());
     CHECK_FALSE(opts.comment().has_value());
     CHECK_FALSE(opts.read_preference().has_value());
+    CHECK_FALSE(opts.read_concern().has_value());
 }
 
 TEST_CASE("collation", "[mongocxx][v1][distinct_options]") {
@@ -127,6 +129,17 @@ TEST_CASE("read_preference", "[mongocxx][v1][distinct_options]") {
     }));
 
     CHECK(distinct_options{}.read_preference(v).read_preference() == v);
+}
+
+TEST_CASE("read_concern", "[mongocxx][v1][distinct_options]") {
+    using T = mongocxx::v1::read_concern;
+
+    auto const v = GENERATE(values({
+        T{},
+        T{}.acknowledge_level(T::level::k_majority),
+    }));
+
+    CHECK(distinct_options{}.read_concern(v).read_concern() == v);
 }
 
 } // namespace v1

--- a/src/mongocxx/test/v_noabi/options/distinct.cpp
+++ b/src/mongocxx/test/v_noabi/options/distinct.cpp
@@ -16,6 +16,7 @@
 
 //
 
+#include <mongocxx/v1/read_concern.hpp>
 #include <mongocxx/v1/read_preference.hpp>
 
 #include <bsoncxx/test/v1/document/value.hh>
@@ -31,6 +32,7 @@
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/types/bson_value/view.hpp>
 
+#include <mongocxx/read_concern.hpp>
 #include <mongocxx/read_preference.hpp>
 
 #include <bsoncxx/test/catch.hh>
@@ -50,6 +52,7 @@ TEST_CASE("distinct", "[distinct][option]") {
     CHECK_OPTIONAL_ARGUMENT(dist, collation, collation.view());
     CHECK_OPTIONAL_ARGUMENT(dist, max_time, std::chrono::milliseconds{1000});
     CHECK_OPTIONAL_ARGUMENT(dist, read_preference, read_preference{});
+    CHECK_OPTIONAL_ARGUMENT(dist, read_concern, read_concern{});
 }
 } // namespace
 
@@ -64,12 +67,14 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][distinct]") {
     bsoncxx::v1::stdx::optional<std::chrono::milliseconds> max_time;
     bsoncxx::v1::stdx::optional<bsoncxx::v1::types::value> comment;
     bsoncxx::v1::stdx::optional<v1::read_preference> read_preference;
+    bsoncxx::v1::stdx::optional<v1::read_concern> read_concern;
 
     if (has_value) {
         collation.emplace();
         max_time.emplace();
         comment.emplace();
         read_preference.emplace();
+        read_concern.emplace();
     }
 
     using v_noabi = v_noabi::options::distinct;
@@ -83,6 +88,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][distinct]") {
             from.max_time(*max_time);
             from.comment(*comment);
             from.read_preference(*read_preference);
+            from.read_concern(*read_concern);
         }
 
         v_noabi const to{from};
@@ -92,11 +98,13 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][distinct]") {
             CHECK(to.max_time() == *max_time);
             CHECK(to.comment().value() == *comment);
             CHECK(to.read_preference() == *read_preference);
+            CHECK(to.read_concern() == *read_concern);
         } else {
             CHECK_FALSE(to.collation().has_value());
             CHECK_FALSE(to.max_time().has_value());
             CHECK_FALSE(to.comment().has_value());
             CHECK_FALSE(to.read_preference().has_value());
+            CHECK_FALSE(to.read_concern().has_value());
         }
     }
 
@@ -108,6 +116,7 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][distinct]") {
             from.max_time(*max_time);
             from.comment(from_v1(comment->view()));
             from.read_preference(*read_preference);
+            from.read_concern(*read_concern);
         }
 
         v1 const to{from};
@@ -117,11 +126,13 @@ TEST_CASE("v1", "[mongocxx][v_noabi][options][distinct]") {
             CHECK(to.max_time() == *max_time);
             CHECK(to.comment().value() == *comment);
             CHECK(to.read_preference() == *read_preference);
+            CHECK(to.read_concern() == *read_concern);
         } else {
             CHECK_FALSE(to.collation().has_value());
             CHECK_FALSE(to.max_time().has_value());
             CHECK_FALSE(to.comment().has_value());
             CHECK_FALSE(to.read_preference().has_value());
+            CHECK_FALSE(to.read_concern().has_value());
         }
     }
 }


### PR DESCRIPTION
**Related Ticket:** [CXX-3452](https://jira.mongodb.org/browse/CXX-3452)

## Summary
This PR addresses [CXX-3452](https://jira.mongodb.org/browse/CXX-3452), a subtask of [CXX-1748](https://jira.mongodb.org/browse/CXX-1748), which tracks `read_concern` support for individual operations. It introduces support for setting `read_concern` on the following:
- `v1::distinct_options`
- `v_noabi::options::distinct`

Previously, unlike `write_concern`, `read_concern` could not be set per operation. This change aligns the API with the existing behaviour for write concerns.

## Tests
Added unit tests for `read_concern` in:
- `v1/distinct_options.cpp`
- `v_noabi/options/distinct.cpp`