### PR TITLE
CXX-2699 sync explain.json

### DIFF
--- a/data/client_side_encryption/legacy/explain.json
+++ b/data/client_side_encryption/legacy/explain.json
@@ -1,7 +1,7 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.1.10"
+      "minServerVersion": "7.0.0"
     }
   ],
   "database_name": "default",


### PR DESCRIPTION
Sync the legacy CSFLE explain.json test to specifications https://github.com/mongodb/specifications/commit/05ca6b36b95b0b331a18ad1fdb0460eeb394270a.

Motivation: was brought to my attention as an easy opportunity to close the parent DRIVERS-2612.