### PR TITLE
CXX-3502 Fix explicit "upsert: false" behavior for "findOneAnd*" commands (#1652)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ## 4.3.1 [Unreleased]
 
-<!-- Will contain entries for the next patch release. -->
+### Fixed
+
+- Do not set `upsert: true` in "findOneAnd*" operations when the option is explicitly set to `false` (regression in 4.2.0).
 
 ## 4.3.0
 

--- a/src/mongocxx/lib/mongocxx/v1/collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/collection.cpp
@@ -754,7 +754,7 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> find_one_and_replace_i
     v1::find_one_and_replace_options const& options) {
     auto flags = MONGOC_FIND_AND_MODIFY_NONE;
 
-    if (options.upsert()) {
+    if (options.upsert().value_or(false)) {
         flags = static_cast<mongoc_find_and_modify_flags_t>(flags | MONGOC_FIND_AND_MODIFY_UPSERT);
     }
 
@@ -781,7 +781,7 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::value> find_one_and_update_im
     v1::find_one_and_update_options const& options) {
     auto flags = MONGOC_FIND_AND_MODIFY_NONE;
 
-    if (options.upsert()) {
+    if (options.upsert().value_or(false)) {
         flags = static_cast<mongoc_find_and_modify_flags_t>(flags | MONGOC_FIND_AND_MODIFY_UPSERT);
     }
 

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
@@ -743,7 +743,7 @@ bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::value> find_one_and
     v_noabi::options::find_one_and_replace const& options) {
     auto flags = MONGOC_FIND_AND_MODIFY_NONE;
 
-    if (options.upsert()) {
+    if (options.upsert().value_or(false)) {
         flags = static_cast<mongoc_find_and_modify_flags_t>(flags | MONGOC_FIND_AND_MODIFY_UPSERT);
     }
 
@@ -770,7 +770,7 @@ bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::value> find_one_and
     v_noabi::options::find_one_and_update const& options) {
     auto flags = MONGOC_FIND_AND_MODIFY_NONE;
 
-    if (options.upsert()) {
+    if (options.upsert().value_or(false)) {
         flags = static_cast<mongoc_find_and_modify_flags_t>(flags | MONGOC_FIND_AND_MODIFY_UPSERT);
     }
 

--- a/src/mongocxx/test/v_noabi/collection.cpp
+++ b/src/mongocxx/test/v_noabi/collection.cpp
@@ -1380,6 +1380,36 @@ TEST_CASE("CRUD functionality", "[driver::collection]") {
             REQUIRE(doc);
             REQUIRE(doc->view()["x"].get_string().value == bsoncxx::stdx::string_view{"bar"});
         }
+
+        SECTION("upsert true inserts when no match") {
+            auto coll = db["find_one_and_update_upsert_true"];
+
+            CHECK_NOTHROW(coll.drop());
+            CHECK(coll.count_documents({}) == 0);
+
+            auto const missing = make_document(kvp("x", "1"));
+
+            options::find_one_and_update opts;
+            opts.upsert(true);
+
+            CHECK_NOTHROW(coll.find_one_and_update(missing.view(), update.view(), opts));
+            CHECK(coll.count_documents({}) == 1);
+        }
+
+        SECTION("upsert false does not insert when no match") {
+            auto coll = db["find_one_and_update_upsert_false"];
+
+            CHECK_NOTHROW(coll.drop());
+            CHECK(coll.count_documents({}) == 0);
+
+            auto const missing = make_document(kvp("x", "1"));
+
+            options::find_one_and_update opts;
+            opts.upsert(false);
+
+            CHECK_NOTHROW(coll.find_one_and_update(missing.view(), update.view(), opts));
+            CHECK(coll.count_documents({}) == 0);
+        }
     }
 
     SECTION("find_one_and_delete works", "[collection]") {


### PR DESCRIPTION
Cherry-pick of https://github.com/mongodb/mongo-cxx-driver/pull/1652 onto the release/v4.3 branch targeting a 4.3.1 release.