### PR TITLE
Apply post-4.4.1 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Changes prior to 3.9.0 are documented as [release notes on GitHub](https://githu
 
 - Support appending client handshake metadata after initialization and per-client/pool. This is useful for projects wrapping the C++ driver to self-identify.
 
+## 4.4.1
+
+### Changed
+
+- Bump the minimum required C Driver version to [2.3.3](https://github.com/mongodb/mongo-c-driver/releases/tag/2.3.3).
+
 ## 4.4.0
 
 > [!IMPORTANT]

--- a/Doxyfile
+++ b/Doxyfile
@@ -1617,7 +1617,7 @@ TOC_EXPAND             = NO
 # protocol see https://www.sitemaps.org
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-SITEMAP_URL            = https://mongocxx.org/api/mongocxx-4.4.0/
+SITEMAP_URL            = https://mongocxx.org/api/mongocxx-4.4.1/
 
 # If the GENERATE_QHP tag is set to YES and both QHP_NAMESPACE and
 # QHP_VIRTUAL_FOLDER are set, an additional index file will be generated that

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ git clone -b releases/stable https://github.com/mongodb/mongo-cxx-driver.git
 | Version     | Soversion       | Development Stability       | Development Status |
 | :---------: | :-------------: | :-------------------------: | :----------------: |
 | master      | N/A             | _Do not use in production!_ | Active             |
-| 4.4.0       | 1               | Ready for Use               | Bug Fixes Only     |
+| 4.4.1       | 1               | Ready for Use               | Bug Fixes Only     |
+| 4.4.0       | 1               | Ready for Use               | Not Supported      |
 | 4.3.1       | None            | Ready for Use               | Not Supported      |
 | ...         | ...             | ...                         | ...                |
 | 4.0.0       | None            | Ready for Use               | Not Supported      |

--- a/etc/apidocmenu.md
+++ b/etc/apidocmenu.md
@@ -2,6 +2,7 @@
 
 <h1>Driver Documentation By Version</h1>
 
+[4.4.1](../mongocxx-4.4.1) |
 [4.4.0](../mongocxx-4.4.0) |
 [4.3.1](../mongocxx-4.3.1) |
 [4.3.0](../mongocxx-4.3.0) |
@@ -59,7 +60,8 @@
 | Version     | Soversion       | Development Stability       | Development Status |
 | :---------: | :-------------: | :-------------------------: | :----------------: |
 | master      | N/A             | _Do not use in production!_ | Active             |
-| 4.4.0       | 1               | Ready for Use               | Bug Fixes Only     |
+| 4.4.1       | 1               | Ready for Use               | Bug Fixes Only     |
+| 4.4.0       | 1               | Ready for Use               | Not Supported      |
 | 4.3.1       | None            | Ready for Use               | Not Supported      |
 | ...         | ...             | ...                         | ...                |
 | 4.0.0       | None            | Ready for Use               | Not Supported      |

--- a/etc/generate-latest-apidocs.sh
+++ b/etc/generate-latest-apidocs.sh
@@ -10,7 +10,7 @@
 set -o errexit
 set -o pipefail
 
-LATEST_VERSION="4.4.0"
+LATEST_VERSION="4.4.1"
 DOXYGEN_VERSION_REQUIRED="1.15.0"
 
 # Permit using a custom Doxygen binary.

--- a/etc/releasing.md
+++ b/etc/releasing.md
@@ -751,6 +751,8 @@ Sync the entries in the patch release section to be consistent with the entries 
 > [!TIP]
 > Use `git restore --source=rX.Y.Z --worktree CHANGELOG.md` to obtain the `CHANGELOG.md` in `rX.Y.Z` as unstaged changes.
 
+Apply changes from `README.md` and `etc/apidocmenu.md` for the added release.
+
 #### ... for a Non-Patch Release
 
 Checkout the `releases/vX.Y` release branch.


### PR DESCRIPTION
Includes a missing release step for patch releases to apply changes to README.md and apidocmenu.md.