### PR TITLE
Update CHANGELOG and docs for 4.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changes prior to 3.9.0 are documented as [release notes on GitHub](https://github.com/mongodb/mongo-cxx-driver/releases).
 
-## 4.5.0 [Unreleased]
+## 4.5.0
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ git clone -b releases/stable https://github.com/mongodb/mongo-cxx-driver.git
 | Version     | Soversion       | Development Stability       | Development Status |
 | :---------: | :-------------: | :-------------------------: | :----------------: |
 | master      | N/A             | _Do not use in production!_ | Active             |
-| 4.4.1       | 1               | Ready for Use               | Bug Fixes Only     |
-| 4.4.0       | 1               | Ready for Use               | Not Supported      |
+| 4.5.0       | 1               | Ready for Use               | Bug Fixes Only     |
+| 4.4.1       | 1               | Ready for Use               | Not Supported      |
 | 4.3.1       | None            | Ready for Use               | Not Supported      |
 | ...         | ...             | ...                         | ...                |
 | 4.0.0       | None            | Ready for Use               | Not Supported      |

--- a/etc/apidocmenu.md
+++ b/etc/apidocmenu.md
@@ -2,6 +2,7 @@
 
 <h1>Driver Documentation By Version</h1>
 
+[4.5.0](../mongocxx-4.5.0) |
 [4.4.1](../mongocxx-4.4.1) |
 [4.4.0](../mongocxx-4.4.0) |
 [4.3.1](../mongocxx-4.3.1) |
@@ -60,8 +61,8 @@
 | Version     | Soversion       | Development Stability       | Development Status |
 | :---------: | :-------------: | :-------------------------: | :----------------: |
 | master      | N/A             | _Do not use in production!_ | Active             |
-| 4.4.1       | 1               | Ready for Use               | Bug Fixes Only     |
-| 4.4.0       | 1               | Ready for Use               | Not Supported      |
+| 4.5.0       | 1               | Ready for Use               | Bug Fixes Only     |
+| 4.4.1       | 1               | Ready for Use               | Not Supported      |
 | 4.3.1       | None            | Ready for Use               | Not Supported      |
 | ...         | ...             | ...                         | ...                |
 | 4.0.0       | None            | Ready for Use               | Not Supported      |


### PR DESCRIPTION
Follows pre-release steps to prepare for the C++ driver 4.5.0 release.