### PR TITLE
Use new abi-dumper for abi-compliance-checker + Ninja by default

### DIFF
--- a/.evergreen/config_generator/components/abi_stability.py
+++ b/.evergreen/config_generator/components/abi_stability.py
@@ -43,7 +43,7 @@ class AbiComplianceCheck(Function):
             bucket='mciuploads',
             content_type='text/html',
             display_name='ABI Compliance Check (Stable): ',
-            local_files_include_filter='cxx-abi/compat_reports/**/compat_report.html',
+            local_files_include_filter=['cxx-abi/*.html'],
             permissions='public-read',
             remote_file='mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${task_id}/${execution}/abi-compliance-check/abi/',
         ),
@@ -54,7 +54,7 @@ class AbiComplianceCheck(Function):
             bucket='mciuploads',
             content_type='text/plain',
             display_name='ABI Compliance Check (Stable): ',
-            local_files_include_filter='cxx-abi/logs/**/log.txt',
+            local_files_include_filter=['cxx-abi/**/*.log', 'cxx-abi/**/log.txt'],
             permissions='public-read',
             remote_file='mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${task_id}/${execution}/abi-compliance-check/abi/',
         ),
@@ -65,7 +65,7 @@ class AbiComplianceCheck(Function):
             bucket='mciuploads',
             content_type='text/html',
             display_name='ABI Compliance Check (Unstable): ',
-            local_files_include_filter='cxx-noabi/compat_reports/**/compat_report.html',
+            local_files_include_filter=['cxx-noabi/*.html'],
             permissions='public-read',
             remote_file='mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${task_id}/${execution}/abi-compliance-check/noabi/',
         ),
@@ -76,7 +76,7 @@ class AbiComplianceCheck(Function):
             bucket='mciuploads',
             content_type='text/plain',
             display_name='ABI Compliance Check (Unstable): ',
-            local_files_include_filter='cxx-noabi/logs/**/log.txt',
+            local_files_include_filter=['cxx-noabi/**/*.log', 'cxx-noabi/**/log.txt'],
             permissions='public-read',
             remote_file='mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${task_id}/${execution}/abi-compliance-check/noabi/',
         ),
@@ -101,7 +101,7 @@ class Abidiff(Function):
             bucket='mciuploads',
             content_type='text/plain',
             display_name='abidiff (Stable): ',
-            local_files_include_filter='cxx-abi/*.txt',
+            local_files_include_filter=['cxx-abi/*.txt'],
             permissions='public-read',
             remote_file='mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${task_id}/${execution}/abidiff/abi/',
         ),
@@ -112,7 +112,7 @@ class Abidiff(Function):
             bucket='mciuploads',
             content_type='text/plain',
             display_name='abidiff (Unstable): ',
-            local_files_include_filter='cxx-noabi/*.txt',
+            local_files_include_filter=['cxx-noabi/*.txt'],
             permissions='public-read',
             remote_file='mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${task_id}/${execution}/abidiff/noabi/',
         ),
@@ -142,9 +142,9 @@ def generate_tasks():
 
     for func, (polyfill, cxx_standard) in product(funcs, MATRIX):
         if func is Abidiff:
-            distro_name = 'ubuntu2204'  # Clang 12, libabigail is not available on RHEL distros.
+            distro_name = 'ubuntu2204'  # Clang 14, libabigail is not available on RHEL distros.
         else:
-            distro_name = 'rhel95'  # Clang 19.
+            distro_name = 'rhel95'  # Clang 20.
 
         distro = find_large_distro(distro_name)
 
@@ -182,7 +182,7 @@ def task_groups():
             setup_task_can_fail_task=True,
             setup_task=[
                 git_get_project(directory='mongo-cxx-driver'),
-                InstallCDriver.call(),
+                InstallCDriver.call(vars={'SKIP_INSTALL_LIBMONGOCRYPT': 1}),
                 bash_exec(
                     command_type=EvgCommandType.SETUP,
                     env={
@@ -199,7 +199,7 @@ def task_groups():
                     bucket='mciuploads',
                     content_type='text/plain',
                     display_name='ABI Stability Setup: ',
-                    local_files_include_filter='*.log',
+                    local_files_include_filter=['*.log'],
                     permissions='public-read',
                     remote_file='mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${task_id}/${execution}/abi-stability-setup/',
                 ),

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -22,7 +22,8 @@ functions:
         aws_secret: ${aws_secret}
         bucket: mciuploads
         content_type: text/html
-        local_files_include_filter: cxx-abi/compat_reports/**/compat_report.html
+        local_files_include_filter:
+          - cxx-abi/*.html
         permissions: public-read
         remote_file: mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${task_id}/${execution}/abi-compliance-check/abi/
     - command: s3.put
@@ -33,7 +34,9 @@ functions:
         aws_secret: ${aws_secret}
         bucket: mciuploads
         content_type: text/plain
-        local_files_include_filter: cxx-abi/logs/**/log.txt
+        local_files_include_filter:
+          - cxx-abi/**/*.log
+          - cxx-abi/**/log.txt
         permissions: public-read
         remote_file: mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${task_id}/${execution}/abi-compliance-check/abi/
     - command: s3.put
@@ -44,7 +47,8 @@ functions:
         aws_secret: ${aws_secret}
         bucket: mciuploads
         content_type: text/html
-        local_files_include_filter: cxx-noabi/compat_reports/**/compat_report.html
+        local_files_include_filter:
+          - cxx-noabi/*.html
         permissions: public-read
         remote_file: mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${task_id}/${execution}/abi-compliance-check/noabi/
     - command: s3.put
@@ -55,7 +59,9 @@ functions:
         aws_secret: ${aws_secret}
         bucket: mciuploads
         content_type: text/plain
-        local_files_include_filter: cxx-noabi/logs/**/log.txt
+        local_files_include_filter:
+          - cxx-noabi/**/*.log
+          - cxx-noabi/**/log.txt
         permissions: public-read
         remote_file: mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${task_id}/${execution}/abi-compliance-check/noabi/
   abi-prohibited-symbols:
@@ -89,7 +95,8 @@ functions:
         aws_secret: ${aws_secret}
         bucket: mciuploads
         content_type: text/plain
-        local_files_include_filter: cxx-abi/*.txt
+        local_files_include_filter:
+          - cxx-abi/*.txt
         permissions: public-read
         remote_file: mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${task_id}/${execution}/abidiff/abi/
     - command: s3.put
@@ -100,7 +107,8 @@ functions:
         aws_secret: ${aws_secret}
         bucket: mciuploads
         content_type: text/plain
-        local_files_include_filter: cxx-noabi/*.txt
+        local_files_include_filter:
+          - cxx-noabi/*.txt
         permissions: public-read
         remote_file: mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${task_id}/${execution}/abidiff/noabi/
   backtrace:

--- a/.evergreen/generated_configs/task_groups.yml
+++ b/.evergreen/generated_configs/task_groups.yml
@@ -6,6 +6,8 @@ task_groups:
         params:
           directory: mongo-cxx-driver
       - func: install_c_driver
+        vars:
+          SKIP_INSTALL_LIBMONGOCRYPT: 1
       - command: subprocess.exec
         type: setup
         params:
@@ -26,7 +28,8 @@ task_groups:
           aws_secret: ${aws_secret}
           bucket: mciuploads
           content_type: text/plain
-          local_files_include_filter: "*.log"
+          local_files_include_filter:
+            - "*.log"
           permissions: public-read
           remote_file: mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${task_id}/${execution}/abi-stability-setup/
     setup_task_can_fail_task: true
@@ -49,6 +52,8 @@ task_groups:
         params:
           directory: mongo-cxx-driver
       - func: install_c_driver
+        vars:
+          SKIP_INSTALL_LIBMONGOCRYPT: 1
       - command: subprocess.exec
         type: setup
         params:
@@ -69,7 +74,8 @@ task_groups:
           aws_secret: ${aws_secret}
           bucket: mciuploads
           content_type: text/plain
-          local_files_include_filter: "*.log"
+          local_files_include_filter:
+            - "*.log"
           permissions: public-read
           remote_file: mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${task_id}/${execution}/abi-stability-setup/
     setup_task_can_fail_task: true
@@ -92,6 +98,8 @@ task_groups:
         params:
           directory: mongo-cxx-driver
       - func: install_c_driver
+        vars:
+          SKIP_INSTALL_LIBMONGOCRYPT: 1
       - command: subprocess.exec
         type: setup
         params:
@@ -112,7 +120,8 @@ task_groups:
           aws_secret: ${aws_secret}
           bucket: mciuploads
           content_type: text/plain
-          local_files_include_filter: "*.log"
+          local_files_include_filter:
+            - "*.log"
           permissions: public-read
           remote_file: mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${task_id}/${execution}/abi-stability-setup/
     setup_task_can_fail_task: true
@@ -135,6 +144,8 @@ task_groups:
         params:
           directory: mongo-cxx-driver
       - func: install_c_driver
+        vars:
+          SKIP_INSTALL_LIBMONGOCRYPT: 1
       - command: subprocess.exec
         type: setup
         params:
@@ -155,7 +166,8 @@ task_groups:
           aws_secret: ${aws_secret}
           bucket: mciuploads
           content_type: text/plain
-          local_files_include_filter: "*.log"
+          local_files_include_filter:
+            - "*.log"
           permissions: public-read
           remote_file: mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${task_id}/${execution}/abi-stability-setup/
     setup_task_can_fail_task: true
@@ -178,6 +190,8 @@ task_groups:
         params:
           directory: mongo-cxx-driver
       - func: install_c_driver
+        vars:
+          SKIP_INSTALL_LIBMONGOCRYPT: 1
       - command: subprocess.exec
         type: setup
         params:
@@ -198,7 +212,8 @@ task_groups:
           aws_secret: ${aws_secret}
           bucket: mciuploads
           content_type: text/plain
-          local_files_include_filter: "*.log"
+          local_files_include_filter:
+            - "*.log"
           permissions: public-read
           remote_file: mongo-cxx-driver/${branch_name}/${revision}/${version_id}/${build_id}/${task_id}/${execution}/abi-stability-setup/
     setup_task_can_fail_task: true

--- a/.evergreen/scripts/abi-compliance-check-setup.sh
+++ b/.evergreen/scripts/abi-compliance-check-setup.sh
@@ -25,7 +25,7 @@ echo "Fetching abi-compliance-checker..."
 } >/dev/null
 echo "Fetching abi-compliance-checker... done."
 
-# Obtain ctags.
+# Obtain ctags (required by abi-compliance-checker).
 echo "Fetching ctags..."
 [[ -d ctags ]] || {
   git clone -b "v6.0.0" --depth 1 https://github.com/universal-ctags/ctags.git ctags
@@ -38,4 +38,26 @@ echo "Fetching ctags..."
 } >/dev/null
 echo "Fetching ctags... done."
 
+# Obtain abi-dumper (required by abi-compliance-checker).
+echo "Fetching abi-dumper..."
+[[ -d abi-dumper ]] || {
+  git clone -b "1.4" --depth 1 https://github.com/lvc/abi-dumper.git abi-dumper
+  pushd abi-dumper
+  make -j "${parallel_level:?}" install prefix="${working_dir:?}/install"
+  popd # abi-dumper
+} >/dev/null
+echo "Fetching abi-dumper... done."
+
+# Obtain vtable-dumper (required by abi-dumper).
+echo "Fetching vtable-dumper..."
+[[ -d vtable-dumper ]] || {
+  git clone -b "1.2" --depth 1 https://github.com/lvc/vtable-dumper.git vtable-dumper
+  pushd vtable-dumper
+  make -j "${parallel_level:?}" install prefix="${working_dir:?}/install"
+  popd # vtable-dumper
+} >/dev/null
+echo "Fetching vtable-dumper... done."
+
 command -V abi-compliance-checker
+command -V abi-dumper
+command -V vtable-dumper

--- a/.evergreen/scripts/abi-compliance-check-test.sh
+++ b/.evergreen/scripts/abi-compliance-check-test.sh
@@ -19,157 +19,123 @@ old_ver="${base:1}-base"
 new_ver="${current:1}-current"
 
 command -V abi-compliance-checker >/dev/null
+command -V abi-dumper >/dev/null
+command -V parallel >/dev/null
 
 mkdir cxx-abi cxx-noabi
 
-# Generate XML descriptors with sections used by both old and new tests.
-if true; then
-  cat >old.xml <<DOC
-<version>
-  ${old_ver:?}
-</version>
+declare bsoncxx_old bsoncxx_new mongocxx_old mongocxx_new
+bsoncxx_old="${working_dir:?}/install/old/lib/libbsoncxx1.so"
+bsoncxx_new="${working_dir:?}/install/new/lib/libbsoncxx1.so"
+mongocxx_old="${working_dir:?}/install/old/lib/libmongocxx1.so"
+mongocxx_new="${working_dir:?}/install/new/lib/libmongocxx1.so"
 
-<libs>
-  ../install/old/lib
-</libs>
+# Forward compatibility with upcoming stable ABI library filenames.
+[[ -f "${bsoncxx_old:?}" ]] || bsoncxx_old="${working_dir:?}/install/old/lib/libbsoncxx.so"
+[[ -f "${bsoncxx_new:?}" ]] || bsoncxx_new="${working_dir:?}/install/new/lib/libbsoncxx.so"
+[[ -f "${mongocxx_old:?}" ]] || mongocxx_old="${working_dir:?}/install/old/lib/libmongocxx.so"
+[[ -f "${mongocxx_new:?}" ]] || mongocxx_new="${working_dir:?}/install/new/lib/libmongocxx.so"
 
-<add_include_paths>
-  ../install/old/include/
-</add_include_paths>
+# Usage: generate_abi_report <label> <dir> <abi> <can_fail_task>
+#   label: "stable" or "unstable".
+#   dir: "cxx-abi" or "cxx-noabi".
+#   abi: "v1" or "v_noabi".
+#   can_fail_task: "true" or "false".
+generate_abi_report() (
+  declare label="${1:?}" dir="${2:?}" abi="${3:?}" can_fail_task="${4:?}"
 
-<skip_including>
-  /v_noabi/bsoncxx/enums/
-  /v_noabi/bsoncxx/config/
-  /v_noabi/mongocxx/config/
-  /v1/detail/prelude.hpp
-  /v1/detail/postlude.hpp
-</skip_including>
+  cd "${dir:?}"
+  echo "Generating ${label:?} ABI report..."
 
-DOC
+  # Use "new" usage pattern based on binary debug-info analysis.
+  # -keep-registers-and-offsets: abi-dumper doesn't detect `-Og` with Clang.
+  # "WARNING: a "Struct" type with no attributes detected in the DWARF dump" is caused by missing mongoc debug-info.
+  # "ERROR: missed type id <N>" is false-positive caused by otherwise-unused forward-decls in a template parameter.
+  parallel --halt now,fail=1 --keep-order --tagstring '[{#}]' ::: \
+    "abi-dumper '${bsoncxx_old:?}' \
+      -o bsoncxx-old.dump \
+      -lver '${old_ver:?}' \
+      -keep-registers-and-offsets \
+      -public-headers '${working_dir:?}/install/old/include/bsoncxx/${abi:?}' \
+      -include-paths '${working_dir:?}/install/old/include/bsoncxx/v_noabi/bsoncxx' \
+      -include-paths '${working_dir:?}/install/old/include/bsoncxx'" \
+    "abi-dumper '${bsoncxx_new:?}' \
+      -o bsoncxx-new.dump \
+      -lver '${new_ver:?}' \
+      -keep-registers-and-offsets \
+      -public-headers '${working_dir:?}/install/new/include/bsoncxx/${abi:?}' \
+      -include-paths '${working_dir:?}/install/new/include/bsoncxx/v_noabi/bsoncxx' \
+      -include-paths '${working_dir:?}/install/new/include/bsoncxx'" \
+    "abi-dumper '${mongocxx_old:?}' \
+      -o mongocxx-old.dump \
+      -lver '${old_ver:?}' \
+      -keep-registers-and-offsets \
+      -public-headers '${working_dir:?}/install/old/include/mongocxx/${abi:?}' \
+      -include-paths '${working_dir:?}/install/old/include/mongocxx/v_noabi/mongocxx' \
+      -include-paths '${working_dir:?}/install/old/include/mongocxx'" \
+    "abi-dumper '${mongocxx_new:?}' \
+      -o mongocxx-new.dump \
+      -lver '${new_ver:?}' \
+      -keep-registers-and-offsets \
+      -public-headers '${working_dir:?}/install/new/include/mongocxx/${abi:?}' \
+      -include-paths '${working_dir:?}/install/new/include/mongocxx/v_noabi/mongocxx' \
+      -include-paths '${working_dir:?}/install/new/include/mongocxx'" \
+    &>abi-dumper.log || {
+    cat abi-dumper.log 1>&2
+    exit 1
+  }
 
-  cat >new.xml <<DOC
-<version>
-  ${new_ver:?}
-</version>
+  # Exclude internal detail namespaces, matching <skip_namespaces> in the legacy XML descriptors.
+  declare -a skip_args=(-skip-internal-types "::detail::")
 
-<libs>
-  ../install/new/lib
-</libs>
+  if [[ "${abi:?}" == "v1" ]]; then
+    skip_args+=(
+      -skip-internal-symbols "\dv_noabi\d"
+      -skip-internal-types "::v_noabi::"
+    )
+  elif [[ "${abi:?}" == "v_noabi" ]]; then
+    skip_args+=(
+      -skip-internal-symbols "\dv1\d"
+      -skip-internal-types "::v1::"
+    )
+  fi
 
-<add_include_paths>
-  ../install/new/include/
-</add_include_paths>
+  declare bsoncxx_ret mongocxx_ret bsoncxx_pid mongocxx_pid
+  abi-compliance-checker \
+    -report-path bsoncxx.html \
+    -lib bsoncxx \
+    -old bsoncxx-old.dump \
+    -new bsoncxx-new.dump \
+    "${skip_args[@]}" &
+  bsoncxx_pid=$!
 
-<skip_including>
-  /v_noabi/bsoncxx/enums/
-  /v_noabi/bsoncxx/config/
-  /v_noabi/mongocxx/config/
-  /v1/detail/prelude.hpp
-  /v1/detail/postlude.hpp
-</skip_including>
+  abi-compliance-checker \
+    -report-path mongocxx.html \
+    -lib mongocxx \
+    -old mongocxx-old.dump \
+    -new mongocxx-new.dump \
+    "${skip_args[@]}" &
+  mongocxx_pid=$!
+  wait "${bsoncxx_pid:?}" && bsoncxx_ret=$? || bsoncxx_ret=$?
+  wait "${mongocxx_pid:?}" && mongocxx_ret=$? || mongocxx_ret=$?
 
-DOC
+  # Allow task to upload logs and HTML reports despite failed status by using the EVG task HTTP endpoint.
+  if [[ "${bsoncxx_ret:?}" -gt 1 || "${mongocxx_ret:?}" -gt 1 ]]; then
+    declare status='{"status":"failed","type":"test","should_continue":true,"desc":"abi-compliance-checker emitted one or more errors"}'
+    curl -sS -d "${status:?}" -H "Content-Type: application/json" -X POST localhost:2285/task_status || true
+  elif [[ "${can_fail_task:?}" == "true" ]] && [[ "${bsoncxx_ret:?}" -gt 0 || "${mongocxx_ret:?}" -gt 0 ]]; then
+    declare status='{"status":"failed","type":"test","should_continue":true,"desc":"detected stable ABI incompatibility"}'
+    curl -sS -d "${status:?}" -H "Content-Type: application/json" -X POST localhost:2285/task_status || true
+  fi
 
-  tee cxx-abi/old.xml cxx-noabi/old.xml <old.xml >/dev/null
-  tee cxx-abi/new.xml cxx-noabi/new.xml <new.xml >/dev/null
-  rm old.xml new.xml
-fi
-
-# Append sections specific to each ABI test.
-if true; then
-  cat >>cxx-abi/old.xml <<DOC
-<headers>
-  ../install/old/include/bsoncxx/
-  ../install/old/include/mongocxx/
-</headers>
-
-<skip_headers>
-  /v_noabi/
-</skip_headers>
-
-<skip_namespaces>
-  bsoncxx::detail
-  mongocxx::detail
-</skip_namespaces>
-DOC
-
-  cat >>cxx-abi/new.xml <<DOC
-<headers>
-  ../install/new/include/mongocxx/
-  ../install/new/include/bsoncxx/
-</headers>
-
-<skip_headers>
-  /v_noabi/
-</skip_headers>
-
-<skip_namespaces>
-  bsoncxx::detail
-  mongocxx::detail
-</skip_headers>
-DOC
-
-  cat >>cxx-noabi/old.xml <<DOC
-<headers>
-  ../install/old/include/bsoncxx/v_noabi
-  ../install/old/include/mongocxx/v_noabi
-</headers>
-
-<skip_namespaces>
-  bsoncxx::detail
-  mongocxx::detail
-  bsoncxx::v1
-  mongocxx::v1
-</skip_namespaces>
-DOC
-
-  cat >>cxx-noabi/new.xml <<DOC
-<headers>
-  ../install/new/include/bsoncxx/v_noabi
-  ../install/new/include/mongocxx/v_noabi
-</headers>
-
-<skip_namespaces>
-  bsoncxx::detail
-  mongocxx::detail
-  bsoncxx::v1
-  mongocxx::v1
-</skip_namespaces>
-DOC
-fi
-
-args=(
-  -lib mongo-cxx-driver
-  -old old.xml
-  -new new.xml
+  echo "Generating ${label:?} ABI report... done."
 )
 
-# Allow task to upload the HTML report despite failed status.
-echo "Generating stable ABI report..."
-pushd cxx-abi
-declare ret
-abi-compliance-checker "${args[@]}" 2>&1 && ret="$?" || ret="$?"
-if [[ "${ret:?}" -gt 1 ]]; then
-  declare status
-  status='{"status":"failed", "type":"test", "should_continue":true, "desc":"abi-compliance-checker emitted one or more errors"}'
-  curl -sS -d "${status:?}" -H "Content-Type: application/json" -X POST localhost:2285/task_status || true
-elif [[ "${ret:?}" -gt 0 ]]; then
-  declare status
-  status='{"status":"failed", "type":"test", "should_continue":true, "desc":"detected stable ABI incompatibility"}'
-  curl -sS -d "${status:?}" -H "Content-Type: application/json" -X POST localhost:2285/task_status || true
-fi
-popd # cxx-abi
-echo "Generating stable ABI report... done."
-
-# Also create a report for the unstable ABI. Errors are expected and OK.
-echo "Generating unstable ABI report..."
-pushd cxx-noabi
-declare ret
-abi-compliance-checker "${args[@]}" 2>&1 && ret="$?" || ret="$?"
-if [[ "${ret:?}" -gt 1 ]]; then
-  declare status
-  status='{"status":"failed", "type":"test", "should_continue":true, "desc":"abi-compliance-checker emitted one or more errors"}'
-  curl -sS -d "${status:?}" -H "Content-Type: application/json" -X POST localhost:2285/task_status || true
-fi
-popd # cxx-noabi
-echo "Generating unstable ABI report... done."
+export working_dir old_ver new_ver bsoncxx_old bsoncxx_new mongocxx_old mongocxx_new
+export -f generate_abi_report
+parallel --link --keep-order --tagstring '[{#}]' \
+  generate_abi_report {1} {2} {3} {4} \
+  ::: stable unstable \
+  ::: cxx-abi cxx-noabi \
+  ::: v1 v_noabi \
+  ::: true false

--- a/.evergreen/scripts/abi-stability-setup.sh
+++ b/.evergreen/scripts/abi-stability-setup.sh
@@ -71,8 +71,8 @@ mkdir -p "${working_dir}/install"
 
 # As encouraged by ABI compatibility checkers.
 export CFLAGS CXXFLAGS
-CFLAGS="-g -Og"
-CXXFLAGS="-g -Og"
+CFLAGS="-gdwarf-4 -Og"
+CXXFLAGS="-gdwarf-4 -Og"
 
 # Common configuration flags.
 configure_flags=(
@@ -92,14 +92,13 @@ stdlib) configure_flags+=("-DBSONCXX_POLY_USE_STD=ON") ;;
 esac
 
 # Build and install the base commit first.
-git -C mongo-cxx-driver stash push -u
-git -C mongo-cxx-driver reset --hard "${base:?}"
+git -C mongo-cxx-driver worktree add -d ../mongo-cxx-driver-base "${base:?}"
 
 # Install old (base) to install/old.
 echo "Building old libraries..."
 (
   cmake \
-    -S mongo-cxx-driver \
+    -S mongo-cxx-driver-base \
     -B build/old \
     -DCMAKE_INSTALL_PREFIX=install/old \
     -DBUILD_VERSION="${old_ver:?}-base" \
@@ -111,10 +110,6 @@ echo "Building old libraries..."
   exit 1
 }
 echo "Building old libraries... done."
-
-# Restore all pending changes.
-git -C mongo-cxx-driver reset --hard "HEAD@{1}"
-git -C mongo-cxx-driver stash pop -q || true # Only patch builds have stashed changes.
 
 # Install new (current) to install/new.
 echo "Building new libraries..."

--- a/.evergreen/scripts/install-build-tools.sh
+++ b/.evergreen/scripts/install-build-tools.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 export_uv_tool_dirs() {
-  UV_TOOL_DIR="$(mktemp -d)" || return
-  UV_TOOL_BIN_DIR="$(mktemp -d)" || return
+  : "${UV_TOOL_DIR:="$(mktemp -d)"}" || return
+  : "${UV_TOOL_BIN_DIR:="$(mktemp -d)"}" || return
 
-  PATH="${UV_TOOL_BIN_DIR:?}:${PATH:-}" || return
+  PATH="${UV_TOOL_BIN_DIR:?}:${PATH:-}"
 
   # Windows requires "C:\path\to\dir" instead of "/cygdrive/c/path/to/dir" (PATH is automatically converted).
   if [[ "${OSTYPE:?}" == cygwin ]]; then
@@ -12,10 +12,9 @@ export_uv_tool_dirs() {
     UV_TOOL_BIN_DIR="$(cygpath -aw "${UV_TOOL_BIN_DIR:?}")" || return
   fi
 
-  # PyPI `cmake` requires a sufficiently recent Python version.
-  UV_PYTHON_INSTALL_DIR="${UV_TOOL_DIR:?}" || return
+  UV_PYTHON_INSTALL_DIR="${UV_TOOL_DIR:?}"
 
-  export UV_TOOL_DIR UV_TOOL_BIN_DIR UV_PYTHON_INSTALL_DIR
+  export PATH UV_TOOL_DIR UV_TOOL_BIN_DIR UV_PYTHON_INSTALL_DIR
 }
 
 install_build_tools() {
@@ -26,7 +25,7 @@ install_build_tools() {
 
   uv tool install -q cmake || return
 
-  if [[ -f /etc/redhat-release ]]; then
+  if [[ -f /etc/redhat-release && -x /opt/mongodbtoolchain/v4/bin/ninja ]]; then
     # Avoid strange "Could NOT find Threads" CMake configuration error on RHEL when using PyPI CMake, PyPI Ninja, and
     # C++20 or newer by using MongoDB Toolchain's Ninja binary instead.
     ln -sf /opt/mongodbtoolchain/v4/bin/ninja "${UV_TOOL_BIN_DIR:?}/ninja" || return
@@ -42,4 +41,8 @@ install_build_tools() {
   cmake --version | head -n 1 || return
   echo "ninja version: $(ninja --version)" || return
   echo "pkgconf version: $(pkgconf --version 2>/dev/null)" || return
+
+  if [[ "${OSTYPE:?}" != "cygwin" ]]; then
+    export CMAKE_GENERATOR="${CMAKE_GENERATOR:="Ninja"}"
+  fi
 }

--- a/etc/run-clang-tidy.sh
+++ b/etc/run-clang-tidy.sh
@@ -14,7 +14,6 @@ fi
 # shellcheck source=/dev/null
 . .evergreen/scripts/install-build-tools.sh
 install_build_tools
-export CMAKE_GENERATOR="Ninja"
 
 uv tool install -q clang-tidy
 version="$(clang-tidy --version | perl -lne 'print $1 if m|LLVM version (\d+\.\d+\.\d+)|')"


### PR DESCRIPTION
Cherry-picks https://github.com/mongodb/mongo-cxx-driver/pull/1646 and https://github.com/mongodb/mongo-cxx-driver/pull/1648 onto the releases/v4.3 branch to resolve ABI stability task failures.