### PR TITLE
Add missing ABI conversion helper functions

### DIFF
--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client_encryption.hpp
@@ -307,6 +307,20 @@ class client_encryption {
     get_key_by_alt_name(bsoncxx::v_noabi::string::view_or_value key_alt_name);
 };
 
+///
+/// Convert from the @ref mongocxx::v1 equivalent of `v`.
+///
+inline v_noabi::client_encryption from_v1(v1::client_encryption v) {
+    return {std::move(v)};
+}
+
+///
+/// Convert to the @ref mongocxx::v1 equivalent of `v`.
+///
+inline v1::client_encryption to_v1(v_noabi::client_encryption v) {
+    return v1::client_encryption{std::move(v)};
+}
+
 } // namespace v_noabi
 } // namespace mongocxx
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/pipeline.hpp
@@ -704,6 +704,20 @@ class pipeline {
     class internal;
 };
 
+///
+/// Convert from the @ref mongocxx::v1 equivalent of `v`.
+///
+inline v_noabi::pipeline from_v1(v1::pipeline v) {
+    return {std::move(v)};
+}
+
+///
+/// Convert to the @ref mongocxx::v1 equivalent of `v`.
+///
+inline v1::pipeline to_v1(v_noabi::pipeline v) {
+    return v1::pipeline{std::move(v)};
+}
+
 } // namespace v_noabi
 } // namespace mongocxx
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/gridfs/upload.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/result/gridfs/upload.hpp
@@ -20,6 +20,8 @@
 
 #include <mongocxx/v1/gridfs/upload_result.hpp> // IWYU pragma: export
 
+#include <utility>
+
 #include <bsoncxx/array/value.hpp> // IWYU pragma: keep: backward compatibility, to be removed.
 #include <bsoncxx/types/value.hpp>
 #include <bsoncxx/types/view.hpp>
@@ -89,6 +91,26 @@ class upload {
 
 } // namespace gridfs
 } // namespace result
+} // namespace v_noabi
+} // namespace mongocxx
+
+namespace mongocxx {
+namespace v_noabi {
+
+///
+/// Convert from the @ref mongocxx::v1 equivalent of `v`.
+///
+inline v_noabi::result::gridfs::upload from_v1(v1::gridfs::upload_result v) {
+    return {std::move(v)};
+}
+
+///
+/// Convert to the @ref mongocxx::v1 equivalent of `v`.
+///
+inline v1::gridfs::upload_result to_v1(v_noabi::result::gridfs::upload const& v) {
+    return v1::gridfs::upload_result{v};
+}
+
 } // namespace v_noabi
 } // namespace mongocxx
 


### PR DESCRIPTION
Identified during review of https://github.com/mongodb/mongo-cxx-driver/pull/1647. Extends ABI conversion helpers to a few more classes which already provide straightforward UDCFs to/from v1 equivalents.