### PR TITLE
Add Atlas Stream Processing v1 API

### DIFF
--- a/src/mongocxx/include/mongocxx/v1/create_stream_processor_options-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v1/create_stream_processor_options-fwd.hpp
@@ -1,0 +1,32 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/detail/prelude.hpp>
+
+namespace mongocxx {
+namespace v1 {
+
+class create_stream_processor_options;
+
+} // namespace v1
+} // namespace mongocxx
+
+#include <mongocxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref mongocxx::v1::create_stream_processor_options.
+///

--- a/src/mongocxx/include/mongocxx/v1/create_stream_processor_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/create_stream_processor_options.hpp
@@ -1,0 +1,89 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/create_stream_processor_options-fwd.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/v1/detail/prelude.hpp>
+
+#include <bsoncxx/v1/document/value-fwd.hpp>
+#include <bsoncxx/v1/document/view-fwd.hpp>
+
+#include <bsoncxx/v1/document/value.hpp>
+#include <bsoncxx/v1/stdx/optional.hpp>
+#include <bsoncxx/v1/stdx/string_view.hpp>
+
+#include <mongocxx/v1/config/export.hpp>
+
+#include <string>
+
+namespace mongocxx {
+namespace v1 {
+
+///
+/// Options for the createStreamProcessor command.
+///
+class create_stream_processor_options {
+   private:
+    class impl;
+    void* _impl;
+
+   public:
+    MONGOCXX_ABI_EXPORT_CDECL() ~create_stream_processor_options();
+    MONGOCXX_ABI_EXPORT_CDECL() create_stream_processor_options(create_stream_processor_options&&) noexcept;
+    MONGOCXX_ABI_EXPORT_CDECL(create_stream_processor_options&) operator=(create_stream_processor_options&&) noexcept;
+    MONGOCXX_ABI_EXPORT_CDECL() create_stream_processor_options(create_stream_processor_options const&);
+    MONGOCXX_ABI_EXPORT_CDECL(create_stream_processor_options&) operator=(create_stream_processor_options const&);
+    MONGOCXX_ABI_EXPORT_CDECL() create_stream_processor_options();
+
+    ///
+    /// Dead letter queue configuration document.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(create_stream_processor_options&) dlq(bsoncxx::v1::document::value v);
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view>) dlq() const;
+
+    ///
+    /// Field name for stream metadata.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(create_stream_processor_options&) stream_meta_field_name(std::string v);
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bsoncxx::v1::stdx::string_view>) stream_meta_field_name()
+        const;
+
+    ///
+    /// Compute tier.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(create_stream_processor_options&) tier(std::string v);
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bsoncxx::v1::stdx::string_view>) tier() const;
+
+    ///
+    /// Enable failover.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(create_stream_processor_options&) failover(bool v);
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bool>) failover() const;
+
+    class internal;
+};
+
+} // namespace v1
+} // namespace mongocxx
+
+#include <mongocxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref mongocxx::v1::create_stream_processor_options.
+///

--- a/src/mongocxx/include/mongocxx/v1/failover_options-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v1/failover_options-fwd.hpp
@@ -1,0 +1,32 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/detail/prelude.hpp>
+
+namespace mongocxx {
+namespace v1 {
+
+class failover_options;
+
+} // namespace v1
+} // namespace mongocxx
+
+#include <mongocxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref mongocxx::v1::failover_options.
+///

--- a/src/mongocxx/include/mongocxx/v1/failover_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/failover_options.hpp
@@ -1,0 +1,82 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/failover_options-fwd.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/v1/detail/prelude.hpp>
+
+#include <bsoncxx/v1/stdx/optional.hpp>
+#include <bsoncxx/v1/stdx/string_view.hpp>
+
+#include <mongocxx/v1/config/export.hpp>
+
+#include <string>
+
+namespace mongocxx {
+namespace v1 {
+
+///
+/// Options for failover behavior when starting a stream processor.
+///
+class failover_options {
+   private:
+    class impl;
+    void* _impl;
+
+   public:
+    MONGOCXX_ABI_EXPORT_CDECL() ~failover_options();
+    MONGOCXX_ABI_EXPORT_CDECL() failover_options(failover_options&&) noexcept;
+    MONGOCXX_ABI_EXPORT_CDECL(failover_options&) operator=(failover_options&&) noexcept;
+    MONGOCXX_ABI_EXPORT_CDECL() failover_options(failover_options const&);
+    MONGOCXX_ABI_EXPORT_CDECL(failover_options&) operator=(failover_options const&);
+
+    ///
+    /// Construct with a required target region.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL() explicit failover_options(std::string region);
+
+    ///
+    /// Set the target failover region. Required.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(failover_options&) region(std::string v);
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::string_view) region() const;
+
+    ///
+    /// Set the failover mode ("GRACEFUL" or "FORCED"). Defaults to "GRACEFUL".
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(failover_options&) mode(std::string v);
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bsoncxx::v1::stdx::string_view>) mode() const;
+
+    ///
+    /// If true, validates the failover request without executing it.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(failover_options&) dry_run(bool v);
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bool>) dry_run() const;
+
+    class internal;
+};
+
+} // namespace v1
+} // namespace mongocxx
+
+#include <mongocxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref mongocxx::v1::failover_options.
+///

--- a/src/mongocxx/include/mongocxx/v1/get_stream_processor_samples_options-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v1/get_stream_processor_samples_options-fwd.hpp
@@ -1,0 +1,32 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/detail/prelude.hpp>
+
+namespace mongocxx {
+namespace v1 {
+
+class get_stream_processor_samples_options;
+
+} // namespace v1
+} // namespace mongocxx
+
+#include <mongocxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref mongocxx::v1::get_stream_processor_samples_options.
+///

--- a/src/mongocxx/include/mongocxx/v1/get_stream_processor_samples_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/get_stream_processor_samples_options.hpp
@@ -1,0 +1,82 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/get_stream_processor_samples_options-fwd.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/v1/detail/prelude.hpp>
+
+#include <bsoncxx/v1/stdx/optional.hpp>
+
+#include <mongocxx/v1/config/export.hpp>
+
+#include <cstdint>
+
+namespace mongocxx {
+namespace v1 {
+
+///
+/// Options for get_stream_processor_samples().
+///
+/// On the initial call (cursor_id absent or zero), set `limit` to cap total documents.
+/// On subsequent calls (cursor_id non-zero), set `batch_size` to control batch size.
+///
+class get_stream_processor_samples_options {
+   private:
+    class impl;
+    void* _impl;
+
+   public:
+    MONGOCXX_ABI_EXPORT_CDECL() ~get_stream_processor_samples_options();
+    MONGOCXX_ABI_EXPORT_CDECL() get_stream_processor_samples_options(get_stream_processor_samples_options&&) noexcept;
+    MONGOCXX_ABI_EXPORT_CDECL(get_stream_processor_samples_options&)
+    operator=(get_stream_processor_samples_options&&) noexcept;
+    MONGOCXX_ABI_EXPORT_CDECL() get_stream_processor_samples_options(get_stream_processor_samples_options const&);
+    MONGOCXX_ABI_EXPORT_CDECL(get_stream_processor_samples_options&)
+    operator=(get_stream_processor_samples_options const&);
+    MONGOCXX_ABI_EXPORT_CDECL() get_stream_processor_samples_options();
+
+    ///
+    /// The cursor ID from a previous call. If absent or zero, opens a new sample cursor.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(get_stream_processor_samples_options&) cursor_id(std::int64_t v);
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<std::int64_t>) cursor_id() const;
+
+    ///
+    /// Maximum documents to sample. Only sent on the initial call (cursor_id absent or zero).
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(get_stream_processor_samples_options&) limit(std::int32_t v);
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<std::int32_t>) limit() const;
+
+    ///
+    /// Documents per batch. Only sent on subsequent calls (cursor_id non-zero).
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(get_stream_processor_samples_options&) batch_size(std::int32_t v);
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<std::int32_t>) batch_size() const;
+
+    class internal;
+};
+
+} // namespace v1
+} // namespace mongocxx
+
+#include <mongocxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref mongocxx::v1::get_stream_processor_samples_options.
+///

--- a/src/mongocxx/include/mongocxx/v1/get_stream_processor_samples_result-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v1/get_stream_processor_samples_result-fwd.hpp
@@ -1,0 +1,32 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/detail/prelude.hpp>
+
+namespace mongocxx {
+namespace v1 {
+
+class get_stream_processor_samples_result;
+
+} // namespace v1
+} // namespace mongocxx
+
+#include <mongocxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref mongocxx::v1::get_stream_processor_samples_result.
+///

--- a/src/mongocxx/include/mongocxx/v1/get_stream_processor_samples_result.hpp
+++ b/src/mongocxx/include/mongocxx/v1/get_stream_processor_samples_result.hpp
@@ -1,0 +1,79 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/get_stream_processor_samples_result-fwd.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/v1/detail/prelude.hpp>
+
+#include <bsoncxx/v1/document/value.hpp>
+
+#include <mongocxx/v1/config/export.hpp>
+
+#include <cstdint>
+#include <vector>
+
+namespace mongocxx {
+namespace v1 {
+
+///
+/// Result of get_stream_processor_samples().
+///
+/// Callers MUST check cursor_id: a value of 0 means the cursor is exhausted and no further calls
+/// should be made.
+///
+class get_stream_processor_samples_result {
+   public:
+    ///
+    /// Construct with cursor ID and sampled documents.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL()
+    get_stream_processor_samples_result(std::int64_t cursor_id, std::vector<bsoncxx::v1::document::value> documents);
+
+    MONGOCXX_ABI_EXPORT_CDECL() get_stream_processor_samples_result(get_stream_processor_samples_result&&) noexcept;
+    MONGOCXX_ABI_EXPORT_CDECL(get_stream_processor_samples_result&)
+    operator=(get_stream_processor_samples_result&&) noexcept;
+
+    get_stream_processor_samples_result(get_stream_processor_samples_result const&) = delete;
+    get_stream_processor_samples_result& operator=(get_stream_processor_samples_result const&) = delete;
+
+    MONGOCXX_ABI_EXPORT_CDECL() ~get_stream_processor_samples_result();
+
+    ///
+    /// The cursor ID for the next call. Zero means the cursor is exhausted.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(std::int64_t) cursor_id() const noexcept;
+
+    ///
+    /// The sampled documents returned by this call.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(std::vector<bsoncxx::v1::document::value> const&) documents() const noexcept;
+
+   private:
+    std::int64_t _cursor_id;
+    std::vector<bsoncxx::v1::document::value> _documents;
+};
+
+} // namespace v1
+} // namespace mongocxx
+
+#include <mongocxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref mongocxx::v1::get_stream_processor_samples_result.
+///

--- a/src/mongocxx/include/mongocxx/v1/get_stream_processor_stats_options-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v1/get_stream_processor_stats_options-fwd.hpp
@@ -1,0 +1,32 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/detail/prelude.hpp>
+
+namespace mongocxx {
+namespace v1 {
+
+class get_stream_processor_stats_options;
+
+} // namespace v1
+} // namespace mongocxx
+
+#include <mongocxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref mongocxx::v1::get_stream_processor_stats_options.
+///

--- a/src/mongocxx/include/mongocxx/v1/get_stream_processor_stats_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/get_stream_processor_stats_options.hpp
@@ -1,0 +1,65 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/get_stream_processor_stats_options-fwd.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/v1/detail/prelude.hpp>
+
+#include <bsoncxx/v1/stdx/optional.hpp>
+
+#include <mongocxx/v1/config/export.hpp>
+
+namespace mongocxx {
+namespace v1 {
+
+///
+/// Options for the getStreamProcessorStats command.
+///
+class get_stream_processor_stats_options {
+   private:
+    class impl;
+    void* _impl;
+
+   public:
+    MONGOCXX_ABI_EXPORT_CDECL() ~get_stream_processor_stats_options();
+    MONGOCXX_ABI_EXPORT_CDECL() get_stream_processor_stats_options(get_stream_processor_stats_options&&) noexcept;
+    MONGOCXX_ABI_EXPORT_CDECL(get_stream_processor_stats_options&)
+    operator=(get_stream_processor_stats_options&&) noexcept;
+    MONGOCXX_ABI_EXPORT_CDECL() get_stream_processor_stats_options(get_stream_processor_stats_options const&);
+    MONGOCXX_ABI_EXPORT_CDECL(get_stream_processor_stats_options&)
+    operator=(get_stream_processor_stats_options const&);
+    MONGOCXX_ABI_EXPORT_CDECL() get_stream_processor_stats_options();
+
+    ///
+    /// If true, includes per-operator statistics in the response.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(get_stream_processor_stats_options&) verbose(bool v);
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bool>) verbose() const;
+
+    class internal;
+};
+
+} // namespace v1
+} // namespace mongocxx
+
+#include <mongocxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref mongocxx::v1::get_stream_processor_stats_options.
+///

--- a/src/mongocxx/include/mongocxx/v1/start_stream_processor_options-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v1/start_stream_processor_options-fwd.hpp
@@ -1,0 +1,32 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/detail/prelude.hpp>
+
+namespace mongocxx {
+namespace v1 {
+
+class start_stream_processor_options;
+
+} // namespace v1
+} // namespace mongocxx
+
+#include <mongocxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref mongocxx::v1::start_stream_processor_options.
+///

--- a/src/mongocxx/include/mongocxx/v1/start_stream_processor_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/start_stream_processor_options.hpp
@@ -1,0 +1,109 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/start_stream_processor_options-fwd.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/v1/detail/prelude.hpp>
+
+#include <bsoncxx/v1/document/value-fwd.hpp>
+#include <bsoncxx/v1/document/view-fwd.hpp>
+
+#include <mongocxx/v1/failover_options-fwd.hpp>
+
+#include <bsoncxx/v1/stdx/optional.hpp>
+#include <bsoncxx/v1/stdx/string_view.hpp>
+#include <bsoncxx/v1/types/view.hpp>
+
+#include <mongocxx/v1/config/export.hpp>
+#include <mongocxx/v1/failover_options.hpp> // IWYU pragma: export
+
+#include <cstdint>
+#include <string>
+
+namespace mongocxx {
+namespace v1 {
+
+///
+/// Options for the startStreamProcessor command.
+///
+class start_stream_processor_options {
+   private:
+    class impl;
+    void* _impl;
+
+   public:
+    MONGOCXX_ABI_EXPORT_CDECL() ~start_stream_processor_options();
+    MONGOCXX_ABI_EXPORT_CDECL() start_stream_processor_options(start_stream_processor_options&&) noexcept;
+    MONGOCXX_ABI_EXPORT_CDECL(start_stream_processor_options&) operator=(start_stream_processor_options&&) noexcept;
+    MONGOCXX_ABI_EXPORT_CDECL() start_stream_processor_options(start_stream_processor_options const&);
+    MONGOCXX_ABI_EXPORT_CDECL(start_stream_processor_options&) operator=(start_stream_processor_options const&);
+    MONGOCXX_ABI_EXPORT_CDECL() start_stream_processor_options();
+
+    ///
+    /// Number of workers.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(start_stream_processor_options&) workers(std::int32_t v);
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<std::int32_t>) workers() const;
+
+    ///
+    /// If true, clears checkpoints before starting.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(start_stream_processor_options&) clear_checkpoints(bool v);
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bool>) clear_checkpoints() const;
+
+    ///
+    /// Resume from a specific operation time.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(start_stream_processor_options&) start_at_operation_time(
+        bsoncxx::v1::types::b_timestamp v);
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bsoncxx::v1::types::b_timestamp>) start_at_operation_time()
+        const;
+
+    ///
+    /// Compute tier. Valid values: "SP2", "SP5", "SP10", "SP30", "SP50".
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(start_stream_processor_options&) tier(std::string v);
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bsoncxx::v1::stdx::string_view>) tier() const;
+
+    ///
+    /// Enable auto-scaling.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(start_stream_processor_options&) enable_auto_scaling(bool v);
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bool>) enable_auto_scaling() const;
+
+    ///
+    /// Failover options. When set, the failover field is included in the command.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(start_stream_processor_options&) failover(v1::failover_options v);
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<v1::failover_options>) failover() const;
+
+    class internal;
+};
+
+} // namespace v1
+} // namespace mongocxx
+
+#include <mongocxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref mongocxx::v1::start_stream_processor_options.
+///
+/// @par Includes
+/// - @ref mongocxx/v1/failover_options.hpp
+///

--- a/src/mongocxx/include/mongocxx/v1/stream_processing_client-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v1/stream_processing_client-fwd.hpp
@@ -1,0 +1,32 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/detail/prelude.hpp>
+
+namespace mongocxx {
+namespace v1 {
+
+class stream_processing_client;
+
+} // namespace v1
+} // namespace mongocxx
+
+#include <mongocxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref mongocxx::v1::stream_processing_client.
+///

--- a/src/mongocxx/include/mongocxx/v1/stream_processing_client.hpp
+++ b/src/mongocxx/include/mongocxx/v1/stream_processing_client.hpp
@@ -1,0 +1,84 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/stream_processing_client-fwd.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/v1/detail/prelude.hpp>
+
+#include <mongocxx/v1/stream_processors-fwd.hpp>
+
+#include <mongocxx/v1/client.hpp>
+#include <mongocxx/v1/config/export.hpp>
+#include <mongocxx/v1/stream_processors.hpp> // IWYU pragma: export
+#include <mongocxx/v1/uri.hpp>
+
+namespace mongocxx {
+namespace v1 {
+
+///
+/// A client connected to an Atlas Stream Processing workspace.
+///
+/// TLS is required for all workspace connections. If the URI hostname matches the
+/// atlas-stream-* pattern and TLS is not explicitly enabled in the URI, TLS is silently
+/// enabled. authSource defaults to "admin"; specifying any other authSource throws an exception.
+///
+class stream_processing_client {
+   private:
+    class impl;
+    void* _impl;
+
+   public:
+    MONGOCXX_ABI_EXPORT_CDECL() ~stream_processing_client();
+    MONGOCXX_ABI_EXPORT_CDECL() stream_processing_client(stream_processing_client&&) noexcept;
+    MONGOCXX_ABI_EXPORT_CDECL(stream_processing_client&) operator=(stream_processing_client&&) noexcept;
+
+    stream_processing_client(stream_processing_client const&) = delete;
+    stream_processing_client& operator=(stream_processing_client const&) = delete;
+
+    ///
+    /// Constructs a client connected to the given URI.
+    ///
+    /// @throws mongocxx::v1::exception if the URI specifies authSource other than "admin".
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL() explicit stream_processing_client(v1::uri uri);
+
+    ///
+    /// Constructs a client connected to the given URI with additional client options.
+    ///
+    /// @throws mongocxx::v1::exception if the URI specifies authSource other than "admin".
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL() stream_processing_client(v1::uri uri, v1::client::options const& options);
+
+    ///
+    /// Returns a handle for managing stream processors in this workspace.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(v1::stream_processors) stream_processors();
+};
+
+} // namespace v1
+} // namespace mongocxx
+
+#include <mongocxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref mongocxx::v1::stream_processing_client.
+///
+/// @par Includes
+/// - @ref mongocxx/v1/stream_processors.hpp
+///

--- a/src/mongocxx/include/mongocxx/v1/stream_processor-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v1/stream_processor-fwd.hpp
@@ -1,0 +1,32 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/detail/prelude.hpp>
+
+namespace mongocxx {
+namespace v1 {
+
+class stream_processor;
+
+} // namespace v1
+} // namespace mongocxx
+
+#include <mongocxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref mongocxx::v1::stream_processor.
+///

--- a/src/mongocxx/include/mongocxx/v1/stream_processor.hpp
+++ b/src/mongocxx/include/mongocxx/v1/stream_processor.hpp
@@ -1,0 +1,119 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/stream_processor-fwd.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/v1/detail/prelude.hpp>
+
+#include <mongocxx/v1/get_stream_processor_samples_options-fwd.hpp>
+#include <mongocxx/v1/get_stream_processor_samples_result-fwd.hpp>
+#include <mongocxx/v1/get_stream_processor_stats_options-fwd.hpp>
+#include <mongocxx/v1/start_stream_processor_options-fwd.hpp>
+
+#include <bsoncxx/v1/document/value.hpp>
+#include <bsoncxx/v1/stdx/string_view.hpp>
+
+#include <mongocxx/v1/config/export.hpp>
+#include <mongocxx/v1/get_stream_processor_samples_options.hpp> // IWYU pragma: export
+#include <mongocxx/v1/get_stream_processor_samples_result.hpp>  // IWYU pragma: export
+#include <mongocxx/v1/get_stream_processor_stats_options.hpp>   // IWYU pragma: export
+#include <mongocxx/v1/start_stream_processor_options.hpp>       // IWYU pragma: export
+
+#include <string>
+
+namespace mongocxx {
+namespace v1 {
+
+///
+/// A handle for a specific named stream processor.
+///
+/// Does not imply the processor currently exists on the server. All methods
+/// send commands to the admin database of the associated workspace.
+///
+class stream_processor {
+   private:
+    stream_processor() = default;
+
+    class impl;
+    void* _impl{nullptr};
+
+   public:
+    MONGOCXX_ABI_EXPORT_CDECL() ~stream_processor();
+    MONGOCXX_ABI_EXPORT_CDECL() stream_processor(stream_processor&&) noexcept;
+    MONGOCXX_ABI_EXPORT_CDECL(stream_processor&) operator=(stream_processor&&) noexcept;
+
+    stream_processor(stream_processor const&) = delete;
+    stream_processor& operator=(stream_processor const&) = delete;
+
+    class internal;
+
+    ///
+    /// Returns the processor name.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::string_view) name() const;
+
+    ///
+    /// Starts the processor. Sends startStreamProcessor.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(void) start(v1::start_stream_processor_options const& options = {});
+
+    ///
+    /// Stops the processor. Sends stopStreamProcessor.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(void) stop();
+
+    ///
+    /// Permanently deletes the processor. Sends dropStreamProcessor.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(void) drop();
+
+    ///
+    /// Returns runtime statistics. Sends getStreamProcessorStats.
+    /// Returns an error if the processor is not in the STARTED state.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::document::value)
+    stats(v1::get_stream_processor_stats_options const& options = {});
+
+    ///
+    /// Retrieves a batch of sampled documents from a running stream processor.
+    ///
+    /// On the initial call (cursor_id absent or zero in options), sends startSampleStreamProcessor
+    /// followed immediately by getMoreSampleStreamProcessor to return the first batch.
+    /// On subsequent calls (cursor_id non-zero), sends getMoreSampleStreamProcessor directly.
+    ///
+    /// Check the returned cursor_id: zero means the cursor is exhausted.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(v1::get_stream_processor_samples_result)
+    get_stream_processor_samples(v1::get_stream_processor_samples_options const& options = {});
+};
+
+} // namespace v1
+} // namespace mongocxx
+
+#include <mongocxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref mongocxx::v1::stream_processor.
+///
+/// @par Includes
+/// - @ref mongocxx/v1/start_stream_processor_options.hpp
+/// - @ref mongocxx/v1/get_stream_processor_stats_options.hpp
+/// - @ref mongocxx/v1/get_stream_processor_samples_options.hpp
+/// - @ref mongocxx/v1/get_stream_processor_samples_result.hpp
+///

--- a/src/mongocxx/include/mongocxx/v1/stream_processor_info-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v1/stream_processor_info-fwd.hpp
@@ -1,0 +1,32 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/detail/prelude.hpp>
+
+namespace mongocxx {
+namespace v1 {
+
+class stream_processor_info;
+
+} // namespace v1
+} // namespace mongocxx
+
+#include <mongocxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref mongocxx::v1::stream_processor_info.
+///

--- a/src/mongocxx/include/mongocxx/v1/stream_processor_info.hpp
+++ b/src/mongocxx/include/mongocxx/v1/stream_processor_info.hpp
@@ -1,0 +1,101 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/stream_processor_info-fwd.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/v1/detail/prelude.hpp>
+
+#include <bsoncxx/v1/array/value-fwd.hpp>
+#include <bsoncxx/v1/array/view-fwd.hpp>
+#include <bsoncxx/v1/document/value-fwd.hpp>
+#include <bsoncxx/v1/document/view-fwd.hpp>
+
+#include <bsoncxx/v1/array/value.hpp>
+#include <bsoncxx/v1/document/value.hpp>
+#include <bsoncxx/v1/stdx/optional.hpp>
+#include <bsoncxx/v1/stdx/string_view.hpp>
+
+#include <mongocxx/v1/config/export.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace mongocxx {
+namespace v1 {
+
+///
+/// Information about a stream processor returned by getStreamProcessor.
+///
+class stream_processor_info {
+   private:
+    class impl;
+    void* _impl;
+
+   public:
+    MONGOCXX_ABI_EXPORT_CDECL() ~stream_processor_info();
+    MONGOCXX_ABI_EXPORT_CDECL() stream_processor_info(stream_processor_info&&) noexcept;
+    MONGOCXX_ABI_EXPORT_CDECL(stream_processor_info&) operator=(stream_processor_info&&) noexcept;
+    MONGOCXX_ABI_EXPORT_CDECL() stream_processor_info(stream_processor_info const&);
+    MONGOCXX_ABI_EXPORT_CDECL(stream_processor_info&) operator=(stream_processor_info const&);
+
+    ///
+    /// Construct from a getStreamProcessor command response document.
+    /// Unknown fields in the document are silently ignored.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL() explicit stream_processor_info(bsoncxx::v1::document::view doc);
+
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::string_view) id() const;
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::string_view) name() const;
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::string_view) state() const;
+
+    ///
+    /// The processor pipeline as an array of documents.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::array::view) pipeline() const;
+
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<std::int32_t>) pipeline_version() const;
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bsoncxx::v1::stdx::string_view>) tier() const;
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view>) dlq() const;
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<bsoncxx::v1::stdx::string_view>) stream_meta_field_name()
+        const;
+    MONGOCXX_ABI_EXPORT_CDECL(bool) enable_auto_scaling() const;
+    MONGOCXX_ABI_EXPORT_CDECL(bool) failover_enabled() const;
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::string_view) active_region() const;
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::string_view) workspace_default_region() const;
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<std::chrono::system_clock::time_point>) last_state_change()
+        const;
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<std::chrono::system_clock::time_point>) last_modified_at()
+        const;
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::string_view) modified_by() const;
+    MONGOCXX_ABI_EXPORT_CDECL(bool) has_started() const;
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::string_view) error_msg() const;
+    MONGOCXX_ABI_EXPORT_CDECL(bool) error_retryable() const;
+    MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<std::int32_t>) error_code() const;
+};
+
+} // namespace v1
+} // namespace mongocxx
+
+#include <mongocxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref mongocxx::v1::stream_processor_info.
+///

--- a/src/mongocxx/include/mongocxx/v1/stream_processors-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v1/stream_processors-fwd.hpp
@@ -1,0 +1,32 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/detail/prelude.hpp>
+
+namespace mongocxx {
+namespace v1 {
+
+class stream_processors;
+
+} // namespace v1
+} // namespace mongocxx
+
+#include <mongocxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref mongocxx::v1::stream_processors.
+///

--- a/src/mongocxx/include/mongocxx/v1/stream_processors.hpp
+++ b/src/mongocxx/include/mongocxx/v1/stream_processors.hpp
@@ -1,0 +1,97 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/stream_processors-fwd.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/v1/detail/prelude.hpp>
+
+#include <mongocxx/v1/create_stream_processor_options-fwd.hpp>
+#include <mongocxx/v1/stream_processor-fwd.hpp>
+#include <mongocxx/v1/stream_processor_info-fwd.hpp>
+
+#include <bsoncxx/v1/array/view.hpp>
+#include <bsoncxx/v1/stdx/string_view.hpp>
+
+#include <mongocxx/v1/config/export.hpp>
+#include <mongocxx/v1/create_stream_processor_options.hpp> // IWYU pragma: export
+#include <mongocxx/v1/stream_processor.hpp>                // IWYU pragma: export
+#include <mongocxx/v1/stream_processor_info.hpp>           // IWYU pragma: export
+
+#include <string>
+
+namespace mongocxx {
+namespace v1 {
+
+///
+/// A handle for managing stream processors in a stream processing workspace.
+///
+/// Obtained via stream_processing_client::stream_processors().
+/// The caller must ensure the associated stream_processing_client outlives this handle.
+///
+class stream_processors {
+   private:
+    stream_processors() = default;
+
+    class impl;
+    void* _impl{nullptr};
+
+   public:
+    MONGOCXX_ABI_EXPORT_CDECL() ~stream_processors();
+    MONGOCXX_ABI_EXPORT_CDECL() stream_processors(stream_processors&&) noexcept;
+    MONGOCXX_ABI_EXPORT_CDECL(stream_processors&) operator=(stream_processors&&) noexcept;
+
+    stream_processors(stream_processors const&) = delete;
+    stream_processors& operator=(stream_processors const&) = delete;
+
+    ///
+    /// Creates a new stream processor. Sends createStreamProcessor.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(void)
+    create(
+        std::string name,
+        bsoncxx::v1::array::view pipeline,
+        v1::create_stream_processor_options const& options = {});
+
+    ///
+    /// Returns a handle for an existing stream processor by name.
+    /// No network call is made.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(v1::stream_processor) get(std::string name);
+
+    ///
+    /// Returns information about a stream processor. Sends getStreamProcessor.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL(v1::stream_processor_info) get_info(std::string const& name);
+
+    class internal;
+};
+
+} // namespace v1
+} // namespace mongocxx
+
+#include <mongocxx/v1/detail/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref mongocxx::v1::stream_processors.
+///
+/// @par Includes
+/// - @ref mongocxx/v1/stream_processor.hpp
+/// - @ref mongocxx/v1/stream_processor_info.hpp
+/// - @ref mongocxx/v1/create_stream_processor_options.hpp
+///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/create_stream_processor-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/create_stream_processor-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+namespace v_noabi {
+namespace options {
+
+class create_stream_processor;
+
+} // namespace options
+} // namespace v_noabi
+} // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/create_stream_processor.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/create_stream_processor.hpp
@@ -1,0 +1,99 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/options/create_stream_processor-fwd.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/v1/create_stream_processor_options.hpp> // IWYU pragma: export
+
+#include <bsoncxx/document/view_or_value.hpp>
+#include <bsoncxx/stdx/optional.hpp>
+#include <bsoncxx/string/view_or_value.hpp>
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+namespace v_noabi {
+namespace options {
+
+///
+/// Options for creating a stream processor.
+///
+class create_stream_processor {
+   public:
+    create_stream_processor() = default;
+
+    /* explicit(false) */ create_stream_processor(v1::create_stream_processor_options opts)
+        : _opts{std::move(opts)} {}
+
+    explicit operator v1::create_stream_processor_options() const {
+        return _opts;
+    }
+
+    create_stream_processor& dlq(bsoncxx::v_noabi::document::view_or_value v) {
+        _opts.dlq(bsoncxx::v1::document::value{v.view()});
+        return *this;
+    }
+
+    bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> dlq() const {
+        return _opts.dlq();
+    }
+
+    create_stream_processor& stream_meta_field_name(bsoncxx::v_noabi::string::view_or_value v) {
+        _opts.stream_meta_field_name(std::string{v.view()});
+        return *this;
+    }
+
+    bsoncxx::v1::stdx::optional<bsoncxx::v1::stdx::string_view> stream_meta_field_name() const {
+        return _opts.stream_meta_field_name();
+    }
+
+    create_stream_processor& tier(bsoncxx::v_noabi::string::view_or_value v) {
+        _opts.tier(std::string{v.view()});
+        return *this;
+    }
+
+    bsoncxx::v1::stdx::optional<bsoncxx::v1::stdx::string_view> tier() const {
+        return _opts.tier();
+    }
+
+    create_stream_processor& failover(bool v) {
+        _opts.failover(v);
+        return *this;
+    }
+
+    bsoncxx::v1::stdx::optional<bool> failover() const {
+        return _opts.failover();
+    }
+
+   private:
+    v1::create_stream_processor_options _opts;
+};
+
+} // namespace options
+} // namespace v_noabi
+} // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref mongocxx::v_noabi::options::create_stream_processor.
+///
+/// @par Includes
+/// - @ref mongocxx/v1/create_stream_processor_options.hpp
+///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/get_stream_processor_samples-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/get_stream_processor_samples-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+namespace v_noabi {
+namespace options {
+
+class get_stream_processor_samples;
+
+} // namespace options
+} // namespace v_noabi
+} // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/get_stream_processor_samples.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/get_stream_processor_samples.hpp
@@ -1,0 +1,87 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/options/get_stream_processor_samples-fwd.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/v1/get_stream_processor_samples_options.hpp> // IWYU pragma: export
+
+#include <bsoncxx/stdx/optional.hpp>
+
+#include <mongocxx/config/prelude.hpp>
+
+#include <cstdint>
+
+namespace mongocxx {
+namespace v_noabi {
+namespace options {
+
+///
+/// Options for get_stream_processor_samples().
+///
+class get_stream_processor_samples {
+   public:
+    get_stream_processor_samples() = default;
+
+    /* explicit(false) */ get_stream_processor_samples(v1::get_stream_processor_samples_options opts)
+        : _opts{std::move(opts)} {}
+
+    explicit operator v1::get_stream_processor_samples_options() const {
+        return _opts;
+    }
+
+    get_stream_processor_samples& cursor_id(std::int64_t v) {
+        _opts.cursor_id(v);
+        return *this;
+    }
+    bsoncxx::v1::stdx::optional<std::int64_t> cursor_id() const {
+        return _opts.cursor_id();
+    }
+
+    get_stream_processor_samples& limit(std::int32_t v) {
+        _opts.limit(v);
+        return *this;
+    }
+    bsoncxx::v1::stdx::optional<std::int32_t> limit() const {
+        return _opts.limit();
+    }
+
+    get_stream_processor_samples& batch_size(std::int32_t v) {
+        _opts.batch_size(v);
+        return *this;
+    }
+    bsoncxx::v1::stdx::optional<std::int32_t> batch_size() const {
+        return _opts.batch_size();
+    }
+
+   private:
+    v1::get_stream_processor_samples_options _opts;
+};
+
+} // namespace options
+} // namespace v_noabi
+} // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref mongocxx::v_noabi::options::get_stream_processor_samples.
+///
+/// @par Includes
+/// - @ref mongocxx/v1/get_stream_processor_samples_options.hpp
+///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/get_stream_processor_stats-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/get_stream_processor_stats-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+namespace v_noabi {
+namespace options {
+
+class get_stream_processor_stats;
+
+} // namespace options
+} // namespace v_noabi
+} // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/get_stream_processor_stats.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/get_stream_processor_stats.hpp
@@ -1,0 +1,70 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/options/get_stream_processor_stats-fwd.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/v1/get_stream_processor_stats_options.hpp> // IWYU pragma: export
+
+#include <bsoncxx/stdx/optional.hpp>
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+namespace v_noabi {
+namespace options {
+
+///
+/// Options for retrieving stream processor statistics.
+///
+class get_stream_processor_stats {
+   public:
+    get_stream_processor_stats() = default;
+
+    /* explicit(false) */ get_stream_processor_stats(v1::get_stream_processor_stats_options opts)
+        : _opts{std::move(opts)} {}
+
+    explicit operator v1::get_stream_processor_stats_options() const {
+        return _opts;
+    }
+
+    get_stream_processor_stats& verbose(bool v) {
+        _opts.verbose(v);
+        return *this;
+    }
+
+    bsoncxx::v1::stdx::optional<bool> verbose() const {
+        return _opts.verbose();
+    }
+
+   private:
+    v1::get_stream_processor_stats_options _opts;
+};
+
+} // namespace options
+} // namespace v_noabi
+} // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref mongocxx::v_noabi::options::get_stream_processor_stats.
+///
+/// @par Includes
+/// - @ref mongocxx/v1/get_stream_processor_stats_options.hpp
+///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/start_stream_processor-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/start_stream_processor-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+namespace v_noabi {
+namespace options {
+
+class start_stream_processor;
+
+} // namespace options
+} // namespace v_noabi
+} // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/start_stream_processor.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/options/start_stream_processor.hpp
@@ -1,0 +1,111 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/options/start_stream_processor-fwd.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/v1/start_stream_processor_options.hpp> // IWYU pragma: export
+
+#include <bsoncxx/stdx/optional.hpp>
+#include <bsoncxx/string/view_or_value.hpp>
+#include <bsoncxx/v1/types/view.hpp>
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+namespace v_noabi {
+namespace options {
+
+///
+/// Options for starting a stream processor.
+///
+class start_stream_processor {
+   public:
+    start_stream_processor() = default;
+
+    /* explicit(false) */ start_stream_processor(v1::start_stream_processor_options opts)
+        : _opts{std::move(opts)} {}
+
+    explicit operator v1::start_stream_processor_options() const {
+        return _opts;
+    }
+
+    start_stream_processor& workers(std::int32_t v) {
+        _opts.workers(v);
+        return *this;
+    }
+    bsoncxx::v1::stdx::optional<std::int32_t> workers() const {
+        return _opts.workers();
+    }
+
+    start_stream_processor& clear_checkpoints(bool v) {
+        _opts.clear_checkpoints(v);
+        return *this;
+    }
+    bsoncxx::v1::stdx::optional<bool> clear_checkpoints() const {
+        return _opts.clear_checkpoints();
+    }
+
+    start_stream_processor& start_at_operation_time(bsoncxx::v1::types::b_timestamp v) {
+        _opts.start_at_operation_time(v);
+        return *this;
+    }
+    bsoncxx::v1::stdx::optional<bsoncxx::v1::types::b_timestamp> start_at_operation_time() const {
+        return _opts.start_at_operation_time();
+    }
+
+    start_stream_processor& tier(bsoncxx::v_noabi::string::view_or_value v) {
+        _opts.tier(std::string{v.view()});
+        return *this;
+    }
+    bsoncxx::v1::stdx::optional<bsoncxx::v1::stdx::string_view> tier() const {
+        return _opts.tier();
+    }
+
+    start_stream_processor& enable_auto_scaling(bool v) {
+        _opts.enable_auto_scaling(v);
+        return *this;
+    }
+    bsoncxx::v1::stdx::optional<bool> enable_auto_scaling() const {
+        return _opts.enable_auto_scaling();
+    }
+
+    start_stream_processor& failover(v1::failover_options v) {
+        _opts.failover(std::move(v));
+        return *this;
+    }
+    bsoncxx::v1::stdx::optional<v1::failover_options> failover() const {
+        return _opts.failover();
+    }
+
+   private:
+    v1::start_stream_processor_options _opts;
+};
+
+} // namespace options
+} // namespace v_noabi
+} // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref mongocxx::v_noabi::options::start_stream_processor.
+///
+/// @par Includes
+/// - @ref mongocxx/v1/start_stream_processor_options.hpp
+///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/get_stream_processor_samples-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/get_stream_processor_samples-fwd.hpp
@@ -1,0 +1,29 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+namespace v_noabi {
+namespace result {
+
+class get_stream_processor_samples;
+
+} // namespace result
+} // namespace v_noabi
+} // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/get_stream_processor_samples.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/get_stream_processor_samples.hpp
@@ -1,0 +1,75 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/result/get_stream_processor_samples-fwd.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/v1/get_stream_processor_samples_result.hpp> // IWYU pragma: export
+
+#include <bsoncxx/document/value.hpp>
+
+#include <mongocxx/config/prelude.hpp>
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace mongocxx {
+namespace v_noabi {
+namespace result {
+
+///
+/// Result of get_stream_processor_samples().
+///
+class get_stream_processor_samples {
+   public:
+    /* explicit(false) */ get_stream_processor_samples(v1::get_stream_processor_samples_result res)
+        : _result{std::move(res)} {}
+
+    explicit operator v1::get_stream_processor_samples_result() && {
+        return std::move(_result);
+    }
+
+    std::int64_t cursor_id() const noexcept {
+        return _result.cursor_id();
+    }
+
+    std::vector<bsoncxx::v1::document::value> const& documents() const noexcept {
+        return _result.documents();
+    }
+
+   private:
+    v1::get_stream_processor_samples_result _result;
+};
+
+inline v_noabi::result::get_stream_processor_samples from_v1(v1::get_stream_processor_samples_result v) {
+    return {std::move(v)};
+}
+
+} // namespace result
+} // namespace v_noabi
+} // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref mongocxx::v_noabi::result::get_stream_processor_samples.
+///
+/// @par Includes
+/// - @ref mongocxx/v1/get_stream_processor_samples_result.hpp
+///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stream_processing_client-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stream_processing_client-fwd.hpp
@@ -1,0 +1,34 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/stream_processing_client-fwd.hpp>
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+namespace v_noabi {
+
+class stream_processing_client;
+
+} // namespace v_noabi
+} // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref mongocxx::v_noabi::stream_processing_client.
+///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stream_processing_client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stream_processing_client.hpp
@@ -1,0 +1,86 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/stream_processing_client-fwd.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/v1/stream_processing_client.hpp> // IWYU pragma: export
+
+#include <mongocxx/stream_processors.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <mongocxx/config/prelude.hpp>
+
+#include <utility>
+
+namespace mongocxx {
+namespace v_noabi {
+
+///
+/// A client connected to an Atlas Stream Processing workspace.
+///
+/// TLS is silently enabled for atlas-stream-* hosts if not already set.
+/// authSource defaults to "admin"; specifying another authSource throws.
+///
+class stream_processing_client {
+   public:
+    /* explicit(false) */ stream_processing_client(v1::stream_processing_client client)
+        : _client{std::move(client)} {}
+
+    explicit operator v1::stream_processing_client() && {
+        return std::move(_client);
+    }
+
+    ///
+    /// Constructs a client for the given workspace URI.
+    ///
+    explicit stream_processing_client(v_noabi::uri const& uri)
+        : _client{v1::stream_processing_client{v1::uri{uri.to_string()}}} {}
+
+    ///
+    /// Constructs a client with the given workspace URI and client options.
+    ///
+    stream_processing_client(v_noabi::uri const& uri, v_noabi::options::client const& options)
+        : _client{v1::stream_processing_client{v1::uri{uri.to_string()}, v1::client::options{options}}} {}
+
+    ///
+    /// Returns a handle for managing stream processors in this workspace.
+    ///
+    v_noabi::stream_processors stream_processors() {
+        return from_v1(_client.stream_processors());
+    }
+
+   private:
+    v1::stream_processing_client _client;
+};
+
+inline v_noabi::stream_processing_client from_v1(v1::stream_processing_client v) {
+    return {std::move(v)};
+}
+
+} // namespace v_noabi
+} // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref mongocxx::v_noabi::stream_processing_client.
+///
+/// @par Includes
+/// - @ref mongocxx/v1/stream_processing_client.hpp
+///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stream_processor-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stream_processor-fwd.hpp
@@ -1,0 +1,34 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/stream_processor-fwd.hpp>
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+namespace v_noabi {
+
+class stream_processor;
+
+} // namespace v_noabi
+} // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref mongocxx::v_noabi::stream_processor.
+///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stream_processor.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stream_processor.hpp
@@ -1,0 +1,93 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/stream_processor-fwd.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/v1/stream_processor.hpp> // IWYU pragma: export
+
+#include <bsoncxx/document/value.hpp>
+#include <bsoncxx/stdx/string_view.hpp>
+
+#include <mongocxx/options/get_stream_processor_samples.hpp>
+#include <mongocxx/options/get_stream_processor_stats.hpp>
+#include <mongocxx/options/start_stream_processor.hpp>
+#include <mongocxx/result/get_stream_processor_samples.hpp>
+
+#include <mongocxx/config/prelude.hpp>
+
+#include <utility>
+
+namespace mongocxx {
+namespace v_noabi {
+
+///
+/// A handle for a specific named stream processor.
+///
+class stream_processor {
+   public:
+    /* explicit(false) */ stream_processor(v1::stream_processor proc) : _proc{std::move(proc)} {}
+
+    explicit operator v1::stream_processor() && {
+        return std::move(_proc);
+    }
+
+    bsoncxx::v1::stdx::string_view name() const {
+        return _proc.name();
+    }
+
+    void start(v_noabi::options::start_stream_processor const& options = {}) {
+        _proc.start(v1::start_stream_processor_options{options});
+    }
+
+    void stop() {
+        _proc.stop();
+    }
+
+    void drop() {
+        _proc.drop();
+    }
+
+    bsoncxx::v1::document::value stats(v_noabi::options::get_stream_processor_stats const& options = {}) {
+        return _proc.stats(v1::get_stream_processor_stats_options{options});
+    }
+
+    v_noabi::result::get_stream_processor_samples get_stream_processor_samples(
+        v_noabi::options::get_stream_processor_samples const& options = {}) {
+        return from_v1(_proc.get_stream_processor_samples(v1::get_stream_processor_samples_options{options}));
+    }
+
+   private:
+    v1::stream_processor _proc;
+};
+
+inline v_noabi::stream_processor from_v1(v1::stream_processor v) {
+    return {std::move(v)};
+}
+
+} // namespace v_noabi
+} // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref mongocxx::v_noabi::stream_processor.
+///
+/// @par Includes
+/// - @ref mongocxx/v1/stream_processor.hpp
+///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stream_processor_info-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stream_processor_info-fwd.hpp
@@ -1,0 +1,34 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/stream_processor_info-fwd.hpp>
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+namespace v_noabi {
+
+class stream_processor_info;
+
+} // namespace v_noabi
+} // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref mongocxx::v_noabi::stream_processor_info.
+///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stream_processor_info.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stream_processor_info.hpp
@@ -1,0 +1,134 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/stream_processor_info-fwd.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/v1/stream_processor_info.hpp> // IWYU pragma: export
+
+#include <bsoncxx/array/view.hpp>
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/stdx/optional.hpp>
+#include <bsoncxx/stdx/string_view.hpp>
+
+#include <mongocxx/config/prelude.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <utility>
+
+namespace mongocxx {
+namespace v_noabi {
+
+///
+/// Information about a stream processor returned by StreamProcessors::get_info().
+///
+class stream_processor_info {
+   public:
+    /* explicit(false) */ stream_processor_info(v1::stream_processor_info info)
+        : _info{std::move(info)} {}
+
+    explicit operator v1::stream_processor_info() && {
+        return std::move(_info);
+    }
+
+    explicit operator v1::stream_processor_info() const& {
+        return _info;
+    }
+
+    bsoncxx::v1::stdx::string_view id() const {
+        return _info.id();
+    }
+    bsoncxx::v1::stdx::string_view name() const {
+        return _info.name();
+    }
+    bsoncxx::v1::stdx::string_view state() const {
+        return _info.state();
+    }
+    bsoncxx::v1::array::view pipeline() const {
+        return _info.pipeline();
+    }
+    bsoncxx::v1::stdx::optional<std::int32_t> pipeline_version() const {
+        return _info.pipeline_version();
+    }
+    bsoncxx::v1::stdx::optional<bsoncxx::v1::stdx::string_view> tier() const {
+        return _info.tier();
+    }
+    bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> dlq() const {
+        return _info.dlq();
+    }
+    bsoncxx::v1::stdx::optional<bsoncxx::v1::stdx::string_view> stream_meta_field_name() const {
+        return _info.stream_meta_field_name();
+    }
+    bool enable_auto_scaling() const {
+        return _info.enable_auto_scaling();
+    }
+    bool failover_enabled() const {
+        return _info.failover_enabled();
+    }
+    bsoncxx::v1::stdx::string_view active_region() const {
+        return _info.active_region();
+    }
+    bsoncxx::v1::stdx::string_view workspace_default_region() const {
+        return _info.workspace_default_region();
+    }
+    bsoncxx::v1::stdx::optional<std::chrono::system_clock::time_point> last_state_change() const {
+        return _info.last_state_change();
+    }
+    bsoncxx::v1::stdx::optional<std::chrono::system_clock::time_point> last_modified_at() const {
+        return _info.last_modified_at();
+    }
+    bsoncxx::v1::stdx::string_view modified_by() const {
+        return _info.modified_by();
+    }
+    bool has_started() const {
+        return _info.has_started();
+    }
+    bsoncxx::v1::stdx::string_view error_msg() const {
+        return _info.error_msg();
+    }
+    bool error_retryable() const {
+        return _info.error_retryable();
+    }
+    bsoncxx::v1::stdx::optional<std::int32_t> error_code() const {
+        return _info.error_code();
+    }
+
+   private:
+    v1::stream_processor_info _info;
+};
+
+inline v_noabi::stream_processor_info from_v1(v1::stream_processor_info v) {
+    return {std::move(v)};
+}
+
+inline v1::stream_processor_info to_v1(v_noabi::stream_processor_info v) {
+    return v1::stream_processor_info{std::move(v)};
+}
+
+} // namespace v_noabi
+} // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref mongocxx::v_noabi::stream_processor_info.
+///
+/// @par Includes
+/// - @ref mongocxx/v1/stream_processor_info.hpp
+///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stream_processors-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stream_processors-fwd.hpp
@@ -1,0 +1,34 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/stream_processors-fwd.hpp>
+
+#include <mongocxx/config/prelude.hpp>
+
+namespace mongocxx {
+namespace v_noabi {
+
+class stream_processors;
+
+} // namespace v_noabi
+} // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>
+
+///
+/// @file
+/// Declares @ref mongocxx::v_noabi::stream_processors.
+///

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stream_processors.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/stream_processors.hpp
@@ -1,0 +1,81 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/stream_processors-fwd.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/v1/stream_processors.hpp> // IWYU pragma: export
+
+#include <bsoncxx/array/view.hpp>
+#include <bsoncxx/string/view_or_value.hpp>
+
+#include <mongocxx/options/create_stream_processor.hpp>
+#include <mongocxx/stream_processor.hpp>
+#include <mongocxx/stream_processor_info.hpp>
+
+#include <mongocxx/config/prelude.hpp>
+
+#include <utility>
+
+namespace mongocxx {
+namespace v_noabi {
+
+///
+/// A handle for managing stream processors in a stream processing workspace.
+///
+class stream_processors {
+   public:
+    /* explicit(false) */ stream_processors(v1::stream_processors procs) : _procs{std::move(procs)} {}
+
+    explicit operator v1::stream_processors() && {
+        return std::move(_procs);
+    }
+
+    void create(bsoncxx::v_noabi::string::view_or_value name,
+                bsoncxx::v_noabi::array::view pipeline,
+                v_noabi::options::create_stream_processor const& options = {}) {
+        _procs.create(std::string{name.view()}, pipeline, v1::create_stream_processor_options{options});
+    }
+
+    v_noabi::stream_processor get(bsoncxx::v_noabi::string::view_or_value name) {
+        return from_v1(_procs.get(std::string{name.view()}));
+    }
+
+    v_noabi::stream_processor_info get_info(bsoncxx::v_noabi::string::view_or_value name) {
+        return from_v1(_procs.get_info(std::string{name.view()}));
+    }
+
+   private:
+    v1::stream_processors _procs;
+};
+
+inline v_noabi::stream_processors from_v1(v1::stream_processors v) {
+    return {std::move(v)};
+}
+
+} // namespace v_noabi
+} // namespace mongocxx
+
+#include <mongocxx/config/postlude.hpp>
+
+///
+/// @file
+/// Provides @ref mongocxx::v_noabi::stream_processors.
+///
+/// @par Includes
+/// - @ref mongocxx/v1/stream_processors.hpp
+///

--- a/src/mongocxx/lib/CMakeLists.txt
+++ b/src/mongocxx/lib/CMakeLists.txt
@@ -133,6 +133,7 @@ set(mongocxx_sources_v1
     mongocxx/v1/config/export.cpp
     mongocxx/v1/config/version.cpp
     mongocxx/v1/count_options.cpp
+    mongocxx/v1/create_stream_processor_options.cpp
     mongocxx/v1/cursor.cpp
     mongocxx/v1/data_key_options.cpp
     mongocxx/v1/database.cpp
@@ -160,10 +161,14 @@ set(mongocxx_sources_v1
     mongocxx/v1/events/topology_description.cpp
     mongocxx/v1/events/topology_opening.cpp
     mongocxx/v1/exception.cpp
+    mongocxx/v1/failover_options.cpp
     mongocxx/v1/find_one_and_delete_options.cpp
     mongocxx/v1/find_one_and_replace_options.cpp
     mongocxx/v1/find_one_and_update_options.cpp
     mongocxx/v1/find_options.cpp
+    mongocxx/v1/get_stream_processor_samples_options.cpp
+    mongocxx/v1/get_stream_processor_samples_result.cpp
+    mongocxx/v1/get_stream_processor_stats_options.cpp
     mongocxx/v1/gridfs/bucket.cpp
     mongocxx/v1/gridfs/downloader.cpp
     mongocxx/v1/gridfs/upload_options.cpp
@@ -193,6 +198,11 @@ set(mongocxx_sources_v1
     mongocxx/v1/search_indexes.cpp
     mongocxx/v1/server_api.cpp
     mongocxx/v1/server_error.cpp
+    mongocxx/v1/start_stream_processor_options.cpp
+    mongocxx/v1/stream_processing_client.cpp
+    mongocxx/v1/stream_processor.cpp
+    mongocxx/v1/stream_processor_info.cpp
+    mongocxx/v1/stream_processors.cpp
     mongocxx/v1/text_options.cpp
     mongocxx/v1/tls.cpp
     mongocxx/v1/transaction_options.cpp

--- a/src/mongocxx/lib/mongocxx/v1/create_stream_processor_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/create_stream_processor_options.cpp
@@ -1,0 +1,156 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/v1/create_stream_processor_options.hh>
+
+//
+
+#include <bsoncxx/v1/document/value.hpp>
+#include <bsoncxx/v1/document/view.hpp>
+#include <bsoncxx/v1/stdx/optional.hpp>
+#include <bsoncxx/v1/stdx/string_view.hpp>
+
+#include <string>
+
+#include <bsoncxx/private/bson.hh>
+
+#include <mongocxx/private/scoped_bson.hh>
+#include <mongocxx/private/utility.hh>
+
+namespace mongocxx {
+namespace v1 {
+
+class create_stream_processor_options::impl {
+   public:
+    bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> _dlq;
+    bsoncxx::v1::stdx::optional<std::string> _stream_meta_field_name;
+    bsoncxx::v1::stdx::optional<std::string> _tier;
+    bsoncxx::v1::stdx::optional<bool> _failover;
+
+    static impl const& with(create_stream_processor_options const& other) {
+        return *static_cast<impl const*>(other._impl);
+    }
+    static impl const* with(create_stream_processor_options const* other) {
+        return static_cast<impl const*>(other->_impl);
+    }
+    static impl& with(create_stream_processor_options& other) {
+        return *static_cast<impl*>(other._impl);
+    }
+    static impl* with(create_stream_processor_options* other) {
+        return static_cast<impl*>(other->_impl);
+    }
+    static impl* with(void* ptr) {
+        return static_cast<impl*>(ptr);
+    }
+};
+
+// NOLINTBEGIN(cppcoreguidelines-owning-memory)
+
+create_stream_processor_options::~create_stream_processor_options() {
+    delete impl::with(_impl);
+}
+
+create_stream_processor_options::create_stream_processor_options(create_stream_processor_options&& other) noexcept
+    : _impl{exchange(other._impl, nullptr)} {}
+
+create_stream_processor_options& create_stream_processor_options::operator=(
+    create_stream_processor_options&& other) noexcept {
+    if (this != &other) {
+        delete impl::with(exchange(_impl, exchange(other._impl, nullptr)));
+    }
+    return *this;
+}
+
+create_stream_processor_options::create_stream_processor_options(create_stream_processor_options const& other)
+    : _impl{new impl{impl::with(other)}} {}
+
+create_stream_processor_options& create_stream_processor_options::operator=(
+    create_stream_processor_options const& other) {
+    if (this != &other) {
+        delete impl::with(exchange(_impl, new impl{impl::with(other)}));
+    }
+    return *this;
+}
+
+create_stream_processor_options::create_stream_processor_options() : _impl{new impl{}} {}
+
+// NOLINTEND(cppcoreguidelines-owning-memory)
+
+create_stream_processor_options& create_stream_processor_options::dlq(bsoncxx::v1::document::value v) {
+    impl::with(this)->_dlq = std::move(v);
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> create_stream_processor_options::dlq() const {
+    return impl::with(this)->_dlq;
+}
+
+create_stream_processor_options& create_stream_processor_options::stream_meta_field_name(std::string v) {
+    impl::with(this)->_stream_meta_field_name = std::move(v);
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<bsoncxx::v1::stdx::string_view> create_stream_processor_options::stream_meta_field_name()
+    const {
+    if (auto const& v = impl::with(this)->_stream_meta_field_name) {
+        return bsoncxx::v1::stdx::string_view{*v};
+    }
+    return bsoncxx::v1::stdx::nullopt;
+}
+
+create_stream_processor_options& create_stream_processor_options::tier(std::string v) {
+    impl::with(this)->_tier = std::move(v);
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<bsoncxx::v1::stdx::string_view> create_stream_processor_options::tier() const {
+    if (auto const& v = impl::with(this)->_tier) {
+        return bsoncxx::v1::stdx::string_view{*v};
+    }
+    return bsoncxx::v1::stdx::nullopt;
+}
+
+create_stream_processor_options& create_stream_processor_options::failover(bool v) {
+    impl::with(this)->_failover = v;
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<bool> create_stream_processor_options::failover() const {
+    return impl::with(this)->_failover;
+}
+
+void create_stream_processor_options::internal::append_options_to(
+    create_stream_processor_options const& self,
+    scoped_bson& doc) {
+    auto const& i = impl::with(self);
+
+    scoped_bson opts_doc;
+    if (i._dlq) {
+        scoped_bson_view dlq_view{i._dlq->view()};
+        opts_doc += scoped_bson{BCON_NEW("dlq", BCON_DOCUMENT(dlq_view.bson()))};
+    }
+    if (i._stream_meta_field_name) {
+        opts_doc += scoped_bson{BCON_NEW("streamMetaFieldName", BCON_UTF8(i._stream_meta_field_name->c_str()))};
+    }
+    if (i._tier) {
+        opts_doc += scoped_bson{BCON_NEW("tier", BCON_UTF8(i._tier->c_str()))};
+    }
+    if (i._failover) {
+        opts_doc += scoped_bson{BCON_NEW("failover", BCON_BOOL(*i._failover))};
+    }
+    doc += scoped_bson{BCON_NEW("options", BCON_DOCUMENT(opts_doc.bson()))};
+}
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v1/create_stream_processor_options.hh
+++ b/src/mongocxx/lib/mongocxx/v1/create_stream_processor_options.hh
@@ -1,0 +1,32 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/create_stream_processor_options.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/private/scoped_bson.hh>
+
+namespace mongocxx {
+namespace v1 {
+
+class create_stream_processor_options::internal {
+   public:
+    static void append_options_to(create_stream_processor_options const& self, scoped_bson& doc);
+};
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v1/failover_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/failover_options.cpp
@@ -1,0 +1,128 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/v1/failover_options.hh>
+
+//
+
+#include <bsoncxx/v1/stdx/optional.hpp>
+#include <bsoncxx/v1/stdx/string_view.hpp>
+
+#include <string>
+
+#include <bsoncxx/private/bson.hh>
+
+#include <mongocxx/private/scoped_bson.hh>
+#include <mongocxx/private/utility.hh>
+
+namespace mongocxx {
+namespace v1 {
+
+class failover_options::impl {
+   public:
+    std::string _region;
+    bsoncxx::v1::stdx::optional<std::string> _mode;
+    bsoncxx::v1::stdx::optional<bool> _dry_run;
+
+    static impl const& with(failover_options const& other) {
+        return *static_cast<impl const*>(other._impl);
+    }
+    static impl const* with(failover_options const* other) {
+        return static_cast<impl const*>(other->_impl);
+    }
+    static impl& with(failover_options& other) {
+        return *static_cast<impl*>(other._impl);
+    }
+    static impl* with(failover_options* other) {
+        return static_cast<impl*>(other->_impl);
+    }
+    static impl* with(void* ptr) {
+        return static_cast<impl*>(ptr);
+    }
+};
+
+// NOLINTBEGIN(cppcoreguidelines-owning-memory)
+
+failover_options::~failover_options() {
+    delete impl::with(_impl);
+}
+
+failover_options::failover_options(failover_options&& other) noexcept : _impl{exchange(other._impl, nullptr)} {}
+
+failover_options& failover_options::operator=(failover_options&& other) noexcept {
+    if (this != &other) {
+        delete impl::with(exchange(_impl, exchange(other._impl, nullptr)));
+    }
+    return *this;
+}
+
+failover_options::failover_options(failover_options const& other) : _impl{new impl{impl::with(other)}} {}
+
+failover_options& failover_options::operator=(failover_options const& other) {
+    if (this != &other) {
+        delete impl::with(exchange(_impl, new impl{impl::with(other)}));
+    }
+    return *this;
+}
+
+failover_options::failover_options(std::string region) : _impl{new impl{}} {
+    impl::with(this)->_region = std::move(region);
+}
+
+// NOLINTEND(cppcoreguidelines-owning-memory)
+
+failover_options& failover_options::region(std::string v) {
+    impl::with(this)->_region = std::move(v);
+    return *this;
+}
+
+bsoncxx::v1::stdx::string_view failover_options::region() const {
+    return impl::with(this)->_region;
+}
+
+failover_options& failover_options::mode(std::string v) {
+    impl::with(this)->_mode = std::move(v);
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<bsoncxx::v1::stdx::string_view> failover_options::mode() const {
+    if (auto const& v = impl::with(this)->_mode) {
+        return bsoncxx::v1::stdx::string_view{*v};
+    }
+    return bsoncxx::v1::stdx::nullopt;
+}
+
+failover_options& failover_options::dry_run(bool v) {
+    impl::with(this)->_dry_run = v;
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<bool> failover_options::dry_run() const {
+    return impl::with(this)->_dry_run;
+}
+
+void failover_options::internal::append_to(failover_options const& self, scoped_bson& doc) {
+    auto const& i = impl::with(self);
+
+    doc += scoped_bson{BCON_NEW("region", BCON_UTF8(i._region.c_str()))};
+    if (i._mode) {
+        doc += scoped_bson{BCON_NEW("mode", BCON_UTF8(i._mode->c_str()))};
+    }
+    if (i._dry_run) {
+        doc += scoped_bson{BCON_NEW("dryRun", BCON_BOOL(*i._dry_run))};
+    }
+}
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v1/failover_options.hh
+++ b/src/mongocxx/lib/mongocxx/v1/failover_options.hh
@@ -1,0 +1,32 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/failover_options.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/private/scoped_bson.hh>
+
+namespace mongocxx {
+namespace v1 {
+
+class failover_options::internal {
+   public:
+    static void append_to(failover_options const& self, scoped_bson& doc);
+};
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v1/get_stream_processor_samples_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/get_stream_processor_samples_options.cpp
@@ -1,0 +1,113 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/v1/get_stream_processor_samples_options.hh>
+
+//
+
+#include <bsoncxx/v1/stdx/optional.hpp>
+
+#include <cstdint>
+
+#include <mongocxx/private/utility.hh>
+
+namespace mongocxx {
+namespace v1 {
+
+class get_stream_processor_samples_options::impl {
+   public:
+    bsoncxx::v1::stdx::optional<std::int64_t> _cursor_id;
+    bsoncxx::v1::stdx::optional<std::int32_t> _limit;
+    bsoncxx::v1::stdx::optional<std::int32_t> _batch_size;
+
+    static impl const& with(get_stream_processor_samples_options const& other) {
+        return *static_cast<impl const*>(other._impl);
+    }
+    static impl const* with(get_stream_processor_samples_options const* other) {
+        return static_cast<impl const*>(other->_impl);
+    }
+    static impl& with(get_stream_processor_samples_options& other) {
+        return *static_cast<impl*>(other._impl);
+    }
+    static impl* with(get_stream_processor_samples_options* other) {
+        return static_cast<impl*>(other->_impl);
+    }
+    static impl* with(void* ptr) {
+        return static_cast<impl*>(ptr);
+    }
+};
+
+// NOLINTBEGIN(cppcoreguidelines-owning-memory)
+
+get_stream_processor_samples_options::~get_stream_processor_samples_options() {
+    delete impl::with(_impl);
+}
+
+get_stream_processor_samples_options::get_stream_processor_samples_options(
+    get_stream_processor_samples_options&& other) noexcept
+    : _impl{exchange(other._impl, nullptr)} {}
+
+get_stream_processor_samples_options& get_stream_processor_samples_options::operator=(
+    get_stream_processor_samples_options&& other) noexcept {
+    if (this != &other) {
+        delete impl::with(exchange(_impl, exchange(other._impl, nullptr)));
+    }
+    return *this;
+}
+
+get_stream_processor_samples_options::get_stream_processor_samples_options(
+    get_stream_processor_samples_options const& other)
+    : _impl{new impl{impl::with(other)}} {}
+
+get_stream_processor_samples_options& get_stream_processor_samples_options::operator=(
+    get_stream_processor_samples_options const& other) {
+    if (this != &other) {
+        delete impl::with(exchange(_impl, new impl{impl::with(other)}));
+    }
+    return *this;
+}
+
+get_stream_processor_samples_options::get_stream_processor_samples_options() : _impl{new impl{}} {}
+
+// NOLINTEND(cppcoreguidelines-owning-memory)
+
+get_stream_processor_samples_options& get_stream_processor_samples_options::cursor_id(std::int64_t v) {
+    impl::with(this)->_cursor_id = v;
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<std::int64_t> get_stream_processor_samples_options::cursor_id() const {
+    return impl::with(this)->_cursor_id;
+}
+
+get_stream_processor_samples_options& get_stream_processor_samples_options::limit(std::int32_t v) {
+    impl::with(this)->_limit = v;
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<std::int32_t> get_stream_processor_samples_options::limit() const {
+    return impl::with(this)->_limit;
+}
+
+get_stream_processor_samples_options& get_stream_processor_samples_options::batch_size(std::int32_t v) {
+    impl::with(this)->_batch_size = v;
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<std::int32_t> get_stream_processor_samples_options::batch_size() const {
+    return impl::with(this)->_batch_size;
+}
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v1/get_stream_processor_samples_options.hh
+++ b/src/mongocxx/lib/mongocxx/v1/get_stream_processor_samples_options.hh
@@ -1,0 +1,27 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/get_stream_processor_samples_options.hpp> // IWYU pragma: export
+
+//
+
+namespace mongocxx {
+namespace v1 {
+
+class get_stream_processor_samples_options::internal {};
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v1/get_stream_processor_samples_result.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/get_stream_processor_samples_result.cpp
@@ -1,0 +1,49 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/v1/get_stream_processor_samples_result.hh>
+
+//
+
+#include <bsoncxx/v1/document/value.hpp>
+
+#include <cstdint>
+#include <vector>
+
+namespace mongocxx {
+namespace v1 {
+
+get_stream_processor_samples_result::get_stream_processor_samples_result(
+    std::int64_t cursor_id,
+    std::vector<bsoncxx::v1::document::value> documents)
+    : _cursor_id{cursor_id}, _documents{std::move(documents)} {}
+
+get_stream_processor_samples_result::get_stream_processor_samples_result(
+    get_stream_processor_samples_result&&) noexcept = default;
+
+get_stream_processor_samples_result& get_stream_processor_samples_result::operator=(
+    get_stream_processor_samples_result&&) noexcept = default;
+
+get_stream_processor_samples_result::~get_stream_processor_samples_result() = default;
+
+std::int64_t get_stream_processor_samples_result::cursor_id() const noexcept {
+    return _cursor_id;
+}
+
+std::vector<bsoncxx::v1::document::value> const& get_stream_processor_samples_result::documents() const noexcept {
+    return _documents;
+}
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v1/get_stream_processor_samples_result.hh
+++ b/src/mongocxx/lib/mongocxx/v1/get_stream_processor_samples_result.hh
@@ -1,0 +1,17 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/get_stream_processor_samples_result.hpp> // IWYU pragma: export

--- a/src/mongocxx/lib/mongocxx/v1/get_stream_processor_stats_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/get_stream_processor_stats_options.cpp
@@ -1,0 +1,105 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/v1/get_stream_processor_stats_options.hh>
+
+//
+
+#include <bsoncxx/v1/stdx/optional.hpp>
+
+#include <bsoncxx/private/bson.hh>
+
+#include <mongocxx/private/scoped_bson.hh>
+#include <mongocxx/private/utility.hh>
+
+namespace mongocxx {
+namespace v1 {
+
+class get_stream_processor_stats_options::impl {
+   public:
+    bsoncxx::v1::stdx::optional<bool> _verbose;
+
+    static impl const& with(get_stream_processor_stats_options const& other) {
+        return *static_cast<impl const*>(other._impl);
+    }
+    static impl const* with(get_stream_processor_stats_options const* other) {
+        return static_cast<impl const*>(other->_impl);
+    }
+    static impl& with(get_stream_processor_stats_options& other) {
+        return *static_cast<impl*>(other._impl);
+    }
+    static impl* with(get_stream_processor_stats_options* other) {
+        return static_cast<impl*>(other->_impl);
+    }
+    static impl* with(void* ptr) {
+        return static_cast<impl*>(ptr);
+    }
+};
+
+// NOLINTBEGIN(cppcoreguidelines-owning-memory)
+
+get_stream_processor_stats_options::~get_stream_processor_stats_options() {
+    delete impl::with(_impl);
+}
+
+get_stream_processor_stats_options::get_stream_processor_stats_options(
+    get_stream_processor_stats_options&& other) noexcept
+    : _impl{exchange(other._impl, nullptr)} {}
+
+get_stream_processor_stats_options& get_stream_processor_stats_options::operator=(
+    get_stream_processor_stats_options&& other) noexcept {
+    if (this != &other) {
+        delete impl::with(exchange(_impl, exchange(other._impl, nullptr)));
+    }
+    return *this;
+}
+
+get_stream_processor_stats_options::get_stream_processor_stats_options(get_stream_processor_stats_options const& other)
+    : _impl{new impl{impl::with(other)}} {}
+
+get_stream_processor_stats_options& get_stream_processor_stats_options::operator=(
+    get_stream_processor_stats_options const& other) {
+    if (this != &other) {
+        delete impl::with(exchange(_impl, new impl{impl::with(other)}));
+    }
+    return *this;
+}
+
+get_stream_processor_stats_options::get_stream_processor_stats_options() : _impl{new impl{}} {}
+
+// NOLINTEND(cppcoreguidelines-owning-memory)
+
+get_stream_processor_stats_options& get_stream_processor_stats_options::verbose(bool v) {
+    impl::with(this)->_verbose = v;
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<bool> get_stream_processor_stats_options::verbose() const {
+    return impl::with(this)->_verbose;
+}
+
+void get_stream_processor_stats_options::internal::append_options_to(
+    get_stream_processor_stats_options const& self,
+    scoped_bson& doc) {
+    auto const& i = impl::with(self);
+
+    scoped_bson opts_doc;
+    if (i._verbose) {
+        opts_doc += scoped_bson{BCON_NEW("verbose", BCON_BOOL(*i._verbose))};
+    }
+    doc += scoped_bson{BCON_NEW("options", BCON_DOCUMENT(opts_doc.bson()))};
+}
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v1/get_stream_processor_stats_options.hh
+++ b/src/mongocxx/lib/mongocxx/v1/get_stream_processor_stats_options.hh
@@ -1,0 +1,32 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/get_stream_processor_stats_options.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/private/scoped_bson.hh>
+
+namespace mongocxx {
+namespace v1 {
+
+class get_stream_processor_stats_options::internal {
+   public:
+    static void append_options_to(get_stream_processor_stats_options const& self, scoped_bson& doc);
+};
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v1/start_stream_processor_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/start_stream_processor_options.cpp
@@ -1,0 +1,192 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/v1/start_stream_processor_options.hh>
+
+//
+
+#include <bsoncxx/v1/stdx/optional.hpp>
+#include <bsoncxx/v1/stdx/string_view.hpp>
+#include <bsoncxx/v1/types/view.hpp>
+
+#include <mongocxx/v1/failover_options.hh>
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+#include <bsoncxx/private/bson.hh>
+
+#include <mongocxx/private/scoped_bson.hh>
+#include <mongocxx/private/utility.hh>
+
+namespace mongocxx {
+namespace v1 {
+
+class start_stream_processor_options::impl {
+   public:
+    bsoncxx::v1::stdx::optional<std::int32_t> _workers;
+    bsoncxx::v1::stdx::optional<bool> _clear_checkpoints;
+    bsoncxx::v1::stdx::optional<bsoncxx::v1::types::b_timestamp> _start_at_operation_time;
+    bsoncxx::v1::stdx::optional<std::string> _tier;
+    bsoncxx::v1::stdx::optional<bool> _enable_auto_scaling;
+    bsoncxx::v1::stdx::optional<v1::failover_options> _failover;
+
+    static impl const& with(start_stream_processor_options const& other) {
+        return *static_cast<impl const*>(other._impl);
+    }
+    static impl const* with(start_stream_processor_options const* other) {
+        return static_cast<impl const*>(other->_impl);
+    }
+    static impl& with(start_stream_processor_options& other) {
+        return *static_cast<impl*>(other._impl);
+    }
+    static impl* with(start_stream_processor_options* other) {
+        return static_cast<impl*>(other->_impl);
+    }
+    static impl* with(void* ptr) {
+        return static_cast<impl*>(ptr);
+    }
+};
+
+// NOLINTBEGIN(cppcoreguidelines-owning-memory)
+
+start_stream_processor_options::~start_stream_processor_options() {
+    delete impl::with(_impl);
+}
+
+start_stream_processor_options::start_stream_processor_options(start_stream_processor_options&& other) noexcept
+    : _impl{exchange(other._impl, nullptr)} {}
+
+start_stream_processor_options& start_stream_processor_options::operator=(
+    start_stream_processor_options&& other) noexcept {
+    if (this != &other) {
+        delete impl::with(exchange(_impl, exchange(other._impl, nullptr)));
+    }
+    return *this;
+}
+
+start_stream_processor_options::start_stream_processor_options(start_stream_processor_options const& other)
+    : _impl{new impl{impl::with(other)}} {}
+
+start_stream_processor_options& start_stream_processor_options::operator=(start_stream_processor_options const& other) {
+    if (this != &other) {
+        delete impl::with(exchange(_impl, new impl{impl::with(other)}));
+    }
+    return *this;
+}
+
+start_stream_processor_options::start_stream_processor_options() : _impl{new impl{}} {}
+
+// NOLINTEND(cppcoreguidelines-owning-memory)
+
+start_stream_processor_options& start_stream_processor_options::workers(std::int32_t v) {
+    impl::with(this)->_workers = v;
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<std::int32_t> start_stream_processor_options::workers() const {
+    return impl::with(this)->_workers;
+}
+
+start_stream_processor_options& start_stream_processor_options::clear_checkpoints(bool v) {
+    impl::with(this)->_clear_checkpoints = v;
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<bool> start_stream_processor_options::clear_checkpoints() const {
+    return impl::with(this)->_clear_checkpoints;
+}
+
+start_stream_processor_options& start_stream_processor_options::start_at_operation_time(
+    bsoncxx::v1::types::b_timestamp v) {
+    impl::with(this)->_start_at_operation_time = v;
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<bsoncxx::v1::types::b_timestamp> start_stream_processor_options::start_at_operation_time()
+    const {
+    return impl::with(this)->_start_at_operation_time;
+}
+
+start_stream_processor_options& start_stream_processor_options::tier(std::string v) {
+    impl::with(this)->_tier = std::move(v);
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<bsoncxx::v1::stdx::string_view> start_stream_processor_options::tier() const {
+    if (auto const& v = impl::with(this)->_tier) {
+        return bsoncxx::v1::stdx::string_view{*v};
+    }
+    return bsoncxx::v1::stdx::nullopt;
+}
+
+start_stream_processor_options& start_stream_processor_options::enable_auto_scaling(bool v) {
+    impl::with(this)->_enable_auto_scaling = v;
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<bool> start_stream_processor_options::enable_auto_scaling() const {
+    return impl::with(this)->_enable_auto_scaling;
+}
+
+start_stream_processor_options& start_stream_processor_options::failover(v1::failover_options v) {
+    impl::with(this)->_failover = std::move(v);
+    return *this;
+}
+
+bsoncxx::v1::stdx::optional<v1::failover_options> start_stream_processor_options::failover() const {
+    return impl::with(this)->_failover;
+}
+
+void start_stream_processor_options::internal::append_to(start_stream_processor_options const& self, scoped_bson& doc) {
+    auto const& i = impl::with(self);
+
+    if (i._workers) {
+        doc += scoped_bson{BCON_NEW("workers", BCON_INT32(*i._workers))};
+    }
+
+    scoped_bson opts_doc;
+    if (i._clear_checkpoints) {
+        opts_doc += scoped_bson{BCON_NEW("clearCheckpoints", BCON_BOOL(*i._clear_checkpoints))};
+    }
+    if (i._start_at_operation_time) {
+        auto const& ts = *i._start_at_operation_time;
+        scoped_bson v;
+        // BCON_TIMESTAMP() incorrectly uses int32_ptr instead of uint32_ptr. Use BSON_*() API instead.
+        if (!BSON_APPEND_TIMESTAMP(v.inout_ptr(), "startAtOperationTime", ts.timestamp, ts.increment)) {
+            throw std::logic_error{"start_stream_processor_options: BSON_APPEND_TIMESTAMP failed"};
+        }
+        opts_doc += v;
+    }
+    // NOTE: startAfter is RESERVED and MUST NOT be serialized to the wire.
+    if (i._tier) {
+        opts_doc += scoped_bson{BCON_NEW("tier", BCON_UTF8(i._tier->c_str()))};
+    }
+    if (i._enable_auto_scaling) {
+        opts_doc += scoped_bson{BCON_NEW("enableAutoScaling", BCON_BOOL(*i._enable_auto_scaling))};
+    }
+    if (opts_doc.view()) {
+        doc += scoped_bson{BCON_NEW("options", BCON_DOCUMENT(opts_doc.bson()))};
+    }
+
+    if (i._failover) {
+        scoped_bson failover_doc;
+        v1::failover_options::internal::append_to(*i._failover, failover_doc);
+        doc += scoped_bson{BCON_NEW("failover", BCON_DOCUMENT(failover_doc.bson()))};
+    }
+}
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v1/start_stream_processor_options.hh
+++ b/src/mongocxx/lib/mongocxx/v1/start_stream_processor_options.hh
@@ -1,0 +1,32 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/start_stream_processor_options.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/private/scoped_bson.hh>
+
+namespace mongocxx {
+namespace v1 {
+
+class start_stream_processor_options::internal {
+   public:
+    static void append_to(start_stream_processor_options const& self, scoped_bson& doc);
+};
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v1/stream_processing_client.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/stream_processing_client.cpp
@@ -1,0 +1,137 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/v1/stream_processing_client.hh>
+
+//
+
+#include <bsoncxx/v1/stdx/string_view.hpp>
+
+#include <mongocxx/v1/client.hpp>
+#include <mongocxx/v1/database.hpp>
+
+#include <mongocxx/v1/exception.hh>
+#include <mongocxx/v1/stream_processors.hh>
+#include <mongocxx/v1/uri.hh>
+
+#include <string>
+#include <vector>
+
+#include <mongocxx/private/utility.hh>
+
+namespace mongocxx {
+namespace v1 {
+
+namespace {
+
+bool is_workspace_host(v1::uri const& uri) {
+    auto const hosts = uri.hosts();
+    for (auto const& host : hosts) {
+        std::string const& hostname = host.name;
+        if (hostname.find("atlas-stream-") == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+v1::uri prepare_workspace_uri(v1::uri const& in_uri) {
+    auto const auth_src = in_uri.auth_source();
+
+    if (!auth_src.empty() && auth_src != "admin") {
+        throw v1::exception::internal::make(
+            v1::uri::errc::set_failure,
+            "only authSource=admin is supported for stream processing workspace connections");
+    }
+
+    // Build a modified URI string:
+    // - Force TLS=true for atlas-stream-* hosts.
+    // - Inject authSource=admin if not already present.
+    std::string uri_str{in_uri.to_string()};
+
+    // Determine how to append query parameters.
+    bool has_query = uri_str.find('?') != std::string::npos;
+    auto append_param = [&](std::string const& param) {
+        if (has_query) {
+            uri_str += '&';
+        } else {
+            uri_str += '?';
+            has_query = true;
+        }
+        uri_str += param;
+    };
+
+    if (is_workspace_host(in_uri) && !in_uri.tls()) {
+        append_param("tls=true");
+    }
+
+    if (auth_src.empty()) {
+        append_param("authSource=admin");
+    }
+
+    return v1::uri{uri_str};
+}
+
+} // namespace
+
+class stream_processing_client::impl {
+   public:
+    v1::client _client;
+
+    static impl const& with(stream_processing_client const& other) {
+        return *static_cast<impl const*>(other._impl);
+    }
+    static impl const* with(stream_processing_client const* other) {
+        return static_cast<impl const*>(other->_impl);
+    }
+    static impl& with(stream_processing_client& other) {
+        return *static_cast<impl*>(other._impl);
+    }
+    static impl* with(stream_processing_client* other) {
+        return static_cast<impl*>(other->_impl);
+    }
+    static impl* with(void* ptr) {
+        return static_cast<impl*>(ptr);
+    }
+};
+
+// NOLINTBEGIN(cppcoreguidelines-owning-memory)
+
+stream_processing_client::~stream_processing_client() {
+    delete impl::with(_impl);
+}
+
+stream_processing_client::stream_processing_client(stream_processing_client&& other) noexcept
+    : _impl{exchange(other._impl, nullptr)} {}
+
+stream_processing_client& stream_processing_client::operator=(stream_processing_client&& other) noexcept {
+    if (this != &other) {
+        delete impl::with(exchange(_impl, exchange(other._impl, nullptr)));
+    }
+    return *this;
+}
+
+stream_processing_client::stream_processing_client(v1::uri uri) : stream_processing_client{std::move(uri), {}} {}
+
+stream_processing_client::stream_processing_client(v1::uri uri, v1::client::options const& options)
+    : _impl{new impl{v1::client{prepare_workspace_uri(uri), options}}} {}
+
+// NOLINTEND(cppcoreguidelines-owning-memory)
+
+v1::stream_processors stream_processing_client::stream_processors() {
+    return v1::stream_processors::internal::make(impl::with(this)->_client["admin"]);
+}
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v1/stream_processing_client.hh
+++ b/src/mongocxx/lib/mongocxx/v1/stream_processing_client.hh
@@ -1,0 +1,17 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/stream_processing_client.hpp> // IWYU pragma: export

--- a/src/mongocxx/lib/mongocxx/v1/stream_processor.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/stream_processor.cpp
@@ -1,0 +1,177 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/v1/stream_processor.hh>
+
+//
+
+#include <bsoncxx/v1/document/value.hpp>
+#include <bsoncxx/v1/document/view.hpp>
+#include <bsoncxx/v1/element/view.hpp>
+#include <bsoncxx/v1/stdx/optional.hpp>
+#include <bsoncxx/v1/stdx/string_view.hpp>
+#include <bsoncxx/v1/types/id.hpp>
+
+#include <mongocxx/v1/database.hpp>
+
+#include <mongocxx/v1/get_stream_processor_samples_options.hh>
+#include <mongocxx/v1/get_stream_processor_samples_result.hh>
+#include <mongocxx/v1/get_stream_processor_stats_options.hh>
+#include <mongocxx/v1/start_stream_processor_options.hh>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <bsoncxx/private/bson.hh>
+
+#include <mongocxx/private/scoped_bson.hh>
+#include <mongocxx/private/utility.hh>
+
+namespace mongocxx {
+namespace v1 {
+
+class stream_processor::impl {
+   public:
+    std::string _name;
+    v1::database _admin_db;
+
+    static impl const& with(stream_processor const& other) {
+        return *static_cast<impl const*>(other._impl);
+    }
+    static impl const* with(stream_processor const* other) {
+        return static_cast<impl const*>(other->_impl);
+    }
+    static impl& with(stream_processor& other) {
+        return *static_cast<impl*>(other._impl);
+    }
+    static impl* with(stream_processor* other) {
+        return static_cast<impl*>(other->_impl);
+    }
+    static impl* with(void* ptr) {
+        return static_cast<impl*>(ptr);
+    }
+};
+
+// NOLINTBEGIN(cppcoreguidelines-owning-memory)
+
+stream_processor::~stream_processor() {
+    delete impl::with(_impl);
+}
+
+stream_processor::stream_processor(stream_processor&& other) noexcept : _impl{exchange(other._impl, nullptr)} {}
+
+stream_processor& stream_processor::operator=(stream_processor&& other) noexcept {
+    if (this != &other) {
+        delete impl::with(exchange(_impl, exchange(other._impl, nullptr)));
+    }
+    return *this;
+}
+
+// NOLINTEND(cppcoreguidelines-owning-memory)
+
+bsoncxx::v1::stdx::string_view stream_processor::name() const {
+    return impl::with(this)->_name;
+}
+
+void stream_processor::start(v1::start_stream_processor_options const& options) {
+    scoped_bson cmd;
+    cmd += scoped_bson{BCON_NEW("startStreamProcessor", BCON_UTF8(impl::with(this)->_name.c_str()))};
+    v1::start_stream_processor_options::internal::append_to(options, cmd);
+    impl::with(this)->_admin_db.run_command(cmd.view());
+}
+
+void stream_processor::stop() {
+    scoped_bson cmd;
+    cmd += scoped_bson{BCON_NEW("stopStreamProcessor", BCON_UTF8(impl::with(this)->_name.c_str()))};
+    impl::with(this)->_admin_db.run_command(cmd.view());
+}
+
+void stream_processor::drop() {
+    scoped_bson cmd;
+    cmd += scoped_bson{BCON_NEW("dropStreamProcessor", BCON_UTF8(impl::with(this)->_name.c_str()))};
+    impl::with(this)->_admin_db.run_command(cmd.view());
+}
+
+bsoncxx::v1::document::value stream_processor::stats(v1::get_stream_processor_stats_options const& options) {
+    scoped_bson cmd;
+    cmd += scoped_bson{BCON_NEW("getStreamProcessorStats", BCON_UTF8(impl::with(this)->_name.c_str()))};
+    v1::get_stream_processor_stats_options::internal::append_options_to(options, cmd);
+    return impl::with(this)->_admin_db.run_command(cmd.view());
+}
+
+v1::get_stream_processor_samples_result stream_processor::get_stream_processor_samples(
+    v1::get_stream_processor_samples_options const& options) {
+    auto const& name = impl::with(this)->_name;
+    auto& db = impl::with(this)->_admin_db;
+
+    auto cursor_id_opt = options.cursor_id();
+    bool is_initial = !cursor_id_opt || *cursor_id_opt == 0;
+
+    std::int64_t active_cursor_id{};
+
+    if (is_initial) {
+        scoped_bson start_cmd;
+        start_cmd += scoped_bson{BCON_NEW("startSampleStreamProcessor", BCON_UTF8(name.c_str()))};
+        if (auto lim = options.limit()) {
+            start_cmd += scoped_bson{BCON_NEW("limit", BCON_INT32(*lim))};
+        }
+        auto start_reply = db.run_command(start_cmd.view());
+        if (auto cursor_el = start_reply.view()["cursorId"];
+            cursor_el && cursor_el.type_id() == bsoncxx::v1::types::id::k_int64) {
+            active_cursor_id = cursor_el.get_int64().value;
+        }
+    } else {
+        active_cursor_id = *cursor_id_opt;
+    }
+
+    scoped_bson get_more_cmd;
+    get_more_cmd += scoped_bson{BCON_NEW("getMoreSampleStreamProcessor", BCON_UTF8(name.c_str()))};
+    get_more_cmd += scoped_bson{BCON_NEW("cursorId", BCON_INT64(active_cursor_id))};
+    if (!is_initial) {
+        if (auto bs = options.batch_size()) {
+            get_more_cmd += scoped_bson{BCON_NEW("batchSize", BCON_INT32(*bs))};
+        }
+    }
+
+    auto get_more_reply = db.run_command(get_more_cmd.view());
+    auto reply_view = get_more_reply.view();
+
+    std::int64_t next_cursor_id{0};
+    if (auto el = reply_view["cursorId"]; el && el.type_id() == bsoncxx::v1::types::id::k_int64) {
+        next_cursor_id = el.get_int64().value;
+    }
+
+    std::vector<bsoncxx::v1::document::value> documents;
+    if (auto el = reply_view["messages"]; el && el.type_id() == bsoncxx::v1::types::id::k_array) {
+        for (auto const& msg : el.get_array().value) {
+            if (msg.type_id() == bsoncxx::v1::types::id::k_document) {
+                documents.emplace_back(bsoncxx::v1::document::value{msg.get_document().value});
+            }
+        }
+    }
+
+    return v1::get_stream_processor_samples_result{next_cursor_id, std::move(documents)};
+}
+
+stream_processor stream_processor::internal::make(std::string name, v1::database admin_db) {
+    stream_processor result;
+    // NOLINTBEGIN(cppcoreguidelines-owning-memory)
+    result._impl = new impl{std::move(name), std::move(admin_db)};
+    // NOLINTEND(cppcoreguidelines-owning-memory)
+    return result;
+}
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v1/stream_processor.hh
+++ b/src/mongocxx/lib/mongocxx/v1/stream_processor.hh
@@ -1,0 +1,34 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/stream_processor.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/v1/database.hpp>
+
+#include <mongocxx/private/export.hh>
+
+namespace mongocxx {
+namespace v1 {
+
+class stream_processor::internal {
+   public:
+    static MONGOCXX_ABI_EXPORT_CDECL_TESTING(stream_processor) make(std::string name, v1::database admin_db);
+};
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v1/stream_processor_info.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/stream_processor_info.cpp
@@ -1,0 +1,249 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/v1/stream_processor_info.hh>
+
+//
+
+#include <bsoncxx/v1/array/value.hpp>
+#include <bsoncxx/v1/array/view.hpp>
+#include <bsoncxx/v1/document/value.hpp>
+#include <bsoncxx/v1/document/view.hpp>
+#include <bsoncxx/v1/element/view.hpp>
+#include <bsoncxx/v1/stdx/optional.hpp>
+#include <bsoncxx/v1/stdx/string_view.hpp>
+#include <bsoncxx/v1/types/id.hpp>
+#include <bsoncxx/v1/types/view.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+
+#include <mongocxx/private/utility.hh>
+
+namespace mongocxx {
+namespace v1 {
+
+class stream_processor_info::impl {
+   public:
+    std::string _id;
+    std::string _name;
+    std::string _state;
+    bsoncxx::v1::array::value _pipeline{};
+    bsoncxx::v1::stdx::optional<std::int32_t> _pipeline_version;
+    bsoncxx::v1::stdx::optional<std::string> _tier;
+    bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> _dlq;
+    bsoncxx::v1::stdx::optional<std::string> _stream_meta_field_name;
+    bool _enable_auto_scaling{false};
+    bool _failover_enabled{false};
+    std::string _active_region;
+    std::string _workspace_default_region;
+    bsoncxx::v1::stdx::optional<std::chrono::system_clock::time_point> _last_state_change;
+    bsoncxx::v1::stdx::optional<std::chrono::system_clock::time_point> _last_modified_at;
+    std::string _modified_by;
+    bool _has_started{false};
+    std::string _error_msg;
+    bool _error_retryable{false};
+    bsoncxx::v1::stdx::optional<std::int32_t> _error_code;
+
+    static impl const& with(stream_processor_info const& other) {
+        return *static_cast<impl const*>(other._impl);
+    }
+    static impl const* with(stream_processor_info const* other) {
+        return static_cast<impl const*>(other->_impl);
+    }
+    static impl& with(stream_processor_info& other) {
+        return *static_cast<impl*>(other._impl);
+    }
+    static impl* with(stream_processor_info* other) {
+        return static_cast<impl*>(other->_impl);
+    }
+    static impl* with(void* ptr) {
+        return static_cast<impl*>(ptr);
+    }
+};
+
+namespace {
+
+bsoncxx::v1::stdx::optional<std::chrono::system_clock::time_point> date_from_element(bsoncxx::v1::element::view el) {
+    if (el && el.type_id() == bsoncxx::v1::types::id::k_date) {
+        return std::chrono::system_clock::time_point{
+            std::chrono::duration_cast<std::chrono::system_clock::duration>(el.get_date().value)};
+    }
+    return bsoncxx::v1::stdx::nullopt;
+}
+
+} // namespace
+
+// NOLINTBEGIN(cppcoreguidelines-owning-memory)
+
+stream_processor_info::~stream_processor_info() {
+    delete impl::with(_impl);
+}
+
+stream_processor_info::stream_processor_info(stream_processor_info&& other) noexcept
+    : _impl{exchange(other._impl, nullptr)} {}
+
+stream_processor_info& stream_processor_info::operator=(stream_processor_info&& other) noexcept {
+    if (this != &other) {
+        delete impl::with(exchange(_impl, exchange(other._impl, nullptr)));
+    }
+    return *this;
+}
+
+stream_processor_info::stream_processor_info(stream_processor_info const& other) : _impl{new impl{impl::with(other)}} {}
+
+stream_processor_info& stream_processor_info::operator=(stream_processor_info const& other) {
+    if (this != &other) {
+        delete impl::with(exchange(_impl, new impl{impl::with(other)}));
+    }
+    return *this;
+}
+
+// NOLINTEND(cppcoreguidelines-owning-memory)
+
+stream_processor_info::stream_processor_info(bsoncxx::v1::document::view doc) : _impl{new impl{}} {
+    auto* i = impl::with(this);
+
+    // The server nests processor fields under different keys depending on the
+    // command and server version. Try known wrapper keys in priority order,
+    // then fall back to the top-level document.
+    bsoncxx::v1::document::view src = doc;
+    for (auto const* key : {"result", "streamProcessor"}) {
+        if (auto el = doc[key]; el && el.type_id() == bsoncxx::v1::types::id::k_document) {
+            src = el.get_document().value;
+            break;
+        }
+    }
+
+    auto extract_string = [&](char const* key, std::string& out) {
+        auto el = src[key];
+        if (el && el.type_id() == bsoncxx::v1::types::id::k_string) {
+            out = std::string{el.get_string().value};
+        }
+    };
+
+    auto extract_bool = [&](char const* key, bool& out) {
+        auto el = src[key];
+        if (el && el.type_id() == bsoncxx::v1::types::id::k_bool) {
+            out = el.get_bool().value;
+        }
+    };
+
+    extract_string("_id", i->_id);
+    extract_string("id", i->_id); // server may use either
+    extract_string("name", i->_name);
+    extract_string("state", i->_state);
+
+    if (auto el = src["pipeline"]; el && el.type_id() == bsoncxx::v1::types::id::k_array) {
+        i->_pipeline = bsoncxx::v1::array::value{el.get_array().value};
+    }
+
+    if (auto el = src["pipelineVersion"]; el && el.type_id() == bsoncxx::v1::types::id::k_int32) {
+        i->_pipeline_version = el.get_int32().value;
+    }
+    if (auto el = src["tier"]; el && el.type_id() == bsoncxx::v1::types::id::k_string) {
+        i->_tier = std::string{el.get_string().value};
+    }
+    if (auto el = src["dlq"]; el && el.type_id() == bsoncxx::v1::types::id::k_document) {
+        i->_dlq = bsoncxx::v1::document::value{el.get_document().value};
+    }
+    if (auto el = src["streamMetaFieldName"]; el && el.type_id() == bsoncxx::v1::types::id::k_string) {
+        i->_stream_meta_field_name = std::string{el.get_string().value};
+    }
+
+    extract_bool("enableAutoScaling", i->_enable_auto_scaling);
+    extract_bool("failoverEnabled", i->_failover_enabled);
+    extract_string("activeRegion", i->_active_region);
+    extract_string("workspaceDefaultRegion", i->_workspace_default_region);
+
+    i->_last_state_change = date_from_element(src["lastStateChange"]);
+    i->_last_modified_at = date_from_element(src["lastModifiedAt"]);
+
+    extract_string("modifiedBy", i->_modified_by);
+    extract_bool("hasStarted", i->_has_started);
+    extract_string("errorMsg", i->_error_msg);
+    extract_bool("errorRetryable", i->_error_retryable);
+
+    if (auto el = src["errorCode"]; el && el.type_id() == bsoncxx::v1::types::id::k_int32) {
+        i->_error_code = el.get_int32().value;
+    }
+}
+
+bsoncxx::v1::stdx::string_view stream_processor_info::id() const {
+    return impl::with(this)->_id;
+}
+bsoncxx::v1::stdx::string_view stream_processor_info::name() const {
+    return impl::with(this)->_name;
+}
+bsoncxx::v1::stdx::string_view stream_processor_info::state() const {
+    return impl::with(this)->_state;
+}
+bsoncxx::v1::array::view stream_processor_info::pipeline() const {
+    return impl::with(this)->_pipeline.view();
+}
+bsoncxx::v1::stdx::optional<std::int32_t> stream_processor_info::pipeline_version() const {
+    return impl::with(this)->_pipeline_version;
+}
+bsoncxx::v1::stdx::optional<bsoncxx::v1::stdx::string_view> stream_processor_info::tier() const {
+    if (auto const& v = impl::with(this)->_tier) {
+        return bsoncxx::v1::stdx::string_view{*v};
+    }
+    return bsoncxx::v1::stdx::nullopt;
+}
+bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> stream_processor_info::dlq() const {
+    return impl::with(this)->_dlq;
+}
+bsoncxx::v1::stdx::optional<bsoncxx::v1::stdx::string_view> stream_processor_info::stream_meta_field_name() const {
+    if (auto const& v = impl::with(this)->_stream_meta_field_name) {
+        return bsoncxx::v1::stdx::string_view{*v};
+    }
+    return bsoncxx::v1::stdx::nullopt;
+}
+bool stream_processor_info::enable_auto_scaling() const {
+    return impl::with(this)->_enable_auto_scaling;
+}
+bool stream_processor_info::failover_enabled() const {
+    return impl::with(this)->_failover_enabled;
+}
+bsoncxx::v1::stdx::string_view stream_processor_info::active_region() const {
+    return impl::with(this)->_active_region;
+}
+bsoncxx::v1::stdx::string_view stream_processor_info::workspace_default_region() const {
+    return impl::with(this)->_workspace_default_region;
+}
+bsoncxx::v1::stdx::optional<std::chrono::system_clock::time_point> stream_processor_info::last_state_change() const {
+    return impl::with(this)->_last_state_change;
+}
+bsoncxx::v1::stdx::optional<std::chrono::system_clock::time_point> stream_processor_info::last_modified_at() const {
+    return impl::with(this)->_last_modified_at;
+}
+bsoncxx::v1::stdx::string_view stream_processor_info::modified_by() const {
+    return impl::with(this)->_modified_by;
+}
+bool stream_processor_info::has_started() const {
+    return impl::with(this)->_has_started;
+}
+bsoncxx::v1::stdx::string_view stream_processor_info::error_msg() const {
+    return impl::with(this)->_error_msg;
+}
+bool stream_processor_info::error_retryable() const {
+    return impl::with(this)->_error_retryable;
+}
+bsoncxx::v1::stdx::optional<std::int32_t> stream_processor_info::error_code() const {
+    return impl::with(this)->_error_code;
+}
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v1/stream_processor_info.hh
+++ b/src/mongocxx/lib/mongocxx/v1/stream_processor_info.hh
@@ -1,0 +1,17 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/stream_processor_info.hpp> // IWYU pragma: export

--- a/src/mongocxx/lib/mongocxx/v1/stream_processors.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/stream_processors.cpp
@@ -1,0 +1,109 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/v1/stream_processors.hh>
+
+//
+
+#include <bsoncxx/v1/array/view.hpp>
+#include <bsoncxx/v1/document/value.hpp>
+#include <bsoncxx/v1/document/view.hpp>
+
+#include <mongocxx/v1/database.hpp>
+
+#include <mongocxx/v1/create_stream_processor_options.hh>
+#include <mongocxx/v1/stream_processor.hh>
+#include <mongocxx/v1/stream_processor_info.hh>
+
+#include <string>
+
+#include <bsoncxx/private/bson.hh>
+
+#include <mongocxx/private/scoped_bson.hh>
+#include <mongocxx/private/utility.hh>
+
+namespace mongocxx {
+namespace v1 {
+
+class stream_processors::impl {
+   public:
+    v1::database _admin_db;
+
+    static impl const& with(stream_processors const& other) {
+        return *static_cast<impl const*>(other._impl);
+    }
+    static impl const* with(stream_processors const* other) {
+        return static_cast<impl const*>(other->_impl);
+    }
+    static impl& with(stream_processors& other) {
+        return *static_cast<impl*>(other._impl);
+    }
+    static impl* with(stream_processors* other) {
+        return static_cast<impl*>(other->_impl);
+    }
+    static impl* with(void* ptr) {
+        return static_cast<impl*>(ptr);
+    }
+};
+
+// NOLINTBEGIN(cppcoreguidelines-owning-memory)
+
+stream_processors::~stream_processors() {
+    delete impl::with(_impl);
+}
+
+stream_processors::stream_processors(stream_processors&& other) noexcept : _impl{exchange(other._impl, nullptr)} {}
+
+stream_processors& stream_processors::operator=(stream_processors&& other) noexcept {
+    if (this != &other) {
+        delete impl::with(exchange(_impl, exchange(other._impl, nullptr)));
+    }
+    return *this;
+}
+
+// NOLINTEND(cppcoreguidelines-owning-memory)
+
+void stream_processors::create(
+    std::string name,
+    bsoncxx::v1::array::view pipeline,
+    v1::create_stream_processor_options const& options) {
+    scoped_bson cmd;
+    cmd += scoped_bson{BCON_NEW("createStreamProcessor", BCON_UTF8(name.c_str()))};
+    scoped_bson_view pipeline_as_doc{static_cast<bsoncxx::v1::document::view>(pipeline)};
+    cmd += scoped_bson{BCON_NEW("pipeline", BCON_ARRAY(pipeline_as_doc.bson()))};
+    v1::create_stream_processor_options::internal::append_options_to(options, cmd);
+    impl::with(this)->_admin_db.run_command(cmd.view());
+}
+
+v1::stream_processor stream_processors::get(std::string name) {
+    return v1::stream_processor::internal::make(std::move(name), impl::with(this)->_admin_db);
+}
+
+v1::stream_processor_info stream_processors::get_info(std::string const& name) {
+    scoped_bson cmd;
+    cmd += scoped_bson{BCON_NEW("getStreamProcessor", BCON_UTF8(name.c_str()))};
+    auto reply = impl::with(this)->_admin_db.run_command(cmd.view());
+    return v1::stream_processor_info{reply.view()};
+}
+
+stream_processors stream_processors::internal::make(v1::database admin_db) {
+    stream_processors result;
+    // NOLINTBEGIN(cppcoreguidelines-owning-memory)
+    result._impl = new impl{std::move(admin_db)};
+    // NOLINTEND(cppcoreguidelines-owning-memory)
+    return result;
+}
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v1/stream_processors.hh
+++ b/src/mongocxx/lib/mongocxx/v1/stream_processors.hh
@@ -1,0 +1,34 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mongocxx/v1/stream_processors.hpp> // IWYU pragma: export
+
+//
+
+#include <mongocxx/v1/database.hpp>
+
+#include <mongocxx/private/export.hh>
+
+namespace mongocxx {
+namespace v1 {
+
+class stream_processors::internal {
+   public:
+    static MONGOCXX_ABI_EXPORT_CDECL_TESTING(stream_processors) make(v1::database admin_db);
+};
+
+} // namespace v1
+} // namespace mongocxx


### PR DESCRIPTION
Introduces mongocxx::v1 support for Atlas Stream Processing:
- stream_processing_client: workspace-level client with URI preparation (TLS, authSource)
- stream_processors: create/get/get_info operations
- stream_processor: start/stop/drop/stats/get_stream_processor_samples per-processor ops
- stream_processor_info: typed info struct from getStreamProcessor response
- Options/result types: create, start, stats, samples options; samples result with cursor
- v_noabi wrapper headers for all new types
- CMakeLists.txt wired to build all 10 new implementation files