### PR TITLE
CXX-3502 Fix explicit "upsert: false" behavior for "findOneAnd*" commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ### Fixed
 
-- Correctly set `upsert: false` for "findOneAnd*" commands when the option is explicitly set to `false` (regression in 4.2.0).
+- Do not set `upsert: true` in "findOneAnd*" operations when the option is explicitly set to `false` (regression in 4.2.0).
 - Include of `v1/text_options.hpp` (normal header) by `options/text-fwd.hpp` (forward header).
 - Include of v\_noabi macro guard headers by `text_options.hpp` (v1).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ### Fixed
 
+- Correctly set `upsert: false` for "findOneAnd*" commands when the option is explicitly set to `false` (regression in 4.2.0).
 - Include of `v1/text_options.hpp` (normal header) by `options/text-fwd.hpp` (forward header).
 - Include of v\_noabi macro guard headers by `text_options.hpp` (v1).
 

--- a/src/mongocxx/lib/mongocxx/v1/collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/collection.cpp
@@ -791,7 +791,7 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> find_one_and_replace_i
     v1::find_one_and_replace_options const& options) {
     auto flags = MONGOC_FIND_AND_MODIFY_NONE;
 
-    if (options.upsert()) {
+    if (options.upsert().value_or(false)) {
         flags = static_cast<mongoc_find_and_modify_flags_t>(flags | MONGOC_FIND_AND_MODIFY_UPSERT);
     }
 
@@ -818,7 +818,7 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> find_one_and_update_im
     v1::find_one_and_update_options const& options) {
     auto flags = MONGOC_FIND_AND_MODIFY_NONE;
 
-    if (options.upsert()) {
+    if (options.upsert().value_or(false)) {
         flags = static_cast<mongoc_find_and_modify_flags_t>(flags | MONGOC_FIND_AND_MODIFY_UPSERT);
     }
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
@@ -772,7 +772,7 @@ bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::value> find_one_and
     v_noabi::options::find_one_and_replace const& options) {
     auto flags = MONGOC_FIND_AND_MODIFY_NONE;
 
-    if (options.upsert()) {
+    if (options.upsert().value_or(false)) {
         flags = static_cast<mongoc_find_and_modify_flags_t>(flags | MONGOC_FIND_AND_MODIFY_UPSERT);
     }
 
@@ -799,7 +799,7 @@ bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::value> find_one_and
     v_noabi::options::find_one_and_update const& options) {
     auto flags = MONGOC_FIND_AND_MODIFY_NONE;
 
-    if (options.upsert()) {
+    if (options.upsert().value_or(false)) {
         flags = static_cast<mongoc_find_and_modify_flags_t>(flags | MONGOC_FIND_AND_MODIFY_UPSERT);
     }
 

--- a/src/mongocxx/test/v_noabi/collection.cpp
+++ b/src/mongocxx/test/v_noabi/collection.cpp
@@ -1380,6 +1380,36 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
             REQUIRE(doc);
             REQUIRE(doc->view()["x"].get_string().value == bsoncxx::stdx::string_view{"bar"});
         }
+
+        SECTION("upsert true inserts when no match") {
+            auto coll = db["find_one_and_update_upsert_true"];
+
+            CHECK_NOTHROW(coll.drop());
+            CHECK(coll.count_documents({}) == 0);
+
+            auto const missing = make_document(kvp("x", "1"));
+
+            options::find_one_and_update opts;
+            opts.upsert(true);
+
+            CHECK_NOTHROW(coll.find_one_and_update(missing.view(), update.view(), opts));
+            CHECK(coll.count_documents({}) == 1);
+        }
+
+        SECTION("upsert false does not insert when no match") {
+            auto coll = db["find_one_and_update_upsert_false"];
+
+            CHECK_NOTHROW(coll.drop());
+            CHECK(coll.count_documents({}) == 0);
+
+            auto const missing = make_document(kvp("x", "1"));
+
+            options::find_one_and_update opts;
+            opts.upsert(false);
+
+            CHECK_NOTHROW(coll.find_one_and_update(missing.view(), update.view(), opts));
+            CHECK(coll.count_documents({}) == 0);
+        }
     }
 
     SECTION("find_one_and_delete works", "[collection]") {


### PR DESCRIPTION
Resolves CXX-3502. https://github.com/mongodb/mongo-cxx-driver/pull/1568 introduced a regression in the 4.2.0 release for the "findOneAndReplace" and "findOneAndUpdate" commands: the `if (options.upsert().value_or(false))` check was incorrectly refactored to `if (options.upsert())`, where `options.upsert()` returns an `Optional<bool>`. This results in `upsert: true` being set for the command when the field is _set at all_, regardless of its underlying value. No unified spec test or prose test appears to exercise this code path (none explicitly set `upsert: false`; they only explicitly set `upsert: true` or leave it implicitly false).