### PR TITLE
Fix test comments describing "assign-or-destroy-only" states

### DIFF
--- a/src/mongocxx/test/v1/aggregate_options.cpp
+++ b/src/mongocxx/test/v1/aggregate_options.cpp
@@ -52,13 +52,13 @@ TEST_CASE("ownership", "[mongocxx][v1][aggregate_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.comment() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.comment() == source_value);
     }

--- a/src/mongocxx/test/v1/apm.cpp
+++ b/src/mongocxx/test/v1/apm.cpp
@@ -74,13 +74,13 @@ TEST_CASE("ownership", "[mongocxx][v1][apm]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(get_target(move.command_started()) == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(get_target(target.command_started()) == source_value);
     }

--- a/src/mongocxx/test/v1/auto_encryption_options.cpp
+++ b/src/mongocxx/test/v1/auto_encryption_options.cpp
@@ -51,13 +51,13 @@ TEST_CASE("ownership", "[mongocxx][v1][auto_encryption_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.extra_options() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.extra_options() == source_value);
     }

--- a/src/mongocxx/test/v1/bulk_write.cpp
+++ b/src/mongocxx/test/v1/bulk_write.cpp
@@ -295,14 +295,14 @@ TEST_CASE("ownership", "[mongocxx][v1][bulk_write]") {
         {
             auto move = std::move(source);
 
-            // source is in an assign-or-move-only state.
+            // source is in an assign-or-destroy-only state.
 
             CHECK(bulk_write::internal::as_mongoc(move) == bulk1);
             CHECK(destroy_count == 0);
 
             target = std::move(move);
 
-            // move is in an assign-or-move-only state.
+            // move is in an assign-or-destroy-only state.
 
             CHECK(bulk_write::internal::as_mongoc(target) == bulk1);
             CHECK(destroy_count == 1);
@@ -324,13 +324,13 @@ void test_ownership(Op& target, Op& source) {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.filter() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.filter() == source_value);
     }
@@ -460,14 +460,14 @@ TEST_CASE("ownership", "[mongocxx][v1][bulk_write][single]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(get_value(move).data() == source_data);
         CHECK(get_value(move) == source_value);
 
         target = std::move(move);
 
-        // move is in an assign-or-move-only state.
+        // move is in an assign-or-destroy-only state.
 
         CHECK(get_value(target).data() == source_data);
         CHECK(get_value(target) == source_value);
@@ -599,13 +599,13 @@ TEST_CASE("ownership", "[mongocxx][v1][bulk_write][options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.comment() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.comment() == source_value);
     }
@@ -640,13 +640,13 @@ TEST_CASE("ownership", "[mongocxx][v1][bulk_write][result]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(reply(move).data() == source_data);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(reply(target).data() == source_data);
     }

--- a/src/mongocxx/test/v1/client.cpp
+++ b/src/mongocxx/test/v1/client.cpp
@@ -542,7 +542,7 @@ TEST_CASE("ownership", "[mongocxx][v1][client]") {
         {
             auto move = std::move(source);
 
-            // source is in an assign-or-move-only state.
+            // source is in an assign-or-destroy-only state.
             CHECK_FALSE(source);
 
             CHECK(move);
@@ -551,7 +551,7 @@ TEST_CASE("ownership", "[mongocxx][v1][client]") {
 
             target = std::move(move);
 
-            // move is in an assign-or-move-only state.
+            // move is in an assign-or-destroy-only state.
             CHECK_FALSE(move);
 
             CHECK(target);
@@ -579,13 +579,13 @@ TEST_CASE("ownership", "[mongocxx][v1][client][options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.tls_opts().value().ca_file() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.tls_opts().value().ca_file() == source_value);
     }

--- a/src/mongocxx/test/v1/client_encryption.cpp
+++ b/src/mongocxx/test/v1/client_encryption.cpp
@@ -70,14 +70,14 @@ TEST_CASE("ownership", "[mongocxx][v1][client_encryption]") {
         {
             auto move = std::move(source);
 
-            // source is in an assign-or-move-only state.
+            // source is in an assign-or-destroy-only state.
 
             CHECK(client_encryption::internal::as_mongoc(move) == ce1);
             CHECK(destroy_count == 0);
 
             target = std::move(move);
 
-            // move is in an assign-or-move-only state.
+            // move is in an assign-or-destroy-only state.
 
             CHECK(client_encryption::internal::as_mongoc(target) == ce1);
             CHECK(destroy_count == 1);
@@ -106,13 +106,13 @@ TEST_CASE("ownership", "[mongocxx][v1][client_encryption][options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.key_vault_client() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.key_vault_client() == source_value);
     }

--- a/src/mongocxx/test/v1/client_session.cpp
+++ b/src/mongocxx/test/v1/client_session.cpp
@@ -548,14 +548,14 @@ TEST_CASE("ownership", "[mongocxx][v1][client_session]") {
         {
             auto move = std::move(source);
 
-            // source is in an assign-or-move-only state.
+            // source is in an assign-or-destroy-only state.
 
             CHECK(client_session::internal::as_mongoc(move) == session1);
             CHECK(destroy_count == 0);
 
             target = std::move(move);
 
-            // move is in an assign-or-move-only state.
+            // move is in an assign-or-destroy-only state.
 
             CHECK(client_session::internal::as_mongoc(target) == session1);
             CHECK(destroy_count == 1);
@@ -598,14 +598,14 @@ TEST_CASE("ownership", "[mongocxx][v1][client_session][options]") {
         {
             auto move = std::move(source);
 
-            // source is in an assign-or-move-only state.
+            // source is in an assign-or-destroy-only state.
 
             CHECK(client_session::options::internal::as_mongoc(move) == opts1);
             CHECK(destroy_count == 0);
 
             target = std::move(move);
 
-            // move is in an assign-or-move-only state.
+            // move is in an assign-or-destroy-only state.
 
             CHECK(client_session::options::internal::as_mongoc(target) == opts1);
             CHECK(destroy_count == 1);

--- a/src/mongocxx/test/v1/count_options.cpp
+++ b/src/mongocxx/test/v1/count_options.cpp
@@ -50,13 +50,13 @@ TEST_CASE("ownership", "[mongocxx][v1][count_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.limit() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.limit() == source_value);
     }

--- a/src/mongocxx/test/v1/data_key_options.cpp
+++ b/src/mongocxx/test/v1/data_key_options.cpp
@@ -55,13 +55,13 @@ TEST_CASE("ownership", "[mongocxx][v1][data_key_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.master_key() == source_key.view());
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.master_key() == source_key.view());
     }

--- a/src/mongocxx/test/v1/delete_many_options.cpp
+++ b/src/mongocxx/test/v1/delete_many_options.cpp
@@ -49,13 +49,13 @@ TEST_CASE("ownership", "[mongocxx][v1][delete_many_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.comment() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.comment() == source_value);
     }

--- a/src/mongocxx/test/v1/delete_many_result.cpp
+++ b/src/mongocxx/test/v1/delete_many_result.cpp
@@ -43,13 +43,13 @@ TEST_CASE("ownership", "[mongocxx][v1][delete_many_result]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.result() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.result() == source_value);
     }

--- a/src/mongocxx/test/v1/delete_one_options.cpp
+++ b/src/mongocxx/test/v1/delete_one_options.cpp
@@ -49,13 +49,13 @@ TEST_CASE("ownership", "[mongocxx][v1][delete_one_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.comment() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.comment() == source_value);
     }

--- a/src/mongocxx/test/v1/delete_one_result.cpp
+++ b/src/mongocxx/test/v1/delete_one_result.cpp
@@ -43,13 +43,13 @@ TEST_CASE("ownership", "[mongocxx][v1][delete_one_result]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.result() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.result() == source_value);
     }

--- a/src/mongocxx/test/v1/distinct_options.cpp
+++ b/src/mongocxx/test/v1/distinct_options.cpp
@@ -48,13 +48,13 @@ TEST_CASE("ownership", "[mongocxx][v1][distinct_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.max_time() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.max_time() == source_value);
     }

--- a/src/mongocxx/test/v1/encrypt_options.cpp
+++ b/src/mongocxx/test/v1/encrypt_options.cpp
@@ -47,13 +47,13 @@ TEST_CASE("ownership", "[mongocxx][v1][encrypt_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.key_alt_name() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.key_alt_name() == source_value);
     }

--- a/src/mongocxx/test/v1/estimated_document_count_options.cpp
+++ b/src/mongocxx/test/v1/estimated_document_count_options.cpp
@@ -49,13 +49,13 @@ TEST_CASE("ownership", "[mongocxx][v1][estimated_document_count_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.max_time() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.max_time() == source_value);
     }

--- a/src/mongocxx/test/v1/find_one_and_delete_options.cpp
+++ b/src/mongocxx/test/v1/find_one_and_delete_options.cpp
@@ -52,13 +52,13 @@ TEST_CASE("ownership", "[mongocxx][v1][find_one_and_delete_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.comment() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.comment() == source_value);
     }

--- a/src/mongocxx/test/v1/find_one_and_replace_options.cpp
+++ b/src/mongocxx/test/v1/find_one_and_replace_options.cpp
@@ -53,13 +53,13 @@ TEST_CASE("ownership", "[mongocxx][v1][find_one_and_replace_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.comment() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.comment() == source_value);
     }

--- a/src/mongocxx/test/v1/find_one_and_update_options.cpp
+++ b/src/mongocxx/test/v1/find_one_and_update_options.cpp
@@ -53,13 +53,13 @@ TEST_CASE("ownership", "[mongocxx][v1][find_one_and_update_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.comment() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.comment() == source_value);
     }

--- a/src/mongocxx/test/v1/find_options.cpp
+++ b/src/mongocxx/test/v1/find_options.cpp
@@ -52,13 +52,13 @@ TEST_CASE("ownership", "[mongocxx][v1][find_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.limit() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.limit() == source_value);
     }

--- a/src/mongocxx/test/v1/gridfs/bucket.cpp
+++ b/src/mongocxx/test/v1/gridfs/bucket.cpp
@@ -243,13 +243,13 @@ TEST_CASE("ownership", "[mongocxx][v1][gridfs][bucket][options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.bucket_name() == source_value);
 
         target = std::move(move);
 
-        // move is in an assign-or-move-only state.
+        // move is in an assign-or-destroy-only state.
 
         CHECK(target.bucket_name() == source_value);
     }

--- a/src/mongocxx/test/v1/gridfs/upload_options.cpp
+++ b/src/mongocxx/test/v1/gridfs/upload_options.cpp
@@ -44,13 +44,13 @@ TEST_CASE("ownership", "[mongocxx][v1][gridfs][upload_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.chunk_size_bytes() == source_value);
 
         target = std::move(move);
 
-        // move is in an assign-or-move-only state.
+        // move is in an assign-or-destroy-only state.
 
         CHECK(target.chunk_size_bytes() == source_value);
     }

--- a/src/mongocxx/test/v1/gridfs/upload_result.cpp
+++ b/src/mongocxx/test/v1/gridfs/upload_result.cpp
@@ -39,13 +39,13 @@ TEST_CASE("ownership", "[mongocxx][v1][gridfs][upload_result]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.id() == source_value);
 
         target = std::move(move);
 
-        // move is in an assign-or-move-only state.
+        // move is in an assign-or-destroy-only state.
 
         CHECK(target.id() == source_value);
     }

--- a/src/mongocxx/test/v1/hint.cpp
+++ b/src/mongocxx/test/v1/hint.cpp
@@ -39,13 +39,13 @@ TEST_CASE("ownership", "[mongocxx][v1][hint]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.str() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.str() == source_value);
     }

--- a/src/mongocxx/test/v1/indexes.cpp
+++ b/src/mongocxx/test/v1/indexes.cpp
@@ -127,13 +127,13 @@ TEST_CASE("ownership", "[mongocxx][v1][indexes]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(get_collection(move) == coll1_id);
 
         target = std::move(move);
 
-        // move is in an assign-or-move-only state.
+        // move is in an assign-or-destroy-only state.
 
         CHECK(get_collection(target) == coll1_id);
     }
@@ -167,13 +167,13 @@ TEST_CASE("ownership", "[mongocxx][v1][indexes][options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.name() == source_value);
 
         target = std::move(move);
 
-        // move is in an assign-or-move-only state.
+        // move is in an assign-or-destroy-only state.
 
         CHECK(target.name() == source_value);
     }
@@ -204,13 +204,13 @@ TEST_CASE("ownership", "[mongocxx][v1][indexes][model]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.keys() == source_value.view());
 
         target = std::move(move);
 
-        // move is in an assign-or-move-only state.
+        // move is in an assign-or-destroy-only state.
 
         CHECK(target.keys() == source_value.view());
     }
@@ -244,13 +244,13 @@ TEST_CASE("ownership", "[mongocxx][v1][indexes][create_one_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.comment() == source_value);
 
         target = std::move(move);
 
-        // move is in an assign-or-move-only state.
+        // move is in an assign-or-destroy-only state.
 
         CHECK(target.comment() == source_value);
     }
@@ -284,13 +284,13 @@ TEST_CASE("ownership", "[mongocxx][v1][indexes][create_many_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.comment() == source_value);
 
         target = std::move(move);
 
-        // move is in an assign-or-move-only state.
+        // move is in an assign-or-destroy-only state.
 
         CHECK(target.comment() == source_value);
     }
@@ -324,13 +324,13 @@ TEST_CASE("ownership", "[mongocxx][v1][indexes][drop_one_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.comment() == source_value);
 
         target = std::move(move);
 
-        // move is in an assign-or-move-only state.
+        // move is in an assign-or-destroy-only state.
 
         CHECK(target.comment() == source_value);
     }
@@ -364,13 +364,13 @@ TEST_CASE("ownership", "[mongocxx][v1][indexes][drop_all_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.comment() == source_value);
 
         target = std::move(move);
 
-        // move is in an assign-or-move-only state.
+        // move is in an assign-or-destroy-only state.
 
         CHECK(target.comment() == source_value);
     }
@@ -404,13 +404,13 @@ TEST_CASE("ownership", "[mongocxx][v1][indexes][list_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.batch_size() == source_value);
 
         target = std::move(move);
 
-        // move is in an assign-or-move-only state.
+        // move is in an assign-or-destroy-only state.
 
         CHECK(target.batch_size() == source_value);
     }

--- a/src/mongocxx/test/v1/insert_many_options.cpp
+++ b/src/mongocxx/test/v1/insert_many_options.cpp
@@ -46,13 +46,13 @@ TEST_CASE("ownership", "[mongocxx][v1][insert_many_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.comment() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.comment() == source_value);
     }

--- a/src/mongocxx/test/v1/insert_many_result.cpp
+++ b/src/mongocxx/test/v1/insert_many_result.cpp
@@ -62,14 +62,14 @@ TEST_CASE("ownership", "[mongocxx][v1][insert_many_result]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.result() == source_value);
         CHECK(move.inserted_ids() == source_ids_map);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.result() == source_value);
         CHECK(target.inserted_ids() == source_ids_map);

--- a/src/mongocxx/test/v1/insert_one_options.cpp
+++ b/src/mongocxx/test/v1/insert_one_options.cpp
@@ -46,13 +46,13 @@ TEST_CASE("ownership", "[mongocxx][v1][insert_one_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.comment() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.comment() == source_value);
     }

--- a/src/mongocxx/test/v1/insert_one_result.cpp
+++ b/src/mongocxx/test/v1/insert_one_result.cpp
@@ -52,14 +52,14 @@ TEST_CASE("ownership", "[mongocxx][v1][insert_one_result]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.result() == source_value);
         CHECK(move.inserted_id() == source_id);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.result() == source_value);
         CHECK(target.inserted_id() == source_id);

--- a/src/mongocxx/test/v1/pipeline.cpp
+++ b/src/mongocxx/test/v1/pipeline.cpp
@@ -53,13 +53,13 @@ TEST_CASE("ownership", "[mongocxx][v1][pipeline]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.view_array() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.view_array() == source_value);
     }

--- a/src/mongocxx/test/v1/pool.cpp
+++ b/src/mongocxx/test/v1/pool.cpp
@@ -363,7 +363,7 @@ TEST_CASE("ownership", "[mongocxx][v1][pool]") {
         {
             auto move = std::move(source);
 
-            // source is in an assign-or-move-only state.
+            // source is in an assign-or-destroy-only state.
             CHECK_FALSE(source);
 
             CHECK(move);
@@ -372,7 +372,7 @@ TEST_CASE("ownership", "[mongocxx][v1][pool]") {
 
             target = std::move(move);
 
-            // move is in an assign-or-move-only state.
+            // move is in an assign-or-destroy-only state.
             CHECK_FALSE(move);
 
             CHECK(target);
@@ -401,13 +401,13 @@ TEST_CASE("ownership", "[mongocxx][v1][pool][options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(ca_file(move) == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(ca_file(target) == source_value);
     }
@@ -476,7 +476,7 @@ TEST_CASE("ownership", "[mongocxx][v1][pool][entry]") {
         {
             auto move = std::move(source);
 
-            // source is in an assign-or-move-only state.
+            // source is in an assign-or-destroy-only state.
             CHECK_FALSE(source);
 
             REQUIRE(move);
@@ -487,7 +487,7 @@ TEST_CASE("ownership", "[mongocxx][v1][pool][entry]") {
 
             target = std::move(move);
 
-            // move is in an assign-or-move-only state.
+            // move is in an assign-or-destroy-only state.
             CHECK_FALSE(move);
 
             REQUIRE(target);

--- a/src/mongocxx/test/v1/range_options.cpp
+++ b/src/mongocxx/test/v1/range_options.cpp
@@ -43,13 +43,13 @@ TEST_CASE("ownership", "[mongocxx][v1][range_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.precision() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.precision() == source_value);
     }

--- a/src/mongocxx/test/v1/read_concern.cpp
+++ b/src/mongocxx/test/v1/read_concern.cpp
@@ -41,13 +41,13 @@ TEST_CASE("ownership", "[mongocxx][v1][read_concern]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.acknowledge_string() == "source");
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.acknowledge_string() == "source");
     }

--- a/src/mongocxx/test/v1/read_preference.cpp
+++ b/src/mongocxx/test/v1/read_preference.cpp
@@ -45,13 +45,13 @@ TEST_CASE("ownership", "[mongocxx][v1][read_preference]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.mode() == mode::k_primary_preferred);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.mode() == mode::k_primary_preferred);
     }

--- a/src/mongocxx/test/v1/replace_one_options.cpp
+++ b/src/mongocxx/test/v1/replace_one_options.cpp
@@ -51,13 +51,13 @@ TEST_CASE("ownership", "[mongocxx][v1][replace_one_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.comment() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.comment() == source_value);
     }

--- a/src/mongocxx/test/v1/replace_one_result.cpp
+++ b/src/mongocxx/test/v1/replace_one_result.cpp
@@ -49,13 +49,13 @@ TEST_CASE("ownership", "[mongocxx][v1][replace_one_result]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.result() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.result() == source_value);
     }

--- a/src/mongocxx/test/v1/rewrap_many_datakey_options.cpp
+++ b/src/mongocxx/test/v1/rewrap_many_datakey_options.cpp
@@ -45,13 +45,13 @@ TEST_CASE("ownership", "[mongocxx][v1][rewrap_many_datakey_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.provider() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.provider() == source_value);
     }

--- a/src/mongocxx/test/v1/rewrap_many_datakey_result.cpp
+++ b/src/mongocxx/test/v1/rewrap_many_datakey_result.cpp
@@ -45,13 +45,13 @@ TEST_CASE("ownership", "[mongocxx][v1][rewrap_many_datakey_result]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.result() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.result() == source_value);
     }

--- a/src/mongocxx/test/v1/search_indexes.cpp
+++ b/src/mongocxx/test/v1/search_indexes.cpp
@@ -146,13 +146,13 @@ TEST_CASE("ownership", "[mongocxx][v1][search_indexes][model]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.definition() == source_value.view());
 
         target = std::move(move);
 
-        // move is in an assign-or-move-only state.
+        // move is in an assign-or-destroy-only state.
 
         CHECK(target.definition() == source_value.view());
     }

--- a/src/mongocxx/test/v1/server_api.cpp
+++ b/src/mongocxx/test/v1/server_api.cpp
@@ -112,13 +112,13 @@ TEST_CASE("ownership", "[mongocxx][v1][server_api]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.get_version() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.get_version() == source_value);
     }

--- a/src/mongocxx/test/v1/text_options.cpp
+++ b/src/mongocxx/test/v1/text_options.cpp
@@ -38,13 +38,13 @@ TEST_CASE("ownership", "[mongocxx][v1][text_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.case_sensitive() == source_value);
 
         target = std::move(move);
 
-        // move is in an assign-or-move-only state.
+        // move is in an assign-or-destroy-only state.
 
         CHECK(target.case_sensitive() == source_value);
     }
@@ -75,13 +75,13 @@ TEST_CASE("ownership", "[mongocxx][v1][text_options][prefix]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.str_max_query_length() == source_value);
 
         target = std::move(move);
 
-        // move is in an assign-or-move-only state.
+        // move is in an assign-or-destroy-only state.
 
         CHECK(target.str_max_query_length() == source_value);
     }
@@ -112,13 +112,13 @@ TEST_CASE("ownership", "[mongocxx][v1][text_options][suffix]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.str_max_query_length() == source_value);
 
         target = std::move(move);
 
-        // move is in an assign-or-move-only state.
+        // move is in an assign-or-destroy-only state.
 
         CHECK(target.str_max_query_length() == source_value);
     }
@@ -149,13 +149,13 @@ TEST_CASE("ownership", "[mongocxx][v1][text_options][substring]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.str_max_length() == source_value);
 
         target = std::move(move);
 
-        // move is in an assign-or-move-only state.
+        // move is in an assign-or-destroy-only state.
 
         CHECK(target.str_max_length() == source_value);
     }

--- a/src/mongocxx/test/v1/tls.cpp
+++ b/src/mongocxx/test/v1/tls.cpp
@@ -38,13 +38,13 @@ TEST_CASE("ownership", "[mongocxx][v1][tls]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.pem_file() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.pem_file() == source_value);
     }

--- a/src/mongocxx/test/v1/transaction_options.cpp
+++ b/src/mongocxx/test/v1/transaction_options.cpp
@@ -44,13 +44,13 @@ TEST_CASE("ownership", "[mongocxx][v1][transaction_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.max_commit_time_ms() == source_secs);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.max_commit_time_ms() == source_secs);
     }

--- a/src/mongocxx/test/v1/update_many_options.cpp
+++ b/src/mongocxx/test/v1/update_many_options.cpp
@@ -49,13 +49,13 @@ TEST_CASE("ownership", "[mongocxx][v1][update_many_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.comment() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.comment() == source_value);
     }

--- a/src/mongocxx/test/v1/update_many_result.cpp
+++ b/src/mongocxx/test/v1/update_many_result.cpp
@@ -52,13 +52,13 @@ TEST_CASE("ownership", "[mongocxx][v1][update_many_result]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.result() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.result() == source_value);
     }

--- a/src/mongocxx/test/v1/update_one_options.cpp
+++ b/src/mongocxx/test/v1/update_one_options.cpp
@@ -51,13 +51,13 @@ TEST_CASE("ownership", "[mongocxx][v1][update_one_options]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.comment() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.comment() == source_value);
     }

--- a/src/mongocxx/test/v1/update_one_result.cpp
+++ b/src/mongocxx/test/v1/update_one_result.cpp
@@ -48,13 +48,13 @@ TEST_CASE("ownership", "[mongocxx][v1][update_one_result]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.result() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.result() == source_value);
     }

--- a/src/mongocxx/test/v1/uri.cpp
+++ b/src/mongocxx/test/v1/uri.cpp
@@ -353,13 +353,13 @@ TEST_CASE("ownership", "[mongocxx][v1][uri]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.database() == source_value);
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.database() == source_value);
     }

--- a/src/mongocxx/test/v1/write_concern.cpp
+++ b/src/mongocxx/test/v1/write_concern.cpp
@@ -46,13 +46,13 @@ TEST_CASE("ownership", "[mongocxx][v1][write_concern]") {
     SECTION("move") {
         auto move = std::move(source);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(move.tag() == "source");
 
         target = std::move(move);
 
-        // source is in an assign-or-move-only state.
+        // source is in an assign-or-destroy-only state.
 
         CHECK(target.tag() == "source");
     }


### PR DESCRIPTION
A minor drive-by find-and-replace for misworded comments in test code concerning the "assign-or-destroy-only" state following a move operation.