### PR TITLE
CXX-3552 reject invalid database and collection names

### DIFF
--- a/src/mongocxx/include/mongocxx/v1/client.hpp
+++ b/src/mongocxx/include/mongocxx/v1/client.hpp
@@ -135,10 +135,16 @@ class client {
     ///
     /// Access the database with the given name.
     ///
+    /// @throws mongocxx::v1::exception with @ref mongocxx::v1::client::errc::invalid_database_name when `name`
+    /// is not a valid database name.
+    ///
     MONGOCXX_ABI_EXPORT_CDECL(v1::database) database(bsoncxx::v1::stdx::string_view name);
 
     ///
     /// Equivalent to `this->database(name)`.
+    ///
+    /// @throws mongocxx::v1::exception with @ref mongocxx::v1::client::errc::invalid_database_name when `name`
+    /// is not a valid database name.
     ///
     MONGOCXX_ABI_EXPORT_CDECL(v1::database) operator[](bsoncxx::v1::stdx::string_view name);
 
@@ -303,6 +309,7 @@ class client {
         tls_not_enabled,         ///< TLS is not enabled by URI options.
         tls_not_supported,       ///< TLS is not supported by the mongoc library.
         append_metadata_failure, ///< Failed to append client metadata.
+        invalid_database_name,   ///< The database name is not valid.
     };
 
     ///

--- a/src/mongocxx/include/mongocxx/v1/collection.hpp
+++ b/src/mongocxx/include/mongocxx/v1/collection.hpp
@@ -691,6 +691,8 @@ class collection {
     ///
     /// Change the name of this collection.
     ///
+    /// @throws mongocxx::v1::exception with @ref mongocxx::v1::collection::errc::invalid_collection_name when
+    /// `new_name` is invalid.
     /// @throws mongocxx::v1::exception when a client-side or server-side error is encountered. (mongoc does not return
     /// the raw server response for this command.)
     ///
@@ -903,8 +905,9 @@ class collection {
     /// Errors codes which may be returned by @ref mongocxx::v1::collection.
     ///
     enum class errc {
-        zero,         ///< Zero.
-        max_time_u32, ///< The "maxTimeMS" field must be representable as an `std::uint32_t`.
+        zero,                    ///< Zero.
+        max_time_u32,            ///< The "maxTimeMS" field must be representable as an `std::uint32_t`.
+        invalid_collection_name, ///< The collection name is not valid.
     };
 
     ///

--- a/src/mongocxx/include/mongocxx/v1/database.hpp
+++ b/src/mongocxx/include/mongocxx/v1/database.hpp
@@ -41,6 +41,7 @@
 
 #include <cstdint>
 #include <string>
+#include <system_error>
 #include <vector>
 
 namespace mongocxx {
@@ -159,6 +160,8 @@ class database {
     /// Explicitly create a new collection or view in this database.
     ///
     /// @throws mongocxx::v1::server_error when a server-side error is encountered and a raw server error is available.
+    /// @throws mongocxx::v1::exception with @ref mongocxx::v1::database::errc::invalid_collection_name when `name`
+    /// is not a valid collection name.
     /// @throws mongocxx::v1::exception for all other runtime errors.
     ///
     /// @see
@@ -200,6 +203,8 @@ class database {
     /// Return true when this database contains a collection with the given name.
     ///
     /// @throws mongocxx::v1::server_error when a server-side error is encountered and a raw server error is available.
+    /// @throws mongocxx::v1::exception with @ref mongocxx::v1::database::errc::invalid_collection_name when `name`
+    /// is not a valid collection name.
     /// @throws mongocxx::v1::exception for all other runtime errors.
     ///
     MONGOCXX_ABI_EXPORT_CDECL(bool) has_collection(bsoncxx::v1::stdx::string_view name);
@@ -293,10 +298,16 @@ class database {
     ///
     /// Access the collection with the given name.
     ///
+    /// @throws mongocxx::v1::exception with @ref mongocxx::v1::database::errc::invalid_collection_name when `name`
+    /// is not a valid collection name.
+    ///
     MONGOCXX_ABI_EXPORT_CDECL(v1::collection) collection(bsoncxx::v1::stdx::string_view name) const;
 
     ///
     /// Equivalent to `this->collection(name)`.
+    ///
+    /// @throws mongocxx::v1::exception with @ref mongocxx::v1::database::errc::invalid_collection_name when `name`
+    /// is not a valid collection name.
     ///
     MONGOCXX_ABI_EXPORT_CDECL(v1::collection) operator[](bsoncxx::v1::stdx::string_view name) const;
 
@@ -305,6 +316,9 @@ class database {
     ///
     /// @note When the "bucketName" field is unset, the default bucket name "fs" is used instead.
     /// @note When the "chunkSizeBytes" field is unset, the default chunk size of 255 KiB is used instead.
+    ///
+    /// @throws mongocxx::v1::exception with @ref mongocxx::v1::database::errc::invalid_collection_name when the
+    /// "bucketName" field is not valid.
     ///
     /// @see
     /// - [GridFS (MongoDB Manual)](https://www.mongodb.com/docs/manual/core/gridfs/)
@@ -342,6 +356,26 @@ class database {
     /// @}
     ///
 
+    ///
+    /// Errors codes which may be returned by @ref mongocxx::v1::database.
+    ///
+    enum class errc {
+        zero,                    ///< Zero.
+        invalid_collection_name, ///< The collection name is not valid.
+    };
+
+    ///
+    /// The error category for @ref mongocxx::v1::database::errc.
+    ///
+    static MONGOCXX_ABI_EXPORT_CDECL(std::error_category const&) error_category();
+
+    ///
+    /// Support implicit conversion to `std::error_code`.
+    ///
+    friend std::error_code make_error_code(errc v) {
+        return {static_cast<int>(v), error_category()};
+    }
+
     class internal;
 
    private:
@@ -350,6 +384,13 @@ class database {
 
 } // namespace v1
 } // namespace mongocxx
+
+namespace std {
+
+template <>
+struct is_error_code_enum<mongocxx::v1::database::errc> : true_type {};
+
+} // namespace std
 
 #include <mongocxx/v1/detail/postlude.hpp>
 

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/client.hpp
@@ -235,6 +235,9 @@ class client {
     ///
     /// @return The database
     ///
+    /// @throws mongocxx::v_noabi::logic_error with
+    /// @ref mongocxx::v_noabi::error_code::k_invalid_parameter if `name` is not a valid database name.
+    ///
     MONGOCXX_ABI_EXPORT_CDECL_UNSTABLE(v_noabi::database)
     database(bsoncxx::v_noabi::string::view_or_value name) const&;
 
@@ -250,6 +253,9 @@ class client {
     ///   The name of the database.
     ///
     /// @return Client side representation of a server side database
+    ///
+    /// @throws mongocxx::v_noabi::logic_error with
+    /// @ref mongocxx::v_noabi::error_code::k_invalid_parameter if `name` is not a valid database name.
     ///
     v_noabi::database operator[](bsoncxx::v_noabi::string::view_or_value name) const& {
         return database(name);

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/collection.hpp
@@ -1334,6 +1334,9 @@ class collection {
     /// @exception
     ///   mongocxx::v_noabi::operation_exception if the operation fails.
     ///
+    /// @throws mongocxx::v_noabi::logic_error with
+    /// @ref mongocxx::v_noabi::error_code::k_invalid_parameter if `new_name` is not a valid collection name.
+    ///
     /// @see
     /// - https://www.mongodb.com/docs/manual/reference/command/renameCollection/
     ///
@@ -1360,6 +1363,9 @@ class collection {
     ///
     /// @exception
     ///   mongocxx::v_noabi::operation_exception if the operation fails.
+    ///
+    /// @throws mongocxx::v_noabi::logic_error with
+    /// @ref mongocxx::v_noabi::error_code::k_invalid_parameter if `new_name` is not a valid collection name.
     ///
     /// @see
     /// - https://www.mongodb.com/docs/manual/reference/command/renameCollection/

--- a/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
+++ b/src/mongocxx/include/mongocxx/v_noabi/mongocxx/database.hpp
@@ -248,6 +248,9 @@ class database {
     /// @exception
     ///   mongocxx::v_noabi::operation_exception if the operation fails.
     ///
+    /// @throws mongocxx::v_noabi::logic_error with
+    /// @ref mongocxx::v_noabi::error_code::k_invalid_parameter if `name` is not a valid collection name.
+    ///
     MONGOCXX_ABI_EXPORT_CDECL_UNSTABLE(v_noabi::collection)
     create_collection(
         bsoncxx::v_noabi::stdx::string_view name,
@@ -275,6 +278,9 @@ class database {
     ///
     /// @exception
     ///   mongocxx::v_noabi::operation_exception if the operation fails.
+    ///
+    /// @throws mongocxx::v_noabi::logic_error with
+    /// @ref mongocxx::v_noabi::error_code::k_invalid_parameter if `name` is not a valid collection name.
     ///
     MONGOCXX_ABI_EXPORT_CDECL_UNSTABLE(v_noabi::collection)
     create_collection(
@@ -328,6 +334,9 @@ class database {
     ///
     /// @throws mongocxx::v_noabi::operation_exception if the underlying 'listCollections'
     /// command fails.
+    ///
+    /// @throws mongocxx::v_noabi::logic_error with
+    /// @ref mongocxx::v_noabi::error_code::k_invalid_parameter if `name` is not a valid collection name.
     ///
     MONGOCXX_ABI_EXPORT_CDECL_UNSTABLE(bool)
     has_collection(bsoncxx::v_noabi::string::view_or_value name) const;
@@ -479,6 +488,9 @@ class database {
     ///
     /// @return the collection.
     ///
+    /// @throws mongocxx::v_noabi::logic_error with
+    /// @ref mongocxx::v_noabi::error_code::k_invalid_parameter if `name` is not a valid collection name.
+    ///
     MONGOCXX_ABI_EXPORT_CDECL_UNSTABLE(v_noabi::collection)
     collection(bsoncxx::v_noabi::string::view_or_value name) const;
 
@@ -489,6 +501,9 @@ class database {
     /// @param name the name of the collection to get.
     ///
     /// @return the collection.
+    ///
+    /// @throws mongocxx::v_noabi::logic_error with
+    /// @ref mongocxx::v_noabi::error_code::k_invalid_parameter if `name` is not a valid collection name.
     ///
     v_noabi::collection operator[](bsoncxx::v_noabi::string::view_or_value name) const {
         return this->collection(name);

--- a/src/mongocxx/lib/mongocxx/private/namespace_validation.hh
+++ b/src/mongocxx/lib/mongocxx/private/namespace_validation.hh
@@ -1,0 +1,43 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bsoncxx/v1/stdx/string_view.hpp>
+
+//
+
+namespace mongocxx {
+
+///
+/// Return true when `name` is a valid database name.
+///
+/// A database name must not contain a "." (interpreted by the server as a namespace separator) or
+/// a NUL character (which would truncate the name when it is converted to a C string).
+///
+inline bool is_valid_database_name(bsoncxx::v1::stdx::string_view name) {
+    return name.find('.') == name.npos && name.find('\0') == name.npos;
+}
+
+///
+/// Return true when `name` is a valid collection name.
+///
+/// A collection name must not contain a NUL character (which would truncate the name when it is
+/// converted to a C string). Unlike a database name, a "." is permitted.
+///
+inline bool is_valid_collection_name(bsoncxx::v1::stdx::string_view name) {
+    return name.find('\0') == name.npos;
+}
+
+} // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v1/client.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/client.cpp
@@ -48,6 +48,7 @@
 #include <bsoncxx/private/immortal.hh>
 
 #include <mongocxx/private/mongoc.hh>
+#include <mongocxx/private/namespace_validation.hh>
 #include <mongocxx/private/scoped_bson.hh>
 #include <mongocxx/private/ssl.hh>
 #include <mongocxx/private/utility.hh>
@@ -185,6 +186,10 @@ v1::uri client::uri() const {
 }
 
 v1::database client::database(bsoncxx::v1::stdx::string_view name) {
+    if (!is_valid_database_name(name)) {
+        throw v1::exception::internal::make(code::invalid_database_name);
+    }
+
     auto const _client = impl::with(this)->_client;
 
     return v1::database::internal::make(libmongoc::client_get_database(_client, std::string{name}.c_str()), _client);
@@ -415,6 +420,8 @@ std::error_category const& client::error_category() {
                     return "TLS is not supported by the mongoc library";
                 case code::append_metadata_failure:
                     return "could not append client metadata";
+                case code::invalid_database_name:
+                    return "invalid database name";
                 default:
                     return std::string(this->name()) + ':' + std::to_string(v);
             }
@@ -430,6 +437,7 @@ std::error_category const& client::error_category() {
                     case code::tls_not_enabled:
                     case code::tls_not_supported:
                     case code::append_metadata_failure:
+                    case code::invalid_database_name:
                         return source == condition::mongocxx;
 
                     case code::zero:
@@ -446,6 +454,7 @@ std::error_category const& client::error_category() {
                 switch (static_cast<code>(v)) {
                     case code::tls_not_enabled:
                     case code::tls_not_supported:
+                    case code::invalid_database_name:
                         return type == condition::invalid_argument;
                     case code::append_metadata_failure:
                         return type == condition::runtime_error;

--- a/src/mongocxx/lib/mongocxx/v1/collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/collection.cpp
@@ -77,6 +77,7 @@
 #include <bsoncxx/private/immortal.hh>
 
 #include <mongocxx/private/mongoc.hh>
+#include <mongocxx/private/namespace_validation.hh>
 #include <mongocxx/private/scoped_bson.hh>
 #include <mongocxx/private/utility.hh>
 
@@ -1328,6 +1329,10 @@ void collection::rename(
     bsoncxx::v1::stdx::string_view new_name,
     bool drop_target,
     bsoncxx::v1::stdx::optional<v1::write_concern> const& write_concern) {
+    if (!is_valid_collection_name(new_name)) {
+        throw v1::exception::internal::make(code::invalid_collection_name);
+    }
+
     scoped_bson doc;
 
     if (write_concern) {
@@ -1342,6 +1347,10 @@ void collection::rename(
     bsoncxx::v1::stdx::string_view new_name,
     bool drop_target,
     bsoncxx::v1::stdx::optional<v1::write_concern> const& write_concern) {
+    if (!is_valid_collection_name(new_name)) {
+        throw v1::exception::internal::make(code::invalid_collection_name);
+    }
+
     scoped_bson doc;
 
     if (write_concern) {
@@ -1593,6 +1602,8 @@ std::error_category const& collection::error_category() {
                     return "zero";
                 case code::max_time_u32:
                     return "the \"maxTimeMS\" field must be representable as a `std::uint32_t`";
+                case code::invalid_collection_name:
+                    return "invalid collection name";
                 default:
                     return std::string(this->name()) + ':' + std::to_string(v);
             }
@@ -1606,6 +1617,7 @@ std::error_category const& collection::error_category() {
 
                 switch (static_cast<code>(v)) {
                     case code::max_time_u32:
+                    case code::invalid_collection_name:
                         return source == condition::mongocxx;
 
                     case code::zero:
@@ -1621,6 +1633,7 @@ std::error_category const& collection::error_category() {
 
                 switch (static_cast<code>(v)) {
                     case code::max_time_u32:
+                    case code::invalid_collection_name:
                         return type == condition::invalid_argument;
 
                     case code::zero:

--- a/src/mongocxx/lib/mongocxx/v1/database.cpp
+++ b/src/mongocxx/lib/mongocxx/v1/database.cpp
@@ -39,16 +39,21 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <system_error>
 #include <vector>
 
 #include <bsoncxx/private/bson.hh>
+#include <bsoncxx/private/immortal.hh>
 
 #include <mongocxx/private/mongoc.hh>
+#include <mongocxx/private/namespace_validation.hh>
 #include <mongocxx/private/scoped_bson.hh>
 #include <mongocxx/private/utility.hh>
 
 namespace mongocxx {
 namespace v1 {
+
+using code = database::errc;
 
 class database::impl {
    public:
@@ -230,6 +235,10 @@ v1::collection database::create_collection(
     bsoncxx::v1::stdx::string_view name,
     bsoncxx::v1::document::view opts,
     bsoncxx::v1::stdx::optional<v1::write_concern> const& wc) {
+    if (!is_valid_collection_name(name)) {
+        throw v1::exception::internal::make(code::invalid_collection_name);
+    }
+
     scoped_bson doc;
 
     doc += opts;
@@ -247,6 +256,10 @@ v1::collection database::create_collection(
     bsoncxx::v1::stdx::string_view name,
     bsoncxx::v1::document::view opts,
     bsoncxx::v1::stdx::optional<v1::write_concern> const& wc) {
+    if (!is_valid_collection_name(name)) {
+        throw v1::exception::internal::make(code::invalid_collection_name);
+    }
+
     scoped_bson doc;
 
     doc += opts;
@@ -296,6 +309,10 @@ void database::drop(v1::client_session const& session, bsoncxx::v1::stdx::option
 }
 
 bool database::has_collection(bsoncxx::v1::stdx::string_view name) {
+    if (!is_valid_collection_name(name)) {
+        throw v1::exception::internal::make(code::invalid_collection_name);
+    }
+
     bson_error_t error = {};
 
     auto const ret = libmongoc::database_has_collection(impl::with(this)->_db, std::string{name}.c_str(), &error);
@@ -405,6 +422,10 @@ v1::write_concern database::write_concern() const {
 }
 
 v1::collection database::collection(bsoncxx::v1::stdx::string_view name) const {
+    if (!is_valid_collection_name(name)) {
+        throw v1::exception::internal::make(code::invalid_collection_name);
+    }
+
     return v1::collection::internal::make(
         libmongoc::database_get_collection(impl::with(this)->_db, std::string{name}.c_str()),
         impl::with(this)->_client);
@@ -516,6 +537,63 @@ mongoc_client_t* database::internal::get_client(database& self) {
 }
 
 database::database(void* impl) : _impl{impl} {}
+
+std::error_category const& database::error_category() {
+    class type final : public std::error_category {
+        char const* name() const noexcept override {
+            return "mongocxx::v1::database";
+        }
+
+        std::string message(int v) const noexcept override {
+            switch (static_cast<code>(v)) {
+                case code::zero:
+                    return "zero";
+                case code::invalid_collection_name:
+                    return "invalid collection name";
+                default:
+                    return std::string(this->name()) + ':' + std::to_string(v);
+            }
+        }
+
+        bool equivalent(int v, std::error_condition const& ec) const noexcept override {
+            if (ec.category() == v1::source_error_category()) {
+                using condition = v1::source_errc;
+
+                auto const source = static_cast<condition>(ec.value());
+
+                switch (static_cast<code>(v)) {
+                    case code::invalid_collection_name:
+                        return source == condition::mongocxx;
+
+                    case code::zero:
+                    default:
+                        return false;
+                }
+            }
+
+            if (ec.category() == v1::type_error_category()) {
+                using condition = v1::type_errc;
+
+                auto const type = static_cast<condition>(ec.value());
+
+                switch (static_cast<code>(v)) {
+                    case code::invalid_collection_name:
+                        return type == condition::invalid_argument;
+
+                    case code::zero:
+                    default:
+                        return false;
+                }
+            }
+
+            return false;
+        }
+    };
+
+    static bsoncxx::immortal<type> const instance;
+
+    return instance.value();
+}
 
 } // namespace v1
 } // namespace mongocxx

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/client.cpp
@@ -68,6 +68,7 @@
 #include <bsoncxx/private/bson.hh>
 
 #include <mongocxx/private/mongoc.hh>
+#include <mongocxx/private/namespace_validation.hh>
 #include <mongocxx/private/scoped_bson.hh>
 #include <mongocxx/private/ssl.hh>
 
@@ -192,6 +193,10 @@ v_noabi::write_concern client::write_concern() const {
 }
 
 v_noabi::database client::database(bsoncxx::v_noabi::string::view_or_value name) const& {
+    if (!is_valid_database_name(name.view())) {
+        throw v_noabi::logic_error{v_noabi::error_code::k_invalid_parameter, "invalid database name"};
+    }
+
     // Backward compatibility: `database()` is not logically const.
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     auto& c = const_cast<v1::client&>(check_moved_from(_client));

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/collection.cpp
@@ -121,6 +121,7 @@
 #include <bsoncxx/private/make_unique.hh>
 
 #include <mongocxx/private/mongoc.hh>
+#include <mongocxx/private/namespace_validation.hh>
 
 using bsoncxx::v_noabi::builder::concatenate;
 using bsoncxx::v_noabi::builder::basic::kvp;
@@ -1433,6 +1434,10 @@ void collection::rename(
     bsoncxx::v_noabi::string::view_or_value new_name,
     bool drop_target_before_rename,
     bsoncxx::v_noabi::stdx::optional<v_noabi::write_concern> const& wc) {
+    if (!is_valid_collection_name(new_name.view())) {
+        throw v_noabi::logic_error{v_noabi::error_code::k_invalid_parameter, "invalid collection name"};
+    }
+
     scoped_bson doc;
 
     if (wc) {
@@ -1451,6 +1456,10 @@ void collection::rename(
     bsoncxx::v_noabi::string::view_or_value new_name,
     bool drop_target_before_rename,
     bsoncxx::v_noabi::stdx::optional<v_noabi::write_concern> const& wc) {
+    if (!is_valid_collection_name(new_name.view())) {
+        throw v_noabi::logic_error{v_noabi::error_code::k_invalid_parameter, "invalid collection name"};
+    }
+
     scoped_bson doc;
 
     if (wc) {

--- a/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/database.cpp
+++ b/src/mongocxx/lib/mongocxx/v_noabi/mongocxx/database.cpp
@@ -62,6 +62,7 @@
 #include <bsoncxx/private/make_unique.hh>
 
 #include <mongocxx/private/mongoc.hh>
+#include <mongocxx/private/namespace_validation.hh>
 
 namespace mongocxx {
 namespace v_noabi {
@@ -278,6 +279,10 @@ v_noabi::collection database::create_collection(
     bsoncxx::v_noabi::stdx::string_view name,
     bsoncxx::v_noabi::document::view_or_value collection_options,
     bsoncxx::v_noabi::stdx::optional<v_noabi::write_concern> const& write_concern) {
+    if (!is_valid_collection_name(name)) {
+        throw v_noabi::logic_error{v_noabi::error_code::k_invalid_parameter, "invalid collection name"};
+    }
+
     scoped_bson doc;
 
     doc += to_scoped_bson_view(collection_options);
@@ -296,6 +301,10 @@ v_noabi::collection database::create_collection(
     bsoncxx::v_noabi::stdx::string_view name,
     bsoncxx::v_noabi::document::view_or_value collection_options,
     bsoncxx::v_noabi::stdx::optional<v_noabi::write_concern> const& write_concern) {
+    if (!is_valid_collection_name(name)) {
+        throw v_noabi::logic_error{v_noabi::error_code::k_invalid_parameter, "invalid collection name"};
+    }
+
     scoped_bson doc;
 
     doc += to_scoped_bson_view(collection_options);
@@ -362,6 +371,10 @@ void database::read_preference(v_noabi::read_preference rp) {
 }
 
 bool database::has_collection(bsoncxx::v_noabi::string::view_or_value name) const {
+    if (!is_valid_collection_name(name.view())) {
+        throw v_noabi::logic_error{v_noabi::error_code::k_invalid_parameter, "invalid collection name"};
+    }
+
     // Backward compatibility: `has_collection()` is not logically const.
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     auto& d = const_cast<v1::database&>(check_moved_from(_db));
@@ -391,6 +404,10 @@ v_noabi::write_concern database::write_concern() const {
 }
 
 collection database::collection(bsoncxx::v_noabi::string::view_or_value name) const {
+    if (!is_valid_collection_name(name.view())) {
+        throw v_noabi::logic_error{v_noabi::error_code::k_invalid_parameter, "invalid collection name"};
+    }
+
     // Backward compatibility: `collection()` is not logically const.
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     auto& d = const_cast<v1::database&>(check_moved_from(_db));

--- a/src/mongocxx/test/v1/client.cpp
+++ b/src/mongocxx/test/v1/client.cpp
@@ -114,12 +114,14 @@ TEST_CASE("error code", "[mongocxx][v1][client][error]") {
         CHECK(make_error_code(code::tls_not_enabled) == source_errc::mongocxx);
         CHECK(make_error_code(code::tls_not_supported) == source_errc::mongocxx);
         CHECK(make_error_code(code::append_metadata_failure) == source_errc::mongocxx);
+        CHECK(make_error_code(code::invalid_database_name) == source_errc::mongocxx);
     }
 
     SECTION("type") {
         CHECK(make_error_code(code::tls_not_enabled) == type_errc::invalid_argument);
         CHECK(make_error_code(code::tls_not_supported) == type_errc::invalid_argument);
         CHECK(make_error_code(code::append_metadata_failure) == type_errc::runtime_error);
+        CHECK(make_error_code(code::invalid_database_name) == type_errc::invalid_argument);
     }
 }
 
@@ -1281,6 +1283,39 @@ TEST_CASE("database", "[mongocxx][v1][client]") {
     auto const db = client[input];
 
     CHECK(v1::database::internal::as_mongoc(db) == database_id);
+}
+
+// CXX-3552: a database name is handed to mongoc as a NUL-terminated C string. Without validation,
+// an embedded NUL silently truncates the name and a "." is re-interpreted by the server as a
+// namespace separator, so the namespace used is not the one the caller asked for.
+TEST_CASE("database with an invalid name", "[mongocxx][v1][client]") {
+    client_mocks_type mocks;
+
+    auto get_database = libmongoc::client_get_database.create_instance();
+
+    get_database
+        ->interpose([&](mongoc_client_t*, char const*) -> mongoc_database_t* {
+            FAIL("an invalid database name must be rejected before reaching mongoc");
+            return nullptr;
+        })
+        .forever();
+
+    auto client = mocks.make();
+
+    SECTION("embedded NUL") {
+        std::string const name{"db\0.bad", 7};
+        bsoncxx::v1::stdx::string_view const view{name.data(), name.size()};
+
+        CHECK_THROWS_WITH_CODE(client.database(view), code::invalid_database_name);
+        CHECK_THROWS_WITH_CODE(client[view], code::invalid_database_name);
+    }
+
+    SECTION("dot") {
+        auto const name = GENERATE("db.bad", ".", "a.b");
+
+        CHECK_THROWS_WITH_CODE(client.database(name), code::invalid_database_name);
+        CHECK_THROWS_WITH_CODE(client[name], code::invalid_database_name);
+    }
 }
 
 TEST_CASE("list_databases", "[mongocxx][v1][client]") {

--- a/src/mongocxx/test/v1/collection.cpp
+++ b/src/mongocxx/test/v1/collection.cpp
@@ -23,6 +23,8 @@
 
 #include <mongocxx/private/mongoc.hh>
 
+#include <bsoncxx/test/system_error.hh>
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 
@@ -83,10 +85,12 @@ TEST_CASE("error code", "[mongocxx][v1][collection][error]") {
 
     SECTION("source") {
         CHECK(make_error_code(code::max_time_u32) == source_errc::mongocxx);
+        CHECK(make_error_code(code::invalid_collection_name) == source_errc::mongocxx);
     }
 
     SECTION("type") {
         CHECK(make_error_code(code::max_time_u32) == type_errc::invalid_argument);
+        CHECK(make_error_code(code::invalid_collection_name) == type_errc::invalid_argument);
     }
 }
 
@@ -190,6 +194,34 @@ TEST_CASE("default", "[mongocxx][v1][collection]") {
     collection const coll;
 
     CHECK_FALSE(coll);
+}
+
+// CXX-3552: the new name is handed to mongoc as a NUL-terminated C string, so an embedded NUL
+// would silently truncate it and rename the collection to a name other than the one requested.
+TEST_CASE("rename with an invalid name", "[mongocxx][v1][collection]") {
+    identity_type client_identity;
+    identity_type coll_identity;
+
+    auto const client_id = reinterpret_cast<mongoc_client_t*>(&client_identity);
+    auto const coll_id = reinterpret_cast<mongoc_collection_t*>(&coll_identity);
+
+    auto destroy = libmongoc::collection_destroy.create_instance();
+    destroy->interpose([&](mongoc_collection_t*) -> void {}).forever();
+
+    auto rename = libmongoc::collection_rename_with_opts.create_instance();
+    rename
+        ->interpose([&](mongoc_collection_t*, char const*, char const*, bool, bson_t const*, bson_error_t*) -> bool {
+            FAIL("an invalid collection name must be rejected before reaching mongoc");
+            return false;
+        })
+        .forever();
+
+    auto coll = collection::internal::make(coll_id, client_id);
+
+    std::string const name{"coll\0.bad", 9};
+    bsoncxx::v1::stdx::string_view const view{name.data(), name.size()};
+
+    CHECK_THROWS_WITH_CODE(coll.rename(view, false), code::invalid_collection_name);
 }
 
 } // namespace v1

--- a/src/mongocxx/test/v1/database.cpp
+++ b/src/mongocxx/test/v1/database.cpp
@@ -58,6 +58,61 @@
 namespace mongocxx {
 namespace v1 {
 
+using code = mongocxx::v1::database::errc;
+
+TEST_CASE("error code", "[mongocxx][v1][database][error]") {
+    using mongocxx::v1::source_errc;
+    using mongocxx::v1::type_errc;
+
+    auto const& category = mongocxx::v1::database::error_category();
+    CHECK_THAT(category.name(), Catch::Matchers::Equals("mongocxx::v1::database"));
+
+    auto const zero_errc = make_error_condition(static_cast<std::errc>(0));
+
+    SECTION("unknown") {
+        std::error_code const ec = static_cast<code>(-1);
+
+        CHECK(ec.category() == category);
+        CHECK(ec.value() == -1);
+        CHECK(ec);
+        CHECK(ec.message() == std::string(category.name()) + ":-1");
+    }
+
+    SECTION("zero") {
+        std::error_code const ec = code::zero;
+
+        CHECK(ec.category() == category);
+        CHECK(ec.value() == 0);
+        CHECK_FALSE(ec);
+        CHECK(ec.message() == "zero");
+
+        CHECK(ec != zero_errc);
+        CHECK(ec != source_errc::zero);
+        CHECK(ec != type_errc::zero);
+    }
+
+    SECTION("non-zero") {
+        std::error_code const ec = code::invalid_collection_name;
+
+        CHECK(ec.category() == category);
+        CHECK(ec.value() != static_cast<int>(code::zero));
+        CHECK(ec);
+        CHECK(ec.message() != "zero");
+
+        CHECK(ec != zero_errc);
+        CHECK(ec != source_errc::zero);
+        CHECK(ec != type_errc::zero);
+    }
+
+    SECTION("source") {
+        CHECK(make_error_code(code::invalid_collection_name) == source_errc::mongocxx);
+    }
+
+    SECTION("type") {
+        CHECK(make_error_code(code::invalid_collection_name) == type_errc::invalid_argument);
+    }
+}
+
 namespace {
 
 struct identity_type {};
@@ -1385,6 +1440,65 @@ TEST_CASE("collection", "[mongocxx][v1][database]") {
 
     auto const coll = db[input];
     CHECK(v1::collection::internal::as_mongoc(coll) == coll_id);
+}
+
+// CXX-3552: a collection name is handed to mongoc as a NUL-terminated C string. Without
+// validation, an embedded NUL silently truncates the name, so the namespace used is not the one
+// the caller asked for. Unlike a database name, a "." is legal in a collection name.
+TEST_CASE("collection with an invalid name", "[mongocxx][v1][database]") {
+    database_mocks_type mocks;
+
+    auto db = mocks.make();
+
+    auto get_collection = libmongoc::database_get_collection.create_instance();
+    auto create_collection = libmongoc::database_create_collection.create_instance();
+    auto has_collection = libmongoc::database_has_collection.create_instance();
+
+    get_collection
+        ->interpose([&](mongoc_database_t*, char const*) -> mongoc_collection_t* {
+            FAIL("an invalid collection name must be rejected before reaching mongoc");
+            return nullptr;
+        })
+        .forever();
+
+    create_collection
+        ->interpose([&](mongoc_database_t*, char const*, bson_t const*, bson_error_t*) -> mongoc_collection_t* {
+            FAIL("an invalid collection name must be rejected before reaching mongoc");
+            return nullptr;
+        })
+        .forever();
+
+    has_collection
+        ->interpose([&](mongoc_database_t*, char const*, bson_error_t*) -> bool {
+            FAIL("an invalid collection name must be rejected before reaching mongoc");
+            return false;
+        })
+        .forever();
+
+    std::string const name{"coll\0.bad", 9};
+    bsoncxx::v1::stdx::string_view const view{name.data(), name.size()};
+
+    SECTION("collection") {
+        CHECK_THROWS_WITH_CODE(db.collection(view), code::invalid_collection_name);
+        CHECK_THROWS_WITH_CODE(db[view], code::invalid_collection_name);
+    }
+
+    SECTION("create_collection") {
+        CHECK_THROWS_WITH_CODE(db.create_collection(view, {}), code::invalid_collection_name);
+    }
+
+    SECTION("has_collection") {
+        CHECK_THROWS_WITH_CODE(db.has_collection(view), code::invalid_collection_name);
+    }
+
+    // The bucket name is concatenated into the ".files" and ".chunks" collection names, so an
+    // embedded NUL in the bucket name truncates the resulting collection name.
+    SECTION("gridfs_bucket") {
+        std::string const name{"fs\0.bad", 7};
+
+        CHECK_THROWS_WITH_CODE(
+            db.gridfs_bucket(v1::gridfs::bucket::options{}.bucket_name(name)), code::invalid_collection_name);
+    }
 }
 
 TEST_CASE("gridfs_bucket", "[mongocxx][v1][database]") {

--- a/src/mongocxx/test/v_noabi/client.cpp
+++ b/src/mongocxx/test/v_noabi/client.cpp
@@ -21,6 +21,8 @@
 #include <mongocxx/test/v_noabi/catch_helpers.hh>
 #include <mongocxx/test/v_noabi/client_helpers.hh>
 
+#include <string>
+
 #include <bsoncxx/string/to_string.hpp>
 
 #include <mongocxx/exception/logic_error.hpp>
@@ -34,6 +36,8 @@
 #include <mongocxx/private/ssl.hh>
 
 #include <bsoncxx/test/catch.hh>
+
+#include <catch2/generators/catch_generators.hpp>
 
 namespace {
 using namespace mongocxx;
@@ -341,6 +345,40 @@ TEST_CASE("A client can create a named database object", "[client]") {
     client mongo_client{uri{}, test_util::add_test_server_api()};
     database obtained_database = mongo_client[name];
     REQUIRE(obtained_database.name() == name);
+}
+
+// CXX-3552: a database name is handed to mongoc as a NUL-terminated C string. Without validation,
+// an embedded NUL silently truncates the name and a "." is re-interpreted by the server as a
+// namespace separator, so the namespace used is not the one the caller asked for.
+TEST_CASE("A client rejects a database name containing a NUL or a dot", "[client]") {
+    MOCK_CLIENT;
+
+    auto database_get = libmongoc::client_get_database.create_instance();
+    database_get
+        ->interpose([](mongoc_client_t*, char const*) -> mongoc_database_t* {
+            FAIL("an invalid database name must be rejected before reaching mongoc");
+            return nullptr;
+        })
+        .forever();
+    auto database_destroy = libmongoc::database_destroy.create_instance();
+    database_destroy->interpose([](mongoc_database_t*) {}).forever();
+
+    client mongo_client{uri{}, test_util::add_test_server_api()};
+
+    SECTION("embedded NUL") {
+        std::string const name{"db\0.bad", 7};
+        bsoncxx::stdx::string_view const view{name.data(), name.size()};
+
+        CHECK_THROWS_AS(mongo_client.database(view), logic_error);
+        CHECK_THROWS_AS(mongo_client[view], logic_error);
+    }
+
+    SECTION("dot") {
+        auto const name = GENERATE("db.bad", ".", "a.b");
+
+        CHECK_THROWS_AS(mongo_client.database(name), logic_error);
+        CHECK_THROWS_AS(mongo_client[name], logic_error);
+    }
 }
 
 TEST_CASE("integration tests for client metadata handshake feature") {

--- a/src/mongocxx/test/v_noabi/collection_mocked.cpp
+++ b/src/mongocxx/test/v_noabi/collection_mocked.cpp
@@ -15,6 +15,7 @@
 #include <mongocxx/test/v_noabi/catch_helpers.hh>
 
 #include <chrono>
+#include <string>
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/document/element.hpp>
@@ -77,6 +78,29 @@ TEST_CASE("read_concern", "[mongocxx][v_noabi][collection]") {
 
     mongo_coll.read_concern(rc);
     REQUIRE(collection_set_rc_called);
+}
+
+// CXX-3552: the new name is handed to mongoc as a NUL-terminated C string, so an embedded NUL
+// would silently truncate it and rename the collection to a name other than the one requested.
+TEST_CASE("rename with an invalid name", "[mongocxx][v_noabi][collection]") {
+    MOCK_DATABASE;
+    MOCK_COLLECTION; // "mocked_collection.dummy_collection"
+
+    client mongo_client{uri{}};
+    auto mongo_coll = mongo_client["mocked_collection"]["dummy_collection"];
+    REQUIRE(mongo_coll);
+
+    auto collection_rename_with_opts = libmongoc::collection_rename_with_opts.create_instance();
+    collection_rename_with_opts
+        ->interpose([](::mongoc_collection_t*, char const*, char const*, bool, bson_t const*, bson_error_t*) -> bool {
+            FAIL("an invalid collection name must be rejected before reaching mongoc");
+            return false;
+        })
+        .forever();
+
+    std::string const name{"coll\0.bad", 9};
+
+    CHECK_THROWS_AS(mongo_coll.rename(bsoncxx::string::view_or_value{name}, false), logic_error);
 }
 
 TEST_CASE("aggregate", "[mongocxx][v_noabi][collection]") {

--- a/src/mongocxx/test/v_noabi/database.cpp
+++ b/src/mongocxx/test/v_noabi/database.cpp
@@ -16,6 +16,7 @@
 #include <mongocxx/test/v_noabi/client_helpers.hh>
 
 #include <set>
+#include <string>
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/string/to_string.hpp>
@@ -26,6 +27,7 @@
 #include <mongocxx/exception/operation_exception.hpp>
 #include <mongocxx/index_view.hpp>
 #include <mongocxx/instance.hpp>
+#include <mongocxx/options/gridfs/bucket.hpp>
 #include <mongocxx/options/index_view.hpp>
 
 #include <mongocxx/conversions.hh>
@@ -279,6 +281,50 @@ TEST_CASE("A database", "[database]") {
         database database = mongo_client[database_name];
         collection obtained_collection = database[collection_name];
         REQUIRE(obtained_collection.name() == collection_name);
+    }
+
+    // CXX-3552: a collection name is handed to mongoc as a NUL-terminated C string. Without
+    // validation, an embedded NUL silently truncates the name, so the namespace used is not the
+    // one the caller asked for. Unlike a database name, a "." is legal in a collection name.
+    SECTION("rejects a collection name containing a NUL") {
+        MOCK_COLLECTION;
+
+        database_get_collection
+            ->interpose([](mongoc_database_t*, char const*) -> mongoc_collection_t* {
+                FAIL("an invalid collection name must be rejected before reaching mongoc");
+                return nullptr;
+            })
+            .forever();
+
+        auto database_create_collection = libmongoc::database_create_collection.create_instance();
+        database_create_collection
+            ->interpose([](mongoc_database_t*, char const*, bson_t const*, bson_error_t*) -> mongoc_collection_t* {
+                FAIL("an invalid collection name must be rejected before reaching mongoc");
+                return nullptr;
+            })
+            .forever();
+
+        database_has_collection
+            ->interpose([](mongoc_database_t*, char const*, bson_error_t*) -> bool {
+                FAIL("an invalid collection name must be rejected before reaching mongoc");
+                return false;
+            })
+            .forever();
+
+        database database = mongo_client[database_name];
+
+        std::string const name{"coll\0.bad", 9};
+        bsoncxx::stdx::string_view const view{name.data(), name.size()};
+
+        CHECK_THROWS_AS(database.collection(view), logic_error);
+        CHECK_THROWS_AS(database[view], logic_error);
+        CHECK_THROWS_AS(database.create_collection(view), logic_error);
+        CHECK_THROWS_AS(database.has_collection(view), logic_error);
+
+        // The bucket name is concatenated into the ".files" and ".chunks" collection names, so an
+        // embedded NUL in the bucket name truncates the resulting collection name.
+        CHECK_THROWS_AS(
+            database.gridfs_bucket(options::gridfs::bucket{}.bucket_name(std::string{"fs\0.bad", 7})), logic_error);
     }
 
     SECTION("supports run_command") {


### PR DESCRIPTION
A PR for this change was previously approved (see link in CXX-3552). The fix was pushed to releases/v4.5 in https://github.com/mongodb/mongo-cxx-driver/commit/9f6abafe16c612ebc128a6e32a0cb98fa73f42bf. This PR applies the changes to master (this is notably a reverse of our typical merge process).