### PR TITLE
CXX-804 Remove "experimental" commands from v1 API

### DIFF
--- a/src/bsoncxx/include/bsoncxx/v1/array/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/array/value.hpp
@@ -36,8 +36,6 @@ namespace array {
 ///
 /// A BSON array.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class value {
    private:
     v1::document::value _value;

--- a/src/bsoncxx/include/bsoncxx/v1/array/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/array/view.hpp
@@ -44,8 +44,6 @@ namespace array {
 /// operation is not satisfiable due to invalid data, the operation will throw an @ref bsoncxx::v1::exception with @ref
 /// bsoncxx::v1::document::view::errc::invalid_data.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class view {
    public:
     /// @copydoc v1::document::view::const_iterator

--- a/src/bsoncxx/include/bsoncxx/v1/decimal128.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/decimal128.hpp
@@ -34,8 +34,6 @@ namespace v1 {
 ///
 /// A BSON Decimal128.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class decimal128 {
    private:
     std::uint64_t _high = 0u;
@@ -101,8 +99,6 @@ class decimal128 {
     ///
     /// Errors codes which may be returned by @ref bsoncxx::v1::decimal128.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     enum class errc {
         zero,                  ///< Zero.
         empty_string,          ///< String must not be empty.
@@ -113,14 +109,10 @@ class decimal128 {
     ///
     /// The error category for @ref bsoncxx::v1::decimal128::errc.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     static BSONCXX_ABI_EXPORT_CDECL(std::error_category const&) error_category();
 
     ///
     /// Support implicit conversion to `std::error_code`.
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     friend std::error_code make_error_code(errc v) {
         return {static_cast<int>(v), error_category()};

--- a/src/bsoncxx/include/bsoncxx/v1/document/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/document/value.hpp
@@ -41,8 +41,6 @@ namespace document {
 ///
 /// A BSON document.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class value {
    public:
     ///

--- a/src/bsoncxx/include/bsoncxx/v1/document/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/document/view.hpp
@@ -49,8 +49,6 @@ namespace document {
 /// operation is not satisfiable due to invalid data, the operation will throw an @ref bsoncxx::v1::exception with @ref
 /// bsoncxx::v1::document::view::errc::invalid_data.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class view {
    public:
     class const_iterator;
@@ -215,8 +213,6 @@ class view {
     ///
     /// Errors codes which may be returned by @ref bsoncxx::v1::document::view.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     enum class errc {
         zero,           ///< Zero.
         invalid_length, ///< Length is invalid.
@@ -226,14 +222,10 @@ class view {
     ///
     /// The error category for @ref bsoncxx::v1::document::view::errc.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     static BSONCXX_ABI_EXPORT_CDECL(std::error_category const&) error_category();
 
     ///
     /// Support implicit conversion to `std::error_code`.
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     friend std::error_code make_error_code(errc v) {
         return {static_cast<int>(v), error_category()};
@@ -268,8 +260,6 @@ inline std::size_t view::size() const {
 /// @note This iterator almost satisfies Cpp17ForwardIterator, but `std::iterator_traits<T>::reference` is defined as
 /// `value_type`, similar to `std::vector<bool>::iterator` and `std::istreambuf_iterator<T>`. Therefore, this iterator
 /// only fully satisfies Cpp17InputIterator.
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 class view::const_iterator {
    private:

--- a/src/bsoncxx/include/bsoncxx/v1/element/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/element/view.hpp
@@ -79,8 +79,6 @@ namespace element {
 /// When an operation is not satisfiable due to invalid data, the operation will throw an @ref bsoncxx::v1::exception
 /// with @ref bsoncxx::v1::document::view::errc::invalid_data.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class view {
    private:
     class impl;
@@ -230,8 +228,6 @@ class view {
     ///
     /// Errors codes which may be returned by @ref bsoncxx::v1::element::view.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     enum class errc {
         zero,         ///< Zero.
         invalid_view, ///< View is invalid.
@@ -241,14 +237,10 @@ class view {
     ///
     /// The error category for @ref bsoncxx::v1::element::view::errc.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     static BSONCXX_ABI_EXPORT_CDECL(std::error_category const&) error_category();
 
     ///
     /// Support implicit conversion to `std::error_code`.
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     friend std::error_code make_error_code(errc v) {
         return {static_cast<int>(v), error_category()};

--- a/src/bsoncxx/include/bsoncxx/v1/exception.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/exception.hpp
@@ -32,8 +32,6 @@ namespace v1 {
 ///
 /// Enumeration identifying the source of a @ref bsoncxx::v1 error.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 enum class source_errc {
     zero,    ///< Zero.
     bsoncxx, ///< From the bsoncxx library.
@@ -43,14 +41,10 @@ enum class source_errc {
 ///
 /// The error category for @ref bsoncxx::v1::source_errc.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 BSONCXX_ABI_EXPORT_CDECL(std::error_category const&) source_error_category();
 
 ///
 /// Support implicit conversion to `std::error_condition`.
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 inline std::error_condition make_error_condition(source_errc code) {
     return {static_cast<int>(code), v1::source_error_category()};
@@ -58,8 +52,6 @@ inline std::error_condition make_error_condition(source_errc code) {
 
 ///
 /// Enumeration identifying the type (cause) of a @ref bsoncxx::v1 error.
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 enum class type_errc {
     zero,             ///< Zero.
@@ -70,14 +62,10 @@ enum class type_errc {
 ///
 /// The error category for @ref bsoncxx::v1::type_errc.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 BSONCXX_ABI_EXPORT_CDECL(std::error_category const&) type_error_category();
 
 ///
 /// Support implicit conversion to `std::error_condition`.
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 inline std::error_condition make_error_condition(type_errc code) {
     return {static_cast<int>(code), v1::type_error_category()};
@@ -92,8 +80,6 @@ BSONCXX_PRIVATE_WARNINGS_DISABLE(MSVC(4275));
 ///
 /// @par Inherits:
 /// - `std::system_error`
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 class exception : public std::system_error {
    public:

--- a/src/bsoncxx/include/bsoncxx/v1/oid.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/oid.hpp
@@ -38,8 +38,6 @@ namespace v1 {
 ///
 /// A BSON ObjectID.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class oid {
    public:
     ///
@@ -166,8 +164,6 @@ class oid {
     ///
     /// Errors codes may be returned by @ref bsoncxx::v1::oid.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     enum class errc {
         zero,           ///< Zero.
         null_bytes_ptr, ///< Bytes pointer must not be null.
@@ -179,14 +175,10 @@ class oid {
     ///
     /// The error category for @ref bsoncxx::v1::oid::errc.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     static BSONCXX_ABI_EXPORT_CDECL(std::error_category const&) error_category();
 
     ///
     /// Support implicit conversion to `std::error_code`.
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     friend std::error_code make_error_code(errc v) {
         return {static_cast<int>(v), error_category()};

--- a/src/bsoncxx/include/bsoncxx/v1/types/id.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/types/id.hpp
@@ -32,8 +32,6 @@ namespace types {
 ///
 /// Enumeration identifying a BSON type.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 /// @showenumvalues
 ///
 enum class id : std::int8_t {
@@ -63,14 +61,10 @@ enum class id : std::int8_t {
 ///
 /// Return the name of the enumerator (e.g. `"double"` given `k_double`).
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 BSONCXX_ABI_EXPORT_CDECL(std::string) to_string(id rhs);
 
 ///
 /// Enumeration identifying a BSON binary subtype.
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 /// @showenumvalues
 ///
@@ -92,8 +86,6 @@ enum class binary_subtype : std::uint8_t {
 /// Return the name of the enumerator (e.g. `"binary"` given `k_binary`).
 ///
 /// @note Values in the range [0x80, 0xFF] are all equivalent to "k_user".
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 BSONCXX_ABI_EXPORT_CDECL(std::string) to_string(binary_subtype rhs);
 

--- a/src/bsoncxx/include/bsoncxx/v1/types/value.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/types/value.hpp
@@ -47,8 +47,6 @@ namespace types {
 ///
 /// A union of BSON type values.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 /// @note A "BSON type value" refers to the value of a BSON element without its key.
 ///
 class value {
@@ -295,8 +293,6 @@ class value {
     ///
     /// Errors codes which may be returned by @ref bsoncxx::v1::types::value.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     enum class errc {
         zero,               ///< Zero.
         invalid_type,       ///< Requested BSON type is not supported.
@@ -306,14 +302,10 @@ class value {
     ///
     /// The error category for @ref bsoncxx::v1::types::value::errc.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     static BSONCXX_ABI_EXPORT_CDECL(std::error_category const&) error_category();
 
     ///
     /// Support implicit conversion to `std::error_code`.
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     friend std::error_code make_error_code(errc v) {
         return {static_cast<int>(v), error_category()};

--- a/src/bsoncxx/include/bsoncxx/v1/types/view.hpp
+++ b/src/bsoncxx/include/bsoncxx/v1/types/view.hpp
@@ -45,8 +45,6 @@ namespace types {
 ///
 /// BSON type value "64-bit Binary Floating Point".
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 struct b_double {
     ///
     /// The type represented by this BSON type value.
@@ -96,8 +94,6 @@ struct b_double {
 ///
 /// BSON type value "UTF-8 String".
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 struct b_string {
     ///
     /// The type represented by this BSON type value.
@@ -143,8 +139,6 @@ struct b_string {
 
 ///
 /// BSON type value "Embedded Document".
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 struct b_document {
     ///
@@ -196,8 +190,6 @@ struct b_document {
 ///
 /// BSON type value "Array".
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 struct b_array {
     ///
     /// The type represented by this BSON type value.
@@ -243,8 +235,6 @@ struct b_array {
 
 ///
 /// BSON type value "Binary Data".
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 struct b_binary {
     ///
@@ -313,8 +303,6 @@ struct b_binary {
 ///
 /// @deprecated This BSON type is deprecated.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 struct b_undefined {
     ///
     /// The type represented by this BSON type value.
@@ -338,8 +326,6 @@ struct b_undefined {
 
 ///
 /// BSON type value "ObjectID".
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 struct b_oid {
     ///
@@ -387,8 +373,6 @@ struct b_oid {
 ///
 /// BSON type value "Boolean".
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 struct b_bool {
     ///
     /// The type represented by this BSON type value.
@@ -434,8 +418,6 @@ struct b_bool {
 
 ///
 /// BSON type value "UTC Datetime".
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 struct b_date {
     ///
@@ -494,8 +476,6 @@ struct b_date {
 ///
 /// BSON type value "Null Value".
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 struct b_null {
     ///
     /// The type represented by this BSON type value.
@@ -519,8 +499,6 @@ struct b_null {
 
 ///
 /// BSON type value "Regular Expression".
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 struct b_regex {
     ///
@@ -573,8 +551,6 @@ struct b_regex {
 ///
 /// @deprecated This BSON type is deprecated.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 struct b_dbpointer {
     ///
     /// The type represented by this BSON type value.
@@ -618,8 +594,6 @@ struct b_dbpointer {
 
 ///
 /// BSON type value "JavaScript Code".
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 struct b_code {
     ///
@@ -669,8 +643,6 @@ struct b_code {
 ///
 /// @deprecated This BSON type is deprecated.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 struct b_symbol {
     ///
     /// The type represented by this BSON type value.
@@ -719,8 +691,6 @@ struct b_symbol {
 ///
 /// @deprecated This BSON type is deprecated.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 struct b_codewscope {
     ///
     /// The type represented by this BSON type value.
@@ -764,8 +734,6 @@ struct b_codewscope {
 
 ///
 /// BSON type value "32-bit Integer".
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 struct b_int32 {
     ///
@@ -813,8 +781,6 @@ struct b_int32 {
 ///
 /// BSON type value "Timestamp".
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 struct b_timestamp {
     ///
     /// The type represented by this BSON type value.
@@ -858,8 +824,6 @@ struct b_timestamp {
 
 ///
 /// BSON type value "64-bit Integer".
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 struct b_int64 {
     ///
@@ -907,8 +871,6 @@ struct b_int64 {
 ///
 /// BSON type value "Decimal128".
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 struct b_decimal128 {
     ///
     /// The type represented by this BSON type value.
@@ -955,8 +917,6 @@ struct b_decimal128 {
 ///
 /// BSON type value "Max Key".
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 struct b_maxkey {
     ///
     /// The type represented by this BSON type value.
@@ -980,8 +940,6 @@ struct b_maxkey {
 
 ///
 /// BSON type value "Min Key".
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 struct b_minkey {
     ///
@@ -1017,8 +975,6 @@ BSONCXX_V1_TYPES_XMACRO(X)
 ///
 /// @note This class only represents the **value** of a BSON element without its key.
 /// @ref bsoncxx::v1::element::view represents a BSON element including its key.
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 class view {
    private:
@@ -1188,8 +1144,6 @@ class view {
     ///
     /// Errors codes which may be returned by @ref bsoncxx::v1::types::view.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     enum class errc {
         zero,          ///< Zero.
         type_mismatch, ///< Requested type does not match the underlying type.
@@ -1198,14 +1152,10 @@ class view {
     ///
     /// The error category for @ref bsoncxx::v1::types::view::errc.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     static BSONCXX_ABI_EXPORT_CDECL(std::error_category const&) error_category();
 
     ///
     /// Support implicit conversion to `std::error_code`.
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     friend std::error_code make_error_code(errc v) {
         return {static_cast<int>(v), error_category()};

--- a/src/mongocxx/include/mongocxx/v1/aggregate_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/aggregate_options.hpp
@@ -59,8 +59,6 @@ namespace v1 {
 /// @see
 /// - [`aggregate` (database command) (MongoDB Manual)](https://www.mongodb.com/docs/manual/aggregation/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class aggregate_options {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v1/bulk_write.hpp
@@ -50,8 +50,6 @@ namespace v1 {
 /// - [Bulk Write Operations (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/bulk-write-operations/)
 /// - [Update Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/update-methods/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class bulk_write {
    private:
     class impl;
@@ -168,8 +166,6 @@ class bulk_write {
 /// @see
 /// - [Bulk Write Operations (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/bulk-write-operations/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class bulk_write::insert_one {
    public:
     ///
@@ -204,8 +200,6 @@ class bulk_write::insert_one {
 ///
 /// @see
 /// - [Bulk Write Operations (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/bulk-write-operations/)
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 class bulk_write::update_one {
    private:
@@ -337,8 +331,6 @@ class bulk_write::update_one {
 /// @see
 /// - [Bulk Write Operations (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/bulk-write-operations/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class bulk_write::update_many {
    private:
     class impl;
@@ -461,8 +453,6 @@ class bulk_write::update_many {
 /// @see
 /// - [Bulk Write Operations (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/bulk-write-operations/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class bulk_write::replace_one {
    private:
     class impl;
@@ -579,8 +569,6 @@ class bulk_write::replace_one {
 /// @see
 /// - [Bulk Write Operations (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/bulk-write-operations/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class bulk_write::delete_one {
    private:
     class impl;
@@ -670,8 +658,6 @@ class bulk_write::delete_one {
 /// @see
 /// - [Bulk Write Operations (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/bulk-write-operations/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class bulk_write::delete_many {
    private:
     class impl;
@@ -756,8 +742,6 @@ class bulk_write::delete_many {
 /// @see
 /// - [Bulk Write Operations (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/bulk-write-operations/)
 /// - [Update Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/update-methods/)
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 class bulk_write::single {
    private:
@@ -906,8 +890,6 @@ class bulk_write::single {
 /// - [Bulk Write Operations (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/bulk-write-operations/)
 /// - [Update Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/update-methods/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class bulk_write::options {
    private:
     class impl;
@@ -1037,8 +1019,6 @@ class bulk_write::options {
 /// - [CRUD API (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/crud/crud/)
 /// - [Bulk Write Operations (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/bulk-write-operations/)
 /// - [Update Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/update-methods/)
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 class bulk_write::result {
    private:

--- a/src/mongocxx/include/mongocxx/v1/change_stream.hpp
+++ b/src/mongocxx/include/mongocxx/v1/change_stream.hpp
@@ -42,8 +42,6 @@ namespace v1 {
 ///
 /// A MongoDB change stream.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 /// @see
 /// - [Change Streams (MongoDB Manual)](https://www.mongodb.com/docs/manual/changeStreams/)
 ///
@@ -168,8 +166,6 @@ class change_stream {
 /// - resume_after ("resumeAfter")
 /// - start_after ("startAfter")
 /// - start_at_operation_time ("startAtOperationTime")
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 class change_stream::options {
    private:
@@ -317,8 +313,6 @@ class change_stream::options {
 
 ///
 /// An iterator over change stream events.
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 /// @important All iterators associated with the same change stream object share the same state.
 /// @important The end iterator has no associated change stream.

--- a/src/mongocxx/include/mongocxx/v1/client.hpp
+++ b/src/mongocxx/include/mongocxx/v1/client.hpp
@@ -56,8 +56,6 @@ namespace v1 {
 /// - [Connection Monitoring and Pooling (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/connection-monitoring-and-pooling/connection-monitoring-and-pooling/)
 /// - [Connection Strings (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/connection-string/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class client {
    private:
     class impl;
@@ -264,8 +262,6 @@ class client {
     ///
     /// Errors codes which may be returned by @ref mongocxx::v1::client.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     enum class errc {
         zero,              ///< Zero.
         tls_not_enabled,   ///< TLS is not enabled by URI options.
@@ -275,14 +271,10 @@ class client {
     ///
     /// The error category for @ref mongocxx::v1::client::errc.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     static MONGOCXX_ABI_EXPORT_CDECL(std::error_category const&) error_category();
 
     ///
     /// Support implicit conversion to `std::error_code`.
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     friend std::error_code make_error_code(errc v) {
         return {static_cast<int>(v), error_category()};
@@ -303,8 +295,6 @@ class client {
 /// - `oidc_callback`
 /// - `server_api_opts`
 /// - `tls_opts`
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 class client::options {
    private:

--- a/src/mongocxx/include/mongocxx/v1/client_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v1/client_encryption.hpp
@@ -56,8 +56,6 @@ namespace v1 {
 ///   - [Queryable Encryption](https://www.mongodb.com/docs/manual/core/queryable-encryption/)
 ///   - [CSFLE](https://www.mongodb.com/docs/manual/core/csfle/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class client_encryption {
    private:
     void* _impl; // mongoc_client_encryption_t
@@ -286,8 +284,6 @@ class client_encryption {
 /// - `key_vault_namespace` ("keyVaultNamespace")
 /// - `kms_providers` ("kmsProviders")
 /// - `tls_opts` ("tlsOptions")
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 class client_encryption::options {
    private:

--- a/src/mongocxx/include/mongocxx/v1/client_session.hpp
+++ b/src/mongocxx/include/mongocxx/v1/client_session.hpp
@@ -43,8 +43,6 @@ namespace v1 {
 /// - [Read Isolation, Consistency, and Recency (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/read-isolation-consistency-recency/)
 /// - [Server Sessions (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/server-sessions/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class client_session {
    private:
     class impl;
@@ -55,8 +53,6 @@ class client_session {
 
     ///
     /// The state of an associated transaction.
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     enum class transaction_state {
         ///
@@ -279,8 +275,6 @@ class client_session {
 /// - `causal_consistency` ("causalConsistency")
 /// - `snapshot` ("snapshot")
 /// - `default_transaction_opts` ("defaultTransactionOptions")
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 class client_session::options {
    private:

--- a/src/mongocxx/include/mongocxx/v1/collection.hpp
+++ b/src/mongocxx/include/mongocxx/v1/collection.hpp
@@ -78,8 +78,6 @@ namespace v1 {
 /// @see
 /// - [Databases and Collections in MongoDB (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/databases-and-collections/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class collection {
    private:
     class impl;
@@ -904,8 +902,6 @@ class collection {
     ///
     /// Errors codes which may be returned by @ref mongocxx::v1::collection.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     enum class errc {
         zero,         ///< Zero.
         max_time_u32, ///< The "maxTimeMS" field must be representable as an `std::uint32_t`.
@@ -914,14 +910,10 @@ class collection {
     ///
     /// The error category for @ref mongocxx::v1::collection::errc.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     static MONGOCXX_ABI_EXPORT_CDECL(std::error_category const&) error_category();
 
     ///
     /// Support implicit conversion to `std::error_code`.
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     friend std::error_code make_error_code(errc v) {
         return {static_cast<int>(v), error_category()};

--- a/src/mongocxx/include/mongocxx/v1/count_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/count_options.hpp
@@ -55,8 +55,6 @@ namespace v1 {
 /// @see
 /// - [CRUD API (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/crud/crud/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class count_options {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/cursor.hpp
+++ b/src/mongocxx/include/mongocxx/v1/cursor.hpp
@@ -36,8 +36,6 @@ namespace v1 {
 /// @see
 /// - [Cursors (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/cursors/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class cursor {
    private:
     class impl;
@@ -135,8 +133,6 @@ class cursor {
 
 ///
 /// An iterator over the results of an associated cursor.
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 /// @important All iterators associated with the same cursor object share the same state.
 /// @important The end iterator has no associated cursor.

--- a/src/mongocxx/include/mongocxx/v1/data_key_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/data_key_options.hpp
@@ -45,8 +45,6 @@ namespace v1 {
 /// @see
 /// - [Encryption Keys and Key Vaults (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/queryable-encryption/fundamentals/keys-key-vaults/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class data_key_options {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/database.hpp
+++ b/src/mongocxx/include/mongocxx/v1/database.hpp
@@ -52,8 +52,6 @@ namespace v1 {
 /// @see
 /// - [Databases and Collections in MongoDB (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/databases-and-collections/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class database {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/delete_many_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/delete_many_options.hpp
@@ -50,8 +50,6 @@ namespace v1 {
 /// @see
 /// - [Delete Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/delete-methods/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class delete_many_options {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/delete_many_result.hpp
+++ b/src/mongocxx/include/mongocxx/v1/delete_many_result.hpp
@@ -34,8 +34,6 @@ namespace v1 {
 /// @see
 /// - [Delete Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/delete-methods/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class delete_many_result {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/delete_one_options-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v1/delete_one_options-fwd.hpp
@@ -25,8 +25,6 @@ namespace v1 {
 /// @see
 /// - [Delete Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/delete-methods/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class delete_one_options;
 
 } // namespace v1

--- a/src/mongocxx/include/mongocxx/v1/delete_one_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/delete_one_options.hpp
@@ -50,8 +50,6 @@ namespace v1 {
 /// @see
 /// - [Delete Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/delete-methods/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class delete_one_options {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/delete_one_result.hpp
+++ b/src/mongocxx/include/mongocxx/v1/delete_one_result.hpp
@@ -37,8 +37,6 @@ namespace v1 {
 /// @see
 /// - [Delete Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/delete-methods/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class delete_one_result {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/encrypt_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/encrypt_options.hpp
@@ -54,8 +54,6 @@ namespace v1 {
 /// - [Encrypted Fields and Enabled Queries (MongoDB Manual)](https://mongodb.com/docs/manual/core/queryable-encryption/fundamentals/encrypt-and-query/)
 /// - [Encryption Schemas](https://www.mongodb.com/docs/manual/core/csfle/fundamentals/create-schema/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class encrypt_options {
     // This class implements `EncryptOpts`:
     //  - https://specifications.readthedocs.io/en/latest/client-side-encryption/client-side-encryption/
@@ -228,8 +226,6 @@ class encrypt_options {
 
     ///
     /// Return the current "textOpts" field.
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<v1::text_options>) text_opts() const;
 

--- a/src/mongocxx/include/mongocxx/v1/encrypt_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/encrypt_options.hpp
@@ -222,10 +222,14 @@ class encrypt_options {
     ///
     /// Set the "textOpts" field.
     ///
+    /// @attention This feature is experimental! It is not ready for use!
+    ///
     MONGOCXX_ABI_EXPORT_CDECL(encrypt_options&) text_opts(v1::text_options v);
 
     ///
     /// Return the current "textOpts" field.
+    ///
+    /// @attention This feature is experimental! It is not ready for use!
     ///
     MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::optional<v1::text_options>) text_opts() const;
 

--- a/src/mongocxx/include/mongocxx/v1/events/command_failed.hpp
+++ b/src/mongocxx/include/mongocxx/v1/events/command_failed.hpp
@@ -40,8 +40,6 @@ namespace events {
 /// @see
 /// - [Command Logging and Monitoring (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/command-logging-and-monitoring/command-logging-and-monitoring/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class command_failed {
    private:
     void const* _impl; // mongoc_apm_command_failed_t const

--- a/src/mongocxx/include/mongocxx/v1/events/command_started.hpp
+++ b/src/mongocxx/include/mongocxx/v1/events/command_started.hpp
@@ -40,8 +40,6 @@ namespace events {
 /// @see
 /// - [Command Logging and Monitoring (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/command-logging-and-monitoring/command-logging-and-monitoring/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class command_started {
    private:
     void const* _impl; // mongoc_apm_command_started_t const

--- a/src/mongocxx/include/mongocxx/v1/events/command_succeeded.hpp
+++ b/src/mongocxx/include/mongocxx/v1/events/command_succeeded.hpp
@@ -40,8 +40,6 @@ namespace events {
 /// @see
 /// - [Command Logging and Monitoring (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/command-logging-and-monitoring/command-logging-and-monitoring/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class command_succeeded {
    private:
     void const* _impl; // mongoc_apm_command_succeeded_t const

--- a/src/mongocxx/include/mongocxx/v1/events/server_closed.hpp
+++ b/src/mongocxx/include/mongocxx/v1/events/server_closed.hpp
@@ -38,8 +38,6 @@ namespace events {
 /// @see
 /// - [SDAM Logging and Monitoring (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class server_closed {
    private:
     void const* _impl; // mongoc_apm_server_closed_t const

--- a/src/mongocxx/include/mongocxx/v1/events/server_description.hpp
+++ b/src/mongocxx/include/mongocxx/v1/events/server_description.hpp
@@ -39,8 +39,6 @@ namespace events {
 /// @see
 /// - [Server Discovery and Monitoring (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class server_description {
    private:
     void* _impl; // mongoc_server_description_t

--- a/src/mongocxx/include/mongocxx/v1/events/server_description_changed.hpp
+++ b/src/mongocxx/include/mongocxx/v1/events/server_description_changed.hpp
@@ -40,8 +40,6 @@ namespace events {
 /// @see
 /// - [SDAM Logging and Monitoring (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class server_description_changed {
    private:
     void const* _impl; // mongoc_apm_server_changed_t const

--- a/src/mongocxx/include/mongocxx/v1/events/server_heartbeat_failed.hpp
+++ b/src/mongocxx/include/mongocxx/v1/events/server_heartbeat_failed.hpp
@@ -37,8 +37,6 @@ namespace events {
 /// @see
 /// - [SDAM Logging and Monitoring (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class server_heartbeat_failed {
    private:
     void const* _impl; // mongoc_apm_server_heartbeat_failed_t const

--- a/src/mongocxx/include/mongocxx/v1/events/server_heartbeat_started.hpp
+++ b/src/mongocxx/include/mongocxx/v1/events/server_heartbeat_started.hpp
@@ -36,8 +36,6 @@ namespace events {
 /// @see
 /// - [SDAM Logging and Monitoring (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class server_heartbeat_started {
    private:
     void const* _impl; // mongoc_apm_server_heartbeat_started_t const

--- a/src/mongocxx/include/mongocxx/v1/events/server_heartbeat_succeeded.hpp
+++ b/src/mongocxx/include/mongocxx/v1/events/server_heartbeat_succeeded.hpp
@@ -38,8 +38,6 @@ namespace events {
 /// @see
 /// - [SDAM Logging and Monitoring (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class server_heartbeat_succeeded {
    private:
     void const* _impl; // mongoc_apm_server_heartbeat_succeeded_t const

--- a/src/mongocxx/include/mongocxx/v1/events/server_opening.hpp
+++ b/src/mongocxx/include/mongocxx/v1/events/server_opening.hpp
@@ -38,8 +38,6 @@ namespace events {
 /// @see
 /// - [SDAM Logging and Monitoring (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class server_opening {
    private:
     void const* _impl; // mongoc_apm_server_opening_t const

--- a/src/mongocxx/include/mongocxx/v1/events/topology_closed.hpp
+++ b/src/mongocxx/include/mongocxx/v1/events/topology_closed.hpp
@@ -34,8 +34,6 @@ namespace events {
 /// @see
 /// - [SDAM Logging and Monitoring (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class topology_closed {
    private:
     void const* _impl; // mongoc_apm_topology_closed_t const

--- a/src/mongocxx/include/mongocxx/v1/events/topology_description.hpp
+++ b/src/mongocxx/include/mongocxx/v1/events/topology_description.hpp
@@ -39,8 +39,6 @@ namespace events {
 /// @see
 /// - [SDAM Logging and Monitoring (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class topology_description {
    private:
     void const* _impl; // mongoc_topology_description_t const

--- a/src/mongocxx/include/mongocxx/v1/events/topology_description_changed.hpp
+++ b/src/mongocxx/include/mongocxx/v1/events/topology_description_changed.hpp
@@ -36,8 +36,6 @@ namespace events {
 /// @see
 /// - [SDAM Logging and Monitoring (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class topology_description_changed {
    private:
     void const* _impl; // mongoc_apm_topology_changed_t const

--- a/src/mongocxx/include/mongocxx/v1/events/topology_opening.hpp
+++ b/src/mongocxx/include/mongocxx/v1/events/topology_opening.hpp
@@ -34,8 +34,6 @@ namespace events {
 /// @see
 /// - [SDAM Logging and Monitoring (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class topology_opening {
    private:
     void const* _impl; // mongoc_apm_topology_opening_t const

--- a/src/mongocxx/include/mongocxx/v1/exception.hpp
+++ b/src/mongocxx/include/mongocxx/v1/exception.hpp
@@ -35,8 +35,6 @@ namespace v1 {
 ///
 /// Enumeration identifying the source of a @ref mongocxx::v1 error.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 enum class source_errc {
     zero,       ///< Zero.
     mongocxx,   ///< From the mongocxx library.
@@ -48,14 +46,10 @@ enum class source_errc {
 ///
 /// The error category for @ref mongocxx::v1::source_errc.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 MONGOCXX_ABI_EXPORT_CDECL(std::error_category const&) source_error_category();
 
 ///
 /// Support implicit conversion to `std::error_condition`.
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 inline std::error_condition make_error_condition(source_errc code) {
     return {static_cast<int>(code), v1::source_error_category()};
@@ -63,8 +57,6 @@ inline std::error_condition make_error_condition(source_errc code) {
 
 ///
 /// Enumeration identifying the type (cause) of a @ref mongocxx::v1 error.
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 enum class type_errc {
     zero,             ///< Zero.
@@ -75,14 +67,10 @@ enum class type_errc {
 ///
 /// The error category for @ref mongocxx::v1::type_errc.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 MONGOCXX_ABI_EXPORT_CDECL(std::error_category const&) type_error_category();
 
 ///
 /// Support implicit conversion to `std::error_condition`.
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 inline std::error_condition make_error_condition(type_errc code) {
     return {static_cast<int>(code), v1::type_error_category()};
@@ -97,8 +85,6 @@ BSONCXX_PRIVATE_WARNINGS_DISABLE(MSVC(4275));
 ///
 /// @par Inherits:
 /// - `std::system_error`
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 class exception : public std::system_error {
    private:

--- a/src/mongocxx/include/mongocxx/v1/find_one_and_delete_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/find_one_and_delete_options.hpp
@@ -56,8 +56,6 @@ namespace v1 {
 /// - [Query Documents (MongoDB Manual)](https://www.mongodb.com/docs/manual/tutorial/query-documents/)
 /// - [Delete Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/delete-methods/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class find_one_and_delete_options {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/find_one_and_replace_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/find_one_and_replace_options.hpp
@@ -60,8 +60,6 @@ namespace v1 {
 /// - [Query Documents (MongoDB Manual)](https://www.mongodb.com/docs/manual/tutorial/query-documents/)
 /// - [Update Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/update-methods/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class find_one_and_replace_options {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/find_one_and_update_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/find_one_and_update_options.hpp
@@ -63,8 +63,6 @@ namespace v1 {
 /// - [Query Documents (MongoDB Manual)](https://www.mongodb.com/docs/manual/tutorial/query-documents/)
 /// - [Update Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/update-methods/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class find_one_and_update_options {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/find_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/find_options.hpp
@@ -69,8 +69,6 @@ namespace v1 {
 /// @see
 /// - [`find` (database command) (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/command/find/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class find_options {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/gridfs/bucket.hpp
+++ b/src/mongocxx/include/mongocxx/v1/gridfs/bucket.hpp
@@ -57,8 +57,6 @@ namespace gridfs {
 /// @see
 /// - [GridFS (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/gridfs/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class bucket {
    private:
     class impl;
@@ -293,8 +291,6 @@ class bucket {
     ///
     /// Errors codes which may be returned by @ref mongocxx::v1::gridfs::bucket.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     enum class errc {
         zero,                     ///< Zero.
         invalid_bucket_name,      ///< The "bucketName" field must not be empty.
@@ -307,14 +303,10 @@ class bucket {
     ///
     /// The error category for @ref mongocxx::v1::gridfs::bucket::errc.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     static MONGOCXX_ABI_EXPORT_CDECL(std::error_category const&) error_category();
 
     ///
     /// Support implicit conversion to `std::error_code`.
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     friend std::error_code make_error_code(errc v) {
         return {static_cast<int>(v), error_category()};
@@ -339,8 +331,6 @@ class bucket {
 /// @see
 /// - [GridFS (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/gridfs/gridfs-spec/)
 /// - [GridFS for Self-Managed Deployments (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/gridfs/)
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 class bucket::options {
    private:

--- a/src/mongocxx/include/mongocxx/v1/gridfs/downloader.hpp
+++ b/src/mongocxx/include/mongocxx/v1/gridfs/downloader.hpp
@@ -39,8 +39,6 @@ namespace gridfs {
 /// @see
 /// - [GridFS (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/gridfs/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class downloader {
    private:
     class impl;
@@ -138,8 +136,6 @@ class downloader {
     ///
     /// Errors codes which may be returned by @ref mongocxx::v1::gridfs::downloader.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     enum class errc {
         zero,         ///< Zero.
         is_closed,    ///< The GridFS file download stream is not open.
@@ -149,14 +145,10 @@ class downloader {
     ///
     /// The error category for @ref mongocxx::v1::gridfs::downloader::errc.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     static MONGOCXX_ABI_EXPORT_CDECL(std::error_category const&) error_category();
 
     ///
     /// Support implicit conversion to `std::error_code`.
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     friend std::error_code make_error_code(errc v) {
         return {static_cast<int>(v), error_category()};

--- a/src/mongocxx/include/mongocxx/v1/gridfs/upload_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/gridfs/upload_options.hpp
@@ -43,8 +43,6 @@ namespace gridfs {
 /// @see
 /// - [GridFS (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/gridfs/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class upload_options {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/gridfs/upload_result.hpp
+++ b/src/mongocxx/include/mongocxx/v1/gridfs/upload_result.hpp
@@ -37,8 +37,6 @@ namespace gridfs {
 /// @see
 /// - [GridFS (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/gridfs/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class upload_result {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/gridfs/uploader.hpp
+++ b/src/mongocxx/include/mongocxx/v1/gridfs/uploader.hpp
@@ -39,8 +39,6 @@ namespace gridfs {
 /// @see
 /// - [GridFS (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/gridfs/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class uploader {
    private:
     class impl;
@@ -173,8 +171,6 @@ class uploader {
     ///
     /// Errors codes which may be returned by @ref mongocxx::v1::gridfs::uploader.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     enum class errc {
         zero,            ///< Zero.
         is_closed,       ///< The GridFS file upload stream is not open.
@@ -184,14 +180,10 @@ class uploader {
     ///
     /// The error category for @ref mongocxx::v1::gridfs::uploader::errc.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     static MONGOCXX_ABI_EXPORT_CDECL(std::error_category const&) error_category();
 
     ///
     /// Support implicit conversion to `std::error_code`.
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     friend std::error_code make_error_code(errc v) {
         return {static_cast<int>(v), error_category()};

--- a/src/mongocxx/include/mongocxx/v1/hint.hpp
+++ b/src/mongocxx/include/mongocxx/v1/hint.hpp
@@ -42,8 +42,6 @@ namespace v1 {
 /// @see
 /// - [Query Optimization (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/query-optimization/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class hint {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/indexes.hpp
+++ b/src/mongocxx/include/mongocxx/v1/indexes.hpp
@@ -53,8 +53,6 @@ namespace v1 {
 /// @see
 /// - [Indexes (MongoDB Manual)](https://www.mongodb.com/docs/manual/indexes/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class indexes {
     // This class implements `IndexView` ("Index View API"):
     //  - https://specifications.readthedocs.io/en/latest/index-management/index-management/
@@ -87,8 +85,6 @@ class indexes {
     /// - `version` ("v")
     /// - `weights`
     /// - `wildcard_projection` ("wildcardProjection")
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     class options {
         // This class implements `IndexOptions` ("Index View API"):
@@ -349,8 +345,6 @@ class indexes {
     ///
     /// @see
     /// - [Indexes (MongoDB Manual)](https://www.mongodb.com/docs/manual/indexes/)
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     class model {
         // This class implements `IndexModel` ("Index View API"):
@@ -1120,8 +1114,6 @@ class indexes {
     ///
     /// Errors codes which may be returned by @ref mongocxx::v1::indexes.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     enum class errc {
         zero,              ///< Zero.
         expired_after_i32, ///< The "expiredAfterSeconds" field must be representable as an `std::int32_t`.
@@ -1131,14 +1123,10 @@ class indexes {
     ///
     /// The error category for @ref mongocxx::v1::instance::errc.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     static MONGOCXX_ABI_EXPORT_CDECL(std::error_category const&) error_category();
 
     ///
     /// Support implicit conversion to `std::error_code`.
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     friend std::error_code make_error_code(errc v) {
         return {static_cast<int>(v), error_category()};

--- a/src/mongocxx/include/mongocxx/v1/insert_many_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/insert_many_options.hpp
@@ -46,8 +46,6 @@ namespace v1 {
 /// @see
 /// - [Insert Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/insert-methods/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class insert_many_options {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/insert_many_result.hpp
+++ b/src/mongocxx/include/mongocxx/v1/insert_many_result.hpp
@@ -40,8 +40,6 @@ namespace v1 {
 /// @see
 /// - [Insert Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/insert-methods/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class insert_many_result {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/insert_one_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/insert_one_options.hpp
@@ -45,8 +45,6 @@ namespace v1 {
 /// @see
 /// - [Insert Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/insert-methods/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class insert_one_options {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/insert_one_result.hpp
+++ b/src/mongocxx/include/mongocxx/v1/insert_one_result.hpp
@@ -40,8 +40,6 @@ namespace v1 {
 /// @see
 /// - [Insert Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/insert-methods/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class insert_one_result {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/instance.hpp
+++ b/src/mongocxx/include/mongocxx/v1/instance.hpp
@@ -34,8 +34,6 @@ namespace v1 {
 ///
 /// An instance of the MongoDB C++ Driver.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 /// All mongocxx API **MUST** be used within the lifetime of the instance object, with special exemptions listed below.
 /// Only **ONE** instance object may exist for the lifetime of a given process. It is undefined behavior to use the
 /// mongocxx API _before_ the instance object is initialized or _after_ the instance object is destroyed. It is
@@ -145,8 +143,6 @@ class instance {
     ///
     /// Errors codes which may be returned by @ref mongocxx::v1::instance.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     enum class errc {
         zero,               ///< Zero.
         multiple_instances, ///< Cannot construct multiple instance objects in a given process.
@@ -155,14 +151,10 @@ class instance {
     ///
     /// The error category for @ref mongocxx::v1::instance::errc.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     static MONGOCXX_ABI_EXPORT_CDECL(std::error_category const&) error_category();
 
     ///
     /// Support implicit conversion to `std::error_code`.
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     friend std::error_code make_error_code(errc v) {
         return {static_cast<int>(v), error_category()};

--- a/src/mongocxx/include/mongocxx/v1/logger.hpp
+++ b/src/mongocxx/include/mongocxx/v1/logger.hpp
@@ -31,8 +31,6 @@ namespace v1 {
 ///
 /// The log level for an unstructured log message.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 enum class log_level {
     k_error,    ///< MONGOC_LOG_LEVEL_ERROR
     k_critical, ///< MONGOC_LOG_LEVEL_CRITICAL
@@ -53,8 +51,6 @@ BSONCXX_PRIVATE_WARNINGS_DISABLE(MSVC(4275));
 /// The interface for an unstructured log message handler.
 ///
 /// @important This interface does NOT fully conform to the CMAP specification!
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 class logger {
    public:
@@ -111,8 +107,6 @@ BSONCXX_PRIVATE_WARNINGS_POP();
 
 ///
 /// A tag type representing mongoc's default unstructured log handler.
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 class default_logger {};
 

--- a/src/mongocxx/include/mongocxx/v1/pipeline.hpp
+++ b/src/mongocxx/include/mongocxx/v1/pipeline.hpp
@@ -38,8 +38,6 @@ namespace v1 {
 /// @see
 /// - [Aggregation Operations (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/aggregates/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class pipeline {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/pool.hpp
+++ b/src/mongocxx/include/mongocxx/v1/pool.hpp
@@ -46,8 +46,6 @@ namespace v1 {
 /// - [Connection Monitoring and Pooling (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/connection-monitoring-and-pooling/connection-monitoring-and-pooling/)
 /// - [Connection Pool Overview (MongoDB Manual)](https://www.mongodb.com/docs/manual/administration/connection-pool-overview/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class pool {
    private:
     class impl;
@@ -150,8 +148,6 @@ class pool {
     ///
     /// Errors codes which may be returned by @ref mongocxx::v1::pool.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     enum class errc {
         zero,               ///< Zero.
         wait_queue_timeout, ///< Failed to acquire a client object due to "waitQueueTimeoutMS".
@@ -160,14 +156,10 @@ class pool {
     ///
     /// The error category for @ref mongocxx::v1::pool::errc.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     static MONGOCXX_ABI_EXPORT_CDECL(std::error_category const&) error_category();
 
     ///
     /// Support implicit conversion to `std::error_code`.
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     friend std::error_code make_error_code(errc v) {
         return {static_cast<int>(v), error_category()};
@@ -181,8 +173,6 @@ class pool {
 
 ///
 /// Options for @ref mongocxx::v1::pool.
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 class pool::options {
    private:
@@ -244,8 +234,6 @@ class pool::options {
 
 ///
 /// A handle to a client object owned by an associated pool.
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 class pool::entry {
    private:

--- a/src/mongocxx/include/mongocxx/v1/range_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/range_options.hpp
@@ -46,8 +46,6 @@ namespace v1 {
 /// - [Client Side Encryption (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/client-side-encryption/client-side-encryption/)
 /// - [Encrypted Fields and Enabled Queries (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/queryable-encryption/fundamentals/encrypt-and-query/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class range_options {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/read_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v1/read_concern.hpp
@@ -39,8 +39,6 @@ namespace v1 {
 /// - [Read Concern (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/read-concern/)
 /// - [Default MongoDB Read Concerns/Write Concerns (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/mongodb-defaults/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class read_concern {
    private:
     void* _impl; // mongoc_read_concern_t
@@ -51,8 +49,6 @@ class read_concern {
     ///
     /// @see
     /// - [Read Concern (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/read-concern/)
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     enum class level {
         ///

--- a/src/mongocxx/include/mongocxx/v1/read_preference.hpp
+++ b/src/mongocxx/include/mongocxx/v1/read_preference.hpp
@@ -44,8 +44,6 @@ namespace v1 {
 /// @see
 /// - [Read Preference (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/read-preference/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class read_preference {
    private:
     void* _impl; // mongoc_read_prefs_t
@@ -56,8 +54,6 @@ class read_preference {
     ///
     /// @see
     /// - [Read Preference (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/read-preference/)
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     enum class read_mode {
         ///

--- a/src/mongocxx/include/mongocxx/v1/replace_one_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/replace_one_options.hpp
@@ -53,8 +53,6 @@ namespace v1 {
 /// @see
 /// - [Update Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/update-methods/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class replace_one_options {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/replace_one_result.hpp
+++ b/src/mongocxx/include/mongocxx/v1/replace_one_result.hpp
@@ -41,8 +41,6 @@ namespace v1 {
 /// @see
 /// - [Update Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/update-methods/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class replace_one_result {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/rewrap_many_datakey_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/rewrap_many_datakey_options.hpp
@@ -43,8 +43,6 @@ namespace v1 {
 /// @see
 /// - [Rotate and Rewrap Encryption Keys (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/queryable-encryption/fundamentals/manage-keys/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class rewrap_many_datakey_options {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/rewrap_many_datakey_result.hpp
+++ b/src/mongocxx/include/mongocxx/v1/rewrap_many_datakey_result.hpp
@@ -37,8 +37,6 @@ namespace v1 {
 /// @see
 /// - [Rotate and Rewrap Encryption Keys (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/queryable-encryption/fundamentals/manage-keys/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class rewrap_many_datakey_result {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/search_indexes.hpp
+++ b/src/mongocxx/include/mongocxx/v1/search_indexes.hpp
@@ -46,8 +46,6 @@ namespace v1 {
 /// @see
 /// - [Queries and Indexes (MongoDB Manual)](https://www.mongodb.com/docs/atlas/atlas-search/searching/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class search_indexes {
    private:
     class impl;
@@ -309,8 +307,6 @@ class search_indexes {
 ///
 /// @see
 /// - [Queries and Indexes (MongoDB Manual)](https://www.mongodb.com/docs/atlas/atlas-search/searching/)
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 class search_indexes::model {
     // This class implements both `SearchIndexModel` and `SearchIndexOptions` ("Index View API"):

--- a/src/mongocxx/include/mongocxx/v1/server_api.hpp
+++ b/src/mongocxx/include/mongocxx/v1/server_api.hpp
@@ -150,8 +150,6 @@ class server_api {
     ///
     /// Errors codes which may be returned by @ref mongocxx::v1::server_api.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     enum class errc {
         zero,            ///< Zero.
         invalid_version, ///< The server API version is invalid.
@@ -160,14 +158,10 @@ class server_api {
     ///
     /// The error category for @ref mongocxx::v1::server_api::errc.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     static MONGOCXX_ABI_EXPORT_CDECL(std::error_category const&) error_category();
 
     ///
     /// Support implicit conversion to `std::error_code`.
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     friend std::error_code make_error_code(errc v) {
         return {static_cast<int>(v), error_category()};

--- a/src/mongocxx/include/mongocxx/v1/text_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/text_options.hpp
@@ -43,6 +43,8 @@ namespace v1 {
 /// - [Client Side Encryption (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/client-side-encryption/client-side-encryption/)
 /// - [Encrypted Fields and Enabled Queries (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/queryable-encryption/fundamentals/encrypt-and-query/)
 ///
+/// @attention This feature is experimental! It is not ready for use!
+///
 class text_options {
    private:
     class impl;
@@ -150,6 +152,8 @@ class text_options {
 ///
 /// Options related to prefix queries in Queryable Encryption.
 ///
+/// @attention This feature is experimental! It is not ready for use!
+///
 class text_options::prefix {
    private:
     class impl;
@@ -221,6 +225,8 @@ class text_options::prefix {
 ///
 /// Options related to suffix queries in Queryable Encryption.
 ///
+/// @attention This feature is experimental! It is not ready for use!
+///
 class text_options::suffix {
    private:
     class impl;
@@ -291,6 +297,8 @@ class text_options::suffix {
 
 ///
 /// Options related to substring queries in Queryable Encryption.
+///
+/// @attention This feature is experimental! It is not ready for use!
 ///
 class text_options::substring {
    private:

--- a/src/mongocxx/include/mongocxx/v1/text_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/text_options.hpp
@@ -43,8 +43,6 @@ namespace v1 {
 /// - [Client Side Encryption (MongoDB Specifications)](https://specifications.readthedocs.io/en/latest/client-side-encryption/client-side-encryption/)
 /// - [Encrypted Fields and Enabled Queries (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/queryable-encryption/fundamentals/encrypt-and-query/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class text_options {
    private:
     class impl;
@@ -152,8 +150,6 @@ class text_options {
 ///
 /// Options related to prefix queries in Queryable Encryption.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class text_options::prefix {
    private:
     class impl;
@@ -225,8 +221,6 @@ class text_options::prefix {
 ///
 /// Options related to suffix queries in Queryable Encryption.
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class text_options::suffix {
    private:
     class impl;
@@ -297,8 +291,6 @@ class text_options::suffix {
 
 ///
 /// Options related to substring queries in Queryable Encryption.
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 class text_options::substring {
    private:

--- a/src/mongocxx/include/mongocxx/v1/transaction_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/transaction_options.hpp
@@ -45,8 +45,6 @@ namespace v1 {
 /// @see
 /// - [Transactions (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/transactions/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class transaction_options {
    private:
     void* _impl; // mongoc_transaction_opt_t

--- a/src/mongocxx/include/mongocxx/v1/update_many_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/update_many_options.hpp
@@ -55,8 +55,6 @@ namespace v1 {
 /// @see
 /// - [Update Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/update-methods/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class update_many_options {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/update_many_result.hpp
+++ b/src/mongocxx/include/mongocxx/v1/update_many_result.hpp
@@ -40,8 +40,6 @@ namespace v1 {
 /// @see
 /// - [Update Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/update-methods/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class update_many_result {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/update_one_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/update_one_options.hpp
@@ -56,8 +56,6 @@ namespace v1 {
 /// @see
 /// - [Update Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/update-methods/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class update_one_options {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/update_one_result.hpp
+++ b/src/mongocxx/include/mongocxx/v1/update_one_result.hpp
@@ -41,8 +41,6 @@ namespace v1 {
 /// @see
 /// - [Update Methods (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/update-methods/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class update_one_result {
    private:
     class impl;

--- a/src/mongocxx/include/mongocxx/v1/uri.hpp
+++ b/src/mongocxx/include/mongocxx/v1/uri.hpp
@@ -1,9 +1,4 @@
-///
-/// A MongoDB connection string.
-///
-/// @see
-/// - [Connection Strings (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/connection-string/)
-///// Copyright 2009-present MongoDB, Inc.
+// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mongocxx/include/mongocxx/v1/uri.hpp
+++ b/src/mongocxx/include/mongocxx/v1/uri.hpp
@@ -3,8 +3,6 @@
 ///
 /// @see
 /// - [Connection Strings (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/connection-string/)
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///// Copyright 2009-present MongoDB, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -92,8 +90,6 @@ namespace v1 {
 ///
 /// @see
 /// - [Connection Strings (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/connection-string/)
-///
-/// @attention This feature is experimental! It is not ready for use!
 ///
 class uri {
    private:
@@ -380,8 +376,6 @@ class uri {
     ///
     /// Errors codes which may be returned by @ref mongocxx::v1::uri.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     enum class errc {
         zero,        ///< Zero.
         set_failure, ///< Failed to set the requested URI option.
@@ -390,14 +384,10 @@ class uri {
     ///
     /// The error category for @ref mongocxx::v1::uri::errc.
     ///
-    /// @attention This feature is experimental! It is not ready for use!
-    ///
     static MONGOCXX_ABI_EXPORT_CDECL(std::error_category const&) error_category();
 
     ///
     /// Support implicit conversion to `std::error_code`.
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     friend std::error_code make_error_code(errc v) {
         return {static_cast<int>(v), error_category()};

--- a/src/mongocxx/include/mongocxx/v1/write_concern.hpp
+++ b/src/mongocxx/include/mongocxx/v1/write_concern.hpp
@@ -44,8 +44,6 @@ namespace v1 {
 /// @see
 /// - [Write Concern (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/write-concern/)
 ///
-/// @attention This feature is experimental! It is not ready for use!
-///
 class write_concern {
    private:
     void* _impl; // mongoc_write_concern_t
@@ -56,8 +54,6 @@ class write_concern {
     ///
     /// @see
     /// - [Write Concern (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/write-concern/)
-    ///
-    /// @attention This feature is experimental! It is not ready for use!
     ///
     enum class level {
         ///


### PR DESCRIPTION
Partially resolves CXX-804 by removing all attention paragraphs which document the v1 API as experimental. Features labeled "preview" (notably QE text option enumerators and related class types) retain their attention paragraphs.

As a drive-by fix, removed a misplaced copy-pasted Doxygen comment at the top of the uri.hpp header.