### PR TITLE
CXX-3529 pin to CMake 4.3.4

### DIFF
--- a/.evergreen/scripts/install-build-tools.sh
+++ b/.evergreen/scripts/install-build-tools.sh
@@ -23,7 +23,8 @@ install_build_tools() {
   # PyPI `cmake` requires a sufficiently recent Python version.
   uv python install --no-bin -q || uv python install -q || return
 
-  uv tool install -q cmake || return
+  # TODO: replace "cmake==4.3.4" with "cmake" once the C driver dependency is updated to 2.3.3 to include CDRIVER-6367.
+  uv tool install -q "cmake==4.3.4" || return
 
   if [[ -f /etc/redhat-release && -x /opt/mongodbtoolchain/v4/bin/ninja ]]; then
     # Avoid strange "Could NOT find Threads" CMake configuration error on RHEL when using PyPI CMake, PyPI Ninja, and

--- a/.evergreen/scripts/install-build-tools.sh
+++ b/.evergreen/scripts/install-build-tools.sh
@@ -24,7 +24,7 @@ install_build_tools() {
   uv python install --no-bin -q || uv python install -q || return
 
   # TODO: replace "cmake==4.3.4" with "cmake" once the C driver dependency is updated to 2.3.3 to include CDRIVER-6367.
-  uv tool install -q "cmake==4.3.4" || return
+  uv tool install -q "cmake<4.4" || return
 
   if [[ -f /etc/redhat-release && -x /opt/mongodbtoolchain/v4/bin/ninja ]]; then
     # Avoid strange "Could NOT find Threads" CMake configuration error on RHEL when using PyPI CMake, PyPI Ninja, and


### PR DESCRIPTION
To temporarily work around CDRIVER-6367 until the C driver dependency is upgraded. Intended to avoid widespread test failures on Evergreen.

The long-term fix is to update the auto-downloaded C driver to 2.3.0. But this seems to need a more substantial change to account for deprecated QE experimental APIs and tests (CXX-3488).