### PR TITLE
Add "ignore" paths to EVG config

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -9,6 +9,15 @@ exec_timeout_secs: 3600
 #   - system: after test (purple).
 command_type: system
 
+# Do not (automatically) trigger builds for changes irrelevant to regular test coverage.
+ignore:
+  - ".git*"
+  - ".ycm*"
+  - "*.md"
+  - "docs"
+  - "extras"
+  - "THIRD-PARTY-NOTICES"
+
 # Ensure Evergreen tests earlier commits when a task fails.
 stepback: true
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -13,7 +13,7 @@ command_type: system
 ignore:
   - ".git*"
   - ".ycm*"
-  - "*.md"
+  - "**/*.md"
   - "docs"
   - "extras"
   - "THIRD-PARTY-NOTICES"


### PR DESCRIPTION
In a small effort to reduce redundant builds in the EVG waterfall, this PR introduces the [ignore](https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Project-Configuration-Files#filtering-by-changed-files) field in the EVG configuration file.

> You can control when tasks and build variants run based on which files have changed in a commit or patch. This is useful for optimizing CI/CD pipelines by only running relevant tests when specific parts of your codebase change. For both options here, this filtering applies to mainline versions and PR testing (so this won't prevent required merge queue testing, for example).

> Some commits to your repository don't need to be tested. The obvious examples here would be documentation or configuration files for other Evergreen projects---changes to README.md don't need to trigger your builds.
>
> To address this, project files can define a top-level `ignore` list of gitignore-style globs which tell Evergreen to not automatically run tasks for commits that only change ignored files, and we will not create PR patches but instead send a successful status for all required checks as well as the base `evergreen` check.

We could also use [build variant path filtering](https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Project-Configuration-Files#build-variant-path-filtering), but this seemed to be the easiest and simplest first step.

Including the `etc` directory was considered, but some files/scripts required by Evergreen (under `.evergreen`) reference files under `etc`, so excluded this directory for now. We may consider adding this directory all such files are migrated to `.evergreen/scripts`.