### PR TITLE
Apply pre-4.4.0 release changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changes prior to 3.9.0 are documented as [release notes on GitHub](https://github.com/mongodb/mongo-cxx-driver/releases).
 
-## 4.4.0 [Unreleased]
+## 4.4.0
 
 > [!IMPORTANT]
 > This is the first release supporting a stable ABI for the bsoncxx and mongocxx libraries.

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ git clone -b releases/stable https://github.com/mongodb/mongo-cxx-driver.git
 > [!IMPORTANT]
 > Relevant bug fixes will be backported from the current major version to the previous major version for a period of one year after the new major version is released.
 
-| Version     | ABI Stability   | Development Stability       | Development Status |
+| Version     | Soversion       | Development Stability       | Development Status |
 | :---------: | :-------------: | :-------------------------: | :----------------: |
 | master      | N/A             | _Do not use in production!_ | Active             |
-| 4.4.0       | v1              | Ready for Use               | Bug Fixes Only     |
+| 4.4.0       | 1               | Ready for Use               | Bug Fixes Only     |
 | 4.3.1       | None            | Ready for Use               | Not Supported      |
 | ...         | ...             | ...                         | ...                |
 | 4.0.0       | None            | Ready for Use               | Not Supported      |

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ git clone -b releases/stable https://github.com/mongodb/mongo-cxx-driver.git
 | Version     | ABI Stability   | Development Stability       | Development Status |
 | :---------: | :-------------: | :-------------------------: | :----------------: |
 | master      | N/A             | _Do not use in production!_ | Active             |
-| 4.3.1       | None            | Ready for Use               | Bug Fixes Only     |
-| 4.3.0       | None            | Ready for Use               | Not Supported      |
+| 4.4.0       | v1              | Ready for Use               | Bug Fixes Only     |
+| 4.3.1       | None            | Ready for Use               | Not Supported      |
 | ...         | ...             | ...                         | ...                |
 | 4.0.0       | None            | Ready for Use               | Not Supported      |
 | 3.11.1      | None            | Ready for Use               | Not Supported      |

--- a/etc/apidocmenu.md
+++ b/etc/apidocmenu.md
@@ -2,6 +2,7 @@
 
 <h1>Driver Documentation By Version</h1>
 
+[4.4.0](../mongocxx-4.4.0) |
 [4.3.1](../mongocxx-4.3.1) |
 [4.3.0](../mongocxx-4.3.0) |
 [4.2.0](../mongocxx-4.2.0) |
@@ -58,8 +59,8 @@
 | Version     | ABI Stability   | Development Stability       | Development Status |
 | :---------: | :-------------: | :-------------------------: | :----------------: |
 | master      | N/A             | _Do not use in production!_ | Active             |
-| 4.3.1       | None            | Ready for Use               | Bug Fixes Only     |
-| 4.3.0       | None            | Ready for Use               | Not Supported      |
+| 4.4.0       | v1              | Ready for Use               | Bug Fixes Only     |
+| 4.3.1       | None            | Ready for Use               | Not Supported      |
 | ...         | ...             | ...                         | ...                |
 | 4.0.0       | None            | Ready for Use               | Not Supported      |
 | 3.11.1      | None            | Ready for Use               | Not Supported      |

--- a/etc/apidocmenu.md
+++ b/etc/apidocmenu.md
@@ -56,10 +56,10 @@
 > [!IMPORTANT]
 > Relevant bug fixes will be backported from the current major version to the previous major version for a period of one year after the new major version is released.
 
-| Version     | ABI Stability   | Development Stability       | Development Status |
+| Version     | Soversion       | Development Stability       | Development Status |
 | :---------: | :-------------: | :-------------------------: | :----------------: |
 | master      | N/A             | _Do not use in production!_ | Active             |
-| 4.4.0       | v1              | Ready for Use               | Bug Fixes Only     |
+| 4.4.0       | 1               | Ready for Use               | Bug Fixes Only     |
 | 4.3.1       | None            | Ready for Use               | Not Supported      |
 | ...         | ...             | ...                         | ...                |
 | 4.0.0       | None            | Ready for Use               | Not Supported      |

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -828,7 +828,7 @@ Please note that this version of mongocxx requires [MongoDB C Driver A.B.C](http
 
 See the [MongoDB C++ Driver Manual](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/) and the [Driver Installation Instructions](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/installation/) for more details on downloading, installing, and using this driver.
 
-NOTE: The mongocxx X.Y.x series does not promise ABI stability of entities in the `v_noabi` namespace.
+NOTE: ABI stability is NOT supported for entities declared in the `v_noabi` namespace.
 
 Please feel free to post any questions on [Stack Overflow](https://stackoverflow.com/questions/tagged/mongodb%20c++). Bug reports should be filed against the [CXX](https://jira.mongodb.org/projects/CXX) project in the MongoDB JIRA. Your feedback on the C++11 driver is greatly appreciated.
 

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -828,7 +828,7 @@ Please note that this version of mongocxx requires [MongoDB C Driver A.B.C](http
 
 See the [MongoDB C++ Driver Manual](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/) and the [Driver Installation Instructions](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/installation/) for more details on downloading, installing, and using this driver.
 
-NOTE: The mongocxx X.Y.x series does not promise API or ABI stability across patch releases.
+NOTE: The mongocxx X.Y.x series does not promise ABI stability of entities in the `v_noabi` namespace.
 
 Please feel free to post any questions on [Stack Overflow](https://stackoverflow.com/questions/tagged/mongodb%20c++). Bug reports should be filed against the [CXX](https://jira.mongodb.org/projects/CXX) project in the MongoDB JIRA. Your feedback on the C++11 driver is greatly appreciated.
 


### PR DESCRIPTION
Follows the "Update CHANGELOG..." release step for the 4.4.0 release.

- Use "v1" in the "ABI Stability" column. This is a new convention, since previous values were "None".
- Update announcement note of "no promises".
    - Remove "API" since I expect API stability is guaranteed (even in `v_noabi`) per [API Versioning](https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/reference/api-abi-versioning/api-versioning/#std-label-cpp-api-source-compatibility)