### PR TITLE
CXX-3514 update CHANGELOG.md with client bulk write info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 - Support for the "readConcern" option field to "delete", "insert", "replace", "bulkWrite", "findOneAnd*", "count", and "distinct" operations.
 - Support for `MONGODB-OIDC` authMechanism.
 - Support for client bulk write API (`mongocxx::client_bulk_write`).
-  - Unlike `mongocxx::bulk_write`, `mongocxx::client_bulk_write` supports writes across more than one collection and can group inserts, updates, and deletes in the same network payload.
+  - Unlike collection bulk write (`mongocxx::bulk_write`), client bulk write supports writes across more than one collection and can group inserts, updates, and deletes in the same network payload.
   - Requires MongoDB Server 8.0 or newer.
   - See:
     - [Bulk Write Operations (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/bulk-write-operations/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 - Support for the "readConcern" option field to "delete", "insert", "replace", "bulkWrite", "findOneAnd*", "count", and "distinct" operations.
 - Support for `MONGODB-OIDC` authMechanism.
+- Support for client bulk write API (`mongocxx::client_bulk_write`).
+  - Unlike `mongocxx::bulk_write`, `mongocxx::client_bulk_write` supports writes across more than one collection and can group inserts, updates, and deletes in the same network payload.
+  - Requires MongoDB Server 8.0 or newer.
+  - See:
+    - [Bulk Write Operations (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/bulk-write-operations/)
+    - [bulkWrite (MongoDB Manual)](https://www.mongodb.com/docs/manual/reference/command/bulkWrite/)
 
 ## 4.3.1
 


### PR DESCRIPTION
CXX-3514

# Summary

This PR updates `CHANGELOG.md` with info about client bulk write. I forgot to do this in #1647 and I wanted to make sure this was addressed before releasing 4.4.0.