### PR TITLE
Close file/pipe descriptors in capture_stderr dtor

### DIFF
--- a/src/mongocxx/test/v1/capture_stderr.cpp
+++ b/src/mongocxx/test/v1/capture_stderr.cpp
@@ -34,7 +34,9 @@ namespace test {
 #if !defined(_WIN32)
 
 capture_stderr::~capture_stderr() {
-    ::dup2(_stderr, STDERR_FILENO); // Restore original stderr.
+    ::dup2(_stderr, STDERR_FILENO);  // Restore original stderr.
+    CHECK(::close(_stderr) != -1);   // Close saved original stderr.
+    CHECK(::close(_pipes[0]) != -1); // Close output pipe.
 }
 
 capture_stderr::capture_stderr()


### PR DESCRIPTION
Minor followup to review of https://github.com/mongodb/mongo-cxx-driver/pull/1682, upon discovering the existing relocated `capture_stderr` helper was potentially leaking file descriptors stored as `_stderr` and `_pipes[0]` (`_pipes[1]` is closed in the ctor). Duped file descriptors must be independently closed even when they refer to the same file description. Both the read _and_ write ends (file descriptors) must be closed to cleanup the entire pipe.