### PR TITLE
Remove `uv sync` instruction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,8 +140,6 @@ uv run --frozen etc/ruff-format-all.sh  # Python scripts.
 uv run --frozen etc/shfmt-format-all.sh # Shell scripts.
 ```
 
-`--frozen` ensures the pinned lockfile is used; if it fails with a lockfile error, update it with `uv sync`.
-
 Also run linting when modifying C++ source files:
 
 ```bash


### PR DESCRIPTION
As suggested during review in https://github.com/mongodb/mongo-c-driver/pull/2356#discussion_r3666424728. Dependency resolution errors should be the user's responsibility.