### PR TITLE
CXX-3557 test server 9.0

### DIFF
--- a/.evergreen/config_generator/components/integration.py
+++ b/.evergreen/config_generator/components/integration.py
@@ -21,11 +21,11 @@ TAG = 'integration'
 LINUX_MATRIX = [
     # Linux x86_64 (full).
     # RHEL 8 x86_64: 4.0+.
-    ('rhel80', None, ['Debug'], ['shared', 'static'], [11, 17], [None], ['plain', 'csfle'], ['4.2', '4.4', '5.0', '6.0', '7.0', '8.0', 'rapid', 'latest'], ['single', 'replica', 'sharded']),
+    ('rhel80', None, ['Debug'], ['shared', 'static'], [11, 17], [None], ['plain', 'csfle'], ['4.2', '4.4', '5.0', '6.0', '7.0', '8.0', '9.0', 'rapid', 'latest'], ['single', 'replica', 'sharded']),
 
     # Linux ARM64 (full).
     # RHEL 8 ARM64: 4.4+.
-    ('rhel8-arm64-latest', None, ['Debug'], ['shared', 'static'], [11, 17], [None], ['plain', 'csfle'], ['4.4', '5.0', '6.0', '7.0', '8.0', 'rapid', 'latest'], ['single', 'replica', 'sharded']),
+    ('rhel8-arm64-latest', None, ['Debug'], ['shared', 'static'], [11, 17], [None], ['plain', 'csfle'], ['4.4', '5.0', '6.0', '7.0', '8.0', '9.0', 'rapid', 'latest'], ['single', 'replica', 'sharded']),
 
     # Linux Power (Resource-limited: use sparingly).
     # RHEL 8 Power: 4.2+.
@@ -39,21 +39,21 @@ LINUX_MATRIX = [
 MACOS_MATRIX = [
     # MacOS ARM64 (shared only, no extra alignment, min-max-latest).
     # MacOS ARM64: 6.0+.
-    ('macos-14-arm64', None, ['Debug'], ['shared'], [11, 17], [None], ['plain', 'csfle'], ['6.0', '8.0', 'latest'], ['single', 'replica', 'sharded']),
+    ('macos-14-arm64', None, ['Debug'], ['shared'], [11, 17], [None], ['plain', 'csfle'], ['6.0', '8.0', '9.0', 'latest'], ['single', 'replica', 'sharded']),
 
     # MacOS x86_64 (shared only, C++11 only, no extra alignment, min-max-latest) (Resource-limited: use sparingly).
     # MacOS x86_64: 4.2+.
-    ('macos-14', None, ['Debug'], ['shared'], [11], [None], ['plain', 'csfle'], ['4.2', '8.0', 'latest'], ['single', 'replica', 'sharded']),
+    ('macos-14', None, ['Debug'], ['shared'], [11], [None], ['plain', 'csfle'], ['4.2', '8.0', '9.0', 'latest'], ['single', 'replica', 'sharded']),
 
 ]
 
 WINDOWS_MATRIX = [
     # Windows x86_64 (min-max-latest).
     # Windows x86_64: 4.2+.
-    ('windows-vsCurrent',   'vs2022x64', ['Debug'], ['shared'], [11, 17], [None], ['plain', 'csfle'], ['4.2',                ], ['single', 'replica', 'sharded']),
-    ('windows-2022-latest', 'vs2022x64', ['Debug'], ['shared'], [11, 17], [None], ['plain', 'csfle'], [       '8.0', 'latest'], ['single', 'replica', 'sharded']),
+    ('windows-vsCurrent',   'vs2022x64', ['Debug'], ['shared'], [11, 17], [None], ['plain', 'csfle'], ['4.2',                       ], ['single', 'replica', 'sharded']),
+    ('windows-2022-latest', 'vs2022x64', ['Debug'], ['shared'], [11, 17], [None], ['plain', 'csfle'], [       '9.0', 'latest'], ['single', 'replica', 'sharded']),
 
-    ('windows-2022-latest', 'gcc',       ['Debug'], ['shared'], [11, 17], [None], ['plain'         ], ['4.2', '8.0', 'latest'], ['single', 'replica', 'sharded']),
+    ('windows-2022-latest', 'gcc',       ['Debug'], ['shared'], [11, 17], [None], ['plain'         ], ['4.2', '9.0', 'latest'], ['single', 'replica', 'sharded']),
 ]
 
 MONGOCRYPTD_MATRIX = [

--- a/.evergreen/config_generator/components/sanitizers.py
+++ b/.evergreen/config_generator/components/sanitizers.py
@@ -19,7 +19,7 @@ TAG = 'sanitizers'
 # pylint: disable=line-too-long
 # fmt: off
 MATRIX = [
-    ('rhel80', ['asan', 'ubsan'], ['static'], ['4.2', '8.0', 'latest'], ['single', 'replica', 'sharded']),
+    ('rhel80', ['asan', 'ubsan'], ['static'], ['4.2', '9.0', 'latest'], ['single', 'replica', 'sharded']),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/valgrind.py
+++ b/.evergreen/config_generator/components/valgrind.py
@@ -20,7 +20,7 @@ TAG = 'valgrind'
 # fmt: off
 MATRIX = [
     # min-max-latest
-    ('rhel80', None, ['shared'], ['4.2', '8.0', 'latest'], ['single', 'replica', 'sharded']),
+    ('rhel80', None, ['shared'], ['4.2', '9.0', 'latest'], ['single', 'replica', 'sharded']),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -2301,6 +2301,83 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
           REQUIRED_CXX_STANDARD: 11
+  - name: integration-macos-14-arm64-debug-shared-cxx11-9.0-replica
+    run_on: macos-14-arm64
+    tags: [integration, macos-14-arm64, macos, debug, shared, cxx11, "9.0", replica]
+    exec_timeout_secs: 7200
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 11
+  - name: integration-macos-14-arm64-debug-shared-cxx11-9.0-sharded
+    run_on: macos-14-arm64
+    tags: [integration, macos-14-arm64, macos, debug, shared, cxx11, "9.0", sharded]
+    exec_timeout_secs: 7200
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 11
+  - name: integration-macos-14-arm64-debug-shared-cxx11-9.0-single
+    run_on: macos-14-arm64
+    tags: [integration, macos-14-arm64, macos, debug, shared, cxx11, "9.0", single]
+    exec_timeout_secs: 7200
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 11
   - name: integration-macos-14-arm64-debug-shared-cxx11-csfle-6.0-replica
     run_on: macos-14-arm64
     tags: [integration, macos-14-arm64, macos, debug, shared, cxx11, csfle, "6.0", replica]
@@ -2448,6 +2525,86 @@ tasks:
       - func: start_mongod
         vars:
           mongodb_version: "8.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 11
+          TEST_WITH_CSFLE: "ON"
+  - name: integration-macos-14-arm64-debug-shared-cxx11-csfle-9.0-replica
+    run_on: macos-14-arm64
+    tags: [integration, macos-14-arm64, macos, debug, shared, cxx11, csfle, "9.0", replica]
+    exec_timeout_secs: 7200
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 11
+          TEST_WITH_CSFLE: "ON"
+  - name: integration-macos-14-arm64-debug-shared-cxx11-csfle-9.0-sharded
+    run_on: macos-14-arm64
+    tags: [integration, macos-14-arm64, macos, debug, shared, cxx11, csfle, "9.0", sharded]
+    exec_timeout_secs: 7200
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 11
+          TEST_WITH_CSFLE: "ON"
+  - name: integration-macos-14-arm64-debug-shared-cxx11-csfle-9.0-single
+    run_on: macos-14-arm64
+    tags: [integration, macos-14-arm64, macos, debug, shared, cxx11, csfle, "9.0", single]
+    exec_timeout_secs: 7200
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -2800,6 +2957,83 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
           REQUIRED_CXX_STANDARD: 17
+  - name: integration-macos-14-arm64-debug-shared-cxx17-9.0-replica
+    run_on: macos-14-arm64
+    tags: [integration, macos-14-arm64, macos, debug, shared, cxx17, "9.0", replica]
+    exec_timeout_secs: 7200
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 17
+  - name: integration-macos-14-arm64-debug-shared-cxx17-9.0-sharded
+    run_on: macos-14-arm64
+    tags: [integration, macos-14-arm64, macos, debug, shared, cxx17, "9.0", sharded]
+    exec_timeout_secs: 7200
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 17
+  - name: integration-macos-14-arm64-debug-shared-cxx17-9.0-single
+    run_on: macos-14-arm64
+    tags: [integration, macos-14-arm64, macos, debug, shared, cxx17, "9.0", single]
+    exec_timeout_secs: 7200
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 17
   - name: integration-macos-14-arm64-debug-shared-cxx17-csfle-6.0-replica
     run_on: macos-14-arm64
     tags: [integration, macos-14-arm64, macos, debug, shared, cxx17, csfle, "6.0", replica]
@@ -2947,6 +3181,86 @@ tasks:
       - func: start_mongod
         vars:
           mongodb_version: "8.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 17
+          TEST_WITH_CSFLE: "ON"
+  - name: integration-macos-14-arm64-debug-shared-cxx17-csfle-9.0-replica
+    run_on: macos-14-arm64
+    tags: [integration, macos-14-arm64, macos, debug, shared, cxx17, csfle, "9.0", replica]
+    exec_timeout_secs: 7200
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 17
+          TEST_WITH_CSFLE: "ON"
+  - name: integration-macos-14-arm64-debug-shared-cxx17-csfle-9.0-sharded
+    run_on: macos-14-arm64
+    tags: [integration, macos-14-arm64, macos, debug, shared, cxx17, csfle, "9.0", sharded]
+    exec_timeout_secs: 7200
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 17
+          TEST_WITH_CSFLE: "ON"
+  - name: integration-macos-14-arm64-debug-shared-cxx17-csfle-9.0-single
+    run_on: macos-14-arm64
+    tags: [integration, macos-14-arm64, macos, debug, shared, cxx17, csfle, "9.0", single]
+    exec_timeout_secs: 7200
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -3271,6 +3585,83 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
           REQUIRED_CXX_STANDARD: 11
+  - name: integration-macos-14-debug-shared-cxx11-9.0-replica
+    run_on: macos-14
+    tags: [integration, macos-14, macos, debug, shared, cxx11, "9.0", replica]
+    exec_timeout_secs: 7200
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 11
+  - name: integration-macos-14-debug-shared-cxx11-9.0-sharded
+    run_on: macos-14
+    tags: [integration, macos-14, macos, debug, shared, cxx11, "9.0", sharded]
+    exec_timeout_secs: 7200
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 11
+  - name: integration-macos-14-debug-shared-cxx11-9.0-single
+    run_on: macos-14
+    tags: [integration, macos-14, macos, debug, shared, cxx11, "9.0", single]
+    exec_timeout_secs: 7200
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 11
   - name: integration-macos-14-debug-shared-cxx11-csfle-4.2-replica
     run_on: macos-14
     tags: [integration, macos-14, macos, debug, shared, cxx11, csfle, "4.2", replica]
@@ -3418,6 +3809,86 @@ tasks:
       - func: start_mongod
         vars:
           mongodb_version: "8.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 11
+          TEST_WITH_CSFLE: "ON"
+  - name: integration-macos-14-debug-shared-cxx11-csfle-9.0-replica
+    run_on: macos-14
+    tags: [integration, macos-14, macos, debug, shared, cxx11, csfle, "9.0", replica]
+    exec_timeout_secs: 7200
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 11
+          TEST_WITH_CSFLE: "ON"
+  - name: integration-macos-14-debug-shared-cxx11-csfle-9.0-sharded
+    run_on: macos-14
+    tags: [integration, macos-14, macos, debug, shared, cxx11, csfle, "9.0", sharded]
+    exec_timeout_secs: 7200
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 11
+          TEST_WITH_CSFLE: "ON"
+  - name: integration-macos-14-debug-shared-cxx11-csfle-9.0-single
+    run_on: macos-14
+    tags: [integration, macos-14, macos, debug, shared, cxx11, csfle, "9.0", single]
+    exec_timeout_secs: 7200
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -3986,6 +4457,80 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
           REQUIRED_CXX_STANDARD: 11
+  - name: integration-rhel8-arm64-latest-debug-shared-cxx11-9.0-replica
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, shared, cxx11, "9.0", replica]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 11
+  - name: integration-rhel8-arm64-latest-debug-shared-cxx11-9.0-sharded
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, shared, cxx11, "9.0", sharded]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 11
+  - name: integration-rhel8-arm64-latest-debug-shared-cxx11-9.0-single
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, shared, cxx11, "9.0", single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 11
   - name: integration-rhel8-arm64-latest-debug-shared-cxx11-csfle-4.4-replica
     run_on: rhel8-arm64-latest-large
     tags: [integration, rhel8-arm64-latest, linux, debug, shared, cxx11, csfle, "4.4", replica]
@@ -4358,6 +4903,83 @@ tasks:
       - func: start_mongod
         vars:
           mongodb_version: "8.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 11
+          TEST_WITH_CSFLE: "ON"
+  - name: integration-rhel8-arm64-latest-debug-shared-cxx11-csfle-9.0-replica
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, shared, cxx11, csfle, "9.0", replica]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 11
+          TEST_WITH_CSFLE: "ON"
+  - name: integration-rhel8-arm64-latest-debug-shared-cxx11-csfle-9.0-sharded
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, shared, cxx11, csfle, "9.0", sharded]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 11
+          TEST_WITH_CSFLE: "ON"
+  - name: integration-rhel8-arm64-latest-debug-shared-cxx11-csfle-9.0-single
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, shared, cxx11, csfle, "9.0", single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -5070,6 +5692,80 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
           REQUIRED_CXX_STANDARD: 17
+  - name: integration-rhel8-arm64-latest-debug-shared-cxx17-9.0-replica
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, shared, cxx17, "9.0", replica]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 17
+  - name: integration-rhel8-arm64-latest-debug-shared-cxx17-9.0-sharded
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, shared, cxx17, "9.0", sharded]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 17
+  - name: integration-rhel8-arm64-latest-debug-shared-cxx17-9.0-single
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, shared, cxx17, "9.0", single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 17
   - name: integration-rhel8-arm64-latest-debug-shared-cxx17-csfle-4.4-replica
     run_on: rhel8-arm64-latest-large
     tags: [integration, rhel8-arm64-latest, linux, debug, shared, cxx17, csfle, "4.4", replica]
@@ -5442,6 +6138,83 @@ tasks:
       - func: start_mongod
         vars:
           mongodb_version: "8.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 17
+          TEST_WITH_CSFLE: "ON"
+  - name: integration-rhel8-arm64-latest-debug-shared-cxx17-csfle-9.0-replica
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, shared, cxx17, csfle, "9.0", replica]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 17
+          TEST_WITH_CSFLE: "ON"
+  - name: integration-rhel8-arm64-latest-debug-shared-cxx17-csfle-9.0-sharded
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, shared, cxx17, csfle, "9.0", sharded]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 17
+          TEST_WITH_CSFLE: "ON"
+  - name: integration-rhel8-arm64-latest-debug-shared-cxx17-csfle-9.0-single
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, shared, cxx17, csfle, "9.0", single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -6157,6 +6930,86 @@ tasks:
           MONGOCXX_TEST_TOPOLOGY: single
           REQUIRED_CXX_STANDARD: 11
           USE_STATIC_LIBS: 1
+  - name: integration-rhel8-arm64-latest-debug-static-cxx11-9.0-replica
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, static, cxx11, "9.0", replica]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
+  - name: integration-rhel8-arm64-latest-debug-static-cxx11-9.0-sharded
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, static, cxx11, "9.0", sharded]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
+  - name: integration-rhel8-arm64-latest-debug-static-cxx11-9.0-single
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, static, cxx11, "9.0", single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
   - name: integration-rhel8-arm64-latest-debug-static-cxx11-csfle-4.4-replica
     run_on: rhel8-arm64-latest-large
     tags: [integration, rhel8-arm64-latest, linux, debug, static, cxx11, csfle, "4.4", replica]
@@ -6557,6 +7410,89 @@ tasks:
       - func: start_mongod
         vars:
           mongodb_version: "8.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 11
+          TEST_WITH_CSFLE: "ON"
+          USE_STATIC_LIBS: 1
+  - name: integration-rhel8-arm64-latest-debug-static-cxx11-csfle-9.0-replica
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, static, cxx11, csfle, "9.0", replica]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 11
+          TEST_WITH_CSFLE: "ON"
+          USE_STATIC_LIBS: 1
+  - name: integration-rhel8-arm64-latest-debug-static-cxx11-csfle-9.0-sharded
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, static, cxx11, csfle, "9.0", sharded]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 11
+          TEST_WITH_CSFLE: "ON"
+          USE_STATIC_LIBS: 1
+  - name: integration-rhel8-arm64-latest-debug-static-cxx11-csfle-9.0-single
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, static, cxx11, csfle, "9.0", single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -7298,6 +8234,86 @@ tasks:
           MONGOCXX_TEST_TOPOLOGY: single
           REQUIRED_CXX_STANDARD: 17
           USE_STATIC_LIBS: 1
+  - name: integration-rhel8-arm64-latest-debug-static-cxx17-9.0-replica
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, static, cxx17, "9.0", replica]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
+  - name: integration-rhel8-arm64-latest-debug-static-cxx17-9.0-sharded
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, static, cxx17, "9.0", sharded]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
+  - name: integration-rhel8-arm64-latest-debug-static-cxx17-9.0-single
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, static, cxx17, "9.0", single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
   - name: integration-rhel8-arm64-latest-debug-static-cxx17-csfle-4.4-replica
     run_on: rhel8-arm64-latest-large
     tags: [integration, rhel8-arm64-latest, linux, debug, static, cxx17, csfle, "4.4", replica]
@@ -7698,6 +8714,89 @@ tasks:
       - func: start_mongod
         vars:
           mongodb_version: "8.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 17
+          TEST_WITH_CSFLE: "ON"
+          USE_STATIC_LIBS: 1
+  - name: integration-rhel8-arm64-latest-debug-static-cxx17-csfle-9.0-replica
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, static, cxx17, csfle, "9.0", replica]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 17
+          TEST_WITH_CSFLE: "ON"
+          USE_STATIC_LIBS: 1
+  - name: integration-rhel8-arm64-latest-debug-static-cxx17-csfle-9.0-sharded
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, static, cxx17, csfle, "9.0", sharded]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 17
+          TEST_WITH_CSFLE: "ON"
+          USE_STATIC_LIBS: 1
+  - name: integration-rhel8-arm64-latest-debug-static-cxx17-csfle-9.0-single
+    run_on: rhel8-arm64-latest-large
+    tags: [integration, rhel8-arm64-latest, linux, debug, static, cxx17, csfle, "9.0", single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -8593,6 +9692,80 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
           REQUIRED_CXX_STANDARD: 11
+  - name: integration-rhel80-debug-shared-cxx11-9.0-replica
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, shared, cxx11, "9.0", replica]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 11
+  - name: integration-rhel80-debug-shared-cxx11-9.0-sharded
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, shared, cxx11, "9.0", sharded]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 11
+  - name: integration-rhel80-debug-shared-cxx11-9.0-single
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, shared, cxx11, "9.0", single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 11
   - name: integration-rhel80-debug-shared-cxx11-csfle-4.2-replica
     run_on: rhel80-large
     tags: [integration, rhel80, linux, debug, shared, cxx11, csfle, "4.2", replica]
@@ -9042,6 +10215,83 @@ tasks:
       - func: start_mongod
         vars:
           mongodb_version: "8.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 11
+          TEST_WITH_CSFLE: "ON"
+  - name: integration-rhel80-debug-shared-cxx11-csfle-9.0-replica
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, shared, cxx11, csfle, "9.0", replica]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 11
+          TEST_WITH_CSFLE: "ON"
+  - name: integration-rhel80-debug-shared-cxx11-csfle-9.0-sharded
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, shared, cxx11, csfle, "9.0", sharded]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 11
+          TEST_WITH_CSFLE: "ON"
+  - name: integration-rhel80-debug-shared-cxx11-csfle-9.0-single
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, shared, cxx11, csfle, "9.0", single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -9828,6 +11078,80 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
           REQUIRED_CXX_STANDARD: 17
+  - name: integration-rhel80-debug-shared-cxx17-9.0-replica
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, shared, cxx17, "9.0", replica]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 17
+  - name: integration-rhel80-debug-shared-cxx17-9.0-sharded
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, shared, cxx17, "9.0", sharded]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 17
+  - name: integration-rhel80-debug-shared-cxx17-9.0-single
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, shared, cxx17, "9.0", single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 17
   - name: integration-rhel80-debug-shared-cxx17-csfle-4.2-replica
     run_on: rhel80-large
     tags: [integration, rhel80, linux, debug, shared, cxx17, csfle, "4.2", replica]
@@ -10277,6 +11601,83 @@ tasks:
       - func: start_mongod
         vars:
           mongodb_version: "8.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 17
+          TEST_WITH_CSFLE: "ON"
+  - name: integration-rhel80-debug-shared-cxx17-csfle-9.0-replica
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, shared, cxx17, csfle, "9.0", replica]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 17
+          TEST_WITH_CSFLE: "ON"
+  - name: integration-rhel80-debug-shared-cxx17-csfle-9.0-sharded
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, shared, cxx17, csfle, "9.0", sharded]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 17
+          TEST_WITH_CSFLE: "ON"
+  - name: integration-rhel80-debug-shared-cxx17-csfle-9.0-single
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, shared, cxx17, csfle, "9.0", single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -11072,6 +12473,86 @@ tasks:
           MONGOCXX_TEST_TOPOLOGY: single
           REQUIRED_CXX_STANDARD: 11
           USE_STATIC_LIBS: 1
+  - name: integration-rhel80-debug-static-cxx11-9.0-replica
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, static, cxx11, "9.0", replica]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
+  - name: integration-rhel80-debug-static-cxx11-9.0-sharded
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, static, cxx11, "9.0", sharded]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
+  - name: integration-rhel80-debug-static-cxx11-9.0-single
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, static, cxx11, "9.0", single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 11
+          USE_STATIC_LIBS: 1
   - name: integration-rhel80-debug-static-cxx11-csfle-4.2-replica
     run_on: rhel80-large
     tags: [integration, rhel80, linux, debug, static, cxx11, csfle, "4.2", replica]
@@ -11555,6 +13036,89 @@ tasks:
       - func: start_mongod
         vars:
           mongodb_version: "8.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 11
+          TEST_WITH_CSFLE: "ON"
+          USE_STATIC_LIBS: 1
+  - name: integration-rhel80-debug-static-cxx11-csfle-9.0-replica
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, static, cxx11, csfle, "9.0", replica]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 11
+          TEST_WITH_CSFLE: "ON"
+          USE_STATIC_LIBS: 1
+  - name: integration-rhel80-debug-static-cxx11-csfle-9.0-sharded
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, static, cxx11, csfle, "9.0", sharded]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 11
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 11
+          TEST_WITH_CSFLE: "ON"
+          USE_STATIC_LIBS: 1
+  - name: integration-rhel80-debug-static-cxx11-csfle-9.0-single
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, static, cxx11, csfle, "9.0", single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -12376,6 +13940,86 @@ tasks:
           MONGOCXX_TEST_TOPOLOGY: single
           REQUIRED_CXX_STANDARD: 17
           USE_STATIC_LIBS: 1
+  - name: integration-rhel80-debug-static-cxx17-9.0-replica
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, static, cxx17, "9.0", replica]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
+  - name: integration-rhel80-debug-static-cxx17-9.0-sharded
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, static, cxx17, "9.0", sharded]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
+  - name: integration-rhel80-debug-static-cxx17-9.0-single
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, static, cxx17, "9.0", single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 17
+          USE_STATIC_LIBS: 1
   - name: integration-rhel80-debug-static-cxx17-csfle-4.2-replica
     run_on: rhel80-large
     tags: [integration, rhel80, linux, debug, static, cxx17, csfle, "4.2", replica]
@@ -12859,6 +14503,89 @@ tasks:
       - func: start_mongod
         vars:
           mongodb_version: "8.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: single
+          REQUIRED_CXX_STANDARD: 17
+          TEST_WITH_CSFLE: "ON"
+          USE_STATIC_LIBS: 1
+  - name: integration-rhel80-debug-static-cxx17-csfle-9.0-replica
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, static, cxx17, csfle, "9.0", replica]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: replica_set
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: replica
+          REQUIRED_CXX_STANDARD: 17
+          TEST_WITH_CSFLE: "ON"
+          USE_STATIC_LIBS: 1
+  - name: integration-rhel80-debug-static-cxx17-csfle-9.0-sharded
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, static, cxx17, csfle, "9.0", sharded]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          TOPOLOGY: sharded_cluster
+          mongodb_version: "9.0"
+      - func: install_c_driver
+      - func: compile
+        vars:
+          ENABLE_TESTS: "ON"
+          REQUIRED_CXX_STANDARD: 17
+          RUN_DISTCHECK: 1
+          USE_STATIC_LIBS: 1
+      - func: fetch-det
+      - func: run_kms_servers
+      - func: test
+        vars:
+          MONGOCXX_TEST_TOPOLOGY: sharded
+          REQUIRED_CXX_STANDARD: 17
+          TEST_WITH_CSFLE: "ON"
+          USE_STATIC_LIBS: 1
+  - name: integration-rhel80-debug-static-cxx17-csfle-9.0-single
+    run_on: rhel80-large
+    tags: [integration, rhel80, linux, debug, static, cxx17, csfle, "9.0", single]
+    commands:
+      - command: expansions.update
+        params:
+          updates:
+            - { key: build_type, value: Debug }
+      - func: setup
+      - func: start_mongod
+        vars:
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -13606,9 +15333,9 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
           REQUIRED_CXX_STANDARD: 11
-  - name: integration-windows-2022-latest-gcc-debug-shared-cxx11-8.0-replica
+  - name: integration-windows-2022-latest-gcc-debug-shared-cxx11-9.0-replica
     run_on: windows-2022-latest-large
-    tags: [integration, windows-2022-latest, windows, debug, shared, cxx11, "8.0", replica]
+    tags: [integration, windows-2022-latest, windows, debug, shared, cxx11, "9.0", replica]
     commands:
       - command: expansions.update
         params:
@@ -13620,7 +15347,7 @@ tasks:
       - func: start_mongod
         vars:
           TOPOLOGY: replica_set
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -13633,9 +15360,9 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: replica
           REQUIRED_CXX_STANDARD: 11
-  - name: integration-windows-2022-latest-gcc-debug-shared-cxx11-8.0-sharded
+  - name: integration-windows-2022-latest-gcc-debug-shared-cxx11-9.0-sharded
     run_on: windows-2022-latest-large
-    tags: [integration, windows-2022-latest, windows, debug, shared, cxx11, "8.0", sharded]
+    tags: [integration, windows-2022-latest, windows, debug, shared, cxx11, "9.0", sharded]
     commands:
       - command: expansions.update
         params:
@@ -13647,7 +15374,7 @@ tasks:
       - func: start_mongod
         vars:
           TOPOLOGY: sharded_cluster
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -13660,9 +15387,9 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: sharded
           REQUIRED_CXX_STANDARD: 11
-  - name: integration-windows-2022-latest-gcc-debug-shared-cxx11-8.0-single
+  - name: integration-windows-2022-latest-gcc-debug-shared-cxx11-9.0-single
     run_on: windows-2022-latest-large
-    tags: [integration, windows-2022-latest, windows, debug, shared, cxx11, "8.0", single]
+    tags: [integration, windows-2022-latest, windows, debug, shared, cxx11, "9.0", single]
     commands:
       - command: expansions.update
         params:
@@ -13673,7 +15400,7 @@ tasks:
       - func: setup
       - func: start_mongod
         vars:
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -13846,9 +15573,9 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
           REQUIRED_CXX_STANDARD: 17
-  - name: integration-windows-2022-latest-gcc-debug-shared-cxx17-8.0-replica
+  - name: integration-windows-2022-latest-gcc-debug-shared-cxx17-9.0-replica
     run_on: windows-2022-latest-large
-    tags: [integration, windows-2022-latest, windows, debug, shared, cxx17, "8.0", replica]
+    tags: [integration, windows-2022-latest, windows, debug, shared, cxx17, "9.0", replica]
     commands:
       - command: expansions.update
         params:
@@ -13860,7 +15587,7 @@ tasks:
       - func: start_mongod
         vars:
           TOPOLOGY: replica_set
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -13873,9 +15600,9 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: replica
           REQUIRED_CXX_STANDARD: 17
-  - name: integration-windows-2022-latest-gcc-debug-shared-cxx17-8.0-sharded
+  - name: integration-windows-2022-latest-gcc-debug-shared-cxx17-9.0-sharded
     run_on: windows-2022-latest-large
-    tags: [integration, windows-2022-latest, windows, debug, shared, cxx17, "8.0", sharded]
+    tags: [integration, windows-2022-latest, windows, debug, shared, cxx17, "9.0", sharded]
     commands:
       - command: expansions.update
         params:
@@ -13887,7 +15614,7 @@ tasks:
       - func: start_mongod
         vars:
           TOPOLOGY: sharded_cluster
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -13900,9 +15627,9 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: sharded
           REQUIRED_CXX_STANDARD: 17
-  - name: integration-windows-2022-latest-gcc-debug-shared-cxx17-8.0-single
+  - name: integration-windows-2022-latest-gcc-debug-shared-cxx17-9.0-single
     run_on: windows-2022-latest-large
-    tags: [integration, windows-2022-latest, windows, debug, shared, cxx17, "8.0", single]
+    tags: [integration, windows-2022-latest, windows, debug, shared, cxx17, "9.0", single]
     commands:
       - command: expansions.update
         params:
@@ -13913,7 +15640,7 @@ tasks:
       - func: setup
       - func: start_mongod
         vars:
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -14006,9 +15733,9 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
           REQUIRED_CXX_STANDARD: 17
-  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx11-8.0-replica
+  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx11-9.0-replica
     run_on: windows-2022-latest-large
-    tags: [integration, windows-2022-latest, windows, debug, shared, cxx11, "8.0", replica]
+    tags: [integration, windows-2022-latest, windows, debug, shared, cxx11, "9.0", replica]
     commands:
       - command: expansions.update
         params:
@@ -14020,7 +15747,7 @@ tasks:
       - func: start_mongod
         vars:
           TOPOLOGY: replica_set
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -14033,9 +15760,9 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: replica
           REQUIRED_CXX_STANDARD: 11
-  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx11-8.0-sharded
+  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx11-9.0-sharded
     run_on: windows-2022-latest-large
-    tags: [integration, windows-2022-latest, windows, debug, shared, cxx11, "8.0", sharded]
+    tags: [integration, windows-2022-latest, windows, debug, shared, cxx11, "9.0", sharded]
     commands:
       - command: expansions.update
         params:
@@ -14047,7 +15774,7 @@ tasks:
       - func: start_mongod
         vars:
           TOPOLOGY: sharded_cluster
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -14060,9 +15787,9 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: sharded
           REQUIRED_CXX_STANDARD: 11
-  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx11-8.0-single
+  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx11-9.0-single
     run_on: windows-2022-latest-large
-    tags: [integration, windows-2022-latest, windows, debug, shared, cxx11, "8.0", single]
+    tags: [integration, windows-2022-latest, windows, debug, shared, cxx11, "9.0", single]
     commands:
       - command: expansions.update
         params:
@@ -14073,7 +15800,7 @@ tasks:
       - func: setup
       - func: start_mongod
         vars:
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -14086,9 +15813,9 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
           REQUIRED_CXX_STANDARD: 11
-  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx11-csfle-8.0-replica
+  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx11-csfle-9.0-replica
     run_on: windows-2022-latest-large
-    tags: [integration, windows-2022-latest, windows, debug, shared, cxx11, csfle, "8.0", replica]
+    tags: [integration, windows-2022-latest, windows, debug, shared, cxx11, csfle, "9.0", replica]
     commands:
       - command: expansions.update
         params:
@@ -14100,7 +15827,7 @@ tasks:
       - func: start_mongod
         vars:
           TOPOLOGY: replica_set
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -14114,9 +15841,9 @@ tasks:
           MONGOCXX_TEST_TOPOLOGY: replica
           REQUIRED_CXX_STANDARD: 11
           TEST_WITH_CSFLE: "ON"
-  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx11-csfle-8.0-sharded
+  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx11-csfle-9.0-sharded
     run_on: windows-2022-latest-large
-    tags: [integration, windows-2022-latest, windows, debug, shared, cxx11, csfle, "8.0", sharded]
+    tags: [integration, windows-2022-latest, windows, debug, shared, cxx11, csfle, "9.0", sharded]
     commands:
       - command: expansions.update
         params:
@@ -14128,7 +15855,7 @@ tasks:
       - func: start_mongod
         vars:
           TOPOLOGY: sharded_cluster
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -14142,9 +15869,9 @@ tasks:
           MONGOCXX_TEST_TOPOLOGY: sharded
           REQUIRED_CXX_STANDARD: 11
           TEST_WITH_CSFLE: "ON"
-  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx11-csfle-8.0-single
+  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx11-csfle-9.0-single
     run_on: windows-2022-latest-large
-    tags: [integration, windows-2022-latest, windows, debug, shared, cxx11, csfle, "8.0", single]
+    tags: [integration, windows-2022-latest, windows, debug, shared, cxx11, csfle, "9.0", single]
     commands:
       - command: expansions.update
         params:
@@ -14155,7 +15882,7 @@ tasks:
       - func: setup
       - func: start_mongod
         vars:
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -14361,9 +16088,9 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
           REQUIRED_CXX_STANDARD: 11
-  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx17-8.0-replica
+  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx17-9.0-replica
     run_on: windows-2022-latest-large
-    tags: [integration, windows-2022-latest, windows, debug, shared, cxx17, "8.0", replica]
+    tags: [integration, windows-2022-latest, windows, debug, shared, cxx17, "9.0", replica]
     commands:
       - command: expansions.update
         params:
@@ -14375,7 +16102,7 @@ tasks:
       - func: start_mongod
         vars:
           TOPOLOGY: replica_set
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -14388,9 +16115,9 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: replica
           REQUIRED_CXX_STANDARD: 17
-  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx17-8.0-sharded
+  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx17-9.0-sharded
     run_on: windows-2022-latest-large
-    tags: [integration, windows-2022-latest, windows, debug, shared, cxx17, "8.0", sharded]
+    tags: [integration, windows-2022-latest, windows, debug, shared, cxx17, "9.0", sharded]
     commands:
       - command: expansions.update
         params:
@@ -14402,7 +16129,7 @@ tasks:
       - func: start_mongod
         vars:
           TOPOLOGY: sharded_cluster
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -14415,9 +16142,9 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: sharded
           REQUIRED_CXX_STANDARD: 17
-  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx17-8.0-single
+  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx17-9.0-single
     run_on: windows-2022-latest-large
-    tags: [integration, windows-2022-latest, windows, debug, shared, cxx17, "8.0", single]
+    tags: [integration, windows-2022-latest, windows, debug, shared, cxx17, "9.0", single]
     commands:
       - command: expansions.update
         params:
@@ -14428,7 +16155,7 @@ tasks:
       - func: setup
       - func: start_mongod
         vars:
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -14441,9 +16168,9 @@ tasks:
         vars:
           MONGOCXX_TEST_TOPOLOGY: single
           REQUIRED_CXX_STANDARD: 17
-  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx17-csfle-8.0-replica
+  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx17-csfle-9.0-replica
     run_on: windows-2022-latest-large
-    tags: [integration, windows-2022-latest, windows, debug, shared, cxx17, csfle, "8.0", replica]
+    tags: [integration, windows-2022-latest, windows, debug, shared, cxx17, csfle, "9.0", replica]
     commands:
       - command: expansions.update
         params:
@@ -14455,7 +16182,7 @@ tasks:
       - func: start_mongod
         vars:
           TOPOLOGY: replica_set
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -14469,9 +16196,9 @@ tasks:
           MONGOCXX_TEST_TOPOLOGY: replica
           REQUIRED_CXX_STANDARD: 17
           TEST_WITH_CSFLE: "ON"
-  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx17-csfle-8.0-sharded
+  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx17-csfle-9.0-sharded
     run_on: windows-2022-latest-large
-    tags: [integration, windows-2022-latest, windows, debug, shared, cxx17, csfle, "8.0", sharded]
+    tags: [integration, windows-2022-latest, windows, debug, shared, cxx17, csfle, "9.0", sharded]
     commands:
       - command: expansions.update
         params:
@@ -14483,7 +16210,7 @@ tasks:
       - func: start_mongod
         vars:
           TOPOLOGY: sharded_cluster
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -14497,9 +16224,9 @@ tasks:
           MONGOCXX_TEST_TOPOLOGY: sharded
           REQUIRED_CXX_STANDARD: 17
           TEST_WITH_CSFLE: "ON"
-  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx17-csfle-8.0-single
+  - name: integration-windows-2022-latest-vs2022x64-debug-shared-cxx17-csfle-9.0-single
     run_on: windows-2022-latest-large
-    tags: [integration, windows-2022-latest, windows, debug, shared, cxx17, csfle, "8.0", single]
+    tags: [integration, windows-2022-latest, windows, debug, shared, cxx17, csfle, "9.0", single]
     commands:
       - command: expansions.update
         params:
@@ -14510,7 +16237,7 @@ tasks:
       - func: setup
       - func: start_mongod
         vars:
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -14859,9 +16586,9 @@ tasks:
           TEST_WITH_CSFLE: "ON"
           example_projects_cxxflags: -fsanitize=address -fno-omit-frame-pointer
           example_projects_ldflags: -fsanitize=address
-  - name: sanitizers-asan-rhel80-clang-static-8.0-replica
+  - name: sanitizers-asan-rhel80-clang-static-9.0-replica
     run_on: rhel80-large
-    tags: [sanitizers, asan, rhel80, clang, static, "8.0", replica]
+    tags: [sanitizers, asan, rhel80, clang, static, "9.0", replica]
     commands:
       - command: expansions.update
         params:
@@ -14874,7 +16601,7 @@ tasks:
       - func: start_mongod
         vars:
           TOPOLOGY: replica_set
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -14890,9 +16617,9 @@ tasks:
           TEST_WITH_CSFLE: "ON"
           example_projects_cxxflags: -fsanitize=address -fno-omit-frame-pointer
           example_projects_ldflags: -fsanitize=address
-  - name: sanitizers-asan-rhel80-clang-static-8.0-sharded
+  - name: sanitizers-asan-rhel80-clang-static-9.0-sharded
     run_on: rhel80-large
-    tags: [sanitizers, asan, rhel80, clang, static, "8.0", sharded]
+    tags: [sanitizers, asan, rhel80, clang, static, "9.0", sharded]
     commands:
       - command: expansions.update
         params:
@@ -14905,7 +16632,7 @@ tasks:
       - func: start_mongod
         vars:
           TOPOLOGY: sharded_cluster
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -14921,9 +16648,9 @@ tasks:
           TEST_WITH_CSFLE: "ON"
           example_projects_cxxflags: -fsanitize=address -fno-omit-frame-pointer
           example_projects_ldflags: -fsanitize=address
-  - name: sanitizers-asan-rhel80-clang-static-8.0-single
+  - name: sanitizers-asan-rhel80-clang-static-9.0-single
     run_on: rhel80-large
-    tags: [sanitizers, asan, rhel80, clang, static, "8.0", single]
+    tags: [sanitizers, asan, rhel80, clang, static, "9.0", single]
     commands:
       - command: expansions.update
         params:
@@ -14935,7 +16662,7 @@ tasks:
       - func: setup
       - func: start_mongod
         vars:
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -15135,9 +16862,9 @@ tasks:
           TEST_WITH_UBSAN: "ON"
           example_projects_cxxflags: -fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer
           example_projects_ldflags: -fsanitize=undefined -fno-sanitize-recover=undefined -static-libsan
-  - name: sanitizers-ubsan-rhel80-clang-static-8.0-replica
+  - name: sanitizers-ubsan-rhel80-clang-static-9.0-replica
     run_on: rhel80-large
-    tags: [sanitizers, ubsan, rhel80, clang, static, "8.0", replica]
+    tags: [sanitizers, ubsan, rhel80, clang, static, "9.0", replica]
     commands:
       - command: expansions.update
         params:
@@ -15150,7 +16877,7 @@ tasks:
       - func: start_mongod
         vars:
           TOPOLOGY: replica_set
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -15166,9 +16893,9 @@ tasks:
           TEST_WITH_UBSAN: "ON"
           example_projects_cxxflags: -fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer
           example_projects_ldflags: -fsanitize=undefined -fno-sanitize-recover=undefined -static-libsan
-  - name: sanitizers-ubsan-rhel80-clang-static-8.0-sharded
+  - name: sanitizers-ubsan-rhel80-clang-static-9.0-sharded
     run_on: rhel80-large
-    tags: [sanitizers, ubsan, rhel80, clang, static, "8.0", sharded]
+    tags: [sanitizers, ubsan, rhel80, clang, static, "9.0", sharded]
     commands:
       - command: expansions.update
         params:
@@ -15181,7 +16908,7 @@ tasks:
       - func: start_mongod
         vars:
           TOPOLOGY: sharded_cluster
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -15197,9 +16924,9 @@ tasks:
           TEST_WITH_UBSAN: "ON"
           example_projects_cxxflags: -fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer
           example_projects_ldflags: -fsanitize=undefined -fno-sanitize-recover=undefined -static-libsan
-  - name: sanitizers-ubsan-rhel80-clang-static-8.0-single
+  - name: sanitizers-ubsan-rhel80-clang-static-9.0-single
     run_on: rhel80-large
-    tags: [sanitizers, ubsan, rhel80, clang, static, "8.0", single]
+    tags: [sanitizers, ubsan, rhel80, clang, static, "9.0", single]
     commands:
       - command: expansions.update
         params:
@@ -15211,7 +16938,7 @@ tasks:
       - func: setup
       - func: start_mongod
         vars:
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
       - func: compile
         vars:
@@ -15616,9 +17343,9 @@ tasks:
           TEST_WITH_VALGRIND: "ON"
           disable_slow_tests: 1
           use_mongocryptd: true
-  - name: valgrind-rhel80-shared-8.0-replica
+  - name: valgrind-rhel80-shared-9.0-replica
     run_on: rhel80-large
-    tags: [valgrind, rhel80, shared, "8.0", replica]
+    tags: [valgrind, rhel80, shared, "9.0", replica]
     commands:
       - command: expansions.update
         params:
@@ -15628,7 +17355,7 @@ tasks:
       - func: start_mongod
         vars:
           TOPOLOGY: replica_set
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
         vars:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
@@ -15644,9 +17371,9 @@ tasks:
           TEST_WITH_VALGRIND: "ON"
           disable_slow_tests: 1
           use_mongocryptd: true
-  - name: valgrind-rhel80-shared-8.0-sharded
+  - name: valgrind-rhel80-shared-9.0-sharded
     run_on: rhel80-large
-    tags: [valgrind, rhel80, shared, "8.0", sharded]
+    tags: [valgrind, rhel80, shared, "9.0", sharded]
     commands:
       - command: expansions.update
         params:
@@ -15656,7 +17383,7 @@ tasks:
       - func: start_mongod
         vars:
           TOPOLOGY: sharded_cluster
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
         vars:
           SKIP_INSTALL_LIBMONGOCRYPT: 1
@@ -15672,9 +17399,9 @@ tasks:
           TEST_WITH_VALGRIND: "ON"
           disable_slow_tests: 1
           use_mongocryptd: true
-  - name: valgrind-rhel80-shared-8.0-single
+  - name: valgrind-rhel80-shared-9.0-single
     run_on: rhel80-large
-    tags: [valgrind, rhel80, shared, "8.0", single]
+    tags: [valgrind, rhel80, shared, "9.0", single]
     commands:
       - command: expansions.update
         params:
@@ -15683,7 +17410,7 @@ tasks:
       - func: setup
       - func: start_mongod
         vars:
-          mongodb_version: "8.0"
+          mongodb_version: "9.0"
       - func: install_c_driver
         vars:
           SKIP_INSTALL_LIBMONGOCRYPT: 1


### PR DESCRIPTION
[skip ci]

# Summary
Add server 9.0 to test matrix.

Lists like `['4.2', '8.0', 'latest']` were updated to `['4.2', '9.0', 'latest']` to follow the test pattern (min, max, and latest).

Evergreen patch: https://spruce.corp.mongodb.com/version/6a7e0c0e40571c0007dc7793

# Motivation

This was an urgent ask to ensure 9.0 has test coverage.


