### PR TITLE
Apply post-4.5.0 release steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changes prior to 3.9.0 are documented as [release notes on GitHub](https://github.com/mongodb/mongo-cxx-driver/releases).
 
+## 4.6.0 [Unreleased]
+
+<!-- Will contain entries for the next minor release. -->
+
 ## 4.5.0
 
 ### Removed

--- a/Doxyfile
+++ b/Doxyfile
@@ -1617,7 +1617,7 @@ TOC_EXPAND             = NO
 # protocol see https://www.sitemaps.org
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-SITEMAP_URL            = https://mongocxx.org/api/mongocxx-4.4.1/
+SITEMAP_URL            = https://mongocxx.org/api/mongocxx-4.5.0/
 
 # If the GENERATE_QHP tag is set to YES and both QHP_NAMESPACE and
 # QHP_VIRTUAL_FOLDER are set, an additional index file will be generated that

--- a/etc/augmented.sbom.json
+++ b/etc/augmented.sbom.json
@@ -33,7 +33,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2026-07-21T13:30:44.031978+00:00",
+    "timestamp": "2026-08-04T13:04:18.467291+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -76,7 +76,7 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:3174e064-5937-42fd-97b9-fae452d8f92b",
+  "serialNumber": "urn:uuid:ee4e6214-b3de-474b-990e-35c262cdc6f2",
   "version": 1,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -33,7 +33,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2026-07-21T13:30:44.031978+00:00",
+    "timestamp": "2026-08-04T13:04:18.467291+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -76,7 +76,7 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:3174e064-5937-42fd-97b9-fae452d8f92b",
+  "serialNumber": "urn:uuid:ee4e6214-b3de-474b-990e-35c262cdc6f2",
   "version": 1,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",

--- a/etc/generate-latest-apidocs.sh
+++ b/etc/generate-latest-apidocs.sh
@@ -10,7 +10,7 @@
 set -o errexit
 set -o pipefail
 
-LATEST_VERSION="4.4.1"
+LATEST_VERSION="4.5.0"
 DOXYGEN_VERSION_REQUIRED="1.15.0"
 
 # Permit using a custom Doxygen binary.


### PR DESCRIPTION
Apply post 4.5.0 release changes following release steps referencing the `post-release-changes` branch (I named mine `post-4.5.0`).