### PR TITLE
Initialize vector elements before subscript comparisons

### DIFF
--- a/src/bsoncxx/test/v_noabi/vector.cpp
+++ b/src/bsoncxx/test/v_noabi/vector.cpp
@@ -138,6 +138,8 @@ void iterator_operations(
     BSONCXX_PRIVATE_WARNINGS_PUSH();
     BSONCXX_PRIVATE_WARNINGS_DISABLE(GNU("-Wfloat-equal"));
 
+    *begin = element_unit;
+    *(begin + 1) = static_cast<Element>(element_unit + Element{1});
     CHECK(iter_copy[0] == *begin);
     CHECK(iter_copy[1] == *(begin + 1));
 


### PR DESCRIPTION
Fixes an observed [flaky test failure](https://parsley.corp.mongodb.com/evergreen/mongo_cxx_driver_integration_matrix_linux_integration_rhel80_debug_static_cxx17_csfle_7.0_sharded_1d9d7e6892d70a6b26ddb34c174e0fcdaf136b2f_26_05_12_16_07_00/0/task?bookmarks=0,2381&shareLine=2358):

```
src/bsoncxx/test/v_noabi/vector.cpp:142: failed: iter_copy[1] == *(begin + 1) for: nan == nan
```

The elements at `vec[0]` and `vec[1]` were being compared before the elements were initialized. Subsequent test assertions use `std::generate()`/`std::copy()`/etc. to initialize all elements in the vector. To preserve the intent of these assertions, set the elements being compared to `element_unit` and `element_unit + 1` respectively (note: static cast is to account for integral promotions from `uint8_t` to `int`).