### PR TITLE
CXX-3507 bump minimum C driver to 2.3.1

### DIFF
--- a/.evergreen/config_generator/components/funcs/install_c_driver.py
+++ b/.evergreen/config_generator/components/funcs/install_c_driver.py
@@ -12,7 +12,7 @@ from config_generator.etc.utils import bash_exec
 # - the default value of --c-driver-build-ref in etc/make_release.py
 # If pinning to an unreleased commit, create a "Blocked" JIRA ticket with
 # a "depends on" link to the appropriate C Driver version release ticket.
-MONGOC_VERSION_MINIMUM = '2.3.0'
+MONGOC_VERSION_MINIMUM = '2.3.1'
 
 
 class InstallCDriver(Function):

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -399,7 +399,7 @@ functions:
       type: setup
       params:
         updates:
-          - { key: mongoc_version_minimum, value: 2.3.0 }
+          - { key: mongoc_version_minimum, value: 2.3.1 }
     - command: subprocess.exec
       type: setup
       params:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 - Library filenames now include the ABI version number, e.g. `libbsoncxx1.so.4.4.0`.
 - pkg-config config filenames now include the ABI version number, e.g. `libbsoncxx1.pc`.
 - CMake package config filenames now use `camelCase`, e.g. `bsoncxxConfig.cmake`.
+- Bump the minimum required C Driver version to [2.3.1](https://github.com/mongodb/mongo-c-driver/releases/tag/2.3.1).
 
 ### Added
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,9 +62,9 @@ else()
 endif()
 
 # Also update etc/purls.txt.
-set(BSON_REQUIRED_VERSION 2.3.0)
-set(MONGOC_REQUIRED_VERSION 2.3.0)
-set(MONGOC_DOWNLOAD_VERSION 2.3.0)
+set(BSON_REQUIRED_VERSION 2.3.1)
+set(MONGOC_REQUIRED_VERSION 2.3.1)
+set(MONGOC_DOWNLOAD_VERSION 2.3.1)
 
 # All of our target compilers support the deprecated
 # attribute. Normally, we would just let the GenerateExportHeader

--- a/etc/augmented.sbom.json
+++ b/etc/augmented.sbom.json
@@ -1,16 +1,16 @@
 {
   "components": [
     {
-      "bom-ref": "pkg:github/mongodb/mongo-c-driver@2.3.0",
+      "bom-ref": "pkg:github/mongodb/mongo-c-driver@2.3.1",
       "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://github.com/mongodb/mongo-c-driver/archive/2.3.0.tar.gz"
+          "url": "https://github.com/mongodb/mongo-c-driver/archive/2.3.1.tar.gz"
         },
         {
           "type": "website",
-          "url": "https://github.com/mongodb/mongo-c-driver/tree/2.3.0"
+          "url": "https://github.com/mongodb/mongo-c-driver/tree/2.3.1"
         }
       ],
       "group": "mongodb",
@@ -22,18 +22,18 @@
         }
       ],
       "name": "mongo-c-driver",
-      "purl": "pkg:github/mongodb/mongo-c-driver@2.3.0",
+      "purl": "pkg:github/mongodb/mongo-c-driver@2.3.1",
       "type": "library",
-      "version": "2.3.0"
+      "version": "2.3.1"
     }
   ],
   "dependencies": [
     {
-      "ref": "pkg:github/mongodb/mongo-c-driver@2.3.0"
+      "ref": "pkg:github/mongodb/mongo-c-driver@2.3.1"
     }
   ],
   "metadata": {
-    "timestamp": "2026-04-22T17:22:08.296916+00:00",
+    "timestamp": "2026-06-16T19:36:31.889240+00:00",
     "tools": [
       {
         "externalReferences": [

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -1,16 +1,16 @@
 {
   "components": [
     {
-      "bom-ref": "pkg:github/mongodb/mongo-c-driver@2.3.0",
+      "bom-ref": "pkg:github/mongodb/mongo-c-driver@2.3.1",
       "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://github.com/mongodb/mongo-c-driver/archive/2.3.0.tar.gz"
+          "url": "https://github.com/mongodb/mongo-c-driver/archive/2.3.1.tar.gz"
         },
         {
           "type": "website",
-          "url": "https://github.com/mongodb/mongo-c-driver/tree/2.3.0"
+          "url": "https://github.com/mongodb/mongo-c-driver/tree/2.3.1"
         }
       ],
       "group": "mongodb",
@@ -22,18 +22,18 @@
         }
       ],
       "name": "mongo-c-driver",
-      "purl": "pkg:github/mongodb/mongo-c-driver@2.3.0",
+      "purl": "pkg:github/mongodb/mongo-c-driver@2.3.1",
       "type": "library",
-      "version": "2.3.0"
+      "version": "2.3.1"
     }
   ],
   "dependencies": [
     {
-      "ref": "pkg:github/mongodb/mongo-c-driver@2.3.0"
+      "ref": "pkg:github/mongodb/mongo-c-driver@2.3.1"
     }
   ],
   "metadata": {
-    "timestamp": "2026-04-22T17:22:08.296916+00:00",
+    "timestamp": "2026-06-16T19:36:31.889240+00:00",
     "tools": [
       {
         "externalReferences": [

--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -100,7 +100,7 @@ ISSUE_TYPE_ID = {
 )
 @click.option(
     '--c-driver-build-ref',
-    default='2.3.0',
+    default='2.3.1',
     show_default=True,
     help='When building the C driver, build at this Git reference',
 )

--- a/etc/purls.txt
+++ b/etc/purls.txt
@@ -6,4 +6,4 @@
 # re-generate the SBOM JSON file!
 
 # bson and mongoc may be obtained via cmake/FetchMongoC.cmake.
-pkg:github/mongodb/mongo-c-driver@2.3.0
+pkg:github/mongodb/mongo-c-driver@2.3.1


### PR DESCRIPTION
**Summary**

Bump minimum required and downloaded version of the C driver from 2.3.0 to 2.3.1.

**Details**

I considered limiting this change to only update the downloaded version, not the required version. I updated both versions. This may simplify user-expectations: a built C++ 4.4.0 driver is guaranteed to include the fixes of C driver 2.3.1. The C driver 2.3.1 contains some [important fixes](https://jira.mongodb.org/issues/?jql=project%3DCDRIVER%20and%20fixVersion%3D2.3.1) (e.g. OpenSSL 4.0 fix).

CSFLE test failures against latest server tasks is tracked in DRIVERS-3547.
