### PR TITLE
Consistently use simple `v` for params of option field setters

### DIFF
--- a/src/mongocxx/include/mongocxx/v1/aggregate_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/aggregate_options.hpp
@@ -109,7 +109,7 @@ class aggregate_options {
     ///
     /// Set the "allowDiskUse" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) allow_disk_use(bool allow_disk_use);
+    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) allow_disk_use(bool v);
 
     ///
     /// Return the current "allowDiskUse" field.
@@ -119,7 +119,7 @@ class aggregate_options {
     ///
     /// Set the "batchSize" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) batch_size(std::int32_t batch_size);
+    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) batch_size(std::int32_t v);
 
     ///
     /// Return the current "batchSize" field.
@@ -129,7 +129,7 @@ class aggregate_options {
     ///
     /// Set the "collation" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) collation(bsoncxx::v1::document::value collation);
+    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) collation(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "collation" field.
@@ -139,7 +139,7 @@ class aggregate_options {
     ///
     /// Set the "let" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) let(bsoncxx::v1::document::value let);
+    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) let(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "let" field.
@@ -149,7 +149,7 @@ class aggregate_options {
     ///
     /// Set the "maxTimeMS" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) max_time(std::chrono::milliseconds max_time);
+    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) max_time(std::chrono::milliseconds v);
 
     ///
     /// Return the current "maxTimeMS" field.
@@ -159,7 +159,7 @@ class aggregate_options {
     ///
     /// Set the "readPreference" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) read_preference(v1::read_preference rp);
+    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) read_preference(v1::read_preference v);
 
     ///
     /// Return the current "readPreference" field.
@@ -169,7 +169,7 @@ class aggregate_options {
     ///
     /// Set the "bypassDocumentValidation" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) bypass_document_validation(bool bypass_document_validation);
+    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) bypass_document_validation(bool v);
 
     ///
     /// Return the current "bypassDocumentValidation" field.
@@ -179,7 +179,7 @@ class aggregate_options {
     ///
     /// Set the "hint" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) hint(v1::hint index_hint);
+    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) hint(v1::hint v);
 
     ///
     /// Return the current "hint" field.
@@ -189,7 +189,7 @@ class aggregate_options {
     ///
     /// Set the "writeConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) write_concern(v1::write_concern write_concern);
+    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) write_concern(v1::write_concern v);
 
     ///
     /// Return the current "writeConcern" field.
@@ -199,7 +199,7 @@ class aggregate_options {
     ///
     /// Set the "readConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) read_concern(v1::read_concern read_concern);
+    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) read_concern(v1::read_concern v);
 
     ///
     /// Return the current "readConcern" field.
@@ -209,7 +209,7 @@ class aggregate_options {
     ///
     /// Set the "comment" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) comment(bsoncxx::v1::types::value comment);
+    MONGOCXX_ABI_EXPORT_CDECL(aggregate_options&) comment(bsoncxx::v1::types::value v);
 
     ///
     /// Return the current "comment" field.

--- a/src/mongocxx/include/mongocxx/v1/bulk_write.hpp
+++ b/src/mongocxx/include/mongocxx/v1/bulk_write.hpp
@@ -941,7 +941,7 @@ class bulk_write::options {
     ///
     /// Set the "bypassDocumentValidation" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(options&) bypass_document_validation(bool bypass_document_validation);
+    MONGOCXX_ABI_EXPORT_CDECL(options&) bypass_document_validation(bool v);
 
     ///
     /// Return the current "bypassDocumentValidation" field.
@@ -951,7 +951,7 @@ class bulk_write::options {
     ///
     /// Set the "comment" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(options&) comment(bsoncxx::v1::types::value comment);
+    MONGOCXX_ABI_EXPORT_CDECL(options&) comment(bsoncxx::v1::types::value v);
 
     ///
     /// Return the current "comment" field.
@@ -961,7 +961,7 @@ class bulk_write::options {
     ///
     /// Set the "let" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(options&) let(bsoncxx::v1::document::value let);
+    MONGOCXX_ABI_EXPORT_CDECL(options&) let(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "let" field.
@@ -971,7 +971,7 @@ class bulk_write::options {
     ///
     /// Set the "ordered" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(options&) ordered(bool ordered);
+    MONGOCXX_ABI_EXPORT_CDECL(options&) ordered(bool v);
 
     ///
     /// Return the current "ordered" field.
@@ -981,7 +981,7 @@ class bulk_write::options {
     ///
     /// Set the "readConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(options&) read_concern(v1::read_concern rc);
+    MONGOCXX_ABI_EXPORT_CDECL(options&) read_concern(v1::read_concern v);
 
     ///
     /// Return the current "readConcern" field.
@@ -991,7 +991,7 @@ class bulk_write::options {
     ///
     /// Set the "writeConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(options&) write_concern(v1::write_concern wc);
+    MONGOCXX_ABI_EXPORT_CDECL(options&) write_concern(v1::write_concern v);
 
     ///
     /// Return the current "writeConcern" field.

--- a/src/mongocxx/include/mongocxx/v1/count_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/count_options.hpp
@@ -105,7 +105,7 @@ class count_options {
     ///
     /// Set the "collation" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(count_options&) collation(bsoncxx::v1::document::value collation);
+    MONGOCXX_ABI_EXPORT_CDECL(count_options&) collation(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "collation" field.
@@ -115,7 +115,7 @@ class count_options {
     ///
     /// Set the "hint" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(count_options&) hint(v1::hint index_hint);
+    MONGOCXX_ABI_EXPORT_CDECL(count_options&) hint(v1::hint v);
 
     ///
     /// Return the current "hint" field.
@@ -125,7 +125,7 @@ class count_options {
     ///
     /// Set the "comment" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(count_options&) comment(bsoncxx::v1::types::value comment);
+    MONGOCXX_ABI_EXPORT_CDECL(count_options&) comment(bsoncxx::v1::types::value v);
 
     ///
     /// Return the current "comment" field.
@@ -135,7 +135,7 @@ class count_options {
     ///
     /// Set the "limit" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(count_options&) limit(std::int64_t limit);
+    MONGOCXX_ABI_EXPORT_CDECL(count_options&) limit(std::int64_t v);
 
     ///
     /// Return the current "limit" field.
@@ -145,7 +145,7 @@ class count_options {
     ///
     /// Set the "maxTimeMS" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(count_options&) max_time(std::chrono::milliseconds max_time);
+    MONGOCXX_ABI_EXPORT_CDECL(count_options&) max_time(std::chrono::milliseconds v);
 
     ///
     /// Return the current "maxTimeMS" field.
@@ -155,7 +155,7 @@ class count_options {
     ///
     /// Set the "skip" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(count_options&) skip(std::int64_t skip);
+    MONGOCXX_ABI_EXPORT_CDECL(count_options&) skip(std::int64_t v);
 
     ///
     /// Return the current "skip" field.
@@ -165,7 +165,7 @@ class count_options {
     ///
     /// Set the "readConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(count_options&) read_concern(v1::read_concern rc);
+    MONGOCXX_ABI_EXPORT_CDECL(count_options&) read_concern(v1::read_concern v);
 
     ///
     /// Return the current "readConcern" field.
@@ -175,7 +175,7 @@ class count_options {
     ///
     /// Set the "readPreference" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(count_options&) read_preference(v1::read_preference rp);
+    MONGOCXX_ABI_EXPORT_CDECL(count_options&) read_preference(v1::read_preference v);
 
     ///
     /// Return the current "readPreference" field.

--- a/src/mongocxx/include/mongocxx/v1/data_key_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/data_key_options.hpp
@@ -95,7 +95,7 @@ class data_key_options {
     ///
     /// Set the "masterKey" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(data_key_options&) master_key(bsoncxx::v1::document::value master_key);
+    MONGOCXX_ABI_EXPORT_CDECL(data_key_options&) master_key(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "masterKey" field.
@@ -105,7 +105,7 @@ class data_key_options {
     ///
     /// Set the "keyAltNames" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(data_key_options&) key_alt_names(std::vector<std::string> key_alt_names);
+    MONGOCXX_ABI_EXPORT_CDECL(data_key_options&) key_alt_names(std::vector<std::string> v);
 
     ///
     /// Return the current "keyAltNames" field.
@@ -120,7 +120,7 @@ class data_key_options {
     ///
     /// Set the "keyMaterial" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(data_key_options&) key_material(key_material_type key_material);
+    MONGOCXX_ABI_EXPORT_CDECL(data_key_options&) key_material(key_material_type v);
 
     ///
     /// Return the current "keyMaterial" field.

--- a/src/mongocxx/include/mongocxx/v1/delete_many_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/delete_many_options.hpp
@@ -100,7 +100,7 @@ class delete_many_options {
     ///
     /// Set the "collation" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(delete_many_options&) collation(bsoncxx::v1::document::value collation);
+    MONGOCXX_ABI_EXPORT_CDECL(delete_many_options&) collation(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "collation" field.
@@ -110,7 +110,7 @@ class delete_many_options {
     ///
     /// Set the "readConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(delete_many_options&) read_concern(v1::read_concern rc);
+    MONGOCXX_ABI_EXPORT_CDECL(delete_many_options&) read_concern(v1::read_concern v);
 
     ///
     /// Return the current "readConcern" field.
@@ -120,7 +120,7 @@ class delete_many_options {
     ///
     /// Set the "writeConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(delete_many_options&) write_concern(v1::write_concern wc);
+    MONGOCXX_ABI_EXPORT_CDECL(delete_many_options&) write_concern(v1::write_concern v);
 
     ///
     /// Return the current "writeConcern" field.
@@ -130,7 +130,7 @@ class delete_many_options {
     ///
     /// Set the "hint" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(delete_many_options&) hint(v1::hint index_hint);
+    MONGOCXX_ABI_EXPORT_CDECL(delete_many_options&) hint(v1::hint v);
 
     ///
     /// Return the current "hint" field.
@@ -140,7 +140,7 @@ class delete_many_options {
     ///
     /// Set the "let" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(delete_many_options&) let(bsoncxx::v1::document::value let);
+    MONGOCXX_ABI_EXPORT_CDECL(delete_many_options&) let(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "let" field.
@@ -150,7 +150,7 @@ class delete_many_options {
     ///
     /// Set the "comment" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(delete_many_options&) comment(bsoncxx::v1::types::value comment);
+    MONGOCXX_ABI_EXPORT_CDECL(delete_many_options&) comment(bsoncxx::v1::types::value v);
 
     ///
     /// Return the current "comment" field.

--- a/src/mongocxx/include/mongocxx/v1/delete_one_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/delete_one_options.hpp
@@ -100,7 +100,7 @@ class delete_one_options {
     ///
     /// Set the "collation" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(delete_one_options&) collation(bsoncxx::v1::document::value collation);
+    MONGOCXX_ABI_EXPORT_CDECL(delete_one_options&) collation(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "collation" field.
@@ -110,7 +110,7 @@ class delete_one_options {
     ///
     /// Set the "readConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(delete_one_options&) read_concern(v1::read_concern rc);
+    MONGOCXX_ABI_EXPORT_CDECL(delete_one_options&) read_concern(v1::read_concern v);
 
     ///
     /// Return the current "readConcern" field.
@@ -120,7 +120,7 @@ class delete_one_options {
     ///
     /// Set the "writeConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(delete_one_options&) write_concern(v1::write_concern wc);
+    MONGOCXX_ABI_EXPORT_CDECL(delete_one_options&) write_concern(v1::write_concern v);
 
     ///
     /// Return the current "writeConcern" field.
@@ -130,7 +130,7 @@ class delete_one_options {
     ///
     /// Set the "hint" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(delete_one_options&) hint(v1::hint index_hint);
+    MONGOCXX_ABI_EXPORT_CDECL(delete_one_options&) hint(v1::hint v);
 
     ///
     /// Return the current "hint" field.
@@ -140,7 +140,7 @@ class delete_one_options {
     ///
     /// Set the "let" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(delete_one_options&) let(bsoncxx::v1::document::value let);
+    MONGOCXX_ABI_EXPORT_CDECL(delete_one_options&) let(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "let" field.
@@ -150,7 +150,7 @@ class delete_one_options {
     ///
     /// Set the "comment" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(delete_one_options&) comment(bsoncxx::v1::types::value comment);
+    MONGOCXX_ABI_EXPORT_CDECL(delete_one_options&) comment(bsoncxx::v1::types::value v);
 
     ///
     /// Return the current "comment" field.

--- a/src/mongocxx/include/mongocxx/v1/distinct_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/distinct_options.hpp
@@ -100,7 +100,7 @@ class distinct_options {
     ///
     /// Set the "collation" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(distinct_options&) collation(bsoncxx::v1::document::value collation);
+    MONGOCXX_ABI_EXPORT_CDECL(distinct_options&) collation(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "collation" field.
@@ -110,7 +110,7 @@ class distinct_options {
     ///
     /// Set the "maxTimeMS" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(distinct_options&) max_time(std::chrono::milliseconds max_time);
+    MONGOCXX_ABI_EXPORT_CDECL(distinct_options&) max_time(std::chrono::milliseconds v);
 
     ///
     /// Return the current "maxTimeMS" field.
@@ -120,7 +120,7 @@ class distinct_options {
     ///
     /// Set the "comment" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(distinct_options&) comment(bsoncxx::v1::types::value comment);
+    MONGOCXX_ABI_EXPORT_CDECL(distinct_options&) comment(bsoncxx::v1::types::value v);
 
     ///
     /// Return the current "comment" field.
@@ -130,7 +130,7 @@ class distinct_options {
     ///
     /// Set the "readPreference" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(distinct_options&) read_preference(v1::read_preference rp);
+    MONGOCXX_ABI_EXPORT_CDECL(distinct_options&) read_preference(v1::read_preference v);
 
     ///
     /// Return the current "readPreference" field.
@@ -140,7 +140,7 @@ class distinct_options {
     ///
     /// Set the "readConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(distinct_options&) read_concern(v1::read_concern rc);
+    MONGOCXX_ABI_EXPORT_CDECL(distinct_options&) read_concern(v1::read_concern v);
 
     ///
     /// Return the current "readConcern" field.

--- a/src/mongocxx/include/mongocxx/v1/estimated_document_count_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/estimated_document_count_options.hpp
@@ -98,7 +98,7 @@ class estimated_document_count_options {
     ///
     /// Set the "maxTimeMS" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(estimated_document_count_options&) max_time(std::chrono::milliseconds max_time);
+    MONGOCXX_ABI_EXPORT_CDECL(estimated_document_count_options&) max_time(std::chrono::milliseconds v);
 
     ///
     /// Return the current "maxTimeMS" field.
@@ -108,7 +108,7 @@ class estimated_document_count_options {
     ///
     /// Set the "comment" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(estimated_document_count_options&) comment(bsoncxx::v1::types::value comment);
+    MONGOCXX_ABI_EXPORT_CDECL(estimated_document_count_options&) comment(bsoncxx::v1::types::value v);
 
     ///
     /// Return the current "comment" field.
@@ -118,7 +118,7 @@ class estimated_document_count_options {
     ///
     /// Set the "readPreference" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(estimated_document_count_options&) read_preference(v1::read_preference rp);
+    MONGOCXX_ABI_EXPORT_CDECL(estimated_document_count_options&) read_preference(v1::read_preference v);
 
     ///
     /// Return the current "readPreference" field.

--- a/src/mongocxx/include/mongocxx/v1/find_one_and_delete_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/find_one_and_delete_options.hpp
@@ -136,7 +136,7 @@ class find_one_and_delete_options {
     ///
     /// Set the "sort" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete_options&) sort(bsoncxx::v1::document::value ordering);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete_options&) sort(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "sort" field.
@@ -166,7 +166,7 @@ class find_one_and_delete_options {
     ///
     /// Set the "hint" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete_options&) hint(v1::hint index_hint);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_delete_options&) hint(v1::hint v);
 
     ///
     /// Return the current "hint" field.

--- a/src/mongocxx/include/mongocxx/v1/find_one_and_replace_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/find_one_and_replace_options.hpp
@@ -130,7 +130,7 @@ class find_one_and_replace_options {
     ///
     /// Set the "hint" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) hint(v1::hint index_hint);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) hint(v1::hint v);
 
     ///
     /// Return the current "hint" field.
@@ -190,7 +190,7 @@ class find_one_and_replace_options {
     ///
     /// Set the "sort" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) sort(bsoncxx::v1::document::value ordering);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_replace_options&) sort(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "sort" field.

--- a/src/mongocxx/include/mongocxx/v1/find_one_and_update_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/find_one_and_update_options.hpp
@@ -133,7 +133,7 @@ class find_one_and_update_options {
     ///
     /// Set the "hint" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) hint(v1::hint index_hint);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) hint(v1::hint v);
 
     ///
     /// Return the current "hint" field.
@@ -193,7 +193,7 @@ class find_one_and_update_options {
     ///
     /// Set the "sort" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) sort(bsoncxx::v1::document::value ordering);
+    MONGOCXX_ABI_EXPORT_CDECL(find_one_and_update_options&) sort(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "sort" field.

--- a/src/mongocxx/include/mongocxx/v1/find_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/find_options.hpp
@@ -119,7 +119,7 @@ class find_options {
     ///
     /// Set the "allowDiskUse" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_options&) allow_disk_use(bool allow_disk_use);
+    MONGOCXX_ABI_EXPORT_CDECL(find_options&) allow_disk_use(bool v);
 
     ///
     /// Return the current "allowDiskUse" field.
@@ -129,7 +129,7 @@ class find_options {
     ///
     /// Set the "allowPartialResults" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_options&) allow_partial_results(bool allow_partial);
+    MONGOCXX_ABI_EXPORT_CDECL(find_options&) allow_partial_results(bool v);
 
     ///
     /// Return the current "allowPartialResults" field.
@@ -139,7 +139,7 @@ class find_options {
     ///
     /// Set the "batchSize" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_options&) batch_size(std::int32_t batch_size);
+    MONGOCXX_ABI_EXPORT_CDECL(find_options&) batch_size(std::int32_t v);
 
     ///
     /// Return the current "batchSize" field.
@@ -149,7 +149,7 @@ class find_options {
     ///
     /// Set the "collation" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_options&) collation(bsoncxx::v1::document::value collation);
+    MONGOCXX_ABI_EXPORT_CDECL(find_options&) collation(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "collation" field.
@@ -159,7 +159,7 @@ class find_options {
     ///
     /// Set the "comment" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_options&) comment(bsoncxx::v1::types::value comment);
+    MONGOCXX_ABI_EXPORT_CDECL(find_options&) comment(bsoncxx::v1::types::value v);
 
     ///
     /// Return the current "comment" field.
@@ -169,7 +169,7 @@ class find_options {
     ///
     /// Set the "cursorType" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_options&) cursor_type(v1::cursor::type cursor_type);
+    MONGOCXX_ABI_EXPORT_CDECL(find_options&) cursor_type(v1::cursor::type v);
 
     ///
     /// Return the current "cursorType" field.
@@ -179,7 +179,7 @@ class find_options {
     ///
     /// Set the "hint" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_options&) hint(v1::hint index_hint);
+    MONGOCXX_ABI_EXPORT_CDECL(find_options&) hint(v1::hint v);
 
     ///
     /// Return the current "hint" field.
@@ -189,7 +189,7 @@ class find_options {
     ///
     /// Set the "let" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_options&) let(bsoncxx::v1::document::value let);
+    MONGOCXX_ABI_EXPORT_CDECL(find_options&) let(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "let" field.
@@ -199,7 +199,7 @@ class find_options {
     ///
     /// Set the "limit" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_options&) limit(std::int64_t limit);
+    MONGOCXX_ABI_EXPORT_CDECL(find_options&) limit(std::int64_t v);
 
     ///
     /// Return the current "limit" field.
@@ -209,7 +209,7 @@ class find_options {
     ///
     /// Set the "max" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_options&) max(bsoncxx::v1::document::value max);
+    MONGOCXX_ABI_EXPORT_CDECL(find_options&) max(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "max" field.
@@ -219,7 +219,7 @@ class find_options {
     ///
     /// Set the "maxAwaitTimeMS" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_options&) max_await_time(std::chrono::milliseconds max_await_time);
+    MONGOCXX_ABI_EXPORT_CDECL(find_options&) max_await_time(std::chrono::milliseconds v);
 
     ///
     /// Return the current "maxAwaitTimeMS" field.
@@ -229,7 +229,7 @@ class find_options {
     ///
     /// Set the "maxTimeMS" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_options&) max_time(std::chrono::milliseconds max_time);
+    MONGOCXX_ABI_EXPORT_CDECL(find_options&) max_time(std::chrono::milliseconds v);
 
     ///
     /// Return the current "maxTimeMS" field.
@@ -239,7 +239,7 @@ class find_options {
     ///
     /// Set the "min" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_options&) min(bsoncxx::v1::document::value min);
+    MONGOCXX_ABI_EXPORT_CDECL(find_options&) min(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "min" field.
@@ -249,7 +249,7 @@ class find_options {
     ///
     /// Set the "noCursorTimeout" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_options&) no_cursor_timeout(bool no_cursor_timeout);
+    MONGOCXX_ABI_EXPORT_CDECL(find_options&) no_cursor_timeout(bool v);
 
     ///
     /// Return the current "noCursorTimeout" field.
@@ -259,7 +259,7 @@ class find_options {
     ///
     /// Set the "projection" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_options&) projection(bsoncxx::v1::document::value projection);
+    MONGOCXX_ABI_EXPORT_CDECL(find_options&) projection(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "projection" field.
@@ -269,7 +269,7 @@ class find_options {
     ///
     /// Set the "readPreference" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_options&) read_preference(v1::read_preference rp);
+    MONGOCXX_ABI_EXPORT_CDECL(find_options&) read_preference(v1::read_preference v);
 
     ///
     /// Return the current "readPreference" field.
@@ -279,7 +279,7 @@ class find_options {
     ///
     /// Set the "readConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_options&) read_concern(v1::read_concern rc);
+    MONGOCXX_ABI_EXPORT_CDECL(find_options&) read_concern(v1::read_concern v);
 
     ///
     /// Return the current "readConcern" field.
@@ -289,7 +289,7 @@ class find_options {
     ///
     /// Set the "returnKey" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_options&) return_key(bool return_key);
+    MONGOCXX_ABI_EXPORT_CDECL(find_options&) return_key(bool v);
 
     ///
     /// Return the current "returnKey" field.
@@ -299,7 +299,7 @@ class find_options {
     ///
     /// Set the "showRecordId" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_options&) show_record_id(bool show_record_id);
+    MONGOCXX_ABI_EXPORT_CDECL(find_options&) show_record_id(bool v);
 
     ///
     /// Return the current "showRecordId" field.
@@ -309,7 +309,7 @@ class find_options {
     ///
     /// Set the "skip" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_options&) skip(std::int64_t skip);
+    MONGOCXX_ABI_EXPORT_CDECL(find_options&) skip(std::int64_t v);
 
     ///
     /// Return the current "skip" field.
@@ -319,7 +319,7 @@ class find_options {
     ///
     /// Set the "sort" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(find_options&) sort(bsoncxx::v1::document::value ordering);
+    MONGOCXX_ABI_EXPORT_CDECL(find_options&) sort(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "sort" field.

--- a/src/mongocxx/include/mongocxx/v1/gridfs/upload_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/gridfs/upload_options.hpp
@@ -93,7 +93,7 @@ class upload_options {
     ///
     /// Set the "chunkSizeBytes" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(upload_options&) chunk_size_bytes(std::int32_t chunk_size_bytes);
+    MONGOCXX_ABI_EXPORT_CDECL(upload_options&) chunk_size_bytes(std::int32_t v);
 
     ///
     /// Return the current "chunkSizeBytes" field.
@@ -103,7 +103,7 @@ class upload_options {
     ///
     /// Set the "metadata" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(upload_options&) metadata(bsoncxx::v1::document::value metadata);
+    MONGOCXX_ABI_EXPORT_CDECL(upload_options&) metadata(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "metadata" field.

--- a/src/mongocxx/include/mongocxx/v1/insert_many_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/insert_many_options.hpp
@@ -96,7 +96,7 @@ class insert_many_options {
     ///
     /// Set the "bypassDocumentValidation" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(insert_many_options&) bypass_document_validation(bool bypass_document_validation);
+    MONGOCXX_ABI_EXPORT_CDECL(insert_many_options&) bypass_document_validation(bool v);
 
     ///
     /// Return the current "bypassDocumentValidation" field.
@@ -106,7 +106,7 @@ class insert_many_options {
     ///
     /// Set the "readConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(insert_many_options&) read_concern(v1::read_concern rc);
+    MONGOCXX_ABI_EXPORT_CDECL(insert_many_options&) read_concern(v1::read_concern v);
 
     ///
     /// Return the current "readConcern" field.
@@ -116,7 +116,7 @@ class insert_many_options {
     ///
     /// Set the "writeConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(insert_many_options&) write_concern(v1::write_concern wc);
+    MONGOCXX_ABI_EXPORT_CDECL(insert_many_options&) write_concern(v1::write_concern v);
 
     ///
     /// Return the current "writeConcern" field.
@@ -126,7 +126,7 @@ class insert_many_options {
     ///
     /// Set the "ordered" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(insert_many_options&) ordered(bool ordered);
+    MONGOCXX_ABI_EXPORT_CDECL(insert_many_options&) ordered(bool v);
 
     ///
     /// Return the current "ordered" field.
@@ -136,7 +136,7 @@ class insert_many_options {
     ///
     /// Set the "comment" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(insert_many_options&) comment(bsoncxx::v1::types::value comment);
+    MONGOCXX_ABI_EXPORT_CDECL(insert_many_options&) comment(bsoncxx::v1::types::value v);
 
     ///
     /// Return the current "comment" field.

--- a/src/mongocxx/include/mongocxx/v1/insert_one_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/insert_one_options.hpp
@@ -95,7 +95,7 @@ class insert_one_options {
     ///
     /// Set the "bypassDocumentValidation" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(insert_one_options&) bypass_document_validation(bool bypass_document_validation);
+    MONGOCXX_ABI_EXPORT_CDECL(insert_one_options&) bypass_document_validation(bool v);
 
     ///
     /// Return the current "bypassDocumentValidation" field.
@@ -105,7 +105,7 @@ class insert_one_options {
     ///
     /// Set the "readConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(insert_one_options&) read_concern(v1::read_concern rc);
+    MONGOCXX_ABI_EXPORT_CDECL(insert_one_options&) read_concern(v1::read_concern v);
 
     ///
     /// Return the current "readConcern" field.
@@ -115,7 +115,7 @@ class insert_one_options {
     ///
     /// Set the "writeConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(insert_one_options&) write_concern(v1::write_concern wc);
+    MONGOCXX_ABI_EXPORT_CDECL(insert_one_options&) write_concern(v1::write_concern v);
 
     ///
     /// Return the current "writeConcern" field.
@@ -125,7 +125,7 @@ class insert_one_options {
     ///
     /// Set the "comment" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(insert_one_options&) comment(bsoncxx::v1::types::value comment);
+    MONGOCXX_ABI_EXPORT_CDECL(insert_one_options&) comment(bsoncxx::v1::types::value v);
 
     ///
     /// Return the current "comment" field.

--- a/src/mongocxx/include/mongocxx/v1/range_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/range_options.hpp
@@ -96,7 +96,7 @@ class range_options {
     ///
     /// Set the "min" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(range_options&) min(bsoncxx::v1::types::value value);
+    MONGOCXX_ABI_EXPORT_CDECL(range_options&) min(bsoncxx::v1::types::value v);
 
     ///
     /// Return the current "min" field.
@@ -107,7 +107,7 @@ class range_options {
     ///
     /// Set the "max" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(range_options&) max(bsoncxx::v1::types::value value);
+    MONGOCXX_ABI_EXPORT_CDECL(range_options&) max(bsoncxx::v1::types::value v);
 
     ///
     /// Return the current "max" field.
@@ -118,7 +118,7 @@ class range_options {
     ///
     /// Set the "sparsity" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(range_options&) sparsity(std::int64_t value);
+    MONGOCXX_ABI_EXPORT_CDECL(range_options&) sparsity(std::int64_t v);
 
     ///
     /// Return the current "sparsity" field.
@@ -129,7 +129,7 @@ class range_options {
     ///
     /// Set the "trimFactor" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(range_options&) trim_factor(std::int32_t value);
+    MONGOCXX_ABI_EXPORT_CDECL(range_options&) trim_factor(std::int32_t v);
 
     ///
     /// Return the current "trimFactor" field.
@@ -140,7 +140,7 @@ class range_options {
     ///
     /// Set the "precision" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(range_options&) precision(std::int32_t value);
+    MONGOCXX_ABI_EXPORT_CDECL(range_options&) precision(std::int32_t v);
 
     ///
     /// Return the current "precision" field.

--- a/src/mongocxx/include/mongocxx/v1/replace_one_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/replace_one_options.hpp
@@ -103,7 +103,7 @@ class replace_one_options {
     ///
     /// Set the "bypassDocumentValidation" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(replace_one_options&) bypass_document_validation(bool bypass_document_validation);
+    MONGOCXX_ABI_EXPORT_CDECL(replace_one_options&) bypass_document_validation(bool v);
 
     ///
     /// Return the current "bypassDocumentValidation" field.
@@ -113,7 +113,7 @@ class replace_one_options {
     ///
     /// Set the "collation" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(replace_one_options&) collation(bsoncxx::v1::document::value collation);
+    MONGOCXX_ABI_EXPORT_CDECL(replace_one_options&) collation(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "collation" field.
@@ -123,7 +123,7 @@ class replace_one_options {
     ///
     /// Set the "upsert" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(replace_one_options&) upsert(bool upsert);
+    MONGOCXX_ABI_EXPORT_CDECL(replace_one_options&) upsert(bool v);
 
     ///
     /// Return the current "upsert" field.
@@ -133,7 +133,7 @@ class replace_one_options {
     ///
     /// Set the "readConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(replace_one_options&) read_concern(v1::read_concern rc);
+    MONGOCXX_ABI_EXPORT_CDECL(replace_one_options&) read_concern(v1::read_concern v);
 
     ///
     /// Return the current "readConcern" field.
@@ -143,7 +143,7 @@ class replace_one_options {
     ///
     /// Set the "writeConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(replace_one_options&) write_concern(v1::write_concern wc);
+    MONGOCXX_ABI_EXPORT_CDECL(replace_one_options&) write_concern(v1::write_concern v);
 
     ///
     /// Return the current "writeConcern" field.
@@ -153,7 +153,7 @@ class replace_one_options {
     ///
     /// Set the "hint" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(replace_one_options&) hint(v1::hint index_hint);
+    MONGOCXX_ABI_EXPORT_CDECL(replace_one_options&) hint(v1::hint v);
 
     ///
     /// Return the current "hint" field.
@@ -163,7 +163,7 @@ class replace_one_options {
     ///
     /// Set the "let" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(replace_one_options&) let(bsoncxx::v1::document::value let);
+    MONGOCXX_ABI_EXPORT_CDECL(replace_one_options&) let(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "let" field.
@@ -173,7 +173,7 @@ class replace_one_options {
     ///
     /// Set the "sort" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(replace_one_options&) sort(bsoncxx::v1::document::value sort);
+    MONGOCXX_ABI_EXPORT_CDECL(replace_one_options&) sort(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "sort" field.
@@ -183,7 +183,7 @@ class replace_one_options {
     ///
     /// Set the "comment" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(replace_one_options&) comment(bsoncxx::v1::types::value comment);
+    MONGOCXX_ABI_EXPORT_CDECL(replace_one_options&) comment(bsoncxx::v1::types::value v);
 
     ///
     /// Return the current "comment" field.

--- a/src/mongocxx/include/mongocxx/v1/rewrap_many_datakey_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/rewrap_many_datakey_options.hpp
@@ -93,7 +93,7 @@ class rewrap_many_datakey_options {
     ///
     /// Set the "provider" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(rewrap_many_datakey_options&) provider(std::string provider);
+    MONGOCXX_ABI_EXPORT_CDECL(rewrap_many_datakey_options&) provider(std::string v);
 
     ///
     /// Return the current "provider" field.
@@ -103,7 +103,7 @@ class rewrap_many_datakey_options {
     ///
     /// Set the "masterKey" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(rewrap_many_datakey_options&) master_key(bsoncxx::v1::document::value master_key);
+    MONGOCXX_ABI_EXPORT_CDECL(rewrap_many_datakey_options&) master_key(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "masterKey" field.

--- a/src/mongocxx/include/mongocxx/v1/update_many_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/update_many_options.hpp
@@ -105,7 +105,7 @@ class update_many_options {
     ///
     /// Set the "bypassDocumentValidation" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(update_many_options&) bypass_document_validation(bool bypass_document_validation);
+    MONGOCXX_ABI_EXPORT_CDECL(update_many_options&) bypass_document_validation(bool v);
 
     ///
     /// Return the current "bypassDocumentValidation" field.
@@ -115,7 +115,7 @@ class update_many_options {
     ///
     /// Set the "collation" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(update_many_options&) collation(bsoncxx::v1::document::value collation);
+    MONGOCXX_ABI_EXPORT_CDECL(update_many_options&) collation(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "collation" field.
@@ -125,7 +125,7 @@ class update_many_options {
     ///
     /// Set the "hint" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(update_many_options&) hint(v1::hint index_hint);
+    MONGOCXX_ABI_EXPORT_CDECL(update_many_options&) hint(v1::hint v);
 
     ///
     /// Return the current "hint" field.
@@ -135,7 +135,7 @@ class update_many_options {
     ///
     /// Set the "let" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(update_many_options&) let(bsoncxx::v1::document::value let);
+    MONGOCXX_ABI_EXPORT_CDECL(update_many_options&) let(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "let" field.
@@ -145,7 +145,7 @@ class update_many_options {
     ///
     /// Set the "comment" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(update_many_options&) comment(bsoncxx::v1::types::value comment);
+    MONGOCXX_ABI_EXPORT_CDECL(update_many_options&) comment(bsoncxx::v1::types::value v);
 
     ///
     /// Return the current "comment" field.
@@ -155,7 +155,7 @@ class update_many_options {
     ///
     /// Set the "upsert" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(update_many_options&) upsert(bool upsert);
+    MONGOCXX_ABI_EXPORT_CDECL(update_many_options&) upsert(bool v);
 
     ///
     /// Return the current "upsert" field.
@@ -165,7 +165,7 @@ class update_many_options {
     ///
     /// Set the "readConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(update_many_options&) read_concern(v1::read_concern rc);
+    MONGOCXX_ABI_EXPORT_CDECL(update_many_options&) read_concern(v1::read_concern v);
 
     ///
     /// Return the current "readConcern" field.
@@ -175,7 +175,7 @@ class update_many_options {
     ///
     /// Set the "writeConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(update_many_options&) write_concern(v1::write_concern wc);
+    MONGOCXX_ABI_EXPORT_CDECL(update_many_options&) write_concern(v1::write_concern v);
 
     ///
     /// Return the current "writeConcern" field.
@@ -185,7 +185,7 @@ class update_many_options {
     ///
     /// Set the "arrayFilters" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(update_many_options&) array_filters(bsoncxx::v1::array::value array_filters);
+    MONGOCXX_ABI_EXPORT_CDECL(update_many_options&) array_filters(bsoncxx::v1::array::value v);
 
     ///
     /// Return the current "arrayFilters" field.

--- a/src/mongocxx/include/mongocxx/v1/update_one_options.hpp
+++ b/src/mongocxx/include/mongocxx/v1/update_one_options.hpp
@@ -106,7 +106,7 @@ class update_one_options {
     ///
     /// Set the "bypassDocumentValidation" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(update_one_options&) bypass_document_validation(bool bypass_document_validation);
+    MONGOCXX_ABI_EXPORT_CDECL(update_one_options&) bypass_document_validation(bool v);
 
     ///
     /// Return the current "bypassDocumentValidation" field.
@@ -116,7 +116,7 @@ class update_one_options {
     ///
     /// Set the "collation" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(update_one_options&) collation(bsoncxx::v1::document::value collation);
+    MONGOCXX_ABI_EXPORT_CDECL(update_one_options&) collation(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "collation" field.
@@ -126,7 +126,7 @@ class update_one_options {
     ///
     /// Set the "hint" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(update_one_options&) hint(v1::hint index_hint);
+    MONGOCXX_ABI_EXPORT_CDECL(update_one_options&) hint(v1::hint v);
 
     ///
     /// Return the current "hint" field.
@@ -136,7 +136,7 @@ class update_one_options {
     ///
     /// Set the "let" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(update_one_options&) let(bsoncxx::v1::document::value let);
+    MONGOCXX_ABI_EXPORT_CDECL(update_one_options&) let(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "let" field.
@@ -146,7 +146,7 @@ class update_one_options {
     ///
     /// Set the "sort" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(update_one_options&) sort(bsoncxx::v1::document::value sort);
+    MONGOCXX_ABI_EXPORT_CDECL(update_one_options&) sort(bsoncxx::v1::document::value v);
 
     ///
     /// Return the current "sort" field.
@@ -156,7 +156,7 @@ class update_one_options {
     ///
     /// Set the "comment" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(update_one_options&) comment(bsoncxx::v1::types::value comment);
+    MONGOCXX_ABI_EXPORT_CDECL(update_one_options&) comment(bsoncxx::v1::types::value v);
 
     ///
     /// Return the current "comment" field.
@@ -166,7 +166,7 @@ class update_one_options {
     ///
     /// Set the "upsert" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(update_one_options&) upsert(bool upsert);
+    MONGOCXX_ABI_EXPORT_CDECL(update_one_options&) upsert(bool v);
 
     ///
     /// Return the current "upsert" field.
@@ -176,7 +176,7 @@ class update_one_options {
     ///
     /// Set the "readConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(update_one_options&) read_concern(v1::read_concern rc);
+    MONGOCXX_ABI_EXPORT_CDECL(update_one_options&) read_concern(v1::read_concern v);
 
     ///
     /// Return the current "readConcern" field.
@@ -186,7 +186,7 @@ class update_one_options {
     ///
     /// Set the "writeConcern" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(update_one_options&) write_concern(v1::write_concern wc);
+    MONGOCXX_ABI_EXPORT_CDECL(update_one_options&) write_concern(v1::write_concern v);
 
     ///
     /// Return the current "writeConcern" field.
@@ -196,7 +196,7 @@ class update_one_options {
     ///
     /// Set the "arrayFilters" field.
     ///
-    MONGOCXX_ABI_EXPORT_CDECL(update_one_options&) array_filters(bsoncxx::v1::array::value array_filters);
+    MONGOCXX_ABI_EXPORT_CDECL(update_one_options&) array_filters(bsoncxx::v1::array::value v);
 
     ///
     /// Return the current "arrayFilters" field.

--- a/src/mongocxx/lib/mongocxx/v1/aggregate_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/aggregate_options.cpp
@@ -104,8 +104,8 @@ aggregate_options::aggregate_options() : _impl{new impl{}} {}
 
 // NOLINTEND(cppcoreguidelines-owning-memory)
 
-aggregate_options& aggregate_options::allow_disk_use(bool allow_disk_use) {
-    impl::with(this)->_allow_disk_use = allow_disk_use;
+aggregate_options& aggregate_options::allow_disk_use(bool v) {
+    impl::with(this)->_allow_disk_use = v;
     return *this;
 }
 
@@ -113,8 +113,8 @@ bsoncxx::v1::stdx::optional<bool> aggregate_options::allow_disk_use() const {
     return impl::with(this)->_allow_disk_use;
 }
 
-aggregate_options& aggregate_options::batch_size(std::int32_t batch_size) {
-    impl::with(this)->_batch_size = batch_size;
+aggregate_options& aggregate_options::batch_size(std::int32_t v) {
+    impl::with(this)->_batch_size = v;
     return *this;
 }
 
@@ -122,8 +122,8 @@ bsoncxx::v1::stdx::optional<std::int32_t> aggregate_options::batch_size() const 
     return impl::with(this)->_batch_size;
 }
 
-aggregate_options& aggregate_options::collation(bsoncxx::v1::document::value collation) {
-    impl::with(this)->_collation = std::move(collation);
+aggregate_options& aggregate_options::collation(bsoncxx::v1::document::value v) {
+    impl::with(this)->_collation = std::move(v);
     return *this;
 }
 
@@ -131,8 +131,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> aggregate_options::coll
     return impl::with(this)->_collation;
 }
 
-aggregate_options& aggregate_options::let(bsoncxx::v1::document::value let) {
-    impl::with(this)->_let = std::move(let);
+aggregate_options& aggregate_options::let(bsoncxx::v1::document::value v) {
+    impl::with(this)->_let = std::move(v);
     return *this;
 }
 
@@ -140,8 +140,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> aggregate_options::let(
     return impl::with(this)->_let;
 }
 
-aggregate_options& aggregate_options::max_time(std::chrono::milliseconds max_time) {
-    impl::with(this)->_max_time = max_time;
+aggregate_options& aggregate_options::max_time(std::chrono::milliseconds v) {
+    impl::with(this)->_max_time = v;
     return *this;
 }
 
@@ -149,8 +149,8 @@ bsoncxx::v1::stdx::optional<std::chrono::milliseconds> aggregate_options::max_ti
     return impl::with(this)->_max_time;
 }
 
-aggregate_options& aggregate_options::read_preference(v1::read_preference rp) {
-    impl::with(this)->_read_preference = std::move(rp);
+aggregate_options& aggregate_options::read_preference(v1::read_preference v) {
+    impl::with(this)->_read_preference = std::move(v);
     return *this;
 }
 
@@ -158,8 +158,8 @@ bsoncxx::v1::stdx::optional<v1::read_preference> aggregate_options::read_prefere
     return impl::with(this)->_read_preference;
 }
 
-aggregate_options& aggregate_options::bypass_document_validation(bool bypass_document_validation) {
-    impl::with(this)->_bypass_document_validation = bypass_document_validation;
+aggregate_options& aggregate_options::bypass_document_validation(bool v) {
+    impl::with(this)->_bypass_document_validation = v;
     return *this;
 }
 
@@ -167,8 +167,8 @@ bsoncxx::v1::stdx::optional<bool> aggregate_options::bypass_document_validation(
     return impl::with(this)->_bypass_document_validation;
 }
 
-aggregate_options& aggregate_options::hint(v1::hint index_hint) {
-    impl::with(this)->_hint = std::move(index_hint);
+aggregate_options& aggregate_options::hint(v1::hint v) {
+    impl::with(this)->_hint = std::move(v);
     return *this;
 }
 
@@ -176,8 +176,8 @@ bsoncxx::v1::stdx::optional<v1::hint> aggregate_options::hint() const {
     return impl::with(this)->_hint;
 }
 
-aggregate_options& aggregate_options::write_concern(v1::write_concern write_concern) {
-    impl::with(this)->_write_concern = std::move(write_concern);
+aggregate_options& aggregate_options::write_concern(v1::write_concern v) {
+    impl::with(this)->_write_concern = std::move(v);
     return *this;
 }
 
@@ -185,8 +185,8 @@ bsoncxx::v1::stdx::optional<v1::write_concern> aggregate_options::write_concern(
     return impl::with(this)->_write_concern;
 }
 
-aggregate_options& aggregate_options::read_concern(v1::read_concern read_concern) {
-    impl::with(this)->_read_concern = std::move(read_concern);
+aggregate_options& aggregate_options::read_concern(v1::read_concern v) {
+    impl::with(this)->_read_concern = std::move(v);
     return *this;
 }
 
@@ -194,8 +194,8 @@ bsoncxx::v1::stdx::optional<v1::read_concern> aggregate_options::read_concern() 
     return impl::with(this)->_read_concern;
 }
 
-aggregate_options& aggregate_options::comment(bsoncxx::v1::types::value comment) {
-    impl::with(this)->_comment = std::move(comment);
+aggregate_options& aggregate_options::comment(bsoncxx::v1::types::value v) {
+    impl::with(this)->_comment = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/bulk_write.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/bulk_write.cpp
@@ -1191,8 +1191,8 @@ bulk_write::options::options() : _impl{new impl{}} {}
 
 // NOLINTEND(cppcoreguidelines-owning-memory)
 
-bulk_write::options& bulk_write::options::bypass_document_validation(bool bypass_document_validation) {
-    impl::with(this)->_bypass_document_validation = bypass_document_validation;
+bulk_write::options& bulk_write::options::bypass_document_validation(bool v) {
+    impl::with(this)->_bypass_document_validation = v;
     return *this;
 }
 
@@ -1200,8 +1200,8 @@ bsoncxx::v1::stdx::optional<bool> bulk_write::options::bypass_document_validatio
     return impl::with(this)->_bypass_document_validation;
 }
 
-bulk_write::options& bulk_write::options::comment(bsoncxx::v1::types::value comment) {
-    impl::with(this)->_comment = std::move(comment);
+bulk_write::options& bulk_write::options::comment(bsoncxx::v1::types::value v) {
+    impl::with(this)->_comment = std::move(v);
     return *this;
 }
 
@@ -1209,8 +1209,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::types::view> bulk_write::options::comme
     return impl::with(this)->_comment;
 }
 
-bulk_write::options& bulk_write::options::let(bsoncxx::v1::document::value let) {
-    impl::with(this)->_let = std::move(let);
+bulk_write::options& bulk_write::options::let(bsoncxx::v1::document::value v) {
+    impl::with(this)->_let = std::move(v);
     return *this;
 }
 
@@ -1218,8 +1218,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> bulk_write::options::le
     return impl::with(this)->_let;
 }
 
-bulk_write::options& bulk_write::options::ordered(bool ordered) {
-    impl::with(this)->_ordered = ordered;
+bulk_write::options& bulk_write::options::ordered(bool v) {
+    impl::with(this)->_ordered = v;
     return *this;
 }
 
@@ -1227,8 +1227,8 @@ bool bulk_write::options::ordered() const {
     return impl::with(this)->_ordered;
 }
 
-bulk_write::options& bulk_write::options::read_concern(v1::read_concern rc) {
-    impl::with(this)->_read_concern = std::move(rc);
+bulk_write::options& bulk_write::options::read_concern(v1::read_concern v) {
+    impl::with(this)->_read_concern = std::move(v);
     return *this;
 }
 
@@ -1236,8 +1236,8 @@ bsoncxx::v1::stdx::optional<v1::read_concern> bulk_write::options::read_concern(
     return impl::with(this)->_read_concern;
 }
 
-bulk_write::options& bulk_write::options::write_concern(v1::write_concern wc) {
-    impl::with(this)->_write_concern = std::move(wc);
+bulk_write::options& bulk_write::options::write_concern(v1::write_concern v) {
+    impl::with(this)->_write_concern = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/count_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/count_options.cpp
@@ -98,8 +98,8 @@ count_options::count_options() : _impl{new impl{}} {}
 
 // NOLINTEND(cppcoreguidelines-owning-memory)
 
-count_options& count_options::collation(bsoncxx::v1::document::value collation) {
-    impl::with(this)->_collation = std::move(collation);
+count_options& count_options::collation(bsoncxx::v1::document::value v) {
+    impl::with(this)->_collation = std::move(v);
     return *this;
 }
 
@@ -107,8 +107,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> count_options::collatio
     return impl::with(this)->_collation;
 }
 
-count_options& count_options::hint(v1::hint index_hint) {
-    impl::with(this)->_hint = std::move(index_hint);
+count_options& count_options::hint(v1::hint v) {
+    impl::with(this)->_hint = std::move(v);
     return *this;
 }
 
@@ -116,8 +116,8 @@ bsoncxx::v1::stdx::optional<v1::hint> count_options::hint() const {
     return impl::with(this)->_hint;
 }
 
-count_options& count_options::comment(bsoncxx::v1::types::value comment) {
-    impl::with(this)->_comment = std::move(comment);
+count_options& count_options::comment(bsoncxx::v1::types::value v) {
+    impl::with(this)->_comment = std::move(v);
     return *this;
 }
 
@@ -125,8 +125,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::types::view> count_options::comment() c
     return impl::with(this)->_comment;
 }
 
-count_options& count_options::limit(std::int64_t limit) {
-    impl::with(this)->_limit = limit;
+count_options& count_options::limit(std::int64_t v) {
+    impl::with(this)->_limit = v;
     return *this;
 }
 
@@ -134,8 +134,8 @@ bsoncxx::v1::stdx::optional<std::int64_t> count_options::limit() const {
     return impl::with(this)->_limit;
 }
 
-count_options& count_options::max_time(std::chrono::milliseconds max_time) {
-    impl::with(this)->_max_time = max_time;
+count_options& count_options::max_time(std::chrono::milliseconds v) {
+    impl::with(this)->_max_time = v;
     return *this;
 }
 
@@ -143,8 +143,8 @@ bsoncxx::v1::stdx::optional<std::chrono::milliseconds> count_options::max_time()
     return impl::with(this)->_max_time;
 }
 
-count_options& count_options::skip(std::int64_t skip) {
-    impl::with(this)->_skip = skip;
+count_options& count_options::skip(std::int64_t v) {
+    impl::with(this)->_skip = v;
     return *this;
 }
 
@@ -152,8 +152,8 @@ bsoncxx::v1::stdx::optional<std::int64_t> count_options::skip() const {
     return impl::with(this)->_skip;
 }
 
-count_options& count_options::read_preference(v1::read_preference rp) {
-    impl::with(this)->_rp = std::move(rp);
+count_options& count_options::read_preference(v1::read_preference v) {
+    impl::with(this)->_rp = std::move(v);
     return *this;
 }
 
@@ -161,8 +161,8 @@ bsoncxx::v1::stdx::optional<v1::read_preference> count_options::read_preference(
     return impl::with(this)->_rp;
 }
 
-count_options& count_options::read_concern(v1::read_concern rc) {
-    impl::with(this)->_read_concern = std::move(rc);
+count_options& count_options::read_concern(v1::read_concern v) {
+    impl::with(this)->_read_concern = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/data_key_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/data_key_options.cpp
@@ -90,8 +90,8 @@ data_key_options::data_key_options() : _impl{new impl{}} {}
 
 // NOLINTEND(cppcoreguidelines-owning-memory)
 
-data_key_options& data_key_options::master_key(bsoncxx::v1::document::value master_key) {
-    impl::with(this)->_master_key = std::move(master_key);
+data_key_options& data_key_options::master_key(bsoncxx::v1::document::value v) {
+    impl::with(this)->_master_key = std::move(v);
     return *this;
 }
 
@@ -99,8 +99,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> data_key_options::maste
     return impl::with(this)->_master_key;
 }
 
-data_key_options& data_key_options::key_alt_names(std::vector<std::string> key_alt_names) {
-    impl::with(this)->_key_alt_names = std::move(key_alt_names);
+data_key_options& data_key_options::key_alt_names(std::vector<std::string> v) {
+    impl::with(this)->_key_alt_names = std::move(v);
     return *this;
 }
 
@@ -108,8 +108,8 @@ std::vector<std::string> data_key_options::key_alt_names() const {
     return impl::with(this)->_key_alt_names;
 }
 
-data_key_options& data_key_options::key_material(key_material_type key_material) {
-    impl::with(this)->_key_material = std::move(key_material);
+data_key_options& data_key_options::key_material(key_material_type v) {
+    impl::with(this)->_key_material = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/delete_many_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/delete_many_options.cpp
@@ -91,8 +91,8 @@ delete_many_options::delete_many_options() : _impl{new impl{}} {}
 
 // NOLINTEND(cppcoreguidelines-owning-memory)
 
-delete_many_options& delete_many_options::collation(bsoncxx::v1::document::value collation) {
-    impl::with(this)->_collation = std::move(collation);
+delete_many_options& delete_many_options::collation(bsoncxx::v1::document::value v) {
+    impl::with(this)->_collation = std::move(v);
     return *this;
 }
 
@@ -100,8 +100,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> delete_many_options::co
     return impl::with(this)->_collation;
 }
 
-delete_many_options& delete_many_options::read_concern(v1::read_concern rc) {
-    impl::with(this)->_read_concern = std::move(rc);
+delete_many_options& delete_many_options::read_concern(v1::read_concern v) {
+    impl::with(this)->_read_concern = std::move(v);
     return *this;
 }
 
@@ -109,8 +109,8 @@ bsoncxx::v1::stdx::optional<v1::read_concern> delete_many_options::read_concern(
     return impl::with(this)->_read_concern;
 }
 
-delete_many_options& delete_many_options::write_concern(v1::write_concern wc) {
-    impl::with(this)->_write_concern = std::move(wc);
+delete_many_options& delete_many_options::write_concern(v1::write_concern v) {
+    impl::with(this)->_write_concern = std::move(v);
     return *this;
 }
 
@@ -118,8 +118,8 @@ bsoncxx::v1::stdx::optional<v1::write_concern> delete_many_options::write_concer
     return impl::with(this)->_write_concern;
 }
 
-delete_many_options& delete_many_options::hint(v1::hint index_hint) {
-    impl::with(this)->_hint = std::move(index_hint);
+delete_many_options& delete_many_options::hint(v1::hint v) {
+    impl::with(this)->_hint = std::move(v);
     return *this;
 }
 
@@ -127,8 +127,8 @@ bsoncxx::v1::stdx::optional<v1::hint> delete_many_options::hint() const {
     return impl::with(this)->_hint;
 }
 
-delete_many_options& delete_many_options::let(bsoncxx::v1::document::value let) {
-    impl::with(this)->_let = std::move(let);
+delete_many_options& delete_many_options::let(bsoncxx::v1::document::value v) {
+    impl::with(this)->_let = std::move(v);
     return *this;
 }
 
@@ -136,8 +136,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> const delete_many_optio
     return impl::with(this)->_let;
 }
 
-delete_many_options& delete_many_options::comment(bsoncxx::v1::types::value comment) {
-    impl::with(this)->_comment = std::move(comment);
+delete_many_options& delete_many_options::comment(bsoncxx::v1::types::value v) {
+    impl::with(this)->_comment = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/delete_one_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/delete_one_options.cpp
@@ -90,8 +90,8 @@ delete_one_options::delete_one_options() : _impl{new impl{}} {}
 
 // NOLINTEND(cppcoreguidelines-owning-memory)
 
-delete_one_options& delete_one_options::collation(bsoncxx::v1::document::value collation) {
-    impl::with(this)->_collation = std::move(collation);
+delete_one_options& delete_one_options::collation(bsoncxx::v1::document::value v) {
+    impl::with(this)->_collation = std::move(v);
     return *this;
 }
 
@@ -99,8 +99,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> delete_one_options::col
     return impl::with(this)->_collation;
 }
 
-delete_one_options& delete_one_options::read_concern(v1::read_concern rc) {
-    impl::with(this)->_read_concern = std::move(rc);
+delete_one_options& delete_one_options::read_concern(v1::read_concern v) {
+    impl::with(this)->_read_concern = std::move(v);
     return *this;
 }
 
@@ -108,8 +108,8 @@ bsoncxx::v1::stdx::optional<v1::read_concern> delete_one_options::read_concern()
     return impl::with(this)->_read_concern;
 }
 
-delete_one_options& delete_one_options::write_concern(v1::write_concern wc) {
-    impl::with(this)->_write_concern = std::move(wc);
+delete_one_options& delete_one_options::write_concern(v1::write_concern v) {
+    impl::with(this)->_write_concern = std::move(v);
     return *this;
 }
 
@@ -117,8 +117,8 @@ bsoncxx::v1::stdx::optional<v1::write_concern> delete_one_options::write_concern
     return impl::with(this)->_write_concern;
 }
 
-delete_one_options& delete_one_options::hint(v1::hint index_hint) {
-    impl::with(this)->_hint = std::move(index_hint);
+delete_one_options& delete_one_options::hint(v1::hint v) {
+    impl::with(this)->_hint = std::move(v);
     return *this;
 }
 
@@ -126,8 +126,8 @@ bsoncxx::v1::stdx::optional<v1::hint> delete_one_options::hint() const {
     return impl::with(this)->_hint;
 }
 
-delete_one_options& delete_one_options::let(bsoncxx::v1::document::value let) {
-    impl::with(this)->_let = std::move(let);
+delete_one_options& delete_one_options::let(bsoncxx::v1::document::value v) {
+    impl::with(this)->_let = std::move(v);
     return *this;
 }
 
@@ -135,8 +135,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> const delete_one_option
     return impl::with(this)->_let;
 }
 
-delete_one_options& delete_one_options::comment(bsoncxx::v1::types::value comment) {
-    impl::with(this)->_comment = std::move(comment);
+delete_one_options& delete_one_options::comment(bsoncxx::v1::types::value v) {
+    impl::with(this)->_comment = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/distinct_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/distinct_options.cpp
@@ -90,8 +90,8 @@ distinct_options::distinct_options() : _impl{new impl{}} {}
 
 // NOLINTEND(cppcoreguidelines-owning-memory)
 
-distinct_options& distinct_options::collation(bsoncxx::v1::document::value collation) {
-    impl::with(this)->_collation = std::move(collation);
+distinct_options& distinct_options::collation(bsoncxx::v1::document::value v) {
+    impl::with(this)->_collation = std::move(v);
     return *this;
 }
 
@@ -99,8 +99,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> distinct_options::colla
     return impl::with(this)->_collation;
 }
 
-distinct_options& distinct_options::max_time(std::chrono::milliseconds max_time) {
-    impl::with(this)->_max_time = std::move(max_time);
+distinct_options& distinct_options::max_time(std::chrono::milliseconds v) {
+    impl::with(this)->_max_time = std::move(v);
     return *this;
 }
 
@@ -108,8 +108,8 @@ bsoncxx::v1::stdx::optional<std::chrono::milliseconds> distinct_options::max_tim
     return impl::with(this)->_max_time;
 }
 
-distinct_options& distinct_options::comment(bsoncxx::v1::types::value comment) {
-    impl::with(this)->_comment = std::move(comment);
+distinct_options& distinct_options::comment(bsoncxx::v1::types::value v) {
+    impl::with(this)->_comment = std::move(v);
     return *this;
 }
 
@@ -117,8 +117,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::types::view> distinct_options::comment(
     return impl::with(this)->_comment;
 }
 
-distinct_options& distinct_options::read_preference(v1::read_preference rp) {
-    impl::with(this)->_read_preference = std::move(rp);
+distinct_options& distinct_options::read_preference(v1::read_preference v) {
+    impl::with(this)->_read_preference = std::move(v);
     return *this;
 }
 
@@ -126,8 +126,8 @@ bsoncxx::v1::stdx::optional<v1::read_preference> distinct_options::read_preferen
     return impl::with(this)->_read_preference;
 }
 
-distinct_options& distinct_options::read_concern(v1::read_concern rc) {
-    impl::with(this)->_read_concern = std::move(rc);
+distinct_options& distinct_options::read_concern(v1::read_concern v) {
+    impl::with(this)->_read_concern = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/estimated_document_count_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/estimated_document_count_options.cpp
@@ -90,8 +90,8 @@ estimated_document_count_options::estimated_document_count_options() : _impl{new
 
 // NOLINTEND(cppcoreguidelines-owning-memory)
 
-estimated_document_count_options& estimated_document_count_options::max_time(std::chrono::milliseconds max_time) {
-    impl::with(this)->_max_time = max_time;
+estimated_document_count_options& estimated_document_count_options::max_time(std::chrono::milliseconds v) {
+    impl::with(this)->_max_time = v;
     return *this;
 }
 
@@ -99,8 +99,8 @@ bsoncxx::v1::stdx::optional<std::chrono::milliseconds> estimated_document_count_
     return impl::with(this)->_max_time;
 }
 
-estimated_document_count_options& estimated_document_count_options::comment(bsoncxx::v1::types::value comment) {
-    impl::with(this)->_comment = std::move(comment);
+estimated_document_count_options& estimated_document_count_options::comment(bsoncxx::v1::types::value v) {
+    impl::with(this)->_comment = std::move(v);
     return *this;
 }
 
@@ -108,8 +108,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::types::view> estimated_document_count_o
     return impl::with(this)->_comment;
 }
 
-estimated_document_count_options& estimated_document_count_options::read_preference(v1::read_preference rp) {
-    impl::with(this)->_read_preference = std::move(rp);
+estimated_document_count_options& estimated_document_count_options::read_preference(v1::read_preference v) {
+    impl::with(this)->_read_preference = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/find_one_and_delete_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/find_one_and_delete_options.cpp
@@ -123,8 +123,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> find_one_and_delete_opt
     return impl::with(this)->_projection;
 }
 
-find_one_and_delete_options& find_one_and_delete_options::sort(bsoncxx::v1::document::value ordering) {
-    impl::with(this)->_sort = std::move(ordering);
+find_one_and_delete_options& find_one_and_delete_options::sort(bsoncxx::v1::document::value v) {
+    impl::with(this)->_sort = std::move(v);
     return *this;
 }
 
@@ -150,8 +150,8 @@ bsoncxx::v1::stdx::optional<v1::write_concern> find_one_and_delete_options::writ
     return impl::with(this)->_write_concern;
 }
 
-find_one_and_delete_options& find_one_and_delete_options::hint(v1::hint index_hint) {
-    impl::with(this)->_hint = std::move(index_hint);
+find_one_and_delete_options& find_one_and_delete_options::hint(v1::hint v) {
+    impl::with(this)->_hint = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/find_one_and_replace_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/find_one_and_replace_options.cpp
@@ -118,8 +118,8 @@ bsoncxx::v1::stdx::optional<bool> find_one_and_replace_options::bypass_document_
     return impl::with(this)->_bypass_document_validation;
 }
 
-find_one_and_replace_options& find_one_and_replace_options::hint(v1::hint index_hint) {
-    impl::with(this)->_hint = std::move(index_hint);
+find_one_and_replace_options& find_one_and_replace_options::hint(v1::hint v) {
+    impl::with(this)->_hint = std::move(v);
     return *this;
 }
 
@@ -172,8 +172,8 @@ bsoncxx::v1::stdx::optional<v1::return_document> find_one_and_replace_options::r
     return impl::with(this)->_return_document;
 }
 
-find_one_and_replace_options& find_one_and_replace_options::sort(bsoncxx::v1::document::value ordering) {
-    impl::with(this)->_sort = std::move(ordering);
+find_one_and_replace_options& find_one_and_replace_options::sort(bsoncxx::v1::document::value v) {
+    impl::with(this)->_sort = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/find_one_and_update_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/find_one_and_update_options.cpp
@@ -120,8 +120,8 @@ bsoncxx::v1::stdx::optional<bool> find_one_and_update_options::bypass_document_v
     return impl::with(this)->_bypass_document_validation;
 }
 
-find_one_and_update_options& find_one_and_update_options::hint(v1::hint index_hint) {
-    impl::with(this)->_hint = std::move(index_hint);
+find_one_and_update_options& find_one_and_update_options::hint(v1::hint v) {
+    impl::with(this)->_hint = std::move(v);
     return *this;
 }
 
@@ -174,8 +174,8 @@ bsoncxx::v1::stdx::optional<v1::return_document> find_one_and_update_options::re
     return impl::with(this)->_return_document;
 }
 
-find_one_and_update_options& find_one_and_update_options::sort(bsoncxx::v1::document::value ordering) {
-    impl::with(this)->_sort = std::move(ordering);
+find_one_and_update_options& find_one_and_update_options::sort(bsoncxx::v1::document::value v) {
+    impl::with(this)->_sort = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/find_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/find_options.cpp
@@ -110,8 +110,8 @@ find_options::find_options() : _impl{new impl{}} {}
 
 // NOLINTEND(cppcoreguidelines-owning-memory)
 
-find_options& find_options::allow_disk_use(bool allow_disk_use) {
-    impl::with(this)->_allow_disk_use = allow_disk_use;
+find_options& find_options::allow_disk_use(bool v) {
+    impl::with(this)->_allow_disk_use = v;
     return *this;
 }
 
@@ -119,8 +119,8 @@ bsoncxx::v1::stdx::optional<bool> find_options::allow_disk_use() const {
     return impl::with(this)->_allow_disk_use;
 }
 
-find_options& find_options::allow_partial_results(bool allow_partial) {
-    impl::with(this)->_allow_partial_results = allow_partial;
+find_options& find_options::allow_partial_results(bool v) {
+    impl::with(this)->_allow_partial_results = v;
     return *this;
 }
 
@@ -128,8 +128,8 @@ bsoncxx::v1::stdx::optional<bool> find_options::allow_partial_results() const {
     return impl::with(this)->_allow_partial_results;
 }
 
-find_options& find_options::batch_size(std::int32_t batch_size) {
-    impl::with(this)->_batch_size = batch_size;
+find_options& find_options::batch_size(std::int32_t v) {
+    impl::with(this)->_batch_size = v;
     return *this;
 }
 
@@ -137,8 +137,8 @@ bsoncxx::v1::stdx::optional<std::int32_t> find_options::batch_size() const {
     return impl::with(this)->_batch_size;
 }
 
-find_options& find_options::collation(bsoncxx::v1::document::value collation) {
-    impl::with(this)->_collation = std::move(collation);
+find_options& find_options::collation(bsoncxx::v1::document::value v) {
+    impl::with(this)->_collation = std::move(v);
     return *this;
 }
 
@@ -146,8 +146,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> find_options::collation
     return impl::with(this)->_collation;
 }
 
-find_options& find_options::comment(bsoncxx::v1::types::value comment) {
-    impl::with(this)->_comment = std::move(comment);
+find_options& find_options::comment(bsoncxx::v1::types::value v) {
+    impl::with(this)->_comment = std::move(v);
     return *this;
 }
 
@@ -155,8 +155,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::types::view> find_options::comment() co
     return impl::with(this)->_comment;
 }
 
-find_options& find_options::cursor_type(v1::cursor::type cursor_type) {
-    impl::with(this)->_cursor_type = cursor_type;
+find_options& find_options::cursor_type(v1::cursor::type v) {
+    impl::with(this)->_cursor_type = v;
     return *this;
 }
 
@@ -164,8 +164,8 @@ bsoncxx::v1::stdx::optional<cursor::type> find_options::cursor_type() const {
     return impl::with(this)->_cursor_type;
 }
 
-find_options& find_options::hint(v1::hint index_hint) {
-    impl::with(this)->_hint = std::move(index_hint);
+find_options& find_options::hint(v1::hint v) {
+    impl::with(this)->_hint = std::move(v);
     return *this;
 }
 
@@ -173,8 +173,8 @@ bsoncxx::v1::stdx::optional<v1::hint> find_options::hint() const {
     return impl::with(this)->_hint;
 }
 
-find_options& find_options::let(bsoncxx::v1::document::value let) {
-    impl::with(this)->_let = std::move(let);
+find_options& find_options::let(bsoncxx::v1::document::value v) {
+    impl::with(this)->_let = std::move(v);
     return *this;
 }
 
@@ -182,8 +182,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> const find_options::let
     return impl::with(this)->_let;
 }
 
-find_options& find_options::limit(std::int64_t limit) {
-    impl::with(this)->_limit = limit;
+find_options& find_options::limit(std::int64_t v) {
+    impl::with(this)->_limit = v;
     return *this;
 }
 
@@ -191,8 +191,8 @@ bsoncxx::v1::stdx::optional<std::int64_t> find_options::limit() const {
     return impl::with(this)->_limit;
 }
 
-find_options& find_options::max(bsoncxx::v1::document::value max) {
-    impl::with(this)->_max = std::move(max);
+find_options& find_options::max(bsoncxx::v1::document::value v) {
+    impl::with(this)->_max = std::move(v);
     return *this;
 }
 
@@ -200,8 +200,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> find_options::max() con
     return impl::with(this)->_max;
 }
 
-find_options& find_options::max_await_time(std::chrono::milliseconds max_await_time) {
-    impl::with(this)->_max_await_time = max_await_time;
+find_options& find_options::max_await_time(std::chrono::milliseconds v) {
+    impl::with(this)->_max_await_time = v;
     return *this;
 }
 
@@ -209,8 +209,8 @@ bsoncxx::v1::stdx::optional<std::chrono::milliseconds> find_options::max_await_t
     return impl::with(this)->_max_await_time;
 }
 
-find_options& find_options::max_time(std::chrono::milliseconds max_time) {
-    impl::with(this)->_max_time = max_time;
+find_options& find_options::max_time(std::chrono::milliseconds v) {
+    impl::with(this)->_max_time = v;
     return *this;
 }
 
@@ -218,8 +218,8 @@ bsoncxx::v1::stdx::optional<std::chrono::milliseconds> find_options::max_time() 
     return impl::with(this)->_max_time;
 }
 
-find_options& find_options::min(bsoncxx::v1::document::value min) {
-    impl::with(this)->_min = std::move(min);
+find_options& find_options::min(bsoncxx::v1::document::value v) {
+    impl::with(this)->_min = std::move(v);
     return *this;
 }
 
@@ -227,8 +227,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> find_options::min() con
     return impl::with(this)->_min;
 }
 
-find_options& find_options::no_cursor_timeout(bool no_cursor_timeout) {
-    impl::with(this)->_no_cursor_timeout = no_cursor_timeout;
+find_options& find_options::no_cursor_timeout(bool v) {
+    impl::with(this)->_no_cursor_timeout = v;
     return *this;
 }
 
@@ -236,8 +236,8 @@ bsoncxx::v1::stdx::optional<bool> find_options::no_cursor_timeout() const {
     return impl::with(this)->_no_cursor_timeout;
 }
 
-find_options& find_options::projection(bsoncxx::v1::document::value projection) {
-    impl::with(this)->_projection = std::move(projection);
+find_options& find_options::projection(bsoncxx::v1::document::value v) {
+    impl::with(this)->_projection = std::move(v);
     return *this;
 }
 
@@ -245,8 +245,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> find_options::projectio
     return impl::with(this)->_projection;
 }
 
-find_options& find_options::read_preference(v1::read_preference rp) {
-    impl::with(this)->_read_preference = std::move(rp);
+find_options& find_options::read_preference(v1::read_preference v) {
+    impl::with(this)->_read_preference = std::move(v);
     return *this;
 }
 
@@ -254,8 +254,8 @@ bsoncxx::v1::stdx::optional<v1::read_preference> find_options::read_preference()
     return impl::with(this)->_read_preference;
 }
 
-find_options& find_options::read_concern(v1::read_concern rc) {
-    impl::with(this)->_read_concern = std::move(rc);
+find_options& find_options::read_concern(v1::read_concern v) {
+    impl::with(this)->_read_concern = std::move(v);
     return *this;
 }
 
@@ -263,8 +263,8 @@ bsoncxx::v1::stdx::optional<v1::read_concern> find_options::read_concern() const
     return impl::with(this)->_read_concern;
 }
 
-find_options& find_options::return_key(bool return_key) {
-    impl::with(this)->_return_key = return_key;
+find_options& find_options::return_key(bool v) {
+    impl::with(this)->_return_key = v;
     return *this;
 }
 
@@ -272,8 +272,8 @@ bsoncxx::v1::stdx::optional<bool> find_options::return_key() const {
     return impl::with(this)->_return_key;
 }
 
-find_options& find_options::show_record_id(bool show_record_id) {
-    impl::with(this)->_show_record_id = show_record_id;
+find_options& find_options::show_record_id(bool v) {
+    impl::with(this)->_show_record_id = v;
     return *this;
 }
 
@@ -281,8 +281,8 @@ bsoncxx::v1::stdx::optional<bool> find_options::show_record_id() const {
     return impl::with(this)->_show_record_id;
 }
 
-find_options& find_options::skip(std::int64_t skip) {
-    impl::with(this)->_skip = skip;
+find_options& find_options::skip(std::int64_t v) {
+    impl::with(this)->_skip = v;
     return *this;
 }
 
@@ -290,8 +290,8 @@ bsoncxx::v1::stdx::optional<std::int64_t> find_options::skip() const {
     return impl::with(this)->_skip;
 }
 
-find_options& find_options::sort(bsoncxx::v1::document::value ordering) {
-    impl::with(this)->_sort = std::move(ordering);
+find_options& find_options::sort(bsoncxx::v1::document::value v) {
+    impl::with(this)->_sort = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/gridfs/upload_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/gridfs/upload_options.cpp
@@ -84,8 +84,8 @@ upload_options::upload_options() : _impl{new impl{}} {}
 
 // NOLINTEND(cppcoreguidelines-owning-memory)
 
-upload_options& upload_options::chunk_size_bytes(std::int32_t chunk_size_bytes) {
-    impl::with(this)->_chunk_size_bytes = chunk_size_bytes;
+upload_options& upload_options::chunk_size_bytes(std::int32_t v) {
+    impl::with(this)->_chunk_size_bytes = v;
     return *this;
 }
 
@@ -93,8 +93,8 @@ bsoncxx::v1::stdx::optional<std::int32_t> upload_options::chunk_size_bytes() con
     return impl::with(this)->_chunk_size_bytes;
 }
 
-upload_options& upload_options::metadata(bsoncxx::v1::document::value metadata) {
-    impl::with(this)->_metadata = std::move(metadata);
+upload_options& upload_options::metadata(bsoncxx::v1::document::value v) {
+    impl::with(this)->_metadata = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/insert_many_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/insert_many_options.cpp
@@ -89,8 +89,8 @@ insert_many_options::insert_many_options() : _impl{new impl{}} {}
 
 // NOLINTEND(cppcoreguidelines-owning-memory)
 
-insert_many_options& insert_many_options::bypass_document_validation(bool bypass_document_validation) {
-    impl::with(this)->_bypass_document_validation = bypass_document_validation;
+insert_many_options& insert_many_options::bypass_document_validation(bool v) {
+    impl::with(this)->_bypass_document_validation = v;
     return *this;
 }
 
@@ -98,8 +98,8 @@ bsoncxx::v1::stdx::optional<bool> insert_many_options::bypass_document_validatio
     return impl::with(this)->_bypass_document_validation;
 }
 
-insert_many_options& insert_many_options::read_concern(v1::read_concern rc) {
-    impl::with(this)->_read_concern = std::move(rc);
+insert_many_options& insert_many_options::read_concern(v1::read_concern v) {
+    impl::with(this)->_read_concern = std::move(v);
     return *this;
 }
 
@@ -107,8 +107,8 @@ bsoncxx::v1::stdx::optional<v1::read_concern> insert_many_options::read_concern(
     return impl::with(this)->_read_concern;
 }
 
-insert_many_options& insert_many_options::write_concern(v1::write_concern wc) {
-    impl::with(this)->_write_concern = std::move(wc);
+insert_many_options& insert_many_options::write_concern(v1::write_concern v) {
+    impl::with(this)->_write_concern = std::move(v);
     return *this;
 }
 
@@ -116,8 +116,8 @@ bsoncxx::v1::stdx::optional<v1::write_concern> insert_many_options::write_concer
     return impl::with(this)->_write_concern;
 }
 
-insert_many_options& insert_many_options::ordered(bool ordered) {
-    impl::with(this)->_ordered = ordered;
+insert_many_options& insert_many_options::ordered(bool v) {
+    impl::with(this)->_ordered = v;
     return *this;
 }
 
@@ -125,8 +125,8 @@ bsoncxx::v1::stdx::optional<bool> insert_many_options::ordered() const {
     return impl::with(this)->_ordered;
 }
 
-insert_many_options& insert_many_options::comment(bsoncxx::v1::types::value comment) {
-    impl::with(this)->_comment = std::move(comment);
+insert_many_options& insert_many_options::comment(bsoncxx::v1::types::value v) {
+    impl::with(this)->_comment = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/insert_one_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/insert_one_options.cpp
@@ -86,8 +86,8 @@ insert_one_options::insert_one_options() : _impl{new impl{}} {}
 
 // NOLINTEND(cppcoreguidelines-owning-memory)
 
-insert_one_options& insert_one_options::bypass_document_validation(bool bypass_document_validation) {
-    impl::with(this)->_bypass_document_validation = bypass_document_validation;
+insert_one_options& insert_one_options::bypass_document_validation(bool v) {
+    impl::with(this)->_bypass_document_validation = v;
     return *this;
 }
 
@@ -95,8 +95,8 @@ bsoncxx::v1::stdx::optional<bool> insert_one_options::bypass_document_validation
     return impl::with(this)->_bypass_document_validation;
 }
 
-insert_one_options& insert_one_options::read_concern(v1::read_concern rc) {
-    impl::with(this)->_read_concern = std::move(rc);
+insert_one_options& insert_one_options::read_concern(v1::read_concern v) {
+    impl::with(this)->_read_concern = std::move(v);
     return *this;
 }
 
@@ -104,8 +104,8 @@ bsoncxx::v1::stdx::optional<v1::read_concern> insert_one_options::read_concern()
     return impl::with(this)->_read_concern;
 }
 
-insert_one_options& insert_one_options::write_concern(v1::write_concern wc) {
-    impl::with(this)->_write_concern = std::move(wc);
+insert_one_options& insert_one_options::write_concern(v1::write_concern v) {
+    impl::with(this)->_write_concern = std::move(v);
     return *this;
 }
 
@@ -113,8 +113,8 @@ bsoncxx::v1::stdx::optional<v1::write_concern> insert_one_options::write_concern
     return impl::with(this)->_write_concern;
 }
 
-insert_one_options& insert_one_options::comment(bsoncxx::v1::types::value comment) {
-    impl::with(this)->_comment = std::move(comment);
+insert_one_options& insert_one_options::comment(bsoncxx::v1::types::value v) {
+    impl::with(this)->_comment = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/range_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/range_options.cpp
@@ -85,8 +85,8 @@ range_options::range_options() : _impl{new impl{}} {}
 
 // NOLINTEND(cppcoreguidelines-owning-memory)
 
-range_options& range_options::min(bsoncxx::v1::types::value value) {
-    impl::with(this)->_min = std::move(value);
+range_options& range_options::min(bsoncxx::v1::types::value v) {
+    impl::with(this)->_min = std::move(v);
     return *this;
 }
 
@@ -94,8 +94,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::types::view> range_options::min() const
     return impl::with(this)->_min;
 }
 
-range_options& range_options::max(bsoncxx::v1::types::value value) {
-    impl::with(this)->_max = std::move(value);
+range_options& range_options::max(bsoncxx::v1::types::value v) {
+    impl::with(this)->_max = std::move(v);
     return *this;
 }
 
@@ -103,8 +103,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::types::view> range_options::max() const
     return impl::with(this)->_max;
 }
 
-range_options& range_options::sparsity(std::int64_t value) {
-    impl::with(this)->_sparsity = std::move(value);
+range_options& range_options::sparsity(std::int64_t v) {
+    impl::with(this)->_sparsity = std::move(v);
     return *this;
 }
 
@@ -112,8 +112,8 @@ bsoncxx::v1::stdx::optional<std::int64_t> range_options::sparsity() const {
     return impl::with(this)->_sparsity;
 }
 
-range_options& range_options::trim_factor(std::int32_t value) {
-    impl::with(this)->_trim_factor = std::move(value);
+range_options& range_options::trim_factor(std::int32_t v) {
+    impl::with(this)->_trim_factor = std::move(v);
     return *this;
 }
 
@@ -121,8 +121,8 @@ bsoncxx::v1::stdx::optional<std::int32_t> range_options::trim_factor() const {
     return impl::with(this)->_trim_factor;
 }
 
-range_options& range_options::precision(std::int32_t value) {
-    impl::with(this)->_precision = std::move(value);
+range_options& range_options::precision(std::int32_t v) {
+    impl::with(this)->_precision = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/replace_one_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/replace_one_options.cpp
@@ -94,8 +94,8 @@ replace_one_options::replace_one_options() : _impl{new impl{}} {}
 
 // NOLINTEND(cppcoreguidelines-owning-memory)
 
-replace_one_options& replace_one_options::bypass_document_validation(bool bypass_document_validation) {
-    impl::with(this)->_bypass_document_validation = std::move(bypass_document_validation);
+replace_one_options& replace_one_options::bypass_document_validation(bool v) {
+    impl::with(this)->_bypass_document_validation = std::move(v);
     return *this;
 }
 
@@ -103,8 +103,8 @@ bsoncxx::v1::stdx::optional<bool> replace_one_options::bypass_document_validatio
     return impl::with(this)->_bypass_document_validation;
 }
 
-replace_one_options& replace_one_options::collation(bsoncxx::v1::document::value collation) {
-    impl::with(this)->_collation = std::move(collation);
+replace_one_options& replace_one_options::collation(bsoncxx::v1::document::value v) {
+    impl::with(this)->_collation = std::move(v);
     return *this;
 }
 
@@ -112,8 +112,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> replace_one_options::co
     return impl::with(this)->_collation;
 }
 
-replace_one_options& replace_one_options::upsert(bool upsert) {
-    impl::with(this)->_upsert = std::move(upsert);
+replace_one_options& replace_one_options::upsert(bool v) {
+    impl::with(this)->_upsert = std::move(v);
     return *this;
 }
 
@@ -121,8 +121,8 @@ bsoncxx::v1::stdx::optional<bool> replace_one_options::upsert() const {
     return impl::with(this)->_upsert;
 }
 
-replace_one_options& replace_one_options::read_concern(v1::read_concern rc) {
-    impl::with(this)->_read_concern = std::move(rc);
+replace_one_options& replace_one_options::read_concern(v1::read_concern v) {
+    impl::with(this)->_read_concern = std::move(v);
     return *this;
 }
 
@@ -130,8 +130,8 @@ bsoncxx::v1::stdx::optional<v1::read_concern> replace_one_options::read_concern(
     return impl::with(this)->_read_concern;
 }
 
-replace_one_options& replace_one_options::write_concern(v1::write_concern wc) {
-    impl::with(this)->_write_concern = std::move(wc);
+replace_one_options& replace_one_options::write_concern(v1::write_concern v) {
+    impl::with(this)->_write_concern = std::move(v);
     return *this;
 }
 
@@ -139,8 +139,8 @@ bsoncxx::v1::stdx::optional<v1::write_concern> replace_one_options::write_concer
     return impl::with(this)->_write_concern;
 }
 
-replace_one_options& replace_one_options::hint(v1::hint index_hint) {
-    impl::with(this)->_hint = std::move(index_hint);
+replace_one_options& replace_one_options::hint(v1::hint v) {
+    impl::with(this)->_hint = std::move(v);
     return *this;
 }
 
@@ -148,8 +148,8 @@ bsoncxx::v1::stdx::optional<v1::hint> replace_one_options::hint() const {
     return impl::with(this)->_hint;
 }
 
-replace_one_options& replace_one_options::let(bsoncxx::v1::document::value let) {
-    impl::with(this)->_let = std::move(let);
+replace_one_options& replace_one_options::let(bsoncxx::v1::document::value v) {
+    impl::with(this)->_let = std::move(v);
     return *this;
 }
 
@@ -157,8 +157,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> const replace_one_optio
     return impl::with(this)->_let;
 }
 
-replace_one_options& replace_one_options::sort(bsoncxx::v1::document::value sort) {
-    impl::with(this)->_sort = std::move(sort);
+replace_one_options& replace_one_options::sort(bsoncxx::v1::document::value v) {
+    impl::with(this)->_sort = std::move(v);
     return *this;
 }
 
@@ -166,8 +166,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> replace_one_options::so
     return impl::with(this)->_sort;
 }
 
-replace_one_options& replace_one_options::comment(bsoncxx::v1::types::value comment) {
-    impl::with(this)->_comment = std::move(comment);
+replace_one_options& replace_one_options::comment(bsoncxx::v1::types::value v) {
+    impl::with(this)->_comment = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/rewrap_many_datakey_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/rewrap_many_datakey_options.cpp
@@ -85,8 +85,8 @@ rewrap_many_datakey_options::rewrap_many_datakey_options() : _impl{new impl{}} {
 
 // NOLINTEND(cppcoreguidelines-owning-memory)
 
-rewrap_many_datakey_options& rewrap_many_datakey_options::provider(std::string provider) {
-    impl::with(this)->_provider = std::move(provider);
+rewrap_many_datakey_options& rewrap_many_datakey_options::provider(std::string v) {
+    impl::with(this)->_provider = std::move(v);
     return *this;
 }
 
@@ -94,8 +94,8 @@ bsoncxx::v1::stdx::string_view rewrap_many_datakey_options::provider() const {
     return impl::with(this)->_provider;
 }
 
-rewrap_many_datakey_options& rewrap_many_datakey_options::master_key(bsoncxx::v1::document::value master_key) {
-    impl::with(this)->_master_key = std::move(master_key);
+rewrap_many_datakey_options& rewrap_many_datakey_options::master_key(bsoncxx::v1::document::value v) {
+    impl::with(this)->_master_key = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/search_indexes.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/search_indexes.cpp
@@ -412,8 +412,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::stdx::string_view> search_indexes::mode
     return impl::with(this)->_type;
 }
 
-search_indexes::model& search_indexes::model::type(std::string type) {
-    impl::with(this)->_type = std::move(type);
+search_indexes::model& search_indexes::model::type(std::string v) {
+    impl::with(this)->_type = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/server_api.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/server_api.cpp
@@ -128,8 +128,8 @@ server_api::version server_api::version_from_string(bsoncxx::v1::stdx::string_vi
     throw v1::exception::internal::make(code::invalid_version);
 }
 
-server_api& server_api::strict(bool strict) {
-    impl::with(this)->_strict = strict;
+server_api& server_api::strict(bool v) {
+    impl::with(this)->_strict = v;
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/update_many_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/update_many_options.cpp
@@ -98,8 +98,8 @@ update_many_options::update_many_options() : _impl{new impl{}} {}
 
 // NOLINTEND(cppcoreguidelines-owning-memory)
 
-update_many_options& update_many_options::bypass_document_validation(bool bypass_document_validation) {
-    impl::with(this)->_bypass_document_validation = bypass_document_validation;
+update_many_options& update_many_options::bypass_document_validation(bool v) {
+    impl::with(this)->_bypass_document_validation = v;
     return *this;
 }
 
@@ -107,8 +107,8 @@ bsoncxx::v1::stdx::optional<bool> update_many_options::bypass_document_validatio
     return impl::with(this)->_bypass_document_validation;
 }
 
-update_many_options& update_many_options::collation(bsoncxx::v1::document::value collation) {
-    impl::with(this)->_collation = std::move(collation);
+update_many_options& update_many_options::collation(bsoncxx::v1::document::value v) {
+    impl::with(this)->_collation = std::move(v);
     return *this;
 }
 
@@ -116,8 +116,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> update_many_options::co
     return impl::with(this)->_collation;
 }
 
-update_many_options& update_many_options::hint(v1::hint index_hint) {
-    impl::with(this)->_hint = std::move(index_hint);
+update_many_options& update_many_options::hint(v1::hint v) {
+    impl::with(this)->_hint = std::move(v);
     return *this;
 }
 
@@ -125,8 +125,8 @@ bsoncxx::v1::stdx::optional<v1::hint> update_many_options::hint() const {
     return impl::with(this)->_hint;
 }
 
-update_many_options& update_many_options::let(bsoncxx::v1::document::value let) {
-    impl::with(this)->_let = std::move(let);
+update_many_options& update_many_options::let(bsoncxx::v1::document::value v) {
+    impl::with(this)->_let = std::move(v);
     return *this;
 }
 
@@ -134,8 +134,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> const update_many_optio
     return impl::with(this)->_let;
 }
 
-update_many_options& update_many_options::comment(bsoncxx::v1::types::value comment) {
-    impl::with(this)->_comment = std::move(comment);
+update_many_options& update_many_options::comment(bsoncxx::v1::types::value v) {
+    impl::with(this)->_comment = std::move(v);
     return *this;
 }
 
@@ -143,8 +143,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::types::view> const update_many_options:
     return impl::with(this)->_comment;
 }
 
-update_many_options& update_many_options::upsert(bool upsert) {
-    impl::with(this)->_upsert = upsert;
+update_many_options& update_many_options::upsert(bool v) {
+    impl::with(this)->_upsert = v;
     return *this;
 }
 
@@ -152,8 +152,8 @@ bsoncxx::v1::stdx::optional<bool> update_many_options::upsert() const {
     return impl::with(this)->_upsert;
 }
 
-update_many_options& update_many_options::read_concern(v1::read_concern rc) {
-    impl::with(this)->_read_concern = std::move(rc);
+update_many_options& update_many_options::read_concern(v1::read_concern v) {
+    impl::with(this)->_read_concern = std::move(v);
     return *this;
 }
 
@@ -161,8 +161,8 @@ bsoncxx::v1::stdx::optional<v1::read_concern> update_many_options::read_concern(
     return impl::with(this)->_read_concern;
 }
 
-update_many_options& update_many_options::write_concern(v1::write_concern wc) {
-    impl::with(this)->_write_concern = std::move(wc);
+update_many_options& update_many_options::write_concern(v1::write_concern v) {
+    impl::with(this)->_write_concern = std::move(v);
     return *this;
 }
 
@@ -170,8 +170,8 @@ bsoncxx::v1::stdx::optional<v1::write_concern> update_many_options::write_concer
     return impl::with(this)->_write_concern;
 }
 
-update_many_options& update_many_options::array_filters(bsoncxx::v1::array::value array_filters) {
-    impl::with(this)->_array_filters = std::move(array_filters);
+update_many_options& update_many_options::array_filters(bsoncxx::v1::array::value v) {
+    impl::with(this)->_array_filters = std::move(v);
     return *this;
 }
 

--- a/src/mongocxx/lib/mongocxx/v1/update_one_options.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/update_one_options.cpp
@@ -97,8 +97,8 @@ update_one_options::update_one_options() : _impl{new impl{}} {}
 
 // NOLINTEND(cppcoreguidelines-owning-memory)
 
-update_one_options& update_one_options::bypass_document_validation(bool bypass_document_validation) {
-    impl::with(this)->_bypass_document_validation = bypass_document_validation;
+update_one_options& update_one_options::bypass_document_validation(bool v) {
+    impl::with(this)->_bypass_document_validation = v;
     return *this;
 }
 
@@ -106,8 +106,8 @@ bsoncxx::v1::stdx::optional<bool> update_one_options::bypass_document_validation
     return impl::with(this)->_bypass_document_validation;
 }
 
-update_one_options& update_one_options::collation(bsoncxx::v1::document::value collation) {
-    impl::with(this)->_collation = std::move(collation);
+update_one_options& update_one_options::collation(bsoncxx::v1::document::value v) {
+    impl::with(this)->_collation = std::move(v);
     return *this;
 }
 
@@ -115,8 +115,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> update_one_options::col
     return impl::with(this)->_collation;
 }
 
-update_one_options& update_one_options::hint(v1::hint index_hint) {
-    impl::with(this)->_hint = std::move(index_hint);
+update_one_options& update_one_options::hint(v1::hint v) {
+    impl::with(this)->_hint = std::move(v);
     return *this;
 }
 
@@ -124,8 +124,8 @@ bsoncxx::v1::stdx::optional<v1::hint> update_one_options::hint() const {
     return impl::with(this)->_hint;
 }
 
-update_one_options& update_one_options::let(bsoncxx::v1::document::value let) {
-    impl::with(this)->_let = std::move(let);
+update_one_options& update_one_options::let(bsoncxx::v1::document::value v) {
+    impl::with(this)->_let = std::move(v);
     return *this;
 }
 
@@ -133,8 +133,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> const update_one_option
     return impl::with(this)->_let;
 }
 
-update_one_options& update_one_options::sort(bsoncxx::v1::document::value sort) {
-    impl::with(this)->_sort = std::move(sort);
+update_one_options& update_one_options::sort(bsoncxx::v1::document::value v) {
+    impl::with(this)->_sort = std::move(v);
     return *this;
 }
 
@@ -142,8 +142,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::document::view> update_one_options::sor
     return impl::with(this)->_sort;
 }
 
-update_one_options& update_one_options::comment(bsoncxx::v1::types::value comment) {
-    impl::with(this)->_comment = std::move(comment);
+update_one_options& update_one_options::comment(bsoncxx::v1::types::value v) {
+    impl::with(this)->_comment = std::move(v);
     return *this;
 }
 
@@ -151,8 +151,8 @@ bsoncxx::v1::stdx::optional<bsoncxx::v1::types::view> const update_one_options::
     return impl::with(this)->_comment;
 }
 
-update_one_options& update_one_options::upsert(bool upsert) {
-    impl::with(this)->_upsert = upsert;
+update_one_options& update_one_options::upsert(bool v) {
+    impl::with(this)->_upsert = v;
     return *this;
 }
 
@@ -160,8 +160,8 @@ bsoncxx::v1::stdx::optional<bool> update_one_options::upsert() const {
     return impl::with(this)->_upsert;
 }
 
-update_one_options& update_one_options::read_concern(v1::read_concern rc) {
-    impl::with(this)->_read_concern = std::move(rc);
+update_one_options& update_one_options::read_concern(v1::read_concern v) {
+    impl::with(this)->_read_concern = std::move(v);
     return *this;
 }
 
@@ -169,8 +169,8 @@ bsoncxx::v1::stdx::optional<v1::read_concern> update_one_options::read_concern()
     return impl::with(this)->_read_concern;
 }
 
-update_one_options& update_one_options::write_concern(v1::write_concern wc) {
-    impl::with(this)->_write_concern = std::move(wc);
+update_one_options& update_one_options::write_concern(v1::write_concern v) {
+    impl::with(this)->_write_concern = std::move(v);
     return *this;
 }
 
@@ -178,8 +178,8 @@ bsoncxx::v1::stdx::optional<v1::write_concern> update_one_options::write_concern
     return impl::with(this)->_write_concern;
 }
 
-update_one_options& update_one_options::array_filters(bsoncxx::v1::array::value array_filters) {
-    impl::with(this)->_array_filters = std::move(array_filters);
+update_one_options& update_one_options::array_filters(bsoncxx::v1::array::value v) {
+    impl::with(this)->_array_filters = std::move(v);
     return *this;
 }
 


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1638: identified more cases of redundant setter parameter names of the form: `T::name(U name)`. This PR changes these to consistently use a simple `v` for the value with which the option field is being set: `T::name(U v)`. These changes are limited to v1 API, but can be applied to v_noabi API as well if desirable. Instances were found by executing `rg '::([a-z_]+)\([^\(]* \1\)'` (ripgrep).