### PR TITLE
CXX-3532 bump C driver to 2.3.3

### DIFF
--- a/.evergreen/config_generator/components/funcs/install_c_driver.py
+++ b/.evergreen/config_generator/components/funcs/install_c_driver.py
@@ -12,7 +12,7 @@ from config_generator.etc.utils import bash_exec
 # - the default value of --c-driver-build-ref in etc/make_release.py
 # If pinning to an unreleased commit, create a "Blocked" JIRA ticket with
 # a "depends on" link to the appropriate C Driver version release ticket.
-MONGOC_VERSION_MINIMUM = '2.3.1'
+MONGOC_VERSION_MINIMUM = '2.3.3'
 
 
 class InstallCDriver(Function):

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -399,7 +399,7 @@ functions:
       type: setup
       params:
         updates:
-          - { key: mongoc_version_minimum, value: 2.3.1 }
+          - { key: mongoc_version_minimum, value: 2.3.3 }
     - command: subprocess.exec
       type: setup
       params:
@@ -533,7 +533,7 @@ functions:
           - |
             set -o errexit
             if test -d drivers-evergreen-tools; then
-                pushd drivers-evergreen-tools
+                cd drivers-evergreen-tools
                 .evergreen/run-mongodb.sh stop
             fi
   test:

--- a/.evergreen/scripts/abi-stability-setup.sh
+++ b/.evergreen/scripts/abi-stability-setup.sh
@@ -39,6 +39,11 @@ esac
 declare working_dir
 working_dir="$(pwd)"
 
+# TODO: remove "UV_CONSTRAINT" of CMake after the base release is r4.4.1+ to include fix of CXX-3529.
+constraint_file="$(mktemp)"
+echo "cmake<4.4" > "${constraint_file:?}"
+UV_CONSTRAINT="${constraint_file:?}"
+
 . mongo-cxx-driver/.evergreen/scripts/install-build-tools.sh
 install_build_tools
 

--- a/.evergreen/scripts/abi-stability-setup.sh
+++ b/.evergreen/scripts/abi-stability-setup.sh
@@ -42,7 +42,7 @@ working_dir="$(pwd)"
 # TODO: remove "UV_CONSTRAINT" of CMake after the base release is r4.4.1+ to include fix of CXX-3529.
 constraint_file="$(mktemp)"
 echo "cmake<4.4" > "${constraint_file:?}"
-UV_CONSTRAINT="${constraint_file:?}"
+export UV_CONSTRAINT="${constraint_file:?}"
 
 . mongo-cxx-driver/.evergreen/scripts/install-build-tools.sh
 install_build_tools

--- a/.evergreen/scripts/install-build-tools.sh
+++ b/.evergreen/scripts/install-build-tools.sh
@@ -23,8 +23,7 @@ install_build_tools() {
   # PyPI `cmake` requires a sufficiently recent Python version.
   uv python install --no-bin -q || uv python install -q || return
 
-  # TODO: replace "cmake==4.3.4" with "cmake" once the C driver dependency is updated to 2.3.3 to include CDRIVER-6367.
-  uv tool install -q "cmake<4.4" || return
+  uv tool install -q "cmake" || return
 
   if [[ -f /etc/redhat-release && -x /opt/mongodbtoolchain/v4/bin/ninja ]]; then
     # Avoid strange "Could NOT find Threads" CMake configuration error on RHEL when using PyPI CMake, PyPI Ninja, and

--- a/.evergreen/scripts/install-c-driver.sh
+++ b/.evergreen/scripts/install-c-driver.sh
@@ -75,7 +75,12 @@ if [[ "${SKIP_INSTALL_LIBMONGOCRYPT:-}" != "1" ]]; then
   # Avoid using compile-libmongocrypt.sh (mongo-c-driver) -> compile.sh (libmongocrypt) -> build_all.sh (libmongocrypt),
   # which hardcodes MSVC-specific compiler flags (-EHsc) and does not support the Ninja Multi-Config generator (see:
   # references to the USE_NINJA environment variable).
-  if [[ "${OSTYPE:?}" == cygwin && "${CMAKE_GENERATOR:?}" != Visual\ Studio\ * ]]; then
+  AVOID_COMPILE_LIBMONGOCRYPT=$([[ "${OSTYPE:?}" == cygwin && "${CMAKE_GENERATOR:?}" != Visual\ Studio\ * ]] && echo 1 || echo 0)
+
+  # Avoid using compile-libmongocrypt.sh (gets libmongocrypt 1.21.0-dev) to avoid test failures due to 1.19.0 dropping "textPreview".
+  AVOID_COMPILE_LIBMONGOCRYPT=1 # TODO: remove this line once CXX-3467 is addressed.
+
+  if [[ "${AVOID_COMPILE_LIBMONGOCRYPT:?}" == "1" ]]; then
     (
       git clone -q https://github.com/mongodb/libmongocrypt --branch 1.18.1 --depth 1
 

--- a/.evergreen/scripts/install-c-driver.sh
+++ b/.evergreen/scripts/install-c-driver.sh
@@ -90,6 +90,9 @@ if [[ "${SKIP_INSTALL_LIBMONGOCRYPT:-}" != "1" ]]; then
         "-DENABLE_ONLINE_TESTS=OFF"
         "-DENABLE_MONGOC=OFF"
         "-DBUILD_VERSION=1.18.1"
+        # libmongocrypt does not use C++20 modules. Disable module scanning to avoid requiring clang-scan-deps
+        # (not present on all CI images), which CMake 4.4+ invokes by default for C++20 targets.
+        "-DCMAKE_CXX_SCAN_FOR_MODULES=OFF"
       )
 
       . "${mongoc_dir}/.evergreen/scripts/find-ccache.sh"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,9 +57,9 @@ else()
 endif()
 
 # Also update etc/purls.txt.
-set(BSON_REQUIRED_VERSION 2.3.1)
-set(MONGOC_REQUIRED_VERSION 2.3.1)
-set(MONGOC_DOWNLOAD_VERSION 2.3.1)
+set(BSON_REQUIRED_VERSION 2.3.3)
+set(MONGOC_REQUIRED_VERSION 2.3.3)
+set(MONGOC_DOWNLOAD_VERSION 2.3.3)
 
 # All of our target compilers support the deprecated
 # attribute. Normally, we would just let the GenerateExportHeader

--- a/etc/augmented.sbom.json
+++ b/etc/augmented.sbom.json
@@ -1,16 +1,16 @@
 {
   "components": [
     {
-      "bom-ref": "pkg:github/mongodb/mongo-c-driver@2.3.1",
+      "bom-ref": "pkg:github/mongodb/mongo-c-driver@2.3.3",
       "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://github.com/mongodb/mongo-c-driver/archive/2.3.1.tar.gz"
+          "url": "https://github.com/mongodb/mongo-c-driver/archive/2.3.3.tar.gz"
         },
         {
           "type": "website",
-          "url": "https://github.com/mongodb/mongo-c-driver/tree/2.3.1"
+          "url": "https://github.com/mongodb/mongo-c-driver/tree/2.3.3"
         }
       ],
       "group": "mongodb",
@@ -22,18 +22,18 @@
         }
       ],
       "name": "mongo-c-driver",
-      "purl": "pkg:github/mongodb/mongo-c-driver@2.3.1",
+      "purl": "pkg:github/mongodb/mongo-c-driver@2.3.3",
       "type": "library",
-      "version": "2.3.1"
+      "version": "2.3.3"
     }
   ],
   "dependencies": [
     {
-      "ref": "pkg:github/mongodb/mongo-c-driver@2.3.1"
+      "ref": "pkg:github/mongodb/mongo-c-driver@2.3.3"
     }
   ],
   "metadata": {
-    "timestamp": "2026-06-24T16:53:55.127365+00:00",
+    "timestamp": "2026-07-21T13:30:44.031978+00:00",
     "tools": [
       {
         "externalReferences": [

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -1,16 +1,16 @@
 {
   "components": [
     {
-      "bom-ref": "pkg:github/mongodb/mongo-c-driver@2.3.1",
+      "bom-ref": "pkg:github/mongodb/mongo-c-driver@2.3.3",
       "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://github.com/mongodb/mongo-c-driver/archive/2.3.1.tar.gz"
+          "url": "https://github.com/mongodb/mongo-c-driver/archive/2.3.3.tar.gz"
         },
         {
           "type": "website",
-          "url": "https://github.com/mongodb/mongo-c-driver/tree/2.3.1"
+          "url": "https://github.com/mongodb/mongo-c-driver/tree/2.3.3"
         }
       ],
       "group": "mongodb",
@@ -22,18 +22,18 @@
         }
       ],
       "name": "mongo-c-driver",
-      "purl": "pkg:github/mongodb/mongo-c-driver@2.3.1",
+      "purl": "pkg:github/mongodb/mongo-c-driver@2.3.3",
       "type": "library",
-      "version": "2.3.1"
+      "version": "2.3.3"
     }
   ],
   "dependencies": [
     {
-      "ref": "pkg:github/mongodb/mongo-c-driver@2.3.1"
+      "ref": "pkg:github/mongodb/mongo-c-driver@2.3.3"
     }
   ],
   "metadata": {
-    "timestamp": "2026-06-24T16:53:55.127365+00:00",
+    "timestamp": "2026-07-21T13:30:44.031978+00:00",
     "tools": [
       {
         "externalReferences": [

--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -100,7 +100,7 @@ ISSUE_TYPE_ID = {
 )
 @click.option(
     '--c-driver-build-ref',
-    default='2.3.1',
+    default='2.3.3',
     show_default=True,
     help='When building the C driver, build at this Git reference',
 )

--- a/etc/purls.txt
+++ b/etc/purls.txt
@@ -6,4 +6,4 @@
 # re-generate the SBOM JSON file!
 
 # bson and mongoc may be obtained via cmake/FetchMongoC.cmake.
-pkg:github/mongodb/mongo-c-driver@2.3.1
+pkg:github/mongodb/mongo-c-driver@2.3.3

--- a/src/mongocxx/test/v1/oidc_callback.cpp
+++ b/src/mongocxx/test/v1/oidc_callback.cpp
@@ -240,7 +240,7 @@ TEST_CASE("OIDC prose tests", "[oidc]") {
 
     SECTION("2.1 Valid Callback Inputs") {
         auto callback_call_count = 0u;
-        bool with_username = GENERATE(/* true, */ false); // TODO CDRIVER-6310: test 'true' once upgraded to 2.3.1.
+        bool with_username = GENERATE(true, false);
         CAPTURE(with_username);
         auto const token = read_token_from_file();
 


### PR DESCRIPTION
# Summary

Bump the required and auto-downloaded C driver to 2.3.3 to include CDRIVER-6367 which fixes the C driver configuration on CMake 4.4.0.

Evergreen patch: https://spruce.corp.mongodb.com/version/6a5fcc23ce67ea0007e2442f

# Details

Though the C driver 2.3.3 only requires [libmongocrypt 1.15.1](https://github.com/mongodb/mongo-c-driver/blob/e8bb60961f2d5921fe741b3c34782d7c988314d0/src/libmongoc/CMakeLists.txt#L495), the C driver's [compile_libmongocrypt.sh](https://github.com/mongodb/mongo-c-driver/blob/2.3.3/.evergreen/scripts/compile-libmongocrypt.sh#L15) was updated to a 1.21.0-dev. This includes backwards breaking changes to drop support for QE experimental API, that the C++ driver has not-yet implemented: CXX-3467.

As a drive-by a test TODO comment "once upgraded to 2.3.1" is addressed.