### PR TITLE
do not include v_noabi headers when unstable ABI export is disabled

### DIFF
--- a/src/bsoncxx/cmake/CMakeLists.txt
+++ b/src/bsoncxx/cmake/CMakeLists.txt
@@ -28,6 +28,11 @@ if(1)
         @ONLY
     )
 
+    set(bsoncxx_target_includes "")
+    if(BSONCXX_ENABLE_UNSTABLE_ABI)
+       list(APPEND bsoncxx_target_includes ${CMAKE_INSTALL_INCLUDEDIR}/bsoncxx/v_noabi)
+    endif()
+    list(APPEND bsoncxx_target_includes ${CMAKE_INSTALL_INCLUDEDIR})
     install(TARGETS
         ${bsoncxx_target_list}
         EXPORT bsoncxx_targets
@@ -35,8 +40,7 @@ if(1)
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT dev
         INCLUDES DESTINATION
-        ${CMAKE_INSTALL_INCLUDEDIR}/bsoncxx/v_noabi
-        ${CMAKE_INSTALL_INCLUDEDIR}
+        ${bsoncxx_target_includes}
     )
 
     install(EXPORT bsoncxx_targets
@@ -79,6 +83,7 @@ if(1)
                 -D "version=$CACHE{BSONCXX_VERSION_NO_EXTRA}"
                 -D "is_static=${is_static}"
                 -D "bson_req_ver=${BSON_REQUIRED_VERSION}"
+                -D "enable_unstable_abi=$CACHE{BSONCXX_ENABLE_UNSTABLE_ABI}"
                 -P ${CMAKE_CURRENT_SOURCE_DIR}/generate-pc.cmake
             MAIN_DEPENDENCY
                 ${CMAKE_CURRENT_SOURCE_DIR}/libbsoncxx.pc.in

--- a/src/bsoncxx/cmake/generate-pc.cmake
+++ b/src/bsoncxx/cmake/generate-pc.cmake
@@ -8,6 +8,7 @@ set(input_vars
     version
     is_static
     bson_req_ver
+    enable_unstable_abi
 )
 
 foreach(var ${input_vars})
@@ -33,7 +34,9 @@ if(1)
         list(APPEND cflags "-DBSONCXX_STATIC")
     endif()
 
-    list(APPEND cflags "-I\${includedir}/bsoncxx/v_noabi")
+    if(enable_unstable_abi)
+        list(APPEND cflags "-I\${includedir}/bsoncxx/v_noabi")
+    endif()
     list(APPEND cflags "-I\${includedir}")
 
     list(JOIN cflags " " cflags)

--- a/src/mongocxx/cmake/CMakeLists.txt
+++ b/src/mongocxx/cmake/CMakeLists.txt
@@ -32,6 +32,11 @@ if(1)
     endfunction()
     configure_mongocxx_config_cmake()
 
+    set(mongocxx_target_includes "")
+    if(MONGOCXX_ENABLE_UNSTABLE_ABI)
+       list(APPEND mongocxx_target_includes ${CMAKE_INSTALL_INCLUDEDIR}/mongocxx/v_noabi)
+    endif()
+    list(APPEND mongocxx_target_includes ${CMAKE_INSTALL_INCLUDEDIR})
     install(TARGETS
         ${mongocxx_target_list}
         EXPORT mongocxx_targets
@@ -39,8 +44,7 @@ if(1)
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT dev
         INCLUDES DESTINATION
-        ${CMAKE_INSTALL_INCLUDEDIR}/mongocxx/v_noabi
-        ${CMAKE_INSTALL_INCLUDEDIR}
+        ${mongocxx_target_includes}
     )
 
     install(EXPORT mongocxx_targets
@@ -106,6 +110,7 @@ if(1)
                 -D "is_static=${is_static}"
                 -D "bsoncxx_name=${bsoncxx_name}"
                 -D "mongoc_req_ver=${MONGOC_REQUIRED_VERSION}"
+                -D "enable_unstable_abi=$CACHE{MONGOCXX_ENABLE_UNSTABLE_ABI}"
                 -P ${CMAKE_CURRENT_SOURCE_DIR}/generate-pc.cmake
             MAIN_DEPENDENCY
                 ${CMAKE_CURRENT_SOURCE_DIR}/libmongocxx.pc.in

--- a/src/mongocxx/cmake/generate-pc.cmake
+++ b/src/mongocxx/cmake/generate-pc.cmake
@@ -9,6 +9,7 @@ set(input_vars
     is_static
     bsoncxx_name
     mongoc_req_ver
+    enable_unstable_abi
 )
 
 foreach(var ${input_vars})
@@ -37,7 +38,9 @@ if(1)
         list(APPEND cflags "-DMONGOCXX_STATIC")
     endif()
 
-    list(APPEND cflags "-I\${includedir}/mongocxx/v_noabi")
+    if(enable_unstable_abi)
+        list(APPEND cflags "-I\${includedir}/mongocxx/v_noabi")
+    endif()
     list(APPEND cflags "-I\${includedir}")
 
     list(JOIN cflags " " cflags)


### PR DESCRIPTION
Evergreen patch build: https://spruce.corp.mongodb.com/version/6aa44f9fbcb89200073c159d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC