### PR TITLE
[CXX-3423] Use mongodb-runner instead of orchestration

### DIFF
--- a/.evergreen/config_generator/components/funcs/stop_mongod.py
+++ b/.evergreen/config_generator/components/funcs/stop_mongod.py
@@ -12,7 +12,7 @@ class StopMongod(Function):
             script="""\
             set -o errexit
             if test -d drivers-evergreen-tools; then
-                pushd drivers-evergreen-tools
+                cd drivers-evergreen-tools
                 .evergreen/run-mongodb.sh stop
             fi
             """,

--- a/.evergreen/config_generator/components/funcs/stop_mongod.py
+++ b/.evergreen/config_generator/components/funcs/stop_mongod.py
@@ -6,19 +6,18 @@ from config_generator.etc.utils import bash_exec
 
 class StopMongod(Function):
     name = 'stop_mongod'
-    commands = bash_exec(
-        command_type=EvgCommandType.SYSTEM,
-        script="""\
+    commands = [
+        bash_exec(
+            command_type=EvgCommandType.SYSTEM,
+            script="""\
             set -o errexit
-            set -o pipefail
-            if cd drivers-evergreen-tools/.evergreen/orchestration 2>/dev/null; then
-                . ../venv-utils.sh
-                if venvactivate venv 2>/dev/null; then
-                    mongo-orchestration stop
-                fi
+            if test -d drivers-evergreen-tools; then
+                pushd drivers-evergreen-tools
+                .evergreen/run-mongodb.sh stop
             fi
-        """,
-    )
+            """,
+        )
+    ]
 
 
 def functions():

--- a/.evergreen/config_generator/components/funcs/test.py
+++ b/.evergreen/config_generator/components/funcs/test.py
@@ -18,7 +18,7 @@ class Test(Function):
         include_expansions_in_env=[
             'ASAN_SYMBOLIZER_PATH',
             'build_type',
-            'CRYPT_SHARED_LIB_PATH',  # Set by run-orchestration.sh in "start_mongod".
+            'CRYPT_SHARED_LIB_PATH',  # Set by run-mongodb.sh in "start_mongod".
             'cse_aws_access_key_id',
             'cse_aws_secret_access_key',
             'cse_azure_client_id',

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -524,21 +524,18 @@ functions:
       params:
         file: drivers-evergreen-tools/mo-expansion.yml
   stop_mongod:
-    command: subprocess.exec
-    type: system
-    params:
-      binary: bash
-      args:
-        - -c
-        - |
-          set -o errexit
-          set -o pipefail
-          if cd drivers-evergreen-tools/.evergreen/orchestration 2>/dev/null; then
-              . ../venv-utils.sh
-              if venvactivate venv 2>/dev/null; then
-                  mongo-orchestration stop
-              fi
-          fi
+    - command: subprocess.exec
+      type: system
+      params:
+        binary: bash
+        args:
+          - -c
+          - |
+            set -o errexit
+            if test -d drivers-evergreen-tools; then
+                pushd drivers-evergreen-tools
+                .evergreen/run-mongodb.sh stop
+            fi
   test:
     command: subprocess.exec
     type: test

--- a/.evergreen/scripts/start-mongod.sh
+++ b/.evergreen/scripts/start-mongod.sh
@@ -86,5 +86,9 @@ if [[ "${TOPOLOGY:-}" == replica_set ]]; then
   echo "Waiting for replset member 27017 to become primary... done."
 fi
 
+if [ -f "${DRIVERS_TOOLS:?}/mongodb/bin/mongocryptd" ]; then
+  cp "${DRIVERS_TOOLS:?}/mongodb/bin/mongocryptd" ../mongocryptd
+fi
+
 cd ../
 pwd

--- a/.evergreen/scripts/start-mongod.sh
+++ b/.evergreen/scripts/start-mongod.sh
@@ -32,8 +32,7 @@ export ORCHESTRATION_FILE
 
 export PATH="${MONGODB_BINARIES:?}:${PATH:-}"
 
-echo "{ \"releases\": { \"default\": \"${MONGODB_BINARIES:?}\" }}" >"${MONGO_ORCHESTRATION_HOME:?}/orchestration.config"
-./.evergreen/run-orchestration.sh
+./.evergreen/run-mongodb.sh start
 
 # MacOS needs some assistance to ensure executable permissions(?).
 chmod +x ${MONGODB_BINARIES:?}/*

--- a/.evergreen/scripts/start-mongod.sh
+++ b/.evergreen/scripts/start-mongod.sh
@@ -28,12 +28,9 @@ export TOPOLOGY
 export REQUIRE_API_VERSION
 export ORCHESTRATION_FILE
 
-export PATH="${MONGODB_BINARIES:?}:${PATH:-}"
+export PATH="${DRIVERS_TOOLS:?}/mongodb/bin:${PATH:-}"
 
 ./.evergreen/run-mongodb.sh start
-
-# MacOS needs some assistance to ensure executable permissions(?).
-chmod +x ${MONGODB_BINARIES:?}/*
 
 declare mongosh_binary
 if command -v mongosh >/dev/null; then
@@ -87,11 +84,6 @@ if [[ "${TOPOLOGY:-}" == replica_set ]]; then
   echo "Waiting for replset member 27017 to become primary..."
   wait_for_primary
   echo "Waiting for replset member 27017 to become primary... done."
-fi
-
-# Copy mongocryptd up so other functions can find it later, since we can't share PATHs
-if [ -f "${MONGODB_BINARIES:?}/mongocryptd" ]; then
-  cp "${MONGODB_BINARIES:?}/mongocryptd" ../mongocryptd
 fi
 
 cd ../

--- a/.evergreen/scripts/start-mongod.sh
+++ b/.evergreen/scripts/start-mongod.sh
@@ -22,8 +22,6 @@ if [ "Windows_NT" == "$OS" ]; then
 fi
 export DRIVERS_TOOLS
 
-export MONGODB_BINARIES="${DRIVERS_TOOLS:?}/mongodb/bin"
-export MONGO_ORCHESTRATION_HOME="${DRIVERS_TOOLS:?}/.evergreen/orchestration"
 export MONGODB_VERSION="${mongodb_version:?}"
 export AUTH
 export TOPOLOGY


### PR DESCRIPTION
Refer: CXX-3423

This changeset simply updates the testing scripts to use `mongodb-runner` in drivers-evergreen-tools rather than `mongo-orchestration`.

There was an attempt to debug issues related to execution on certain macOS hosts, but it appears to be an intermittent issue that is unrelated to any changes that are present in this PR. I'm not sure how common those issues actually are, as it took a long time even to run a single patch. It is possible that this merge could create flaky tests on certain platforms, or it may have been bad luck on the patches that I tried to run.

Because of the script's lack of commentary and the reliance on environment variables to implicitly punch through abstraction layers, I'm not sure what else in the script is only relevant to orchestration and can be removed or modified. Does `runner` reuse the same environment variables as `orchestration`? I do not know.