### PR TITLE
CXX-3517 update CSE tests for server validation

### DIFF
--- a/data/client_side_encryption/explicit-encryption/encryptedFields-c10.json
+++ b/data/client_side_encryption/explicit-encryption/encryptedFields-c10.json
@@ -1,0 +1,30 @@
+{
+  "fields": [
+    {
+      "keyId": {
+        "$binary": {
+          "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+          "subType": "04"
+        }
+      },
+      "path": "encryptedIndexed",
+      "bsonType": "string",
+      "queries": {
+        "queryType": "equality",
+        "contention": {
+          "$numberLong": "10"
+        }
+      }
+    },
+    {
+      "keyId": {
+        "$binary": {
+          "base64": "q83vqxI0mHYSNBI0VniQEg==",
+          "subType": "04"
+        }
+      },
+      "path": "encryptedUnindexed",
+      "bsonType": "string"
+    }
+  ]
+}

--- a/data/client_side_encryption/explicit-encryption/encryptedFields-prefix-suffix.json
+++ b/data/client_side_encryption/explicit-encryption/encryptedFields-prefix-suffix.json
@@ -18,6 +18,9 @@
                     "strMaxQueryLength": {
                         "$numberInt": "10"
                     },
+                    "contention": {
+                        "$numberLong": "0"
+                    },
                     "caseSensitive": true,
                     "diacriticSensitive": true
                 },
@@ -28,6 +31,9 @@
                     },
                     "strMaxQueryLength": {
                         "$numberInt": "10"
+                    },
+                    "contention": {
+                        "$numberLong": "0"
                     },
                     "caseSensitive": true,
                     "diacriticSensitive": true

--- a/data/client_side_encryption/explicit-encryption/encryptedFields-substring.json
+++ b/data/client_side_encryption/explicit-encryption/encryptedFields-substring.json
@@ -21,6 +21,9 @@
                     "strMaxQueryLength": {
                         "$numberInt": "10"
                     },
+                    "contention": {
+                        "$numberLong": "0"
+                    },
                     "caseSensitive": true,
                     "diacriticSensitive": true
                 }

--- a/src/mongocxx/test/v_noabi/client_side_encryption.cpp
+++ b/src/mongocxx/test/v_noabi/client_side_encryption.cpp
@@ -2002,6 +2002,14 @@ std::tuple<mongocxx::client_encryption, mongocxx::client> _setup_explicit_encryp
     // Collection.Drop().
     _drop_and_create_collection("db", "explicit_encryption", "/explicit-encryption/encryptedFields.json");
 
+    // Load the file encryptedFields-c10.json as encryptedFields_c10.
+    auto encrypted_fields_c10 = _doc_from_file("/explicit-encryption/encryptedFields-c10.json");
+
+    // Drop and create the collection db.explicit_encryption using
+    // encryptedFields_c10 as an option. See FLE 2 CreateCollection() and
+    // Collection.Drop().
+    _drop_and_create_collection("db", "explicit_encryption_c10", "/explicit-encryption/encryptedFields-c10.json");
+
     // Drop and create the collection keyvault.datakeys.
     _drop_and_create_collection("keyvault", "datakeys", bsoncxx::stdx::nullopt);
 
@@ -2174,7 +2182,7 @@ TEST_CASE("Explicit Encryption", "[client_side_encryption]") {
             // Use encryptedClient to insert the document { "encryptedIndexed": <insertPayload> }
             // into db.explicit_encryption.
             auto doc = make_document(kvp("encryptedIndexed", insert_payload));
-            encrypted_client["db"]["explicit_encryption"].insert_one(doc.view());
+            encrypted_client["db"]["explicit_encryption_c10"].insert_one(doc.view());
 
             // Repeat the above steps 10 times to insert 10 total documents.
             // The insertPayload must be regenerated each iteration.
@@ -2187,7 +2195,7 @@ TEST_CASE("Explicit Encryption", "[client_side_encryption]") {
         //    keyId : <key1ID>
         //    algorithm: "Indexed",
         //    queryType: "equality",
-        //    contentionFactor: 0
+        //    contentionFactor: 10
         // }
         //
         // Store the result in findPayload.
@@ -2196,53 +2204,13 @@ TEST_CASE("Explicit Encryption", "[client_side_encryption]") {
             encrypt_opts.key_id(key1_id);
             encrypt_opts.algorithm(options::encrypt::encryption_algorithm::k_indexed);
             encrypt_opts.query_type(options::encrypt::encryption_query_type::k_equality);
-            encrypt_opts.contention_factor(0);
+            encrypt_opts.contention_factor(10);
             auto find_payload = client_encryption.encrypt(plain_text_indexed_value, encrypt_opts);
 
             // Use encryptedClient to run a "find" operation on the db.explicit_encryption
             // collection with the filter { "encryptedIndexed": <findPayload> }.
             auto find_filter = make_document(kvp("encryptedIndexed", find_payload));
-            auto found = encrypted_client["db"]["explicit_encryption"].find(find_filter.view());
-            size_t count = 0;
-            for (auto const& it : found) {
-                count++;
-                auto doc = it.find("encryptedIndexed")->get_string().value;
-
-                // Assert less than 10 documents are returned. 0 documents may be returned. Assert
-                // each returned document contains the field { "encryptedIndexed": "encrypted
-                // indexed value" }.
-                REQUIRE(doc == plain_text_indexed_value);
-            }
-
-            // Assert less than 10 documents are returned. 0 documents may be returned. Assert each
-            // returned document contains the field { "encryptedIndexed": "encrypted indexed value"
-            // }.
-            REQUIRE(count < 10);
-        }
-
-        // Use clientEncryption to encrypt the value "encrypted indexed value" with these
-        // EncryptOpts:
-        //
-        // class EncryptOpts {
-        //    keyId : <key1ID>
-        //    algorithm: "Indexed",
-        //    queryType: "equality",
-        //    contentionFactor: 10
-        // }
-        //
-        // Store the result in findPayload2.
-        {
-            options::encrypt encrypt_opts;
-            encrypt_opts.key_id(key1_id);
-            encrypt_opts.algorithm(options::encrypt::encryption_algorithm::k_indexed);
-            encrypt_opts.query_type(options::encrypt::encryption_query_type::k_equality);
-            encrypt_opts.contention_factor(10);
-            auto find_payload2 = client_encryption.encrypt(plain_text_indexed_value, encrypt_opts);
-
-            // Use encryptedClient to run a "find" operation on the db.explicit_encryption
-            // collection with the filter { "encryptedIndexed": <findPayload2> }.
-            auto find_filter = make_document(kvp("encryptedIndexed", find_payload2));
-            auto found = encrypted_client["db"]["explicit_encryption"].find(find_filter.view());
+            auto found = encrypted_client["db"]["explicit_encryption_c10"].find(find_filter.view());
             size_t count = 0;
             for (auto const& it : found) {
                 count++;


### PR DESCRIPTION
Applies similar changes from https://github.com/mongodb/mongo-c-driver/pull/2320 to C++ driver tests to fix failing Client Side Encryption tests against latest servers.