### PR TITLE
Fix consistency issues with `findOneAnd*` ops

### DIFF
--- a/src/mongocxx/include/mongocxx/v1/find_one_and_delete_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/find_one_and_delete_options.hpp
@@ -108,7 +108,7 @@ class find_one_and_delete_options {
     ///
     /// Set the "collation" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete_options&) collation(bsoncxx::v1::document::value collation);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete_options&) collation(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "collation" field.
@@ -118,7 +118,7 @@ class find_one_and_delete_options {
     ///
     /// Set the "maxTimeMS" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete_options&) max_time(std::chrono::milliseconds max_time);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete_options&) max_time(std::chrono::milliseconds v);
 
     ///
     /// Return the current "maxTimeMS" field.
@@ -128,7 +128,7 @@ class find_one_and_delete_options {
     ///
     /// Set the "projection" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete_options&) projection(bsoncxx::v1::document::value projection);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete_options&) projection(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "projection" field.
@@ -148,7 +148,7 @@ class find_one_and_delete_options {
     ///
     /// Set the "readConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete_options&) read_concern(v1::read_concern read_concern);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete_options&) read_concern(v1::read_concern v);
 
     ///
     /// Return the current "readConcern" field.
@@ -158,7 +158,7 @@ class find_one_and_delete_options {
     ///
     /// Set the "writeConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete_options&) write_concern(v1::write_concern write_concern);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete_options&) write_concern(v1::write_concern v);
 
     ///
     /// Return the current "writeConcern" field.
@@ -178,7 +178,7 @@ class find_one_and_delete_options {
     ///
     /// Set the "let" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete_options&) let(bsoncxx::v1::document::value let);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete_options&) let(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "let" field.
@@ -188,7 +188,7 @@ class find_one_and_delete_options {
     ///
     /// Set the "comment" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete_options&) comment(bsoncxx::v1::types::value comment);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete_options&) comment(bsoncxx::v1::types::value v);
 
     ///
     /// Return the current "comment" field.

--- a/src/mongocxx/include/mongocxx/v1/find_one_and_replace_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/find_one_and_replace_options.hpp
@@ -112,7 +112,7 @@ class find_one_and_replace_options {
     ///
     /// Set the "collation" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) collation(bsoncxx::v1::document::value collation);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) collation(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "collation" field.
@@ -122,8 +122,7 @@ class find_one_and_replace_options {
     ///
     /// Set the "bypassDocumentValidation" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) bypass_document_validation(
-        bool bypass_document_validation);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) bypass_document_validation(bool v);
 
     ///
     /// Return the current "bypassDocumentValidation" field.
@@ -143,7 +142,7 @@ class find_one_and_replace_options {
     ///
     /// Set the "let" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) let(bsoncxx::v1::document::value let);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) let(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "let" field.
@@ -153,7 +152,7 @@ class find_one_and_replace_options {
     ///
     /// Set the "comment" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) comment(bsoncxx::v1::types::value comment);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) comment(bsoncxx::v1::types::value v);
 
     ///
     /// Return the current "comment" field.
@@ -163,7 +162,7 @@ class find_one_and_replace_options {
     ///
     /// Set the "maxTimeMS" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) max_time(std::chrono::milliseconds max_time);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) max_time(std::chrono::milliseconds v);
 
     ///
     /// Return the current "maxTimeMS" field.
@@ -173,7 +172,7 @@ class find_one_and_replace_options {
     ///
     /// Set the "projection" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) projection(bsoncxx::v1::document::value projection);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) projection(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "projection" field.
@@ -183,7 +182,7 @@ class find_one_and_replace_options {
     ///
     /// Set the "returnDocument" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) return_document(v1::return_document return_document);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) return_document(v1::return_document v);
 
     ///
     /// Return the current "returnDocument" field.
@@ -203,7 +202,7 @@ class find_one_and_replace_options {
     ///
     /// Set the "upsert" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) upsert(bool upsert);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) upsert(bool v);
 
     ///
     /// Return the current "upsert" field.
@@ -213,7 +212,7 @@ class find_one_and_replace_options {
     ///
     /// Set the "readConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) read_concern(v1::read_concern read_concern);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) read_concern(v1::read_concern v);
 
     ///
     /// Return the current "readConcern" field.
@@ -223,7 +222,7 @@ class find_one_and_replace_options {
     ///
     /// Set the "writeConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) write_concern(v1::write_concern write_concern);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) write_concern(v1::write_concern v);
 
     ///
     /// Return the current "writeConcern" field.

--- a/src/mongocxx/include/mongocxx/v1/find_one_and_update_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/find_one_and_update_options.hpp
@@ -115,7 +115,7 @@ class find_one_and_update_options {
     ///
     /// Set the "collation" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) collation(bsoncxx::v1::document::value collation);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) collation(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "collation" field.
@@ -125,7 +125,7 @@ class find_one_and_update_options {
     ///
     /// Set the "bypassDocumentValidation" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) bypass_document_validation(bool bypass_document_validation);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) bypass_document_validation(bool v);
 
     ///
     /// Return the current "bypassDocumentValidation" field.
@@ -145,7 +145,7 @@ class find_one_and_update_options {
     ///
     /// Set the "let" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) let(bsoncxx::v1::document::value let);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) let(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "let" field.
@@ -155,7 +155,7 @@ class find_one_and_update_options {
     ///
     /// Set the "comment" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) comment(bsoncxx::v1::types::value comment);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) comment(bsoncxx::v1::types::value v);
 
     ///
     /// Return the current "comment" field.
@@ -165,7 +165,7 @@ class find_one_and_update_options {
     ///
     /// Set the "maxTimeMS" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) max_time(std::chrono::milliseconds max_time);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) max_time(std::chrono::milliseconds v);
 
     ///
     /// Return the current "maxTimeMS" field.
@@ -175,7 +175,7 @@ class find_one_and_update_options {
     ///
     /// Set the "projection" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) projection(bsoncxx::v1::document::value projection);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) projection(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "projection" field.
@@ -185,7 +185,7 @@ class find_one_and_update_options {
     ///
     /// Set the "returnDocument" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) return_document(v1::return_document return_document);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) return_document(v1::return_document v);
 
     ///
     /// Return the current "returnDocument" field.
@@ -205,7 +205,7 @@ class find_one_and_update_options {
     ///
     /// Set the "upsert" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) upsert(bool upsert);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) upsert(bool v);
 
     ///
     /// Return the current "upsert" field.
@@ -215,7 +215,7 @@ class find_one_and_update_options {
     ///
     /// Set the "readConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) read_concern(v1::read_concern read_concern);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) read_concern(v1::read_concern v);
 
     ///
     /// Return the current "readConcern" field.
@@ -225,7 +225,7 @@ class find_one_and_update_options {
     ///
     /// Set the "writeConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) write_concern(v1::write_concern write_concern);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) write_concern(v1::write_concern v);
 
     ///
     /// Return the current "writeConcern" field.
@@ -235,7 +235,7 @@ class find_one_and_update_options {
     ///
     /// Set the "arrayFilters" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) array_filters(bsoncxx::v1::array::value array_filters);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) array_filters(bsoncxx::v1::array::value v);
 
     ///
     /// Return the current "arrayFilters" field.

--- a/src/mongocxx/lib/mongocxx/v1/find_one_and_delete_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/find_one_and_delete_options.cpp
@@ -96,8 +96,8 @@ find_one_and_delete_options::find_one_and_delete_options() : _impl{new impl{}} {
 
 // NOLINTEND(cppcoreguidelines-owning-memory)
 
-find_one_and_delete_options& find_one_and_delete_options::collation(bsoncxx::v1::document::value collation) {
-    impl::with(this)->_collation = std::move(collation);
+find_one_and_delete_options& find_one_and_delete_options::collation(bsoncxx::v1::document::value v) {
+    impl::with(this)->_collation = std::move(v);
     return *this;
 }
 
@@ -105,8 +105,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> find_one_and_delete_opt
     return impl::with(this)->_collation;
 }
 
-find_one_and_delete_options& find_one_and_delete_options::max_time(std::chrono::milliseconds max_time) {
-    impl::with(this)->_max_time = std::move(max_time);
+find_one_and_delete_options& find_one_and_delete_options::max_time(std::chrono::milliseconds v) {
+    impl::with(this)->_max_time = std::move(v);
     return *this;
 }
 
@@ -114,8 +114,8 @@ bsoncxx::v1::stdx::optional<std::chrono::milliseconds> find_one_and_delete_optio
     return impl::with(this)->_max_time;
 }
 
-find_one_and_delete_options& find_one_and_delete_options::projection(bsoncxx::v1::document::value projection) {
-    impl::with(this)->_projection = std::move(projection);
+find_one_and_delete_options& find_one_and_delete_options::projection(bsoncxx::v1::document::value v) {
+    impl::with(this)->_projection = std::move(v);
     return *this;
 }
 
@@ -132,8 +132,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> find_one_and_delete_opt
     return impl::with(this)->_sort;
 }
 
-find_one_and_delete_options& find_one_and_delete_options::read_concern(v1::read_concern read_concern) {
-    impl::with(this)->_read_concern = std::move(read_concern);
+find_one_and_delete_options& find_one_and_delete_options::read_concern(v1::read_concern v) {
+    impl::with(this)->_read_concern = std::move(v);
     return *this;
 }
 
@@ -141,8 +141,8 @@ bsoncxx::v1::stdx::optional<v1::read_concern> find_one_and_delete_options::read_
     return impl::with(this)->_read_concern;
 }
 
-find_one_and_delete_options& find_one_and_delete_options::write_concern(v1::write_concern write_concern) {
-    impl::with(this)->_write_concern = std::move(write_concern);
+find_one_and_delete_options& find_one_and_delete_options::write_concern(v1::write_concern v) {
+    impl::with(this)->_write_concern = std::move(v);
     return *this;
 }
 
@@ -159,8 +159,8 @@ bsoncxx::v1::stdx::optional<v1::hint> find_one_and_delete_options::hint() const 
     return impl::with(this)->_hint;
 }
 
-find_one_and_delete_options& find_one_and_delete_options::let(bsoncxx::v1::document::value let) {
-    impl::with(this)->_let = std::move(let);
+find_one_and_delete_options& find_one_and_delete_options::let(bsoncxx::v1::document::value v) {
+    impl::with(this)->_let = std::move(v);
     return *this;
 }
 
@@ -168,8 +168,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> const find_one_and_dele
     return impl::with(this)->_let;
 }
 
-find_one_and_delete_options& find_one_and_delete_options::comment(bsoncxx::v1::types::value comment) {
-    impl::with(this)->_comment = std::move(comment);
+find_one_and_delete_options& find_one_and_delete_options::comment(bsoncxx::v1::types::value v) {
+    impl::with(this)->_comment = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/find_one_and_replace_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/find_one_and_replace_options.cpp
@@ -100,8 +100,8 @@ find_one_and_replace_options::find_one_and_replace_options() : _impl{new impl{}}
 
 // NOLINTEND(cppcoreguidelines-owning-memory)
 
-find_one_and_replace_options& find_one_and_replace_options::collation(bsoncxx::v1::document::value collation) {
-    impl::with(this)->_collation = std::move(collation);
+find_one_and_replace_options& find_one_and_replace_options::collation(bsoncxx::v1::document::value v) {
+    impl::with(this)->_collation = std::move(v);
     return *this;
 }
 
@@ -109,9 +109,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> find_one_and_replace_op
     return impl::with(this)->_collation;
 }
 
-find_one_and_replace_options& find_one_and_replace_options::bypass_document_validation(
-    bool bypass_document_validation) {
-    impl::with(this)->_bypass_document_validation = std::move(bypass_document_validation);
+find_one_and_replace_options& find_one_and_replace_options::bypass_document_validation(bool v) {
+    impl::with(this)->_bypass_document_validation = v;
     return *this;
 }
 
@@ -128,8 +127,8 @@ bsoncxx::v1::stdx::optional<v1::hint> find_one_and_replace_options::hint() const
     return impl::with(this)->_hint;
 }
 
-find_one_and_replace_options& find_one_and_replace_options::let(bsoncxx::v1::document::value let) {
-    impl::with(this)->_let = std::move(let);
+find_one_and_replace_options& find_one_and_replace_options::let(bsoncxx::v1::document::value v) {
+    impl::with(this)->_let = std::move(v);
     return *this;
 }
 
@@ -137,8 +136,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> const find_one_and_repl
     return impl::with(this)->_let;
 }
 
-find_one_and_replace_options& find_one_and_replace_options::comment(bsoncxx::v1::types::value comment) {
-    impl::with(this)->_comment = std::move(comment);
+find_one_and_replace_options& find_one_and_replace_options::comment(bsoncxx::v1::types::value v) {
+    impl::with(this)->_comment = std::move(v);
     return *this;
 }
 
@@ -146,8 +145,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::types::view> const find_one_and_replace
     return impl::with(this)->_comment;
 }
 
-find_one_and_replace_options& find_one_and_replace_options::max_time(std::chrono::milliseconds max_time) {
-    impl::with(this)->_max_time = std::move(max_time);
+find_one_and_replace_options& find_one_and_replace_options::max_time(std::chrono::milliseconds v) {
+    impl::with(this)->_max_time = std::move(v);
     return *this;
 }
 
@@ -155,8 +154,8 @@ bsoncxx::v1::stdx::optional<std::chrono::milliseconds> find_one_and_replace_opti
     return impl::with(this)->_max_time;
 }
 
-find_one_and_replace_options& find_one_and_replace_options::projection(bsoncxx::v1::document::value projection) {
-    impl::with(this)->_projection = std::move(projection);
+find_one_and_replace_options& find_one_and_replace_options::projection(bsoncxx::v1::document::value v) {
+    impl::with(this)->_projection = std::move(v);
     return *this;
 }
 
@@ -164,8 +163,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> find_one_and_replace_op
     return impl::with(this)->_projection;
 }
 
-find_one_and_replace_options& find_one_and_replace_options::return_document(v1::return_document return_document) {
-    impl::with(this)->_return_document = std::move(return_document);
+find_one_and_replace_options& find_one_and_replace_options::return_document(v1::return_document v) {
+    impl::with(this)->_return_document = std::move(v);
     return *this;
 }
 
@@ -182,8 +181,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> find_one_and_replace_op
     return impl::with(this)->_sort;
 }
 
-find_one_and_replace_options& find_one_and_replace_options::upsert(bool upsert) {
-    impl::with(this)->_upsert = std::move(upsert);
+find_one_and_replace_options& find_one_and_replace_options::upsert(bool v) {
+    impl::with(this)->_upsert = v;
     return *this;
 }
 
@@ -191,8 +190,8 @@ bsoncxx::v1::stdx::optional<bool> find_one_and_replace_options::upsert() const {
     return impl::with(this)->_upsert;
 }
 
-find_one_and_replace_options& find_one_and_replace_options::read_concern(v1::read_concern read_concern) {
-    impl::with(this)->_read_concern = std::move(read_concern);
+find_one_and_replace_options& find_one_and_replace_options::read_concern(v1::read_concern v) {
+    impl::with(this)->_read_concern = std::move(v);
     return *this;
 }
 
@@ -200,8 +199,8 @@ bsoncxx::v1::stdx::optional<v1::read_concern> find_one_and_replace_options::read
     return impl::with(this)->_read_concern;
 }
 
-find_one_and_replace_options& find_one_and_replace_options::write_concern(v1::write_concern write_concern) {
-    impl::with(this)->_write_concern = std::move(write_concern);
+find_one_and_replace_options& find_one_and_replace_options::write_concern(v1::write_concern v) {
+    impl::with(this)->_write_concern = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/find_one_and_update_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/find_one_and_update_options.cpp
@@ -102,8 +102,8 @@ find_one_and_update_options::find_one_and_update_options() : _impl{new impl{}} {
 
 // NOLINTEND(cppcoreguidelines-owning-memory)
 
-find_one_and_update_options& find_one_and_update_options::collation(bsoncxx::v1::document::value collation) {
-    impl::with(this)->_collation = std::move(collation);
+find_one_and_update_options& find_one_and_update_options::collation(bsoncxx::v1::document::value v) {
+    impl::with(this)->_collation = std::move(v);
     return *this;
 }
 
@@ -111,8 +111,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> find_one_and_update_opt
     return impl::with(this)->_collation;
 }
 
-find_one_and_update_options& find_one_and_update_options::bypass_document_validation(bool bypass_document_validation) {
-    impl::with(this)->_bypass_document_validation = std::move(bypass_document_validation);
+find_one_and_update_options& find_one_and_update_options::bypass_document_validation(bool v) {
+    impl::with(this)->_bypass_document_validation = v;
     return *this;
 }
 
@@ -129,8 +129,8 @@ bsoncxx::v1::stdx::optional<v1::hint> find_one_and_update_options::hint() const 
     return impl::with(this)->_hint;
 }
 
-find_one_and_update_options& find_one_and_update_options::let(bsoncxx::v1::document::value let) {
-    impl::with(this)->_let = std::move(let);
+find_one_and_update_options& find_one_and_update_options::let(bsoncxx::v1::document::value v) {
+    impl::with(this)->_let = std::move(v);
     return *this;
 }
 
@@ -138,8 +138,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> const find_one_and_upda
     return impl::with(this)->_let;
 }
 
-find_one_and_update_options& find_one_and_update_options::comment(bsoncxx::v1::types::value comment) {
-    impl::with(this)->_comment = std::move(comment);
+find_one_and_update_options& find_one_and_update_options::comment(bsoncxx::v1::types::value v) {
+    impl::with(this)->_comment = std::move(v);
     return *this;
 }
 
@@ -147,8 +147,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::types::view> const find_one_and_update_
     return impl::with(this)->_comment;
 }
 
-find_one_and_update_options& find_one_and_update_options::max_time(std::chrono::milliseconds max_time) {
-    impl::with(this)->_max_time = std::move(max_time);
+find_one_and_update_options& find_one_and_update_options::max_time(std::chrono::milliseconds v) {
+    impl::with(this)->_max_time = std::move(v);
     return *this;
 }
 
@@ -156,8 +156,8 @@ bsoncxx::v1::stdx::optional<std::chrono::milliseconds> find_one_and_update_optio
     return impl::with(this)->_max_time;
 }
 
-find_one_and_update_options& find_one_and_update_options::projection(bsoncxx::v1::document::value projection) {
-    impl::with(this)->_projection = std::move(projection);
+find_one_and_update_options& find_one_and_update_options::projection(bsoncxx::v1::document::value v) {
+    impl::with(this)->_projection = std::move(v);
     return *this;
 }
 
@@ -165,8 +165,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> find_one_and_update_opt
     return impl::with(this)->_projection;
 }
 
-find_one_and_update_options& find_one_and_update_options::return_document(v1::return_document return_document) {
-    impl::with(this)->_return_document = std::move(return_document);
+find_one_and_update_options& find_one_and_update_options::return_document(v1::return_document v) {
+    impl::with(this)->_return_document = std::move(v);
     return *this;
 }
 
@@ -183,8 +183,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> find_one_and_update_opt
     return impl::with(this)->_sort;
 }
 
-find_one_and_update_options& find_one_and_update_options::upsert(bool upsert) {
-    impl::with(this)->_upsert = std::move(upsert);
+find_one_and_update_options& find_one_and_update_options::upsert(bool v) {
+    impl::with(this)->_upsert = v;
     return *this;
 }
 
@@ -192,8 +192,8 @@ bsoncxx::v1::stdx::optional<bool> find_one_and_update_options::upsert() const {
     return impl::with(this)->_upsert;
 }
 
-find_one_and_update_options& find_one_and_update_options::read_concern(v1::read_concern read_concern) {
-    impl::with(this)->_read_concern = std::move(read_concern);
+find_one_and_update_options& find_one_and_update_options::read_concern(v1::read_concern v) {
+    impl::with(this)->_read_concern = std::move(v);
     return *this;
 }
 
@@ -201,8 +201,8 @@ bsoncxx::v1::stdx::optional<v1::read_concern> find_one_and_update_options::read_
     return impl::with(this)->_read_concern;
 }
 
-find_one_and_update_options& find_one_and_update_options::write_concern(v1::write_concern write_concern) {
-    impl::with(this)->_write_concern = std::move(write_concern);
+find_one_and_update_options& find_one_and_update_options::write_concern(v1::write_concern v) {
+    impl::with(this)->_write_concern = std::move(v);
     return *this;
 }
 
@@ -210,8 +210,8 @@ bsoncxx::v1::stdx::optional<v1::write_concern> find_one_and_update_options::writ
     return impl::with(this)->_write_concern;
 }
 
-find_one_and_update_options& find_one_and_update_options::array_filters(bsoncxx::v1::array::value array_filters) {
-    impl::with(this)->_array_filters = std::move(array_filters);
+find_one_and_update_options& find_one_and_update_options::array_filters(bsoncxx::v1::array::value v) {
+    impl::with(this)->_array_filters = std::move(v);
     return *this;
 }
 


### PR DESCRIPTION
Some minor consistency fixes to the `findOneAnd*` components identified during review of CXX-1748 subtickets.