### PR TITLE
CXX-3350 fix compile error in unified test runner

### DIFF
--- a/src/mongocxx/test/spec/unified_tests/runner.cpp
+++ b/src/mongocxx/test/spec/unified_tests/runner.cpp
@@ -1387,7 +1387,10 @@ std::map<std::pair<bsoncxx::stdx::string_view, bsoncxx::stdx::string_view>, bson
          "collection.listIndexNames optional helper is not supported"},
 };
 
-void run_tests(bsoncxx::stdx::string_view test_description, document::view test) {
+void run_tests(
+    bsoncxx::stdx::string_view test_description,
+    document::view test,
+    bsoncxx::stdx::optional<document::value> const& cluster_time) {
     REQUIRE(test["tests"]);
 
     for (auto const& ele : test["tests"].get_array().value) {
@@ -1427,7 +1430,9 @@ void run_tests(bsoncxx::stdx::string_view test_description, document::view test)
                 // test without clearing the existing entity map (unlike top-level "createEntities").
                 if (string::to_string(ops["name"].get_string().value) == "createEntities") {
                     auto const entities = ops["arguments"]["entities"].get_array().value;
-                    REQUIRE(std::all_of(std::begin(entities), std::end(entities), add_to_map));
+                    REQUIRE(std::all_of(std::begin(entities), std::end(entities), [&](array::element const& obj) {
+                        return add_to_map(obj, cluster_time);
+                    }));
                     continue;
                 }
 
@@ -1539,7 +1544,7 @@ void run_tests_in_file(std::string const& test_path) {
     CAPTURE(description);
     auto const cluster_time = load_initial_data(test_spec_view);
     create_entities(test_spec_view, cluster_time);
-    run_tests(description, test_spec_view);
+    run_tests(description, test_spec_view, cluster_time);
 }
 
 // Check the environment for the specified variable; if present, extract it


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/mongo-cxx-driver/pull/1680 to fix test compile errors.

https://github.com/mongodb/mongo-cxx-driver/pull/1681 added a `cluster_time` argument to `add_to_map`:

```c++
bool add_to_map(array::element const& obj, bsoncxx::stdx::optional<document::value> const& cluster_time) {
```

This was not pulled in to https://github.com/mongodb/mongo-cxx-driver/pull/1680 and I neglected to update the branch before merging. 

https://github.com/mongodb/mongo-cxx-driver/pull/1680 adds support for the "createEntities" test operation. Quoting the [Unified Test Format](https://github.com/mongodb/specifications/blob/92b3c0b9287bfba1b0ec4084300858d05c654f8c/source/unified-test-format/unified-test-format.md#migrationconflict-errors-on-sharded-clusters):

> a test runner MUST collect the latest cluster time from processing [initialData](#initialData), which is executed using the internal MongoClient, and use it to advance the cluster time of every session entity created during the test, by either [createEntities](#createentities) or the [special test operation](#operation_createEntities)).

This PR passes the initially captured cluster time to the "createEntities" test operation.
