### PR TITLE
[v4.4] CXX-3532 bump C driver to 2.3.3

### DIFF
--- a/.evergreen/config_generator/components/funcs/install_c_driver.py
+++ b/.evergreen/config_generator/components/funcs/install_c_driver.py
@@ -12,7 +12,7 @@ from config_generator.etc.utils import bash_exec
 # - the default value of --c-driver-build-ref in etc/make_release.py
 # If pinning to an unreleased commit, create a "Blocked" JIRA ticket with
 # a "depends on" link to the appropriate C Driver version release ticket.
-MONGOC_VERSION_MINIMUM = '2.3.1'
+MONGOC_VERSION_MINIMUM = '2.3.3'
 
 
 class InstallCDriver(Function):

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -399,7 +399,7 @@ functions:
       type: setup
       params:
         updates:
-          - { key: mongoc_version_minimum, value: 2.3.1 }
+          - { key: mongoc_version_minimum, value: 2.3.3 }
     - command: subprocess.exec
       type: setup
       params:

--- a/.evergreen/scripts/abi-stability-setup.sh
+++ b/.evergreen/scripts/abi-stability-setup.sh
@@ -39,6 +39,11 @@ esac
 declare working_dir
 working_dir="$(pwd)"
 
+# TODO: remove "UV_CONSTRAINT" of CMake after the base release is r4.4.1+ to include fix of CXX-3529.
+constraint_file="$(mktemp)"
+echo "cmake<4.4" > "${constraint_file:?}"
+export UV_CONSTRAINT="${constraint_file:?}"
+
 . mongo-cxx-driver/.evergreen/scripts/install-build-tools.sh
 install_build_tools
 

--- a/.evergreen/scripts/install-c-driver.sh
+++ b/.evergreen/scripts/install-c-driver.sh
@@ -75,7 +75,12 @@ if [[ "${SKIP_INSTALL_LIBMONGOCRYPT:-}" != "1" ]]; then
   # Avoid using compile-libmongocrypt.sh (mongo-c-driver) -> compile.sh (libmongocrypt) -> build_all.sh (libmongocrypt),
   # which hardcodes MSVC-specific compiler flags (-EHsc) and does not support the Ninja Multi-Config generator (see:
   # references to the USE_NINJA environment variable).
-  if [[ "${OSTYPE:?}" == cygwin && "${CMAKE_GENERATOR:?}" != Visual\ Studio\ * ]]; then
+  AVOID_COMPILE_LIBMONGOCRYPT=$([[ "${OSTYPE:?}" == cygwin && "${CMAKE_GENERATOR:?}" != Visual\ Studio\ * ]] && echo 1 || echo 0)
+
+  # Avoid using compile-libmongocrypt.sh (gets libmongocrypt 1.21.0-dev) to avoid test failures due to 1.19.0 dropping "textPreview".
+  AVOID_COMPILE_LIBMONGOCRYPT=1 # TODO: remove this line once CXX-3467 is addressed.
+
+  if [[ "${AVOID_COMPILE_LIBMONGOCRYPT:?}" == "1" ]]; then
     (
       git clone -q https://github.com/mongodb/libmongocrypt --branch 1.18.1 --depth 1
 
@@ -85,6 +90,9 @@ if [[ "${SKIP_INSTALL_LIBMONGOCRYPT:-}" != "1" ]]; then
         "-DENABLE_ONLINE_TESTS=OFF"
         "-DENABLE_MONGOC=OFF"
         "-DBUILD_VERSION=1.18.1"
+        # libmongocrypt does not use C++20 modules. Disable module scanning to avoid requiring clang-scan-deps
+        # (not present on all CI images), which CMake 4.4+ invokes by default for C++20 targets.
+        "-DCMAKE_CXX_SCAN_FOR_MODULES=OFF"
       )
 
       . "${mongoc_dir}/.evergreen/scripts/find-ccache.sh"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 ## 4.4.1 [Unreleased]
 
-<!-- Will contain entries for the next patch release. -->
+### Changed
+
+- Bump the minimum required C Driver version to [2.3.3](https://github.com/mongodb/mongo-c-driver/releases/tag/2.3.3).
 
 ## 4.4.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,9 +62,9 @@ else()
 endif()
 
 # Also update etc/purls.txt.
-set(BSON_REQUIRED_VERSION 2.3.1)
-set(MONGOC_REQUIRED_VERSION 2.3.1)
-set(MONGOC_DOWNLOAD_VERSION 2.3.1)
+set(BSON_REQUIRED_VERSION 2.3.3)
+set(MONGOC_REQUIRED_VERSION 2.3.3)
+set(MONGOC_DOWNLOAD_VERSION 2.3.3)
 
 # All of our target compilers support the deprecated
 # attribute. Normally, we would just let the GenerateExportHeader

--- a/etc/augmented.sbom.json
+++ b/etc/augmented.sbom.json
@@ -1,16 +1,16 @@
 {
   "components": [
     {
-      "bom-ref": "pkg:github/mongodb/mongo-c-driver@2.3.1",
+      "bom-ref": "pkg:github/mongodb/mongo-c-driver@2.3.3",
       "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://github.com/mongodb/mongo-c-driver/archive/2.3.1.tar.gz"
+          "url": "https://github.com/mongodb/mongo-c-driver/archive/2.3.3.tar.gz"
         },
         {
           "type": "website",
-          "url": "https://github.com/mongodb/mongo-c-driver/tree/2.3.1"
+          "url": "https://github.com/mongodb/mongo-c-driver/tree/2.3.3"
         }
       ],
       "group": "mongodb",
@@ -22,18 +22,18 @@
         }
       ],
       "name": "mongo-c-driver",
-      "purl": "pkg:github/mongodb/mongo-c-driver@2.3.1",
+      "purl": "pkg:github/mongodb/mongo-c-driver@2.3.3",
       "type": "library",
-      "version": "2.3.1"
+      "version": "2.3.3"
     }
   ],
   "dependencies": [
     {
-      "ref": "pkg:github/mongodb/mongo-c-driver@2.3.1"
+      "ref": "pkg:github/mongodb/mongo-c-driver@2.3.3"
     }
   ],
   "metadata": {
-    "timestamp": "2026-06-24T16:42:36.948088+00:00",
+    "timestamp": "2026-07-21T13:30:44.031978+00:00",
     "tools": [
       {
         "externalReferences": [

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -1,16 +1,16 @@
 {
   "components": [
     {
-      "bom-ref": "pkg:github/mongodb/mongo-c-driver@2.3.1",
+      "bom-ref": "pkg:github/mongodb/mongo-c-driver@2.3.3",
       "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://github.com/mongodb/mongo-c-driver/archive/2.3.1.tar.gz"
+          "url": "https://github.com/mongodb/mongo-c-driver/archive/2.3.3.tar.gz"
         },
         {
           "type": "website",
-          "url": "https://github.com/mongodb/mongo-c-driver/tree/2.3.1"
+          "url": "https://github.com/mongodb/mongo-c-driver/tree/2.3.3"
         }
       ],
       "group": "mongodb",
@@ -22,18 +22,18 @@
         }
       ],
       "name": "mongo-c-driver",
-      "purl": "pkg:github/mongodb/mongo-c-driver@2.3.1",
+      "purl": "pkg:github/mongodb/mongo-c-driver@2.3.3",
       "type": "library",
-      "version": "2.3.1"
+      "version": "2.3.3"
     }
   ],
   "dependencies": [
     {
-      "ref": "pkg:github/mongodb/mongo-c-driver@2.3.1"
+      "ref": "pkg:github/mongodb/mongo-c-driver@2.3.3"
     }
   ],
   "metadata": {
-    "timestamp": "2026-06-24T16:42:36.948088+00:00",
+    "timestamp": "2026-07-21T13:30:44.031978+00:00",
     "tools": [
       {
         "externalReferences": [

--- a/etc/make_release.py
+++ b/etc/make_release.py
@@ -100,7 +100,7 @@ ISSUE_TYPE_ID = {
 )
 @click.option(
     '--c-driver-build-ref',
-    default='2.3.1',
+    default='2.3.3',
     show_default=True,
     help='When building the C driver, build at this Git reference',
 )

--- a/etc/purls.txt
+++ b/etc/purls.txt
@@ -6,4 +6,4 @@
 # re-generate the SBOM JSON file!
 
 # bson and mongoc may be obtained via cmake/FetchMongoC.cmake.
-pkg:github/mongodb/mongo-c-driver@2.3.1
+pkg:github/mongodb/mongo-c-driver@2.3.3

--- a/src/mongocxx/test/v1/oidc_callback.cpp
+++ b/src/mongocxx/test/v1/oidc_callback.cpp
@@ -240,7 +240,7 @@ TEST_CASE("OIDC prose tests", "[oidc]") {
 
     SECTION("2.1 Valid Callback Inputs") {
         auto callback_call_count = 0u;
-        bool with_username = GENERATE(/* true, */ false); // TODO CDRIVER-6310: test 'true' once upgraded to 2.3.1.
+        bool with_username = GENERATE(true, false);
         CAPTURE(with_username);
         auto const token = read_token_from_file();
 


### PR DESCRIPTION
Cherry-pick of https://github.com/mongodb/mongo-cxx-driver/pull/1685 onto `releases/v4.4`.

Evergreen patch: https://spruce.corp.mongodb.com/version/6a60d98be34fa5000730fddd