### PR TITLE
CXX-804 Set ABI version number for bsoncxx and mongocxx to 1

### DIFF
--- a/.evergreen/scripts/test.sh
+++ b/.evergreen/scripts/test.sh
@@ -249,8 +249,8 @@ export CXX_STANDARD="${REQUIRED_CXX_STANDARD:-"11"}"
 export CXXFLAGS="${example_projects_cxxflags:-}"
 export LDFLAGS="${example_projects_ldflags:-}"
 
-export BSONCXX_BASENAME="bsoncxx"
-export MONGOCXX_BASENAME="mongocxx"
+export BSONCXX_BASENAME="bsoncxx1"
+export MONGOCXX_BASENAME="mongocxx1"
 
 pushd "${working_dir:?}/build"
 

--- a/.evergreen/scripts/uninstall_check.sh
+++ b/.evergreen/scripts/uninstall_check.sh
@@ -11,7 +11,7 @@ INSTALL_DIR="$BUILD_DIR/install"
 ls -lR "$INSTALL_DIR"
 
 if test -f "$INSTALL_DIR/$LIB_DIR/pkgconfig/lib${BSONCXX_BASENAME:?}.pc"; then
-  echo "lib${BSONCXX_BASENAME:?}.pc found!" # CXX-804: fallback to old library filename pattern.
+  echo "lib${BSONCXX_BASENAME:?}.pc found!"
   exit 1
 else
   echo "lib${BSONCXX_BASENAME:?}.pc check ok"
@@ -29,7 +29,7 @@ else
   echo "$INSTALL_DIR/$LIB_DIR check ok"
 fi
 if test -f "$INSTALL_DIR/$LIB_DIR/pkgconfig/lib${MONGOCXX_BASENAME:?}.pc"; then
-  echo "lib${MONGOCXX_BASENAME:?}.pc found!" # CXX-804: fallback to old library filename pattern.
+  echo "lib${MONGOCXX_BASENAME:?}.pc found!"
   exit 1
 else
   echo "lib${MONGOCXX_BASENAME:?}.pc check ok"

--- a/.evergreen/scripts/uninstall_check.sh
+++ b/.evergreen/scripts/uninstall_check.sh
@@ -2,22 +2,19 @@
 
 set -o errexit # Exit the script with error if any of the commands fail
 
-BSONCXX_BASENAME="bsoncxx"
-MONGOCXX_BASENAME="mongocxx"
+BSONCXX_BASENAME="bsoncxx1"
+MONGOCXX_BASENAME="mongocxx1"
 
 BUILD_DIR="$(pwd)/build"
 INSTALL_DIR="$BUILD_DIR/install"
 
 ls -lR "$INSTALL_DIR"
 
-if test -f "$INSTALL_DIR/$LIB_DIR/pkgconfig/lib${BSONCXX_BASENAME:?}1.pc"; then
-  echo "lib${BSONCXX_BASENAME:?}1.pc found!"
-  exit 1
-elif test -f "$INSTALL_DIR/$LIB_DIR/pkgconfig/lib${BSONCXX_BASENAME:?}.pc"; then
+if test -f "$INSTALL_DIR/$LIB_DIR/pkgconfig/lib${BSONCXX_BASENAME:?}.pc"; then
   echo "lib${BSONCXX_BASENAME:?}.pc found!" # CXX-804: fallback to old library filename pattern.
   exit 1
 else
-  echo "lib${BSONCXX_BASENAME:?}1.pc check ok"
+  echo "lib${BSONCXX_BASENAME:?}.pc check ok"
 fi
 if test ! -f "$INSTALL_DIR/$LIB_DIR/canary.txt"; then
   echo "canary.txt not found!"
@@ -31,14 +28,11 @@ if test ! -d "$INSTALL_DIR/$LIB_DIR"; then
 else
   echo "$INSTALL_DIR/$LIB_DIR check ok"
 fi
-if test -f "$INSTALL_DIR/$LIB_DIR/pkgconfig/lib${MONGOCXX_BASENAME:?}1.pc"; then
-  echo "lib${MONGOCXX_BASENAME:?}1.pc found!"
-  exit 1
-elif test -f "$INSTALL_DIR/$LIB_DIR/pkgconfig/lib${MONGOCXX_BASENAME:?}.pc"; then
+if test -f "$INSTALL_DIR/$LIB_DIR/pkgconfig/lib${MONGOCXX_BASENAME:?}.pc"; then
   echo "lib${MONGOCXX_BASENAME:?}.pc found!" # CXX-804: fallback to old library filename pattern.
   exit 1
 else
-  echo "lib${MONGOCXX_BASENAME:?}1.pc check ok"
+  echo "lib${MONGOCXX_BASENAME:?}.pc check ok"
 fi
 if test -f "$INSTALL_DIR/include/bsoncxx/v_noabi/bsoncxx/json.hpp"; then
   echo "bsoncxx/json.hpp found!"

--- a/.evergreen/scripts/uninstall_check_windows.cmd
+++ b/.evergreen/scripts/uninstall_check_windows.cmd
@@ -1,8 +1,8 @@
 echo on
 echo
 
-set BSONCXX_BASENAME=bsoncxx
-set MONGOCXX_BASENAME=mongocxx
+set BSONCXX_BASENAME=bsoncxx1
+set MONGOCXX_BASENAME=mongocxx1
 
 set INSTALL_DIR=%CD%\build\install
 
@@ -10,14 +10,10 @@ dir %INSTALL_DIR%\share\mongo-cxx-driver
 
 dir %INSTALL_DIR% /s
 
-if exist %INSTALL_DIR%\lib\pkgconfig\lib%BSONCXX_BASENAME%1.pc (
-  echo lib%BSONCXX_BASENAME%1.pc found!
-  exit /B 1
-) else if exist %INSTALL_DIR%\lib\pkgconfig\lib%BSONCXX_BASENAME%.pc (
+if exist %INSTALL_DIR%\lib\pkgconfig\lib%BSONCXX_BASENAME%.pc (
   echo lib%BSONCXX_BASENAME%.pc found!
   exit /B 1
-) else (
-  echo lib%BSONCXX_BASENAME%1.pc check ok
+  echo lib%BSONCXX_BASENAME%.pc check ok
 )
 if not exist %INSTALL_DIR%\lib\canary.txt (
   echo canary.txt not found!
@@ -31,14 +27,10 @@ if not exist %INSTALL_DIR%\lib (
 ) else (
   echo %INSTALL_DIR%\lib check ok
 )
-if exist %INSTALL_DIR%\lib\pkgconfig\lib%MONGOCXX_BASENAME%1.pc (
-  echo lib%MONGOCXX_BASENAME%1.pc found!
-  exit /B 1
-) else if exist %INSTALL_DIR%\lib\pkgconfig\lib%MONGOCXX_BASENAME%.pc (
+if exist %INSTALL_DIR%\lib\pkgconfig\lib%MONGOCXX_BASENAME%.pc (
   echo lib%MONGOCXX_BASENAME%.pc found!
   exit /B 1
-) else (
-  echo lib%MONGOCXX_BASENAME%1.pc check ok
+  echo lib%MONGOCXX_BASENAME%.pc check ok
 )
 if exist %INSTALL_DIR%\include\bsoncxx\v_noabi\bsoncxx\json.hpp (
   echo bsoncxx\json.hpp found!

--- a/.evergreen/scripts/uninstall_check_windows.cmd
+++ b/.evergreen/scripts/uninstall_check_windows.cmd
@@ -13,6 +13,7 @@ dir %INSTALL_DIR% /s
 if exist %INSTALL_DIR%\lib\pkgconfig\lib%BSONCXX_BASENAME%.pc (
   echo lib%BSONCXX_BASENAME%.pc found!
   exit /B 1
+) else (
   echo lib%BSONCXX_BASENAME%.pc check ok
 )
 if not exist %INSTALL_DIR%\lib\canary.txt (
@@ -30,6 +31,7 @@ if not exist %INSTALL_DIR%\lib (
 if exist %INSTALL_DIR%\lib\pkgconfig\lib%MONGOCXX_BASENAME%.pc (
   echo lib%MONGOCXX_BASENAME%.pc found!
   exit /B 1
+) else (
   echo lib%MONGOCXX_BASENAME%.pc check ok
 )
 if exist %INSTALL_DIR%\include\bsoncxx\v_noabi\bsoncxx\json.hpp (

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ## 4.4.0 [Unreleased]
 
+> [!IMPORTANT]
+> This is the first release supporting a stable ABI for the bsoncxx and mongocxx libraries.
+>
+> - The stable ABI is declared under the `v1` namespace of the bsoncxx and mongocxx libraries.
+> - The unstable ABI declared under the `v_noabi` namespace is still supported.
+> - Root namespace redeclarations (e.g. `bsoncxx::document::value`) are recommended when ABI stability is not a requirement. These redeclarations will be updated to the latest ABI version equivalents in an upcoming API major release.
+>
+> See [ABI Versioning](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/reference/api-abi-versioning/abi-versioning/) for more information.
+
 ### Fixed
 
 - Do not set `upsert: true` in "findOneAnd*" operations when the option is explicitly set to `false` (regression in 4.2.0).
@@ -19,6 +28,14 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 - Support for MongoDB Server 4.2.
   - See: [MongoDB Software Lifecycle Schedules](https://www.mongodb.com/legal/support-policy/lifecycles).
+
+### Changed
+
+- Stable ABI (v1) is now officially supported for both bsoncxx and mongocxx libraries.
+- The soversion for both bsoncxx and mongocxx libraries is now set to `1`.
+- Library filenames now include the ABI version number, e.g. `libbsoncxx1.so.4.4.0`.
+- pkg-config config filenames now include the ABI version number, e.g. `bsoncxxConfig.cmake`.
+- CMake package config filenames now use `camelCase`, e.g. `bsoncxxConfig.cmake`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 - Stable ABI (v1) is now officially supported for both bsoncxx and mongocxx libraries.
 - The soversion for both bsoncxx and mongocxx libraries is now set to `1`.
 - Library filenames now include the ABI version number, e.g. `libbsoncxx1.so.4.4.0`.
-- pkg-config config filenames now include the ABI version number, e.g. `bsoncxxConfig.cmake`.
+- pkg-config config filenames now include the ABI version number, e.g. `libbsoncxx1.pc`.
 - CMake package config filenames now use `camelCase`, e.g. `bsoncxxConfig.cmake`.
 
 ### Added

--- a/src/bsoncxx/CMakeLists.txt
+++ b/src/bsoncxx/CMakeLists.txt
@@ -20,7 +20,7 @@ set(BSONCXX_VERSION_NO_EXTRA ${BSONCXX_VERSION_MAJOR}.${BSONCXX_VERSION_MINOR}.$
 set(BSONCXX_VERSION $CACHE{BSONCXX_VERSION_NO_EXTRA}${BSONCXX_VERSION_EXTRA} CACHE INTERNAL "")
 message(STATUS "bsoncxx version: $CACHE{BSONCXX_VERSION}")
 
-set(BSONCXX_SOVERSION "_noabi" CACHE STRING "For internal use only.")
+set(BSONCXX_SOVERSION "1" CACHE STRING "The ABI version number for the bsoncxx library.")
 message(STATUS "bsoncxx soversion: ${BSONCXX_SOVERSION}")
 
 option(BSONCXX_ENABLE_UNSTABLE_ABI "Enable building with unstable ABI symbols." ON)

--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -20,7 +20,7 @@ set(MONGOCXX_VERSION_NO_EXTRA ${MONGOCXX_VERSION_MAJOR}.${MONGOCXX_VERSION_MINOR
 set(MONGOCXX_VERSION ${MONGOCXX_VERSION_NO_EXTRA}${MONGOCXX_VERSION_EXTRA} CACHE INTERNAL "")
 message(STATUS "mongocxx version: $CACHE{MONGOCXX_VERSION}")
 
-set(MONGOCXX_SOVERSION "1" CACHE STRING "The ABI version number for the mongocxx library")
+set(MONGOCXX_SOVERSION "1" CACHE STRING "The ABI version number for the mongocxx library.")
 message(STATUS "mongocxx soversion: ${MONGOCXX_SOVERSION}")
 
 cmake_dependent_option(MONGOCXX_ENABLE_UNSTABLE_ABI "Enable building with unstable ABI symbols." ON "BSONCXX_ENABLE_UNSTABLE_ABI" OFF)

--- a/src/mongocxx/CMakeLists.txt
+++ b/src/mongocxx/CMakeLists.txt
@@ -20,7 +20,7 @@ set(MONGOCXX_VERSION_NO_EXTRA ${MONGOCXX_VERSION_MAJOR}.${MONGOCXX_VERSION_MINOR
 set(MONGOCXX_VERSION ${MONGOCXX_VERSION_NO_EXTRA}${MONGOCXX_VERSION_EXTRA} CACHE INTERNAL "")
 message(STATUS "mongocxx version: $CACHE{MONGOCXX_VERSION}")
 
-set(MONGOCXX_SOVERSION "_noabi" CACHE STRING "For internal use only.")
+set(MONGOCXX_SOVERSION "1" CACHE STRING "The ABI version number for the mongocxx library")
 message(STATUS "mongocxx soversion: ${MONGOCXX_SOVERSION}")
 
 cmake_dependent_option(MONGOCXX_ENABLE_UNSTABLE_ABI "Enable building with unstable ABI symbols." ON "BSONCXX_ENABLE_UNSTABLE_ABI" OFF)


### PR DESCRIPTION
Resolves CXX-804, targeting the 4.4.0 release. Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1586 and https://github.com/mongodb/mongo-cxx-driver/pull/1649.
