### PR TITLE
Apply post-4.4.0 release changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changes prior to 3.9.0 are documented as [release notes on GitHub](https://github.com/mongodb/mongo-cxx-driver/releases).
 
+## 4.5.0 [Unreleased]
+
+<!-- Will contain entries for the next minor release. -->
+
 ## 4.4.0
 
 > [!IMPORTANT]

--- a/Doxyfile
+++ b/Doxyfile
@@ -1617,7 +1617,7 @@ TOC_EXPAND             = NO
 # protocol see https://www.sitemaps.org
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-SITEMAP_URL            = https://mongocxx.org/api/mongocxx-4.3.1/
+SITEMAP_URL            = https://mongocxx.org/api/mongocxx-4.4.0/
 
 # If the GENERATE_QHP tag is set to YES and both QHP_NAMESPACE and
 # QHP_VIRTUAL_FOLDER are set, an additional index file will be generated that

--- a/etc/augmented.sbom.json
+++ b/etc/augmented.sbom.json
@@ -33,7 +33,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2026-06-16T19:36:31.889240+00:00",
+    "timestamp": "2026-06-24T16:53:55.127365+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -76,7 +76,7 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:39419802-c642-4f50-94cc-796659541ee9",
+  "serialNumber": "urn:uuid:3174e064-5937-42fd-97b9-fae452d8f92b",
   "version": 1,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -33,7 +33,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2026-06-16T19:36:31.889240+00:00",
+    "timestamp": "2026-06-24T16:53:55.127365+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -76,7 +76,7 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:39419802-c642-4f50-94cc-796659541ee9",
+  "serialNumber": "urn:uuid:3174e064-5937-42fd-97b9-fae452d8f92b",
   "version": 1,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",

--- a/etc/generate-latest-apidocs.sh
+++ b/etc/generate-latest-apidocs.sh
@@ -10,7 +10,7 @@
 set -o errexit
 set -o pipefail
 
-LATEST_VERSION="4.3.1"
+LATEST_VERSION="4.4.0"
 DOXYGEN_VERSION_REQUIRED="1.15.0"
 
 # Permit using a custom Doxygen binary.

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -775,7 +775,7 @@ Add a section for the next patch release, e.g. following a `1.2.0` release:
 Commit the changes to the `releases/vX.Y` branch:
 
 ```bash
-git commit -m 'Add changelog entry for the next minor release'
+git commit -m 'Add changelog entry for the next patch release'
 ```
 
 Push the branch to the remote repository (a PR is not required for this step).
@@ -797,7 +797,7 @@ Add a section for the next minor release, e.g. following a `1.3.0` release:
 Commit these changes to `post-release-changes`.
 
 ```bash
-git commit -m "Add CHANGELOG section for the next minor release"
+git commit -m "Add changelog entry for the next minor release"
 ```
 
 ### Merge Post-Release Changes


### PR DESCRIPTION
Applies post-4.4.0 release steps. As a drive-by: fixes the commit messages in the release steps for updates to CHANGELOG.md.