### PR TITLE
Fix link to coding guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing Guidelines
 
-Follow the [MongoDB C++ Driver Coding Guidelines](https://github.com/mongodb/mongo-cxx-driver/etc/coding_guidelines.md), ensure files are formatted properly, and follow guidelines for writing PR titles and commit messages.
+Follow the [MongoDB C++ Driver Coding Guidelines](/etc/coding_guidelines.md), ensure files are formatted properly, and follow guidelines for writing PR titles and commit messages.
 
 All contributions must be made via a GitHub pull request (PR).
 


### PR DESCRIPTION
Noticed an ill-formed link to the coding guidelines document in CONTRIBUTING.md. Updates to use `/path/to/file.md` syntax so the link is always relative to the currently-referenced commit. See [Relative Links](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#relative-links) (GitHub Docs) for details.