### PR TITLE
CXX-3544 Fix Clang 22 compat by including missing `<cstdlib>` header

### DIFF
--- a/.evergreen/scripts/abi-stability-setup.sh
+++ b/.evergreen/scripts/abi-stability-setup.sh
@@ -41,7 +41,7 @@ working_dir="$(pwd)"
 
 # TODO: remove "UV_CONSTRAINT" of CMake after the base release is r4.4.1+ to include fix of CXX-3529.
 constraint_file="$(mktemp)"
-echo "cmake<4.4" > "${constraint_file:?}"
+echo "cmake<4.4" >"${constraint_file:?}"
 export UV_CONSTRAINT="${constraint_file:?}"
 
 . mongo-cxx-driver/.evergreen/scripts/install-build-tools.sh

--- a/src/mongocxx/include/mongocxx/v1/detail/macros.hpp
+++ b/src/mongocxx/include/mongocxx/v1/detail/macros.hpp
@@ -16,6 +16,7 @@
 #if !defined(MONGOCXX_V1_DETAIL_MACROS_HPP)
 #define MONGOCXX_V1_DETAIL_MACROS_HPP
 
+// IWYU pragma: private, include <cstdlib>
 #define MONGOCXX_PRIVATE_UNREACHABLE std::abort()
 
 #endif // !defined(MONGOCXX_V1_DETAIL_MACROS_HPP)

--- a/src/mongocxx/lib/mongocxx/private/scoped_bson.hh
+++ b/src/mongocxx/lib/mongocxx/private/scoped_bson.hh
@@ -17,10 +17,13 @@
 #include <bsoncxx/v1/array/value.hpp>
 #include <bsoncxx/v1/document/value.hpp>
 #include <bsoncxx/v1/document/view.hpp>
+#include <bsoncxx/v1/stdx/string_view.hpp>
 
 #include <mongocxx/v1/detail/macros.hpp>
 
+#include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <utility>
 
 #include <bsoncxx/private/bson.hh>


### PR DESCRIPTION
Resolves [CXX-3544](https://jira.mongodb.org/browse/CXX-3544) (+ drive-by formatting fix).

mongocxx/v1/detail/macros.hpp deliberatey avoids including `<cstdlib>` to avoid unconditional transitive-inclusion when `MONGOCXX_PRIVATE_UNREACHABLE` is not actually unused (similar to forward-declared incomplete types being used in a function declaration: the user is only required to include the corresponding declaration header when they actually use the function).

[IWYU supports](https://github.com/include-what-you-use/include-what-you-use/blob/57b6a8ed582bafd66603b01f6c96f4f1df0abce8/docs/IWYUPragmas.md#iwyu-pragma-private) the `private, include <header>` syntax to direct the tool to suggest inclusion of another header (instead of _this_ header). Unable to actually reproduce the intended diagnostic locally with clangd 22.1.8, but nevertheless added the comment for documentation purposes. Other existing IWYU diagnostics for `scoped_bson.hh` are also addressed by this PR (except the one for `ssize_t`, which is provided by `bson/compat.h` via `bson/bson.h`; unsure how to fix this one).