### PR TITLE
Upgrade Catch2: v3.8.1 -> v3.15.0

### DIFF
--- a/cmake/FetchCatch2.cmake
+++ b/cmake/FetchCatch2.cmake
@@ -12,7 +12,7 @@ function(fetch_catch2)
         EP_Catch2
 
         GIT_REPOSITORY https://github.com/catchorg/Catch2
-        GIT_TAG v3.8.1
+        GIT_TAG v3.15.0
         GIT_SHALLOW TRUE
         LOG_DOWNLOAD ON
 


### PR DESCRIPTION
Prompted by recent upgrades to the `uv.lock` file, thought we should take the opportunity to upgrade the Catch2 dependency as well.

The current Catch2 version is 3.8.1, last updated almost exactly [one year ago](https://github.com/mongodb/mongo-cxx-driver/commit/079af6c4a04f67c8f96cb100a77cf1e25eeabe9e). Version 3.15.0 was released earlier today.

Notable fixes and improvements since version 3.8.1 that are relevant to our test suite include:

- `--order rand` is now the default (exposes intertest dependencies).
- `FAIL()` and `SKIP()` are now unreachable-aware (the `SKIP(...); return 0;` pattern to silence warnings is no longer necessary).
- New `UNSCOPED_CAPTURE()` to complement `CAPTURE()` (a la `UNSCOPED_INFO()` and `INFO()`).
- Improved handling of "legacy" section filters (`-c <section-name>`) and new "path" filters (`-p c:<section-name>`).
- Improved diagnostics for nested assertion failures (still should be avoided when able, but the message is no longer obtuse and confusing).
- Various performance improvements (e.g. the trivial `REQUIRE(true)` assertion is supposedly 80% faster for debug builds).
- Various fixes and improvements to compiler warnings and forward compatibility with new C++ standard versions and compilers.
