### PR TITLE
[CXX-1029] Split logging configuration control from instance initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ## 4.5.0 [Unreleased]
 
+### Added
+
+- `mongocxx::v1::logger_function`, a `std::function` handler type for
+  unstructured log messages.
+- `mongocxx::v1::set_global_logger()` to configure the unstructured log message
+  handler at runtime (with any compatible invocable), independent of
+  `mongocxx::v1::instance` construction.
+- `mongocxx::v1::logger_guard`, an RAII scope guard which temporarily replaces
+  the unstructured log message handler and restores the prior handler on
+  destruction.
+
 ### Removed
 
 - Support for Visual Studio 2015 (EOL since Oct 2025). Use Visual Studio 2017 15.9 (MSVC 19.16.27023) or newer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ### Added
 
-- `mongocxx::v1::logger_function`, a `std::function` handler type for
+- `mongocxx::v1::log_handler`, a `std::function` handler type for
   unstructured log messages.
 - `mongocxx::v1::set_global_logger()` to configure the unstructured log message
   handler at runtime (with any compatible invocable), independent of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,12 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ### Added
 
-- `mongocxx::v1::log_handler`, a `std::function` handler type for
-  unstructured log messages.
-- `mongocxx::v1::set_global_logger()` to configure the unstructured log message
-  handler at runtime (with any compatible invocable), independent of
-  `mongocxx::v1::instance` construction.
-- `mongocxx::v1::logger_guard`, an RAII scope guard which temporarily replaces
-  the unstructured log message handler and restores the prior handler on
-  destruction.
+- `mongocxx::log_handler` (v1): a `std::function` type alias for
+  unstructured log message handlers.
+- `mongocxx::set_global_logger()` (v1) to configure the unstructured log message
+  handler at runtime.
+- `mongocxx::logger_guard` (v1): a scope guard to temporarily replace the current
+  unstructured log message handler.
 
 ### Removed
 

--- a/docs/api/mongocxx/examples/logger.md
+++ b/docs/api/mongocxx/examples/logger.md
@@ -2,6 +2,14 @@
 
 @snippet api/mongocxx/examples/logger/basic_usage.cpp Example
 
+# Temporarily Replace the Logger
+
+Use @ref mongocxx::v1::logger_guard to install a log message handler for a scope
+and automatically restore the previously-active handler on exit. Guards nest,
+restoring each prior handler in turn.
+
+@snippet api/mongocxx/examples/logger/logger_guard.cpp Example
+
 # Convert a Log Level to a String
 
 @snippet api/mongocxx/examples/logger/to_string.cpp Example

--- a/examples/api/mongocxx/examples/logger/logger_guard.cpp
+++ b/examples/api/mongocxx/examples/logger/logger_guard.cpp
@@ -28,7 +28,7 @@ namespace {
 void example() {
     mongocxx::instance instance;
 
-    // A handler may be any invocable compatible with mongocxx::logger_function.
+    // A handler may be any invocable compatible with mongocxx::log_handler.
     auto handler =
         [](mongocxx::log_level level, bsoncxx::stdx::string_view domain, bsoncxx::stdx::string_view message) {
             std::cout << mongocxx::to_string(level) << ": " << domain << ": " << message << "\n";

--- a/examples/api/mongocxx/examples/logger/logger_guard.cpp
+++ b/examples/api/mongocxx/examples/logger/logger_guard.cpp
@@ -1,0 +1,65 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+
+#include <bsoncxx/stdx/string_view.hpp>
+
+#include <mongocxx/instance.hpp>
+#include <mongocxx/logger.hpp>
+
+#include <examples/api/runner.hh>
+#include <examples/macros.hh>
+
+namespace {
+
+// [Example]
+void example() {
+    mongocxx::instance instance;
+
+    // A handler may be any invocable compatible with mongocxx::logger_function.
+    auto handler =
+        [](mongocxx::log_level level, bsoncxx::stdx::string_view domain, bsoncxx::stdx::string_view message) {
+            std::cout << mongocxx::to_string(level) << ": " << domain << ": " << message << "\n";
+        };
+
+    // the default logging behavior is active here
+
+    {
+        // Install `handler` for the duration of this scope. Unstructured log messages emitted by
+        // mongoc while the guard is alive are routed to `handler` instead.
+        mongocxx::logger_guard guard{handler};
+
+        // ... perform operations whose log messages should be handled by `handler` ...
+
+        {
+            // Guards nest. Disable unstructured logging entirely for this inner scope by installing
+            // a null handler.
+            mongocxx::logger_guard quiet{nullptr};
+
+            // ... perform operations whose log messages should be suppressed ...
+        }
+
+        // The inner guard has been destroyed, so `handler` is active again.
+    }
+
+    // The outer guard has been destroyed, so the default logging behavior is active again.
+}
+// [Example]
+
+} // namespace
+
+RUNNER_REGISTER_FORKING_COMPONENT() {
+    example();
+}

--- a/src/mongocxx/include/mongocxx/v1/instance.hpp
+++ b/src/mongocxx/include/mongocxx/v1/instance.hpp
@@ -122,6 +122,9 @@ class instance {
     /// @throws mongocxx::v1::exception with @ref mongocxx::v1::instance::errc::multiple_instances if an `instance`
     /// object has already been created.
     ///
+    /// Use @ref mongocxx::v1::set_global_logger (or @ref mongocxx::v1::logger_guard) to configure
+    /// the logger at any time after the instance object has been created.
+    ///
     /// @see
     /// - [Custom Log Handlers (mongoc)](https://mongoc.org/libmongoc/current/unstructured_log.html#custom-log-handlers)
     ///

--- a/src/mongocxx/include/mongocxx/v1/logger-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v1/logger-fwd.hpp
@@ -27,6 +27,8 @@ class MONGOCXX_ABI_EXPORT logger;
 
 class default_logger;
 
+class MONGOCXX_ABI_EXPORT logger_guard;
+
 } // namespace v1
 } // namespace mongocxx
 

--- a/src/mongocxx/include/mongocxx/v1/logger-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v1/logger-fwd.hpp
@@ -27,7 +27,7 @@ class MONGOCXX_ABI_EXPORT logger;
 
 class default_logger;
 
-class MONGOCXX_ABI_EXPORT logger_guard;
+class logger_guard;
 
 } // namespace v1
 } // namespace mongocxx

--- a/src/mongocxx/include/mongocxx/v1/logger.hpp
+++ b/src/mongocxx/include/mongocxx/v1/logger.hpp
@@ -59,7 +59,7 @@ MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::string_view) to_string(log_level le
 /// - @ref mongocxx::v1::set_global_logger
 /// - @ref mongocxx::v1::logger_guard
 ///
-using logger_function =
+using log_handler =
     std::function<void MONGOCXX_ABI_CDECL(log_level, bsoncxx::v1::stdx::string_view, bsoncxx::v1::stdx::string_view)>;
 
 BSONCXX_PRIVATE_WARNINGS_PUSH();
@@ -149,7 +149,7 @@ class default_logger {};
 /// @see
 /// - [Custom Log Handlers (mongoc)](https://mongoc.org/libmongoc/current/unstructured_log.html#custom-log-handlers)
 ///
-MONGOCXX_ABI_EXPORT_CDECL(void) set_global_logger(logger_function handler);
+MONGOCXX_ABI_EXPORT_CDECL(void) set_global_logger(log_handler handler);
 
 ///
 /// Set the process-global unstructured log message handler to mongoc's default handler.
@@ -182,7 +182,7 @@ MONGOCXX_ABI_EXPORT_CDECL(void) set_global_logger(v1::default_logger tag);
 /// ```
 ///
 /// @warning Construction and destruction are NOT thread-safe with respect to unstructured logging.
-/// See @ref mongocxx::v1::set_global_logger(logger_function).
+/// See @ref mongocxx::v1::set_global_logger(log_handler).
 ///
 /// @important A guard's lifetime must be nested strictly within the lifetime of a
 /// @ref mongocxx::v1::instance object.
@@ -206,7 +206,7 @@ class logger_guard {
     ///
     /// @param handler The handler to register. Disable unstructured logging when null (empty).
     ///
-    explicit MONGOCXX_ABI_EXPORT_CDECL() logger_guard(logger_function handler);
+    explicit MONGOCXX_ABI_EXPORT_CDECL() logger_guard(log_handler handler);
 
     ///
     /// Install mongoc's default unstructured log message handler for the lifetime of this guard.

--- a/src/mongocxx/include/mongocxx/v1/logger.hpp
+++ b/src/mongocxx/include/mongocxx/v1/logger.hpp
@@ -59,7 +59,8 @@ MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::string_view) to_string(log_level le
 /// - @ref mongocxx::v1::set_global_logger
 /// - @ref mongocxx::v1::logger_guard
 ///
-using logger_function = std::function<void(log_level, bsoncxx::v1::stdx::string_view, bsoncxx::v1::stdx::string_view)>;
+using logger_function =
+    std::function<void MONGOCXX_ABI_CDECL(log_level, bsoncxx::v1::stdx::string_view, bsoncxx::v1::stdx::string_view)>;
 
 BSONCXX_PRIVATE_WARNINGS_PUSH();
 BSONCXX_PRIVATE_WARNINGS_DISABLE(MSVC(4251));

--- a/src/mongocxx/include/mongocxx/v1/logger.hpp
+++ b/src/mongocxx/include/mongocxx/v1/logger.hpp
@@ -25,6 +25,9 @@
 
 #include <mongocxx/v1/config/export.hpp>
 
+#include <functional>
+#include <memory>
+
 namespace mongocxx {
 namespace v1 {
 
@@ -42,6 +45,21 @@ enum class log_level {
 };
 
 MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::string_view) to_string(log_level level);
+
+///
+/// The type of an unstructured log message handler.
+///
+/// The invocable is passed the log level, the message domain, and the message contents (in that
+/// order) for each unstructured log message emitted by mongoc.
+///
+/// @important The invocable MUST be copyable (a requirement of `std::function`), MUST NOT throw an
+/// exception, and MUST NOT itself emit an unstructured log message.
+///
+/// @see
+/// - @ref mongocxx::v1::set_global_logger
+/// - @ref mongocxx::v1::logger_guard
+///
+using logger_function = std::function<void(log_level, bsoncxx::v1::stdx::string_view, bsoncxx::v1::stdx::string_view)>;
 
 BSONCXX_PRIVATE_WARNINGS_PUSH();
 BSONCXX_PRIVATE_WARNINGS_DISABLE(MSVC(4251));
@@ -103,12 +121,121 @@ class logger {
         bsoncxx::v1::stdx::string_view message) noexcept = 0;
 };
 
-BSONCXX_PRIVATE_WARNINGS_POP();
-
 ///
 /// A tag type representing mongoc's default unstructured log handler.
 ///
 class default_logger {};
+
+///
+/// Set the process-global unstructured log message handler to a custom handler.
+///
+/// Registers the custom unstructured log handler by calling
+/// [`mongoc_log_set_handler()`](https://mongoc.org/libmongoc/current/logging.html). Unlike the
+/// logging behavior configured via @ref mongocxx::v1::instance construction, the handler may be
+/// changed any number of times over the lifetime of the instance object.
+///
+/// A copy of `handler` is stored via type erasure; any compatible invocable is accepted.
+///
+/// @param handler The handler to register. Disable unstructured logging when null (empty).
+///
+/// @warning This function is NOT thread-safe. The global handler is replaced without
+/// synchronization, so the caller MUST ensure that no other thread concurrently configures the
+/// global handler (via this API or @ref mongocxx::v1::logger_guard) or performs any operation which
+/// may emit an unstructured log message for the duration of this call.
+///
+/// @important Must be called within the lifetime of a @ref mongocxx::v1::instance object.
+///
+/// @see
+/// - [Custom Log Handlers (mongoc)](https://mongoc.org/libmongoc/current/unstructured_log.html#custom-log-handlers)
+///
+MONGOCXX_ABI_EXPORT_CDECL(void) set_global_logger(logger_function handler);
+
+///
+/// Set the process-global unstructured log message handler to mongoc's default handler.
+///
+/// Registers mongoc's default unstructured log handler by calling
+/// [`mongoc_log_set_handler()`](https://mongoc.org/libmongoc/current/logging.html).
+///
+/// @param tag Unused: only for overload resolution.
+///
+/// @important Must be called within the lifetime of a @ref mongocxx::v1::instance object.
+///
+MONGOCXX_ABI_EXPORT_CDECL(void) set_global_logger(v1::default_logger tag);
+
+///
+/// A scope guard which temporarily replaces the process-global unstructured log message handler and
+/// restores the prior handler on destruction.
+///
+/// On construction, captures the current global logging configuration and installs the requested
+/// handler. On destruction, restores the captured configuration. Guards nest: destroying guards in
+/// reverse order of construction restores each prior handler in turn.
+///
+/// ```cpp
+/// mongocxx::v1::instance instance;
+/// // ... mongoc's default handler is active ...
+/// {
+///     mongocxx::v1::logger_guard guard{[](auto level, auto domain, auto message) { ... }};
+///     // ... the custom handler is active ...
+/// }
+/// // ... mongoc's default handler is active again ...
+/// ```
+///
+/// @warning Construction and destruction are NOT thread-safe with respect to unstructured logging.
+/// See @ref mongocxx::v1::set_global_logger(logger_function).
+///
+/// @important A guard's lifetime must be nested strictly within the lifetime of a
+/// @ref mongocxx::v1::instance object.
+///
+class logger_guard {
+   private:
+    class impl;
+    std::unique_ptr<impl> _impl;
+
+   public:
+    ///
+    /// Restore the unstructured log message handler that was active when this guard was
+    /// constructed.
+    ///
+    MONGOCXX_ABI_EXPORT_CDECL() ~logger_guard();
+
+    ///
+    /// Install a custom unstructured log message handler for the lifetime of this guard.
+    ///
+    /// A copy of `handler` is stored via type erasure; any compatible invocable is accepted.
+    ///
+    /// @param handler The handler to register. Disable unstructured logging when null (empty).
+    ///
+    explicit MONGOCXX_ABI_EXPORT_CDECL() logger_guard(logger_function handler);
+
+    ///
+    /// Install mongoc's default unstructured log message handler for the lifetime of this guard.
+    ///
+    /// @param tag Unused: only for overload resolution.
+    ///
+    explicit MONGOCXX_ABI_EXPORT_CDECL() logger_guard(v1::default_logger tag);
+
+    ///
+    /// This class is not moveable.
+    ///
+    logger_guard(logger_guard&&) = delete;
+
+    ///
+    /// This class is not moveable.
+    ///
+    logger_guard& operator=(logger_guard&&) = delete;
+
+    ///
+    /// This class is not copyable.
+    ///
+    logger_guard(logger_guard const&) = delete;
+
+    ///
+    /// This class is not copyable.
+    ///
+    logger_guard& operator=(logger_guard const&) = delete;
+};
+
+BSONCXX_PRIVATE_WARNINGS_POP();
 
 } // namespace v1
 } // namespace mongocxx

--- a/src/mongocxx/include/mongocxx/v1/logger.hpp
+++ b/src/mongocxx/include/mongocxx/v1/logger.hpp
@@ -52,8 +52,15 @@ MONGOCXX_ABI_EXPORT_CDECL(bsoncxx::v1::stdx::string_view) to_string(log_level le
 /// The invocable is passed the log level, the message domain, and the message contents (in that
 /// order) for each unstructured log message emitted by mongoc.
 ///
-/// @important The invocable MUST be copyable (a requirement of `std::function`), MUST NOT throw an
-/// exception, and MUST NOT itself emit an unstructured log message.
+/// The invocable must:
+///
+/// - be `std::is_nothrow_destructible<D>`,
+/// - be `std::is_nothrow_move_constructible<D>`,
+/// - not throw an exception when invoked, and
+/// - not itself emit an unstructured log message (no reentrancy).
+///
+/// @important Despite being a `std::function<T>`, @ref log_handler is assumed to behave like a C++23
+/// `std::move_only_function<T>`.
 ///
 /// @see
 /// - @ref mongocxx::v1::set_global_logger
@@ -122,6 +129,8 @@ class logger {
         bsoncxx::v1::stdx::string_view message) noexcept = 0;
 };
 
+BSONCXX_PRIVATE_WARNINGS_POP();
+
 ///
 /// A tag type representing mongoc's default unstructured log handler.
 ///
@@ -164,12 +173,11 @@ MONGOCXX_ABI_EXPORT_CDECL(void) set_global_logger(log_handler handler);
 MONGOCXX_ABI_EXPORT_CDECL(void) set_global_logger(v1::default_logger tag);
 
 ///
-/// A scope guard which temporarily replaces the process-global unstructured log message handler and
-/// restores the prior handler on destruction.
+/// A scope guard to temporarily replace the current unstructured log message handler.
 ///
 /// On construction, captures the current global logging configuration and installs the requested
-/// handler. On destruction, restores the captured configuration. Guards nest: destroying guards in
-/// reverse order of construction restores each prior handler in turn.
+/// handler. On destruction, restores the captured configuration. Nesting is supported: guards restore each prior
+/// handler in reverse order of construction.
 ///
 /// ```cpp
 /// mongocxx::v1::instance instance;
@@ -182,10 +190,9 @@ MONGOCXX_ABI_EXPORT_CDECL(void) set_global_logger(v1::default_logger tag);
 /// ```
 ///
 /// @warning Construction and destruction are NOT thread-safe with respect to unstructured logging.
-/// See @ref mongocxx::v1::set_global_logger(log_handler).
+/// See @ref mongocxx::v1::set_global_logger.
 ///
-/// @important A guard's lifetime must be nested strictly within the lifetime of a
-/// @ref mongocxx::v1::instance object.
+/// @important All guards must be within the lifetime of the @ref mongocxx::v1::instance object.
 ///
 class logger_guard {
    private:
@@ -198,22 +205,6 @@ class logger_guard {
     /// constructed.
     ///
     MONGOCXX_ABI_EXPORT_CDECL() ~logger_guard();
-
-    ///
-    /// Install a custom unstructured log message handler for the lifetime of this guard.
-    ///
-    /// A copy of `handler` is stored via type erasure; any compatible invocable is accepted.
-    ///
-    /// @param handler The handler to register. Disable unstructured logging when null (empty).
-    ///
-    explicit MONGOCXX_ABI_EXPORT_CDECL() logger_guard(log_handler handler);
-
-    ///
-    /// Install mongoc's default unstructured log message handler for the lifetime of this guard.
-    ///
-    /// @param tag Unused: only for overload resolution.
-    ///
-    explicit MONGOCXX_ABI_EXPORT_CDECL() logger_guard(v1::default_logger tag);
 
     ///
     /// This class is not moveable.
@@ -234,9 +225,21 @@ class logger_guard {
     /// This class is not copyable.
     ///
     logger_guard& operator=(logger_guard const&) = delete;
-};
 
-BSONCXX_PRIVATE_WARNINGS_POP();
+    ///
+    /// Register a custom unstructured log message handler for the lifetime of this guard.
+    ///
+    /// @param handler The handler to register. Disable unstructured logging when null (empty).
+    ///
+    explicit MONGOCXX_ABI_EXPORT_CDECL() logger_guard(log_handler handler);
+
+    ///
+    /// Register mongoc's default unstructured log message handler for the lifetime of this guard.
+    ///
+    /// @param tag Unused: only for overload resolution.
+    ///
+    explicit MONGOCXX_ABI_EXPORT_CDECL() logger_guard(v1::default_logger tag);
+};
 
 } // namespace v1
 } // namespace mongocxx

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger-fwd.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger-fwd.hpp
@@ -27,6 +27,8 @@ using v1::logger;
 
 using v1::default_logger;
 
+using v1::logger_guard;
+
 } // namespace v_noabi
 } // namespace mongocxx
 
@@ -37,6 +39,8 @@ using v1::log_level;
 using v1::logger;
 
 using v1::default_logger;
+
+using v1::logger_guard;
 
 } // namespace mongocxx
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger.hpp
@@ -27,7 +27,7 @@ namespace v_noabi {
 
 using v1::to_string;
 
-using v1::logger_function;
+using v1::log_handler;
 
 using v1::set_global_logger;
 
@@ -38,7 +38,7 @@ namespace mongocxx {
 
 using v1::to_string;
 
-using v1::logger_function;
+using v1::log_handler;
 
 using v1::set_global_logger;
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/logger.hpp
@@ -27,12 +27,20 @@ namespace v_noabi {
 
 using v1::to_string;
 
+using v1::logger_function;
+
+using v1::set_global_logger;
+
 } // namespace v_noabi
 } // namespace mongocxx
 
 namespace mongocxx {
 
 using v1::to_string;
+
+using v1::logger_function;
+
+using v1::set_global_logger;
 
 } // namespace mongocxx
 

--- a/src/mongocxx/lib/mongocxx/v1/instance.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/instance.cpp
@@ -77,11 +77,13 @@ class instance::impl {
     explicit impl(std::unique_ptr<v1::logger> handler) {
         this->reserve();
 
-        // Adapt the `v1::logger` handler into a `logger_function`. A shared_ptr is used
-        // so the resulting invocable is copyable, as required by `logger_function` (std::function).
+        // Adapt the `v1::logger` handler into a `logger_function`. A shared_ptr is used (captured by
+        // value) so the resulting invocable is copyable, as required by `logger_function`
+        // (std::function).
         v1::logger_function fn;
         if (handler) {
-            fn = [logger = std::shared_ptr<v1::logger>{std::move(handler)}](
+            std::shared_ptr<v1::logger> const logger{std::move(handler)};
+            fn = [logger](
                      v1::log_level level,
                      bsoncxx::v1::stdx::string_view domain,
                      bsoncxx::v1::stdx::string_view message) { (*logger)(level, domain, message); };

--- a/src/mongocxx/lib/mongocxx/v1/instance.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/instance.cpp
@@ -77,10 +77,10 @@ class instance::impl {
     explicit impl(std::unique_ptr<v1::logger> handler) {
         this->reserve();
 
-        // Adapt the `v1::logger` handler into a `logger_function`. A shared_ptr is used (captured by
-        // value) so the resulting invocable is copyable, as required by `logger_function`
+        // Adapt the `v1::logger` handler into a `log_handler`. A shared_ptr is used (captured by
+        // value) so the resulting invocable is copyable, as required by `log_handler`
         // (std::function).
-        v1::logger_function fn;
+        v1::log_handler fn;
         if (handler) {
             std::shared_ptr<v1::logger> const logger{std::move(handler)};
             fn = [logger](

--- a/src/mongocxx/lib/mongocxx/v1/instance.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/instance.cpp
@@ -23,6 +23,7 @@
 #include <mongocxx/v1/logger.hpp>
 
 #include <mongocxx/v1/exception.hh>
+#include <mongocxx/v1/logger.hh>
 
 #include <atomic>
 #include <memory>
@@ -53,27 +54,15 @@ namespace {
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): support `code::multiple_instances`.
 std::atomic_int instance_state{0};
 
-void custom_log_handler(
-    mongoc_log_level_t log_level,
-    char const* domain,
-    char const* message,
-    void* user_data) noexcept {
-    (*static_cast<v1::logger*>(user_data))(
-        static_cast<v1::log_level>(log_level),
-        bsoncxx::v1::stdx::string_view(domain),
-        bsoncxx::v1::stdx::string_view(message));
-}
-
 } // namespace
 
 class instance::impl {
    public:
-    std::unique_ptr<v1::logger> _handler;
-
     ~impl() {
-        if (_handler) {
-            libmongoc::log_set_handler(nullptr, nullptr);
-        }
+        // Disable unstructured logging and free any custom handler installed via this instance
+        // (or via `set_global_logger`/`logger_guard`) before mongoc cleanup, so no late log
+        // message can be routed to a freed handler.
+        (void)exchange_global_logger(logging_config{log_mode::k_disabled, nullptr});
 
         libmongoc::cleanup();
 
@@ -85,34 +74,46 @@ class instance::impl {
     impl(impl const&) = delete;
     impl& operator=(impl const&) = delete;
 
-    explicit impl(std::unique_ptr<v1::logger> handler) : _handler{std::move(handler)} {
-        this->init(true);
+    explicit impl(std::unique_ptr<v1::logger> handler) {
+        this->reserve();
+
+        // Adapt the `v1::logger` handler into a `logger_function`. A shared_ptr is used
+        // so the resulting invocable is copyable, as required by `logger_function` (std::function).
+        v1::logger_function fn;
+        if (handler) {
+            fn = [logger = std::shared_ptr<v1::logger>{std::move(handler)}](
+                     v1::log_level level,
+                     bsoncxx::v1::stdx::string_view domain,
+                     bsoncxx::v1::stdx::string_view message) { (*logger)(level, domain, message); };
+        }
+
+        // Install the handler before `init()` so that any log messages emitted during
+        // initialization are routed to it.
+        set_global_logger(std::move(fn));
+
+        this->init();
     }
 
     explicit impl(v1::default_logger tag) {
         (void)tag;
-        this->init(false);
+        this->reserve();
+
+        // Leave mongoc's default handler in place (do not register a handler).
+        this->init();
     }
 
    private:
-    void init(bool set_custom_handler) {
-        {
-            int expected = 0;
+    // Reserve the single-instance slot, throwing if an instance already exists.
+    void reserve() {
+        int expected = 0;
 
-            if (!instance_state.compare_exchange_strong(
-                    expected, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
-                throw v1::exception::internal::make(std::error_code{code::multiple_instances});
-            }
+        if (!instance_state.compare_exchange_strong(
+                expected, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
+            throw v1::exception::internal::make(std::error_code{code::multiple_instances});
         }
+    }
 
-        if (set_custom_handler) {
-            if (auto ptr = _handler.get()) {
-                libmongoc::log_set_handler(&custom_log_handler, ptr);
-            } else {
-                libmongoc::log_set_handler(nullptr, nullptr);
-            }
-        }
-
+    void init() {
         libmongoc::init();
 
         {

--- a/src/mongocxx/lib/mongocxx/v1/logger.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/logger.cpp
@@ -18,6 +18,13 @@
 
 #include <bsoncxx/v1/stdx/string_view.hpp>
 
+#include <mongocxx/v1/logger.hh>
+
+#include <memory>
+#include <utility>
+
+#include <bsoncxx/private/make_unique.hh>
+
 #include <mongocxx/private/mongoc.hh>
 
 namespace mongocxx {
@@ -53,6 +60,90 @@ bsoncxx::v1::stdx::string_view to_string(log_level level) {
 }
 
 logger::~logger() = default;
+
+// The C callback registered with mongoc; recovers the `logger_function` from `user_data`.
+// Declared in <mongocxx/v1/logger.hh> so `exchange_global_logger` can reference it.
+void custom_log_handler(
+    mongoc_log_level_t log_level,
+    char const* domain,
+    char const* message,
+    void* user_data) noexcept {
+    (*static_cast<logger_function*>(user_data))(
+        static_cast<v1::log_level>(log_level),
+        bsoncxx::v1::stdx::string_view(domain),
+        bsoncxx::v1::stdx::string_view(message));
+}
+
+namespace {
+
+// Build a `logging_config` for a custom-handler request: a stored copy of `handler` when non-empty,
+// or the disabled state when empty (null).
+logging_config make_custom_config(logger_function handler) {
+    if (handler) {
+        return logging_config{log_mode::k_custom, bsoncxx::make_unique<logger_function>(std::move(handler))};
+    }
+
+    return logging_config{log_mode::k_disabled, nullptr};
+}
+
+} // namespace
+
+logging_config exchange_global_logger(logging_config next) {
+    // The process-global logging configuration.
+    //
+    // This is not thread-safe: concurrent exchanges (or an exchange concurrent with unstructured
+    // logging) are the caller's responsibility to avoid. See `v1::set_global_logger`.
+    static logging_config config;
+
+    switch (next.mode) {
+        case log_mode::k_custom:
+            libmongoc::log_set_handler(&custom_log_handler, next.handler.get());
+            break;
+        case log_mode::k_default:
+            libmongoc::log_set_handler(mongoc_log_default_handler, nullptr);
+            break;
+        case log_mode::k_disabled:
+            libmongoc::log_set_handler(nullptr, nullptr);
+            break;
+    }
+
+    using std::swap;
+    swap(config, next);
+
+    // `next` now holds the previous configuration; returning it transfers ownership of any
+    // previously-installed custom handler to the caller.
+    return next;
+}
+
+void set_global_logger(logger_function handler) {
+    exchange_global_logger(make_custom_config(std::move(handler)));
+}
+
+void set_global_logger(v1::default_logger) {
+    exchange_global_logger(logging_config{log_mode::k_default, nullptr});
+}
+
+class logger_guard::impl {
+   public:
+    logging_config previous;
+
+    explicit impl(logging_config previous) : previous{std::move(previous)} {}
+};
+
+logger_guard::~logger_guard() {
+    // Restore the captured configuration; the configuration this guard installed is returned and
+    // destroyed here (freeing its custom handler, if any).
+    exchange_global_logger(std::move(_impl->previous));
+}
+
+logger_guard::logger_guard(logger_function handler)
+    : _impl{bsoncxx::make_unique<impl>(exchange_global_logger(make_custom_config(std::move(handler))))} {}
+
+logger_guard::logger_guard(v1::default_logger tag) {
+    (void)tag;
+
+    _impl = bsoncxx::make_unique<impl>(exchange_global_logger(logging_config{log_mode::k_default, nullptr}));
+}
 
 } // namespace v1
 } // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v1/logger.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/logger.cpp
@@ -61,14 +61,14 @@ bsoncxx::v1::stdx::string_view to_string(log_level level) {
 
 logger::~logger() = default;
 
-// The C callback registered with mongoc; recovers the `logger_function` from `user_data`.
+// The C callback registered with mongoc; recovers the `log_handler` from `user_data`.
 // Declared in <mongocxx/v1/logger.hh> so `exchange_global_logger` can reference it.
 void custom_log_handler(
     mongoc_log_level_t log_level,
     char const* domain,
     char const* message,
     void* user_data) noexcept {
-    (*static_cast<logger_function*>(user_data))(
+    (*static_cast<log_handler*>(user_data))(
         static_cast<v1::log_level>(log_level),
         bsoncxx::v1::stdx::string_view(domain),
         bsoncxx::v1::stdx::string_view(message));
@@ -78,9 +78,9 @@ namespace {
 
 // Build a `logging_config` for a custom-handler request: a stored copy of `handler` when non-empty,
 // or the disabled state when empty (null).
-logging_config make_custom_config(logger_function handler) {
+logging_config make_custom_config(log_handler handler) {
     if (handler) {
-        return logging_config{log_mode::k_custom, bsoncxx::make_unique<logger_function>(std::move(handler))};
+        return logging_config{log_mode::k_custom, bsoncxx::make_unique<log_handler>(std::move(handler))};
     }
 
     return logging_config{log_mode::k_disabled, nullptr};
@@ -115,7 +115,7 @@ logging_config exchange_global_logger(logging_config next) {
     return next;
 }
 
-void set_global_logger(logger_function handler) {
+void set_global_logger(log_handler handler) {
     exchange_global_logger(make_custom_config(std::move(handler)));
 }
 
@@ -136,7 +136,7 @@ logger_guard::~logger_guard() {
     exchange_global_logger(std::move(_impl->previous));
 }
 
-logger_guard::logger_guard(logger_function handler)
+logger_guard::logger_guard(log_handler handler)
     : _impl{bsoncxx::make_unique<impl>(exchange_global_logger(make_custom_config(std::move(handler))))} {}
 
 logger_guard::logger_guard(v1::default_logger tag) {

--- a/src/mongocxx/lib/mongocxx/v1/logger.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/logger.cpp
@@ -26,6 +26,7 @@
 #include <bsoncxx/private/make_unique.hh>
 
 #include <mongocxx/private/mongoc.hh>
+#include <mongocxx/private/utility.hh>
 
 namespace mongocxx {
 namespace v1 {
@@ -61,8 +62,9 @@ bsoncxx::v1::stdx::string_view to_string(log_level level) {
 
 logger::~logger() = default;
 
+namespace {
+
 // The C callback registered with mongoc; recovers the `log_handler` from `user_data`.
-// Declared in <mongocxx/v1/logger.hh> so `exchange_global_logger` can reference it.
 void custom_log_handler(
     mongoc_log_level_t log_level,
     char const* domain,
@@ -73,8 +75,6 @@ void custom_log_handler(
         bsoncxx::v1::stdx::string_view(domain),
         bsoncxx::v1::stdx::string_view(message));
 }
-
-namespace {
 
 // Build a `logging_config` for a custom-handler request: a stored copy of `handler` when non-empty,
 // or the disabled state when empty (null).
@@ -107,20 +107,17 @@ logging_config exchange_global_logger(logging_config next) {
             break;
     }
 
-    using std::swap;
-    swap(config, next);
-
-    // `next` now holds the previous configuration; returning it transfers ownership of any
+    // Install `next` and return the previous configuration, transferring ownership of any
     // previously-installed custom handler to the caller.
-    return next;
+    return exchange(config, std::move(next));
 }
 
 void set_global_logger(log_handler handler) {
-    exchange_global_logger(make_custom_config(std::move(handler)));
+    (void)exchange_global_logger(make_custom_config(std::move(handler)));
 }
 
 void set_global_logger(v1::default_logger) {
-    exchange_global_logger(logging_config{log_mode::k_default, nullptr});
+    (void)exchange_global_logger(logging_config{log_mode::k_default, nullptr});
 }
 
 class logger_guard::impl {
@@ -133,7 +130,7 @@ class logger_guard::impl {
 logger_guard::~logger_guard() {
     // Restore the captured configuration; the configuration this guard installed is returned and
     // destroyed here (freeing its custom handler, if any).
-    exchange_global_logger(std::move(_impl->previous));
+    (void)exchange_global_logger(std::move(_impl->previous));
 }
 
 logger_guard::logger_guard(log_handler handler)

--- a/src/mongocxx/lib/mongocxx/v1/logger.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/logger.cpp
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mongocxx/v1/logger.hpp>
+#include <mongocxx/v1/logger.hh>
 
 //
 
 #include <bsoncxx/v1/stdx/string_view.hpp>
-
-#include <mongocxx/v1/logger.hh>
 
 #include <memory>
 #include <utility>

--- a/src/mongocxx/lib/mongocxx/v1/logger.hh
+++ b/src/mongocxx/lib/mongocxx/v1/logger.hh
@@ -44,11 +44,11 @@ enum class log_mode {
 // are used to keep this a movable, C++11-compatible type.
 struct logging_config {
     log_mode mode;
-    std::unique_ptr<logger_function> handler;
+    std::unique_ptr<log_handler> handler;
 
     logging_config() noexcept : mode{log_mode::k_default} {}
 
-    logging_config(log_mode mode, std::unique_ptr<logger_function> handler) noexcept
+    logging_config(log_mode mode, std::unique_ptr<log_handler> handler) noexcept
         : mode{mode}, handler{std::move(handler)} {}
 };
 

--- a/src/mongocxx/lib/mongocxx/v1/logger.hh
+++ b/src/mongocxx/lib/mongocxx/v1/logger.hh
@@ -1,0 +1,70 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/v1/logger.hpp> // IWYU pragma: export
+
+//
+
+#include <memory>
+#include <utility>
+
+namespace mongocxx {
+namespace v1 {
+
+// The mongocxx-tracked state of the process-global unstructured log handler.
+//
+// mongoc exposes no getter for the current handler, so mongocxx tracks the "mode" and any owned
+// custom handler itself. This is authoritative only so long as the handler is manipulated
+// exclusively through the mongocxx API (`set_global_logger`, `logger_guard`, and `instance`).
+enum class log_mode {
+    k_default,  // mongoc's default handler (`mongoc_log_default_handler`).
+    k_disabled, // Unstructured logging disabled (null handler).
+    k_custom,   // A custom handler function.
+};
+
+// A snapshot of the global logging configuration.
+//
+// `handler` is non-null if and only if `mode == log_mode::k_custom`. It is heap-allocated so that
+// its address (registered with mongoc as `user_data`) remains stable as the owning `logging_config`
+// is moved. The handler's lifetime is bound to this object: destroying a `logging_config` frees the
+// handler it owns.
+//
+// Explicit constructors (rather than aggregate initialization with a default member initializer)
+// are used to keep this a movable, C++11-compatible type.
+struct logging_config {
+    log_mode mode;
+    std::unique_ptr<logger_function> handler;
+
+    logging_config() noexcept : mode{log_mode::k_default} {}
+
+    logging_config(log_mode mode, std::unique_ptr<logger_function> handler) noexcept
+        : mode{mode}, handler{std::move(handler)} {}
+};
+
+// Install `next` as the process-global logging configuration and return the configuration it
+// replaced.
+//
+// Registers the mongoc handler that corresponds to `next.mode` (`custom_log_handler` for a custom
+// handler, `mongoc_log_default_handler` for the default, or a null handler when disabled), then
+// swaps `next` into the global slot.
+//
+// The returned (previous) configuration owns any custom handler that was previously installed; the
+// caller is responsible for its destruction. This is the shared primitive backing the public
+// `set_global_logger` overloads and `logger_guard`, as well as `instance` construction/teardown.
+//
+// @warning Not thread-safe; see `v1::set_global_logger`.
+logging_config exchange_global_logger(logging_config next);
+
+} // namespace v1
+} // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v1/logger.hh
+++ b/src/mongocxx/lib/mongocxx/v1/logger.hh
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
+
 #include <mongocxx/v1/logger.hpp> // IWYU pragma: export
 
 //

--- a/src/mongocxx/lib/mongocxx/v1/logger.hh
+++ b/src/mongocxx/lib/mongocxx/v1/logger.hh
@@ -46,10 +46,9 @@ struct logging_config {
     log_mode mode;
     std::unique_ptr<log_handler> handler;
 
-    logging_config() noexcept : mode{log_mode::k_default} {}
+    logging_config() : mode{log_mode::k_default} {}
 
-    logging_config(log_mode mode, std::unique_ptr<log_handler> handler) noexcept
-        : mode{mode}, handler{std::move(handler)} {}
+    logging_config(log_mode mode, std::unique_ptr<log_handler> handler) : mode{mode}, handler{std::move(handler)} {}
 };
 
 // Install `next` as the process-global logging configuration and return the configuration it

--- a/src/mongocxx/test/CMakeLists.txt
+++ b/src/mongocxx/test/CMakeLists.txt
@@ -209,6 +209,7 @@ set(mongocxx_test_sources_extra
     v_noabi/client_helpers.cpp
     v_noabi/instance.cpp
     v_noabi/logging.cpp
+    v1/capture_stderr.cpp
     v1/instance.cpp
 )
 
@@ -227,6 +228,7 @@ add_executable(test_driver
     ${mongocxx_test_sources_private}
     ${mongocxx_test_sources_v_noabi}
     ${mongocxx_test_sources_v1}
+    v1/capture_stderr.cpp
     v_noabi/catch_helpers.cpp
 )
 target_link_libraries(test_driver PRIVATE spec_test_common client_helpers)
@@ -235,6 +237,7 @@ add_executable(test_instance
     subprocess.cpp
     v_noabi/instance.cpp
     v_noabi/logging.cpp
+    v1/capture_stderr.cpp
     v1/instance.cpp
 )
 target_compile_definitions(test_instance PRIVATE MONGOCXX_TEST_DISABLE_MAIN_INSTANCE)

--- a/src/mongocxx/test/v1/capture_stderr.cpp
+++ b/src/mongocxx/test/v1/capture_stderr.cpp
@@ -1,0 +1,86 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mongocxx/test/v1/capture_stderr.hh>
+
+//
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdio>
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#if !defined(_WIN32)
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+namespace mongocxx {
+namespace test {
+
+#if !defined(_WIN32)
+
+capture_stderr::~capture_stderr() {
+    ::dup2(_stderr, STDERR_FILENO); // Restore original stderr.
+}
+
+capture_stderr::capture_stderr()
+    : _stderr{::dup(STDERR_FILENO)} // Save original stderr.
+{
+    ::fflush(stderr);
+    REQUIRE(::pipe(_pipes) == 0);                    // Open redirection pipes.
+    REQUIRE(::dup2(_pipes[1], STDERR_FILENO) != -1); // Copy stderr to input pipe.
+    REQUIRE(::close(_pipes[1]) != -1);               // Close original stderr.
+
+    REQUIRE(::fcntl(_pipes[0], F_SETFL, ::fcntl(_pipes[0], F_GETFL) | O_NONBLOCK) != -1); // Do not block on read.
+}
+
+std::string capture_stderr::read() {
+    std::string res;
+
+    {
+        // Capture everything up to this point.
+        // Avoid recursive macro expansion of `stderr` due to Catch expression decomposition.
+        auto const ret = ::fflush(stderr);
+        REQUIRE(ret == 0);
+    }
+
+    while (true) {
+        char buf[BUFSIZ];
+        auto const n = ::read(_pipes[0], buf, std::size_t{BUFSIZ - 1});
+
+        CHECKED_IF(n < 0) {
+            REQUIRE(errno == EAGAIN); // No data left in stream.
+            break;
+        }
+        else {
+            res.append(buf, static_cast<std::size_t>(n));
+        }
+    }
+
+    return res;
+}
+
+#else
+
+std::string capture_stderr::read() {
+    return {};
+}
+
+#endif // !defined(_WIN32)
+
+} // namespace test
+} // namespace mongocxx

--- a/src/mongocxx/test/v1/capture_stderr.hh
+++ b/src/mongocxx/test/v1/capture_stderr.hh
@@ -1,0 +1,102 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdio>
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#if !defined(_WIN32)
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+namespace mongocxx {
+namespace test {
+
+#if !defined(_WIN32)
+
+// Redirect stderr to a pipe for the lifetime of this object so that output (e.g. from mongoc's
+// default log handler) can be inspected via `read()`. Restores the original stderr on destruction.
+class capture_stderr {
+   private:
+    int _pipes[2];
+    int _stderr; // stderr
+
+   public:
+    ~capture_stderr() {
+        ::dup2(_stderr, STDERR_FILENO); // Restore original stderr.
+    }
+
+    capture_stderr(capture_stderr&&) = delete;
+    capture_stderr& operator=(capture_stderr&&) = delete;
+    capture_stderr(capture_stderr const&) = delete;
+    capture_stderr& operator=(capture_stderr const&) = delete;
+
+    capture_stderr()
+        : _stderr{::dup(STDERR_FILENO)} // Save original stderr.
+    {
+        ::fflush(stderr);
+        REQUIRE(::pipe(_pipes) == 0);                    // Open redirection pipes.
+        REQUIRE(::dup2(_pipes[1], STDERR_FILENO) != -1); // Copy stderr to input pipe.
+        REQUIRE(::close(_pipes[1]) != -1);               // Close original stderr.
+
+        REQUIRE(::fcntl(_pipes[0], F_SETFL, ::fcntl(_pipes[0], F_GETFL) | O_NONBLOCK) != -1); // Do not block on read.
+    }
+
+    std::string read() {
+        std::string res;
+
+        {
+            // Capture everything up to this point.
+            // Avoid recursive macro expansion of `stderr` due to Catch expression decomposition.
+            auto const ret = ::fflush(stderr);
+            REQUIRE(ret == 0);
+        }
+
+        while (true) {
+            char buf[BUFSIZ];
+            auto const n = ::read(_pipes[0], buf, std::size_t{BUFSIZ - 1});
+
+            CHECKED_IF(n < 0) {
+                REQUIRE(errno == EAGAIN); // No data left in stream.
+                break;
+            }
+            else {
+                res.append(buf, static_cast<std::size_t>(n));
+            }
+        }
+
+        return res;
+    }
+};
+
+#else
+
+// Windows: stderr redirection is not supported; `read()` yields nothing.
+class capture_stderr {
+   public:
+    std::string read() {
+        return {};
+    }
+};
+
+#endif // !defined(_WIN32)
+
+} // namespace test
+} // namespace mongocxx

--- a/src/mongocxx/test/v1/capture_stderr.hh
+++ b/src/mongocxx/test/v1/capture_stderr.hh
@@ -14,89 +14,42 @@
 
 #pragma once
 
-#include <cerrno>
-#include <cstddef>
-#include <cstdio>
 #include <string>
-
-#include <catch2/catch_test_macros.hpp>
-
-#if !defined(_WIN32)
-#include <fcntl.h>
-#include <unistd.h>
-#endif
 
 namespace mongocxx {
 namespace test {
 
-#if !defined(_WIN32)
-
 // Redirect stderr to a pipe for the lifetime of this object so that output (e.g. from mongoc's
 // default log handler) can be inspected via `read()`. Restores the original stderr on destruction.
+//
+// Member definitions live in capture_stderr.cpp to avoid transitively including system headers in
+// test components which include this header.
 class capture_stderr {
+#if !defined(_WIN32)
    private:
     int _pipes[2];
     int _stderr; // stderr
 
    public:
-    ~capture_stderr() {
-        ::dup2(_stderr, STDERR_FILENO); // Restore original stderr.
-    }
+    ~capture_stderr();
 
     capture_stderr(capture_stderr&&) = delete;
     capture_stderr& operator=(capture_stderr&&) = delete;
     capture_stderr(capture_stderr const&) = delete;
     capture_stderr& operator=(capture_stderr const&) = delete;
 
-    capture_stderr()
-        : _stderr{::dup(STDERR_FILENO)} // Save original stderr.
-    {
-        ::fflush(stderr);
-        REQUIRE(::pipe(_pipes) == 0);                    // Open redirection pipes.
-        REQUIRE(::dup2(_pipes[1], STDERR_FILENO) != -1); // Copy stderr to input pipe.
-        REQUIRE(::close(_pipes[1]) != -1);               // Close original stderr.
+    capture_stderr();
 
-        REQUIRE(::fcntl(_pipes[0], F_SETFL, ::fcntl(_pipes[0], F_GETFL) | O_NONBLOCK) != -1); // Do not block on read.
-    }
-
-    std::string read() {
-        std::string res;
-
-        {
-            // Capture everything up to this point.
-            // Avoid recursive macro expansion of `stderr` due to Catch expression decomposition.
-            auto const ret = ::fflush(stderr);
-            REQUIRE(ret == 0);
-        }
-
-        while (true) {
-            char buf[BUFSIZ];
-            auto const n = ::read(_pipes[0], buf, std::size_t{BUFSIZ - 1});
-
-            CHECKED_IF(n < 0) {
-                REQUIRE(errno == EAGAIN); // No data left in stream.
-                break;
-            }
-            else {
-                res.append(buf, static_cast<std::size_t>(n));
-            }
-        }
-
-        return res;
-    }
-};
+    std::string read();
 
 #else
 
-// Windows: stderr redirection is not supported; `read()` yields nothing.
-class capture_stderr {
    public:
-    std::string read() {
-        return {};
-    }
-};
+    // Windows: stderr redirection is not supported; `read()` yields nothing.
+    std::string read();
 
 #endif // !defined(_WIN32)
+};
 
 } // namespace test
 } // namespace mongocxx

--- a/src/mongocxx/test/v1/instance.cpp
+++ b/src/mongocxx/test/v1/instance.cpp
@@ -18,11 +18,9 @@
 
 #include <bsoncxx/test/v1/stdx/string_view.hh>
 
+#include <mongocxx/test/v1/capture_stderr.hh>
 #include <mongocxx/test/v1/logger.hh>
 
-#include <cerrno>
-#include <cstddef>
-#include <cstdio>
 #include <functional>
 #include <string>
 #include <utility>
@@ -38,10 +36,6 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
-
-#if !defined(_WIN32)
-#include <fcntl.h>
-#endif
 
 namespace mongocxx {
 namespace v1 {
@@ -68,71 +62,7 @@ class custom_logger : public logger {
 } // namespace
 
 TEST_CASE("logger", "[mongocxx][v1][instance]") {
-#if !defined(_WIN32)
-    class capture_stderr {
-       private:
-        int _pipes[2];
-        int _stderr; // stderr
-
-       public:
-        ~capture_stderr() {
-            ::dup2(_stderr, STDERR_FILENO); // Restore original stderr.
-        }
-
-        capture_stderr(capture_stderr&&) = delete;
-        capture_stderr& operator=(capture_stderr&&) = delete;
-        capture_stderr(capture_stderr const&) = delete;
-        capture_stderr& operator=(capture_stderr const&) = delete;
-
-        capture_stderr()
-            : _stderr{::dup(STDERR_FILENO)} // Save original stderr.
-        {
-            ::fflush(stderr);
-            REQUIRE(::pipe(_pipes) == 0);                    // Open redirection pipes.
-            REQUIRE(::dup2(_pipes[1], STDERR_FILENO) != -1); // Copy stderr to input pipe.
-            REQUIRE(::close(_pipes[1]) != -1);               // Close original stderr.
-
-            REQUIRE(
-                ::fcntl(_pipes[0], F_SETFL, ::fcntl(_pipes[0], F_GETFL) | O_NONBLOCK) != -1); // Do not block on read.
-        }
-
-        std::string read() {
-            std::string res;
-
-            {
-                // Capture everything up to this point.
-                // Avoid recursive macro expansion of `stderr` due to Catch expression decomposition.
-                auto const res = ::fflush(stderr);
-                REQUIRE(res == 0);
-            }
-
-            while (true) {
-                char buf[BUFSIZ];
-                auto const n = ::read(_pipes[0], buf, std::size_t{BUFSIZ - 1});
-
-                CHECKED_IF(n < 0) {
-                    REQUIRE(errno == EAGAIN); // No data left in stream.
-                    break;
-                }
-                else {
-                    res.append(buf, static_cast<std::size_t>(n));
-                }
-            }
-
-            return res;
-        }
-    };
-
-#else
-
-    class capture_stderr {
-       public:
-        std::string read() {
-            return {};
-        }
-    };
-
-#endif // !defined(_WIN32)
+    using mongocxx::test::capture_stderr;
 
     {
         auto const test_default = [] {

--- a/src/mongocxx/test/v1/logger.cpp
+++ b/src/mongocxx/test/v1/logger.cpp
@@ -18,11 +18,17 @@
 
 #include <bsoncxx/test/v1/stdx/string_view.hh>
 
+#include <mongocxx/test/v1/capture_stderr.hh>
+
+#include <string>
 #include <type_traits>
+
+#include <mongocxx/private/mongoc.hh>
 
 #include <bsoncxx/test/stringify.hh>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 namespace mongocxx {
 namespace v1 {
@@ -51,6 +57,159 @@ static_assert(std::is_default_constructible<custom_logger>::value, "");
 TEST_CASE("stringify", "[mongocxx][test][v1][logger]") {
     // No point specializing StringMaker for abstract class mongocxx::v1::logger.
     CHECK(bsoncxx::test::stringify(custom_logger{}) == "{?}");
+}
+
+// These tests run within the lifetime of the test suite's global instance (see catch.cpp), which is
+// the required context for the global-logger API. The `restore` guard below returns the global
+// handler to its pre-test configuration so test cases remain isolated from one another.
+TEST_CASE("set_global_logger and logger_guard", "[mongocxx][test][v1][logger]") {
+    using Catch::Matchers::ContainsSubstring;
+    using mongocxx::test::capture_stderr;
+
+    // Recorded state of the most recent custom-handler invocation.
+    int count = 0;
+    log_level level = log_level::k_error;
+    std::string domain;
+    std::string message;
+
+    auto const record = [&](log_level l, bsoncxx::v1::stdx::string_view d, bsoncxx::v1::stdx::string_view m) {
+        ++count;
+        level = l;
+        domain = std::string{d};
+        message = std::string{m};
+    };
+
+    // Declared after `record`/`count`/... so that restoring the prior handler (which frees any
+    // custom handler still installed) happens before those captured variables are destroyed.
+    logger_guard const restore{default_logger{}};
+
+    SECTION("set_global_logger switches handlers at runtime") {
+        set_global_logger(record);
+
+        mongoc_log(MONGOC_LOG_LEVEL_WARNING, "dom", "custom");
+        CHECK(count == 1);
+        CHECK(level == log_level::k_warning);
+        CHECK(domain == "dom");
+        CHECK(message == "custom");
+
+        // Switch to mongoc's default handler: output goes to stderr; the custom handler is inert.
+        set_global_logger(default_logger{});
+        std::string out;
+        {
+            capture_stderr cap;
+            mongoc_log(MONGOC_LOG_LEVEL_WARNING, "dom", "to-stderr");
+            out = cap.read();
+        }
+        CHECK_THAT(out, ContainsSubstring("to-stderr"));
+        CHECK(count == 1);
+
+        // Disable logging: nothing is emitted anywhere.
+        set_global_logger(nullptr);
+        {
+            capture_stderr cap;
+            mongoc_log(MONGOC_LOG_LEVEL_WARNING, "dom", "suppressed");
+            out = cap.read();
+        }
+        CHECK(out.find("suppressed") == std::string::npos);
+        CHECK(count == 1);
+    }
+
+    SECTION("logger_guard installs a custom handler for its scope over the default handler") {
+        {
+            logger_guard const scope{record};
+
+            mongoc_log(MONGOC_LOG_LEVEL_WARNING, "dom", "inside");
+            CHECK(count == 1);
+            CHECK(message == "inside");
+        }
+
+        // The default handler is restored: output goes to stderr; the custom handler is inert.
+        std::string out;
+        {
+            capture_stderr cap;
+            mongoc_log(MONGOC_LOG_LEVEL_WARNING, "dom", "outside");
+            out = cap.read();
+        }
+        CHECK_THAT(out, ContainsSubstring("outside"));
+        CHECK(count == 1);
+    }
+
+    SECTION("logger_guard restores a previously-installed custom handler") {
+        set_global_logger(record);
+
+        {
+            logger_guard const scope{default_logger{}};
+
+            std::string out;
+            {
+                capture_stderr cap;
+                mongoc_log(MONGOC_LOG_LEVEL_WARNING, "dom", "temp-default");
+                out = cap.read();
+            }
+            CHECK_THAT(out, ContainsSubstring("temp-default"));
+            CHECK(count == 0); // The custom handler was displaced by the guard.
+        }
+
+        // The custom handler is restored.
+        mongoc_log(MONGOC_LOG_LEVEL_WARNING, "dom", "restored");
+        CHECK(count == 1);
+        CHECK(message == "restored");
+    }
+
+    SECTION("logger_guard restores the disabled state") {
+        set_global_logger(nullptr); // disabled
+
+        {
+            logger_guard const scope{record};
+
+            mongoc_log(MONGOC_LOG_LEVEL_WARNING, "dom", "inside");
+            CHECK(count == 1);
+        }
+
+        // The disabled state is restored: nothing is emitted anywhere.
+        std::string out;
+        {
+            capture_stderr cap;
+            mongoc_log(MONGOC_LOG_LEVEL_WARNING, "dom", "suppressed");
+            out = cap.read();
+        }
+        CHECK(out.empty());
+        CHECK(count == 1);
+    }
+
+    SECTION("nested logger_guards restore in LIFO order") {
+        int a = 0;
+        int b = 0;
+        int c = 0;
+
+        auto const counter = [](int& n) {
+            return [&n](log_level, bsoncxx::v1::stdx::string_view, bsoncxx::v1::stdx::string_view) { ++n; };
+        };
+
+        logger_guard const outer{counter(a)};
+        mongoc_log(MONGOC_LOG_LEVEL_WARNING, "dom", "a");
+        CHECK((a == 1 && b == 0 && c == 0));
+
+        {
+            logger_guard const middle{counter(b)};
+            mongoc_log(MONGOC_LOG_LEVEL_WARNING, "dom", "b");
+            CHECK((a == 1 && b == 1 && c == 0));
+
+            {
+                logger_guard const inner{counter(c)};
+                mongoc_log(MONGOC_LOG_LEVEL_WARNING, "dom", "c");
+                CHECK((a == 1 && b == 1 && c == 1));
+            }
+
+            // `inner` destroyed: `middle`'s handler is active again.
+            mongoc_log(MONGOC_LOG_LEVEL_WARNING, "dom", "b");
+            CHECK((a == 1 && b == 2 && c == 1));
+        }
+
+        // `middle` destroyed: `outer`'s handler is active again.
+        mongoc_log(MONGOC_LOG_LEVEL_WARNING, "dom", "a");
+        CHECK((a == 2 && b == 2 && c == 1));
+    }
 }
 
 } // namespace v1

--- a/src/mongocxx/test/v1/logger.cpp
+++ b/src/mongocxx/test/v1/logger.cpp
@@ -66,6 +66,10 @@ TEST_CASE("set_global_logger and logger_guard", "[mongocxx][test][v1][logger]") 
     using Catch::Matchers::ContainsSubstring;
     using mongocxx::test::capture_stderr;
 
+#ifdef _WIN32
+    SKIP("Test cases that capture stderr cannot run on Windows");
+#endif
+
     // Recorded state of the most recent custom-handler invocation.
     int count = 0;
     log_level level = log_level::k_error;

--- a/src/mongocxx/test/v1/logger.cpp
+++ b/src/mongocxx/test/v1/logger.cpp
@@ -192,27 +192,37 @@ TEST_CASE("set_global_logger and logger_guard", "[mongocxx][test][v1][logger]") 
 
         logger_guard const outer{counter(a)};
         mongoc_log(MONGOC_LOG_LEVEL_WARNING, "dom", "a");
-        CHECK((a == 1 && b == 0 && c == 0));
+        CHECK(a == 1);
+        CHECK(b == 0);
+        CHECK(c == 0);
 
         {
             logger_guard const middle{counter(b)};
             mongoc_log(MONGOC_LOG_LEVEL_WARNING, "dom", "b");
-            CHECK((a == 1 && b == 1 && c == 0));
+            CHECK(a == 1);
+            CHECK(b == 1);
+            CHECK(c == 0);
 
             {
                 logger_guard const inner{counter(c)};
                 mongoc_log(MONGOC_LOG_LEVEL_WARNING, "dom", "c");
-                CHECK((a == 1 && b == 1 && c == 1));
+                CHECK(a == 1);
+                CHECK(b == 1);
+                CHECK(c == 1);
             }
 
             // `inner` destroyed: `middle`'s handler is active again.
             mongoc_log(MONGOC_LOG_LEVEL_WARNING, "dom", "b");
-            CHECK((a == 1 && b == 2 && c == 1));
+            CHECK(a == 1);
+            CHECK(b == 2);
+            CHECK(c == 1);
         }
 
         // `middle` destroyed: `outer`'s handler is active again.
         mongoc_log(MONGOC_LOG_LEVEL_WARNING, "dom", "a");
-        CHECK((a == 2 && b == 2 && c == 1));
+        CHECK(a == 2);
+        CHECK(b == 2);
+        CHECK(c == 1);
     }
 }
 


### PR DESCRIPTION
Refer: CXX-1029

# Summary

This changeset implements the minimal changes to satisfy CXX-1029 for unstructured logging. This changeset does not directly do anything related to structured logging, which will be reserved for a future PR.

# Changes

Decouple unstructured-logging configuration from `mongocxx::v1::instance` construction so the process-global mongoc log handler can be reconfigured at runtime rather than only once, at construction.

- Add `mongocxx::v1::log_handler` (a `std::function` handler type), `set_global_logger()` (accepts any compatible invocable, stored via type erasure; null disables logging; a `default_logger` overload restores mongoc's default handler), and `logger_guard` (an RAII scope guard that installs a handler and restores the previously-active one on destruction; guards nest LIFO). Exposed under `v_noabi`/`mongocxx` for parity.
- Move handler ownership out of `instance` into a process-global config in the logger component (`exchange_global_logger` in v1/logger.hh). `instance` now only reserves the singleton slot, installs the handler before `mongoc_init`, and disables logging before `mongoc_cleanup`. The retained logger-taking constructors bridge the `v1::logger` ABC into a `logger_function` via a copyable `shared_ptr`-capturing adapter.
- Add tests (runtime switching, scoped/nested guards, restore of custom/default/ disabled state); extract `capture_stderr` into a shared test header. Add a `logger_guard` example and doc section. Update CHANGELOG.

The global logger API is intentionally not thread-safe with respect to concurrent logging (documented), matching mongoc's `mongoc_log_set_handler` contract.

# Reviewer Note

This is my first PR that adds components to the ABI namespaces, and I mimicked the existing patterns in other files. Let me know if anything I did is not actually what we want.