### PR TITLE
CXX-3491 Fix misc. v1::text_options doc comments and includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ## 4.4.0 [Unreleased]
 
+### Fixed
+
+- Include of `v1/text_options.hpp` (normal header) by `options/text-fwd.hpp` (forward header).
+- Include of v\_noabi macro guard headers by `text_options.hpp` (v1).
+
 ### Deprecated
 
 - Support for MongoDB Server 4.2.

--- a/src/mongocxx/include/mongocxx/v1/text_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/text_options.hpp
@@ -18,11 +18,13 @@
 
 //
 
+#include <mongocxx/v1/detail/prelude.hpp>
+
 #include <bsoncxx/v1/stdx/optional.hpp>
 
-#include <cstdint>
+#include <mongocxx/v1/config/export.hpp>
 
-#include <mongocxx/config/prelude.hpp>
+#include <cstdint>
 
 namespace mongocxx {
 namespace v1 {
@@ -378,7 +380,7 @@ class text_options::substring {
 } // namespace v1
 } // namespace mongocxx
 
-#include <mongocxx/config/postlude.hpp>
+#include <mongocxx/v1/detail/postlude.hpp>
 
 ///
 /// @file

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/encrypt.hpp
@@ -269,7 +269,7 @@ class encrypt {
     ///
     /// Sets the text options to use for encryption.
     ///
-    encrypt& text_opts(options::text opts) {
+    encrypt& text_opts(v1::text_options opts) {
         _text_opts = std::move(opts);
         return *this;
     }
@@ -277,7 +277,7 @@ class encrypt {
     ///
     /// Gets the current text options
     ///
-    bsoncxx::v_noabi::stdx::optional<options::text> const& text_opts() const {
+    bsoncxx::v_noabi::stdx::optional<v1::text_options> const& text_opts() const {
         return _text_opts;
     }
 
@@ -290,7 +290,7 @@ class encrypt {
     bsoncxx::v_noabi::stdx::optional<std::int64_t> _contention_factor;
     bsoncxx::v_noabi::stdx::optional<encryption_query_type> _query_type;
     bsoncxx::v_noabi::stdx::optional<options::range> _range_opts;
-    bsoncxx::v_noabi::stdx::optional<options::text> _text_opts;
+    bsoncxx::v_noabi::stdx::optional<v1::text_options> _text_opts;
 };
 
 } // namespace options

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/text-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/text-fwd.hpp
@@ -16,8 +16,6 @@
 
 #include <mongocxx/v1/text_options-fwd.hpp> // IWYU pragma: export
 
-#include <mongocxx/v1/text_options.hpp>
-
 #include <mongocxx/config/prelude.hpp>
 
 namespace mongocxx {
@@ -38,7 +36,7 @@ using v1::text_options;
 
 ///
 /// @file
-/// Declares utilities related to mongocxx logging.
+/// Declares @ref mongocxx::text_options.
 ///
 /// @par Includes
 /// - @ref mongocxx/v1/text_options-fwd.hpp

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/text.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/text.hpp
@@ -44,8 +44,8 @@ using v_noabi::options::text;
 
 ///
 /// @file
-/// Declares @ref mongocxx::v_noabi::options::range.
+/// Provides @ref mongocxx::text_options.
 ///
 /// @par Includes
-/// - @ref mongocxx/v1/range_options.hpp
+/// - @ref mongocxx/v1/text_options.hpp
 ///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/text.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/text.hpp
@@ -26,6 +26,7 @@ namespace mongocxx {
 namespace v_noabi {
 namespace options {
 
+// Preserved for backward compatibility. New v1 API should not be redeclared in v_noabi.
 using text = v1::text_options;
 
 } // namespace options
@@ -35,6 +36,7 @@ using text = v1::text_options;
 namespace mongocxx {
 namespace options {
 
+// Preserved for backward compatibility. New v1 API should not be redeclared in v_noabi.
 using v_noabi::options::text;
 
 } // namespace options


### PR DESCRIPTION
Prompted by questions about new API design for v1 when no v_noabi equivalents already exist, in an attempt to point to `v1::text_options` as reference example, identified several issues with the `v1::text_options`-related headers that were overlooked by https://github.com/mongodb/mongo-cxx-driver/pull/1522:

- Incorrect include of v1 normal header by the v_noabi forward header.
- Incorrect include of v_noabi macro guard headers by the v1 normal header.
- Misc. copy-paste errors in doc comments.
- Update doc comments to refer to the root namespace redeclaration(s) only (users should be using either `mongocxx::text_options` or `v1::text_options`, not `v_noabi::text_options`).

Although `v_noabi::options::text` was deliberatedly added for consistency with existing v_noabi option class declarations, the redeclaration of `v1::text_options` in the v_noabi namespace as `v_noabi::text_options` is incorrect/unnecessary: only the root namespace redeclaration should be provided. Nevertheless, left as-is due to API backward compatibility. New API should not do this going forward.