### PR TITLE
CXX-3544 Fix Clang 22 compat by including missing `<cstdlib>` header (#1691)

### DIFF
--- a/.evergreen/scripts/abi-stability-setup.sh
+++ b/.evergreen/scripts/abi-stability-setup.sh
@@ -41,7 +41,7 @@ working_dir="$(pwd)"
 
 # TODO: remove "UV_CONSTRAINT" of CMake after the base release is r4.4.1+ to include fix of CXX-3529.
 constraint_file="$(mktemp)"
-echo "cmake<4.4" > "${constraint_file:?}"
+echo "cmake<4.4" >"${constraint_file:?}"
 export UV_CONSTRAINT="${constraint_file:?}"
 
 . mongo-cxx-driver/.evergreen/scripts/install-build-tools.sh

--- a/src/mongocxx/include/mongocxx/v1/detail/macros.hpp
+++ b/src/mongocxx/include/mongocxx/v1/detail/macros.hpp
@@ -16,6 +16,7 @@
 #if !defined(MONGOCXX_V1_DETAIL_MACROS_HPP)
 #define MONGOCXX_V1_DETAIL_MACROS_HPP
 
+// IWYU pragma: private, include <cstdlib>
 #define MONGOCXX_PRIVATE_UNREACHABLE std::abort()
 
 #endif // !defined(MONGOCXX_V1_DETAIL_MACROS_HPP)

--- a/src/mongocxx/lib/mongocxx/private/scoped_bson.hh
+++ b/src/mongocxx/lib/mongocxx/private/scoped_bson.hh
@@ -17,10 +17,13 @@
 #include <bsoncxx/v1/array/value.hpp>
 #include <bsoncxx/v1/document/value.hpp>
 #include <bsoncxx/v1/document/view.hpp>
+#include <bsoncxx/v1/stdx/string_view.hpp>
 
 #include <mongocxx/v1/detail/macros.hpp>
 
+#include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <utility>
 
 #include <bsoncxx/private/bson.hh>


### PR DESCRIPTION
Cherry-picks https://github.com/mongodb/mongo-cxx-driver/pull/1691 onto the releases/v4.5 branch.