### PR TITLE
CXX-3563 prevent macOS dotfiles in tarball

### DIFF
--- a/cmake/make_dist/MakeDist.cmake
+++ b/cmake/make_dist/MakeDist.cmake
@@ -16,8 +16,7 @@ include (MakeDistFiles)
 
 function (MAKE_DIST PACKAGE_PREFIX MONGOCXX_SOURCE_DIR BUILD_SOURCE_DIR)
 
-   set (CMAKE_COMMAND_TMP "")
-   set (CMAKE_COMMAND_TMP ${CMAKE_COMMAND} -E env)
+   set (CMAKE_ENV_COMMAND ${CMAKE_COMMAND} -E env)
 
    # -- Remove any existing packaging directory.
 
@@ -69,7 +68,7 @@ function (MAKE_DIST PACKAGE_PREFIX MONGOCXX_SOURCE_DIR BUILD_SOURCE_DIR)
 
    # Set `COPYFILE_DISABLE=1` to prevent macOS from adding AppleDouble `._<name>` files.
    execute_process_and_check_result (COMMAND
-      ${CMAKE_COMMAND_TMP} COPYFILE_DISABLE=1 tar cf ${PACKAGE_PREFIX}.tar ${PACKAGE_PREFIX}
+      ${CMAKE_ENV_COMMAND} COPYFILE_DISABLE=1 tar cf ${PACKAGE_PREFIX}.tar ${PACKAGE_PREFIX}
       WORKING_DIRECTORY .
       ERROR_MSG "tar command to create ${PACKAGE_PREFIX}.tar failed."
    )
@@ -77,7 +76,7 @@ function (MAKE_DIST PACKAGE_PREFIX MONGOCXX_SOURCE_DIR BUILD_SOURCE_DIR)
    # -- Compress the tarball with gzip
 
    execute_process_and_check_result (COMMAND
-      ${CMAKE_COMMAND_TMP} gzip -f ${PACKAGE_PREFIX}.tar
+      ${CMAKE_ENV_COMMAND} gzip -f ${PACKAGE_PREFIX}.tar
       WORKING_DIRECTORY .
       ERROR_MSG "gzip command to create ${PACKAGE_PREFIX}.tar.gz failed."
    )

--- a/cmake/make_dist/MakeDist.cmake
+++ b/cmake/make_dist/MakeDist.cmake
@@ -67,8 +67,9 @@ function (MAKE_DIST PACKAGE_PREFIX MONGOCXX_SOURCE_DIR BUILD_SOURCE_DIR)
 
    # -- Create the tarball.
 
+   # Set `COPYFILE_DISABLE=1` to prevent macOS from adding AppleDouble `._<name>` files.
    execute_process_and_check_result (COMMAND
-      ${CMAKE_COMMAND} -E tar cf ${PACKAGE_PREFIX}.tar ${PACKAGE_PREFIX}
+      ${CMAKE_COMMAND_TMP} COPYFILE_DISABLE=1 tar cf ${PACKAGE_PREFIX}.tar ${PACKAGE_PREFIX}
       WORKING_DIRECTORY .
       ERROR_MSG "tar command to create ${PACKAGE_PREFIX}.tar failed."
    )

--- a/cmake/make_dist/MakeDist.cmake
+++ b/cmake/make_dist/MakeDist.cmake
@@ -67,6 +67,7 @@ function (MAKE_DIST PACKAGE_PREFIX MONGOCXX_SOURCE_DIR BUILD_SOURCE_DIR)
    # -- Create the tarball.
 
    # Set `COPYFILE_DISABLE=1` to prevent macOS from adding AppleDouble `._<name>` files.
+   # Use the system `tar` rather than CMake's built-in (`cmake -E tar`) since CMake's built-in does not respect `COPYFILE_DISABLE`.
    execute_process_and_check_result (COMMAND
       ${CMAKE_ENV_COMMAND} COPYFILE_DISABLE=1 tar cf ${PACKAGE_PREFIX}.tar ${PACKAGE_PREFIX}
       WORKING_DIRECTORY .

--- a/cmake/make_dist/MakeDist.cmake
+++ b/cmake/make_dist/MakeDist.cmake
@@ -66,18 +66,22 @@ function (MAKE_DIST PACKAGE_PREFIX MONGOCXX_SOURCE_DIR BUILD_SOURCE_DIR)
 
    # -- Create the tarball.
 
-   # Set `COPYFILE_DISABLE=1` to prevent macOS from adding AppleDouble `._<name>` files.
    # Use the system `tar` rather than CMake's built-in (`cmake -E tar`) since CMake's built-in does not respect `COPYFILE_DISABLE`.
+   find_program (TAR_EXECUTABLE NAMES tar REQUIRED)
+   
+   # Set `COPYFILE_DISABLE=1` to prevent macOS from adding AppleDouble `._<name>` files.
    execute_process_and_check_result (COMMAND
-      ${CMAKE_ENV_COMMAND} COPYFILE_DISABLE=1 tar cf ${PACKAGE_PREFIX}.tar ${PACKAGE_PREFIX}
+      ${CMAKE_ENV_COMMAND} COPYFILE_DISABLE=1 ${TAR_EXECUTABLE} cf ${PACKAGE_PREFIX}.tar ${PACKAGE_PREFIX}
       WORKING_DIRECTORY .
       ERROR_MSG "tar command to create ${PACKAGE_PREFIX}.tar failed."
    )
 
    # -- Compress the tarball with gzip
 
+   find_program (GZIP_EXECUTABLE NAMES gzip REQUIRED)
+
    execute_process_and_check_result (COMMAND
-      ${CMAKE_ENV_COMMAND} gzip -f ${PACKAGE_PREFIX}.tar
+      ${CMAKE_ENV_COMMAND} ${GZIP_EXECUTABLE} -f ${PACKAGE_PREFIX}.tar
       WORKING_DIRECTORY .
       ERROR_MSG "gzip command to create ${PACKAGE_PREFIX}.tar.gz failed."
    )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -58,6 +58,10 @@ function(add_examples_executable source)
     # path/to/source.cpp -> source
     get_filename_component(name ${source} NAME_WE)
 
+    if ("${name}" STREQUAL "")
+        message(FATAL_ERROR "could not derive a target name from example source: ${source}")
+    endif ()
+
     # path/to/source.cpp -> path/to
     get_filename_component(subdir ${source} DIRECTORY)
 
@@ -163,6 +167,10 @@ function (add_abi_examples)
 
         # path/to/source.cpp -> source
         get_filename_component(name ${source} NAME_WE)
+
+        if ("${name}" STREQUAL "")
+            message(FATAL_ERROR "could not derive a component name from example source: ${source}")
+        endif ()
 
         # path/to/source.cpp -> path/to
         get_filename_component(subdir ${source} DIRECTORY)


### PR DESCRIPTION
# Summary

- Set `COPYFILE_DISABLE=1` to prevent macOS adding dotfiles to the distribution tarball.
- Error earlier if a computed example target `name` is empty.

# Details
CXX-3563 reports "same name already exists" errors running CMake on the release tarball for r4.5.0.

```
CMake Error at examples/CMakeLists.txt:66 (add_executable):
  add_executable cannot create target "mongocxx-mongodb.com-" because another
  target with the same name already exists.  The existing target is an
  executable created in source directory
  "C:/____build/Mongo_Driver/mongo-cxx-driver-r4.5.0/mongo-cxx-driver-r4.5.0/examples".
  See documentation for policy CMP0002 for more details.
```

The cause is the release tarball contains extra dot-files produced by macOS `tar`.  I can reproduce by running `cmake --build cmake-build --target dist` on my macOS laptop and extracting the tarball on a Windows host:

<img width="694" height="411" alt="Screenshot 2026-08-26 at 8 44 48 AM" src="https://github.com/user-attachments/assets/b5b4b4e4-9b39-464f-b070-e43ccae1b13e" />

macOS `tar` may include [metadata dotfiles](https://unix.stackexchange.com/questions/9665/create-tar-archive-of-a-directory-except-for-hidden-files). The glob to get examples sources finds these dotfiles, parses the `name` as an empty string, and later fails when adding duplicate targets.

To fix, the `tar` command now uses the environment variable `COPYFILE_DISABLE=1`, which tested locally and checked dotfiles are no longer generated. There appears to be no utility to the existing dotfiles. Claude's analysis says of r4.5.0 dotfiles: "they carry exactly one thing: an empty com.apple.provenance xattr.".

Once fixed, I plan to regenerate the r4.5.0 release tarball.
