### PR TITLE
CXX-3501 Replace Google Tag Manager with Mixpanel

### DIFF
--- a/404.html
+++ b/404.html
@@ -31,6 +31,15 @@
 
         setTimeout(redirect, milliseconds);
     </script>
+
+    <script type="text/javascript">
+        (function(e,c){if(!c.__SV){var l,h;window.mixpanel=c;c._i=[];c.init=function(q,r,f){function t(d,a){var g=a.split(".");2==g.length&&(d=d[g[0]],a=g[1]);d[a]=function(){d.push([a].concat(Array.prototype.slice.call(arguments,0)))}}var b=c;"undefined"!==typeof f?b=c[f]=[]:f="mixpanel";b.people=b.people||[];b.toString=function(d){var a="mixpanel";"mixpanel"!==f&&(a+="."+f);d||(a+=" (stub)");return a};b.people.toString=function(){return b.toString(1)+".people (stub)"};l="disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking start_batch_senders start_session_recording stop_session_recording people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(" ");
+        for(h=0;h<l.length;h++)t(b,l[h]);var n="set set_once union unset remove delete".split(" ");b.get_group=function(){function d(p){a[p]=function(){b.push([g,[p].concat(Array.prototype.slice.call(arguments,0))])}}for(var a={},g=["get_group"].concat(Array.prototype.slice.call(arguments,0)),m=0;m<n.length;m++)d(n[m]);return a};c._i.push([q,r,f])};c.__SV=1.2;var k=e.createElement("script");k.type="text/javascript";k.async=!0;k.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===
+        e.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";e=e.getElementsByTagName("script")[0];e.parentNode.insertBefore(k,e)}})(document,window.mixpanel||[]); mixpanel.init('f2a38f26e5cc0eee429a9276f296c118', {
+          autocapture: true,
+          record_sessions_percent: 0,
+        })
+    </script>
 </head>
 
 <body>
@@ -44,15 +53,6 @@
     <script type="text/javascript" src="https://mongocxx.org/lib/highlight/highlight.pack.js"></script>
     <script type="text/javascript" src="https://mongocxx.org/js/scripts.js"></script>
 
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-JQHP" height="0" width="0"
-            style="display:none;visibility:hidden"></iframe></noscript>
-    <script>(function (w, d, s, l, i) {
-            w[l] = w[l] || []; w[l].push(
-                { 'gtm.start': new Date().getTime(), event: 'gtm.js' }
-            ); var f = d.getElementsByTagName(s)[0],
-                j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
-                    '//www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
-        })(window, document, 'script', 'dataLayer', 'GTM-JQHP');</script>
     <script type="text/javascript">
         var _elqQ = _elqQ || [];
         _elqQ.push(['elqSetSiteId', '413370795']);
@@ -62,13 +62,6 @@
             if (window.addEventListener) window.addEventListener('DOMContentLoaded', async_load, false);
             else if (window.attachEvent) window.attachEvent('onload', async_load);
         })();
-    </script>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-56KD6L3MDX"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
-        gtag('js', new Date());
-        gtag('config', 'G-56KD6L3MDX');
     </script>
 </body>
 

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-	<meta name="generator" content="Hugo 0.160.1">
+	<meta name="generator" content="Hugo 0.161.1">
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="">
@@ -18,6 +18,14 @@
 <link rel="stylesheet" href="https://mongocxx.org/css/mongodb-docs.css" type="text/css" />
 <link rel="stylesheet" href="https://mongocxx.org/css/overrides.css" type="text/css" />
 <link rel="stylesheet" href="https://mongocxx.org/lib/highlight/styles/idea.css" />
+
+    <script type="text/javascript">
+  (function(e,c){if(!c.__SV){var l,h;window.mixpanel=c;c._i=[];c.init=function(q,r,f){function t(d,a){var g=a.split(".");2==g.length&&(d=d[g[0]],a=g[1]);d[a]=function(){d.push([a].concat(Array.prototype.slice.call(arguments,0)))}}var b=c;"undefined"!==typeof f?b=c[f]=[]:f="mixpanel";b.people=b.people||[];b.toString=function(d){var a="mixpanel";"mixpanel"!==f&&(a+="."+f);d||(a+=" (stub)");return a};b.people.toString=function(){return b.toString(1)+".people (stub)"};l="disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking start_batch_senders start_session_recording stop_session_recording people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(" ");
+  for(h=0;h<l.length;h++)t(b,l[h]);var n="set set_once union unset remove delete".split(" ");b.get_group=function(){function d(p){a[p]=function(){b.push([g,[p].concat(Array.prototype.slice.call(arguments,0))])}}for(var a={},g=["get_group"].concat(Array.prototype.slice.call(arguments,0)),m=0;m<n.length;m++)d(n[m]);return a};c._i.push([q,r,f])};c.__SV=1.2;var k=e.createElement("script");k.type="text/javascript";k.async=!0;k.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===
+  e.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";e=e.getElementsByTagName("script")[0];e.parentNode.insertBefore(k,e)}})(document,window.mixpanel||[]); mixpanel.init('f2a38f26e5cc0eee429a9276f296c118', {
+    autocapture: true,
+    record_sessions_percent: 0,
+  })</script>
 
   </head>
 
@@ -674,17 +682,6 @@ documentation</a>.</p>
 <script type="text/javascript" src="https://mongocxx.org/lib/highlight/highlight.pack.js"></script>
 <script type="text/javascript" src="https://mongocxx.org/js/scripts.js"></script>
 
-
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-JQHP"
-                 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
-  {'gtm.start': new Date().getTime(),event:'gtm.js'}
-);var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-JQHP');</script>
-
-
 <script type="text/javascript">
 var _elqQ = _elqQ || [];
 _elqQ.push(['elqSetSiteId', '413370795']);
@@ -695,16 +692,6 @@ function async_load()
 if (window.addEventListener) window.addEventListener('DOMContentLoaded', async_load, false);
 else if (window.attachEvent) window.attachEvent('onload', async_load);
 })();
-</script>
-
-
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-56KD6L3MDX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-56KD6L3MDX');
 </script>
 
 </body>

--- a/legacy-v1/breaking-changes/index.html
+++ b/legacy-v1/breaking-changes/index.html
@@ -18,6 +18,14 @@
 <link rel="stylesheet" href="https://mongocxx.org/css/overrides.css" type="text/css" />
 <link rel="stylesheet" href="https://mongocxx.org/lib/highlight/styles/idea.css" />
 
+    <script type="text/javascript">
+  (function(e,c){if(!c.__SV){var l,h;window.mixpanel=c;c._i=[];c.init=function(q,r,f){function t(d,a){var g=a.split(".");2==g.length&&(d=d[g[0]],a=g[1]);d[a]=function(){d.push([a].concat(Array.prototype.slice.call(arguments,0)))}}var b=c;"undefined"!==typeof f?b=c[f]=[]:f="mixpanel";b.people=b.people||[];b.toString=function(d){var a="mixpanel";"mixpanel"!==f&&(a+="."+f);d||(a+=" (stub)");return a};b.people.toString=function(){return b.toString(1)+".people (stub)"};l="disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking start_batch_senders start_session_recording stop_session_recording people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(" ");
+  for(h=0;h<l.length;h++)t(b,l[h]);var n="set set_once union unset remove delete".split(" ");b.get_group=function(){function d(p){a[p]=function(){b.push([g,[p].concat(Array.prototype.slice.call(arguments,0))])}}for(var a={},g=["get_group"].concat(Array.prototype.slice.call(arguments,0)),m=0;m<n.length;m++)d(n[m]);return a};c._i.push([q,r,f])};c.__SV=1.2;var k=e.createElement("script");k.type="text/javascript";k.async=!0;k.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===
+  e.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";e=e.getElementsByTagName("script")[0];e.parentNode.insertBefore(k,e)}})(document,window.mixpanel||[]); mixpanel.init('f2a38f26e5cc0eee429a9276f296c118', {
+    autocapture: true,
+    record_sessions_percent: 0,
+  })</script>
+
   </head>
 
   <body>
@@ -825,17 +833,6 @@ release.</p>
 <script type="text/javascript" src="https://mongocxx.org/lib/highlight/highlight.pack.js"></script>
 <script type="text/javascript" src="https://mongocxx.org/js/scripts.js"></script>
 
-
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-JQHP"
-                 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
-  {'gtm.start': new Date().getTime(),event:'gtm.js'}
-);var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-JQHP');</script>
-
-
 <script type="text/javascript">
 var _elqQ = _elqQ || [];
 _elqQ.push(['elqSetSiteId', '413370795']);
@@ -846,16 +843,6 @@ function async_load()
 if (window.addEventListener) window.addEventListener('DOMContentLoaded', async_load, false);
 else if (window.attachEvent) window.attachEvent('onload', async_load);
 })();
-</script>
-
-
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-56KD6L3MDX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-56KD6L3MDX');
 </script>
 
 </body>

--- a/legacy-v1/configuration/index.html
+++ b/legacy-v1/configuration/index.html
@@ -18,6 +18,14 @@
 <link rel="stylesheet" href="https://mongocxx.org/css/overrides.css" type="text/css" />
 <link rel="stylesheet" href="https://mongocxx.org/lib/highlight/styles/idea.css" />
 
+    <script type="text/javascript">
+  (function(e,c){if(!c.__SV){var l,h;window.mixpanel=c;c._i=[];c.init=function(q,r,f){function t(d,a){var g=a.split(".");2==g.length&&(d=d[g[0]],a=g[1]);d[a]=function(){d.push([a].concat(Array.prototype.slice.call(arguments,0)))}}var b=c;"undefined"!==typeof f?b=c[f]=[]:f="mixpanel";b.people=b.people||[];b.toString=function(d){var a="mixpanel";"mixpanel"!==f&&(a+="."+f);d||(a+=" (stub)");return a};b.people.toString=function(){return b.toString(1)+".people (stub)"};l="disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking start_batch_senders start_session_recording stop_session_recording people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(" ");
+  for(h=0;h<l.length;h++)t(b,l[h]);var n="set set_once union unset remove delete".split(" ");b.get_group=function(){function d(p){a[p]=function(){b.push([g,[p].concat(Array.prototype.slice.call(arguments,0))])}}for(var a={},g=["get_group"].concat(Array.prototype.slice.call(arguments,0)),m=0;m<n.length;m++)d(n[m]);return a};c._i.push([q,r,f])};c.__SV=1.2;var k=e.createElement("script");k.type="text/javascript";k.async=!0;k.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===
+  e.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";e=e.getElementsByTagName("script")[0];e.parentNode.insertBefore(k,e)}})(document,window.mixpanel||[]); mixpanel.init('f2a38f26e5cc0eee429a9276f296c118', {
+    autocapture: true,
+    record_sessions_percent: 0,
+  })</script>
+
   </head>
 
   <body>
@@ -861,17 +869,6 @@ threads.</p>
 <script type="text/javascript" src="https://mongocxx.org/lib/highlight/highlight.pack.js"></script>
 <script type="text/javascript" src="https://mongocxx.org/js/scripts.js"></script>
 
-
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-JQHP"
-                 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
-  {'gtm.start': new Date().getTime(),event:'gtm.js'}
-);var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-JQHP');</script>
-
-
 <script type="text/javascript">
 var _elqQ = _elqQ || [];
 _elqQ.push(['elqSetSiteId', '413370795']);
@@ -882,16 +879,6 @@ function async_load()
 if (window.addEventListener) window.addEventListener('DOMContentLoaded', async_load, false);
 else if (window.attachEvent) window.attachEvent('onload', async_load);
 })();
-</script>
-
-
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-56KD6L3MDX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-56KD6L3MDX');
 </script>
 
 </body>

--- a/legacy-v1/index.html
+++ b/legacy-v1/index.html
@@ -18,6 +18,14 @@
 <link rel="stylesheet" href="https://mongocxx.org/css/overrides.css" type="text/css" />
 <link rel="stylesheet" href="https://mongocxx.org/lib/highlight/styles/idea.css" />
 
+    <script type="text/javascript">
+  (function(e,c){if(!c.__SV){var l,h;window.mixpanel=c;c._i=[];c.init=function(q,r,f){function t(d,a){var g=a.split(".");2==g.length&&(d=d[g[0]],a=g[1]);d[a]=function(){d.push([a].concat(Array.prototype.slice.call(arguments,0)))}}var b=c;"undefined"!==typeof f?b=c[f]=[]:f="mixpanel";b.people=b.people||[];b.toString=function(d){var a="mixpanel";"mixpanel"!==f&&(a+="."+f);d||(a+=" (stub)");return a};b.people.toString=function(){return b.toString(1)+".people (stub)"};l="disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking start_batch_senders start_session_recording stop_session_recording people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(" ");
+  for(h=0;h<l.length;h++)t(b,l[h]);var n="set set_once union unset remove delete".split(" ");b.get_group=function(){function d(p){a[p]=function(){b.push([g,[p].concat(Array.prototype.slice.call(arguments,0))])}}for(var a={},g=["get_group"].concat(Array.prototype.slice.call(arguments,0)),m=0;m<n.length;m++)d(n[m]);return a};c._i.push([q,r,f])};c.__SV=1.2;var k=e.createElement("script");k.type="text/javascript";k.async=!0;k.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===
+  e.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";e=e.getElementsByTagName("script")[0];e.parentNode.insertBefore(k,e)}})(document,window.mixpanel||[]); mixpanel.init('f2a38f26e5cc0eee429a9276f296c118', {
+    autocapture: true,
+    record_sessions_percent: 0,
+  })</script>
+
   </head>
 
   <body>
@@ -722,17 +730,6 @@ deprecated C++ driver branch.)</p>
 <script type="text/javascript" src="https://mongocxx.org/lib/highlight/highlight.pack.js"></script>
 <script type="text/javascript" src="https://mongocxx.org/js/scripts.js"></script>
 
-
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-JQHP"
-                 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
-  {'gtm.start': new Date().getTime(),event:'gtm.js'}
-);var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-JQHP');</script>
-
-
 <script type="text/javascript">
 var _elqQ = _elqQ || [];
 _elqQ.push(['elqSetSiteId', '413370795']);
@@ -743,16 +740,6 @@ function async_load()
 if (window.addEventListener) window.addEventListener('DOMContentLoaded', async_load, false);
 else if (window.attachEvent) window.attachEvent('onload', async_load);
 })();
-</script>
-
-
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-56KD6L3MDX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-56KD6L3MDX');
 </script>
 
 </body>

--- a/legacy-v1/installation/index.html
+++ b/legacy-v1/installation/index.html
@@ -18,6 +18,14 @@
 <link rel="stylesheet" href="https://mongocxx.org/css/overrides.css" type="text/css" />
 <link rel="stylesheet" href="https://mongocxx.org/lib/highlight/styles/idea.css" />
 
+    <script type="text/javascript">
+  (function(e,c){if(!c.__SV){var l,h;window.mixpanel=c;c._i=[];c.init=function(q,r,f){function t(d,a){var g=a.split(".");2==g.length&&(d=d[g[0]],a=g[1]);d[a]=function(){d.push([a].concat(Array.prototype.slice.call(arguments,0)))}}var b=c;"undefined"!==typeof f?b=c[f]=[]:f="mixpanel";b.people=b.people||[];b.toString=function(d){var a="mixpanel";"mixpanel"!==f&&(a+="."+f);d||(a+=" (stub)");return a};b.people.toString=function(){return b.toString(1)+".people (stub)"};l="disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking start_batch_senders start_session_recording stop_session_recording people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(" ");
+  for(h=0;h<l.length;h++)t(b,l[h]);var n="set set_once union unset remove delete".split(" ");b.get_group=function(){function d(p){a[p]=function(){b.push([g,[p].concat(Array.prototype.slice.call(arguments,0))])}}for(var a={},g=["get_group"].concat(Array.prototype.slice.call(arguments,0)),m=0;m<n.length;m++)d(n[m]);return a};c._i.push([q,r,f])};c.__SV=1.2;var k=e.createElement("script");k.type="text/javascript";k.async=!0;k.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===
+  e.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";e=e.getElementsByTagName("script")[0];e.parentNode.insertBefore(k,e)}})(document,window.mixpanel||[]); mixpanel.init('f2a38f26e5cc0eee429a9276f296c118', {
+    autocapture: true,
+    record_sessions_percent: 0,
+  })</script>
+
   </head>
 
   <body>
@@ -950,17 +958,6 @@ in hard to diagnose warnings or errors.</p>
 <script type="text/javascript" src="https://mongocxx.org/lib/highlight/highlight.pack.js"></script>
 <script type="text/javascript" src="https://mongocxx.org/js/scripts.js"></script>
 
-
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-JQHP"
-                 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
-  {'gtm.start': new Date().getTime(),event:'gtm.js'}
-);var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-JQHP');</script>
-
-
 <script type="text/javascript">
 var _elqQ = _elqQ || [];
 _elqQ.push(['elqSetSiteId', '413370795']);
@@ -971,16 +968,6 @@ function async_load()
 if (window.addEventListener) window.addEventListener('DOMContentLoaded', async_load, false);
 else if (window.attachEvent) window.attachEvent('onload', async_load);
 })();
-</script>
-
-
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-56KD6L3MDX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-56KD6L3MDX');
 </script>
 
 </body>

--- a/legacy-v1/tutorial/index.html
+++ b/legacy-v1/tutorial/index.html
@@ -18,6 +18,14 @@
 <link rel="stylesheet" href="https://mongocxx.org/css/overrides.css" type="text/css" />
 <link rel="stylesheet" href="https://mongocxx.org/lib/highlight/styles/idea.css" />
 
+    <script type="text/javascript">
+  (function(e,c){if(!c.__SV){var l,h;window.mixpanel=c;c._i=[];c.init=function(q,r,f){function t(d,a){var g=a.split(".");2==g.length&&(d=d[g[0]],a=g[1]);d[a]=function(){d.push([a].concat(Array.prototype.slice.call(arguments,0)))}}var b=c;"undefined"!==typeof f?b=c[f]=[]:f="mixpanel";b.people=b.people||[];b.toString=function(d){var a="mixpanel";"mixpanel"!==f&&(a+="."+f);d||(a+=" (stub)");return a};b.people.toString=function(){return b.toString(1)+".people (stub)"};l="disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking start_batch_senders start_session_recording stop_session_recording people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(" ");
+  for(h=0;h<l.length;h++)t(b,l[h]);var n="set set_once union unset remove delete".split(" ");b.get_group=function(){function d(p){a[p]=function(){b.push([g,[p].concat(Array.prototype.slice.call(arguments,0))])}}for(var a={},g=["get_group"].concat(Array.prototype.slice.call(arguments,0)),m=0;m<n.length;m++)d(n[m]);return a};c._i.push([q,r,f])};c.__SV=1.2;var k=e.createElement("script");k.type="text/javascript";k.async=!0;k.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===
+  e.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";e=e.getElementsByTagName("script")[0];e.parentNode.insertBefore(k,e)}})(document,window.mixpanel||[]); mixpanel.init('f2a38f26e5cc0eee429a9276f296c118', {
+    autocapture: true,
+    record_sessions_percent: 0,
+  })</script>
+
   </head>
 
   <body>
@@ -871,17 +879,6 @@ are many more capabilities. For further exploration:</p>
 <script type="text/javascript" src="https://mongocxx.org/lib/highlight/highlight.pack.js"></script>
 <script type="text/javascript" src="https://mongocxx.org/js/scripts.js"></script>
 
-
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-JQHP"
-                 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
-  {'gtm.start': new Date().getTime(),event:'gtm.js'}
-);var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-JQHP');</script>
-
-
 <script type="text/javascript">
 var _elqQ = _elqQ || [];
 _elqQ.push(['elqSetSiteId', '413370795']);
@@ -892,16 +889,6 @@ function async_load()
 if (window.addEventListener) window.addEventListener('DOMContentLoaded', async_load, false);
 else if (window.attachEvent) window.attachEvent('onload', async_load);
 })();
-</script>
-
-
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-56KD6L3MDX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-56KD6L3MDX');
 </script>
 
 </body>

--- a/legacy-v1/working-with-bson/index.html
+++ b/legacy-v1/working-with-bson/index.html
@@ -18,6 +18,14 @@
 <link rel="stylesheet" href="https://mongocxx.org/css/overrides.css" type="text/css" />
 <link rel="stylesheet" href="https://mongocxx.org/lib/highlight/styles/idea.css" />
 
+    <script type="text/javascript">
+  (function(e,c){if(!c.__SV){var l,h;window.mixpanel=c;c._i=[];c.init=function(q,r,f){function t(d,a){var g=a.split(".");2==g.length&&(d=d[g[0]],a=g[1]);d[a]=function(){d.push([a].concat(Array.prototype.slice.call(arguments,0)))}}var b=c;"undefined"!==typeof f?b=c[f]=[]:f="mixpanel";b.people=b.people||[];b.toString=function(d){var a="mixpanel";"mixpanel"!==f&&(a+="."+f);d||(a+=" (stub)");return a};b.people.toString=function(){return b.toString(1)+".people (stub)"};l="disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking start_batch_senders start_session_recording stop_session_recording people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(" ");
+  for(h=0;h<l.length;h++)t(b,l[h]);var n="set set_once union unset remove delete".split(" ");b.get_group=function(){function d(p){a[p]=function(){b.push([g,[p].concat(Array.prototype.slice.call(arguments,0))])}}for(var a={},g=["get_group"].concat(Array.prototype.slice.call(arguments,0)),m=0;m<n.length;m++)d(n[m]);return a};c._i.push([q,r,f])};c.__SV=1.2;var k=e.createElement("script");k.type="text/javascript";k.async=!0;k.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===
+  e.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";e=e.getElementsByTagName("script")[0];e.parentNode.insertBefore(k,e)}})(document,window.mixpanel||[]); mixpanel.init('f2a38f26e5cc0eee429a9276f296c118', {
+    autocapture: true,
+    record_sessions_percent: 0,
+  })</script>
+
   </head>
 
   <body>
@@ -710,17 +718,6 @@ syntax. An exhaustive list is here:
 <script type="text/javascript" src="https://mongocxx.org/lib/highlight/highlight.pack.js"></script>
 <script type="text/javascript" src="https://mongocxx.org/js/scripts.js"></script>
 
-
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-JQHP"
-                 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
-  {'gtm.start': new Date().getTime(),event:'gtm.js'}
-);var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-JQHP');</script>
-
-
 <script type="text/javascript">
 var _elqQ = _elqQ || [];
 _elqQ.push(['elqSetSiteId', '413370795']);
@@ -731,16 +728,6 @@ function async_load()
 if (window.addEventListener) window.addEventListener('DOMContentLoaded', async_load, false);
 else if (window.attachEvent) window.attachEvent('onload', async_load);
 })();
-</script>
-
-
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-56KD6L3MDX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-56KD6L3MDX');
 </script>
 
 </body>


### PR DESCRIPTION
Resolves CXX-3501 by manually applying the result of the changes in https://github.com/mongodb/mongo-cxx-driver/pull/1650 for immediate deployment. The 404 page needed a manual update, as it is not generated by Hugo. The scope of changes is currently limited to pages which already contained Google Tag Manager tracking scripts (straightforward replacement); note this does not include any API doc pages.