### PR TITLE
Improve support for validating v1-only build configurations

### DIFF
--- a/examples/projects/bsoncxx/hello_bsoncxx.cpp
+++ b/examples/projects/bsoncxx/hello_bsoncxx.cpp
@@ -12,14 +12,64 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Support validation of install prefix with build configuration `BSONCXX_ENABLE_UNSTABLE_ABI=OFF`.
+#if !defined(BSONCXX_ENABLE_UNSTABLE_ABI)
+#define BSONCXX_ENABLE_UNSTABLE_ABI 1
+#endif
+
+#if BSONCXX_ENABLE_UNSTABLE_ABI == 0
+#include <bsoncxx/v1/document/value.hpp>
+#include <bsoncxx/v1/document/view.hpp>
+#include <bsoncxx/v1/element/view.hpp>
+#include <bsoncxx/v1/types/view.hpp> // IWYU pragma: keep
+#else
+#include <bsoncxx/document/element.hpp>
+#include <bsoncxx/document/value.hpp>
+#include <bsoncxx/document/view.hpp>
+#include <bsoncxx/types/view.hpp> // IWYU pragma: keep
+#endif
+
+#include <array>
+#include <cstdint>
+#include <cstdlib>
 #include <iostream>
+#include <system_error>
 
-#include <bsoncxx/builder/basic/document.hpp>
-#include <bsoncxx/json.hpp>
+namespace {
 
-int main(int, char*[]) {
-    using bsoncxx::builder::basic::kvp;
-    using bsoncxx::builder::basic::make_document;
+// clang-format off
+static constexpr std::array<std::uint8_t, 22> bytes = {{
+    0x16, 0x00, 0x00, 0x00,                         // (22 bytes) {
+        0x02,                                       //   (string)
+            0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x00,     //     "Hello":
+            0x06, 0x00, 0x00, 0x00,                 //     (6 bytes)
+                0x77, 0x6f, 0x72, 0x6c, 0x64, 0x00, //       "world"
+    0x00,                                           // }
+}};
+// clang-format on
 
-    std::cout << bsoncxx::to_json(make_document(kvp("field", "data"))) << std::endl;
+} // namespace
+
+int main() try {
+#if BSONCXX_ENABLE_UNSTABLE_ABI == 0
+    using view_type = bsoncxx::v1::document::view;
+    using value_type = bsoncxx::v1::document::value;
+#else
+    using view_type = bsoncxx::document::view;
+    using value_type = bsoncxx::document::value;
+#endif
+
+    // {"Hello": "world"}
+    view_type const view{bytes.data(), bytes.size()};
+    value_type const value{view};
+
+    auto const element = *value.begin();
+
+    // "Hello, world!"
+    std::cout << element.key() << ", " << element.get_string().value << "!" << std::endl;
+
+    return EXIT_SUCCESS;
+} catch (std::system_error const& ex) {
+    std::cerr << "unexpected failure: " << ex.what() << std::endl;
+    return EXIT_FAILURE;
 }

--- a/examples/projects/mongocxx/hello_mongocxx.cpp
+++ b/examples/projects/mongocxx/hello_mongocxx.cpp
@@ -12,36 +12,76 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdlib>
-#include <iostream>
+// Support validation of install prefix with build configuration `MONGOCXX_ENABLE_UNSTABLE_ABI=OFF`.
+#if !defined(MONGOCXX_ENABLE_UNSTABLE_ABI)
+#define MONGOCXX_ENABLE_UNSTABLE_ABI 1
+#endif
 
-#include <bsoncxx/builder/basic/document.hpp>
-#include <bsoncxx/json.hpp>
+#if MONGOCXX_ENABLE_UNSTABLE_ABI == 0
+#include <bsoncxx/v1/document/value.hpp>
+#include <bsoncxx/v1/document/view.hpp>
+
+#include <mongocxx/v1/client.hpp>
+#include <mongocxx/v1/database.hpp>
+#include <mongocxx/v1/instance.hpp>
+#include <mongocxx/v1/uri.hpp>
+#else
+#include <bsoncxx/document/value.hpp>
+#include <bsoncxx/document/view.hpp>
 
 #include <mongocxx/client.hpp>
+#include <mongocxx/database.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>
+#endif
 
-int main(int argc, char* argv[]) {
-    using bsoncxx::builder::basic::kvp;
-    using bsoncxx::builder::basic::make_document;
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <system_error>
 
-    // The mongocxx::instance constructor and destructor initialize and shut down the driver,
-    // respectively. Therefore, a mongocxx::instance must be created before using the driver and
-    // must remain alive for as long as the driver is in use.
-    mongocxx::instance inst;
+namespace {
 
-    try {
-        auto const uri = mongocxx::uri{(argc >= 2) ? argv[1] : mongocxx::uri::k_default_uri};
+// clang-format off
+static constexpr std::array<std::uint8_t, 15> bytes = {{
+    0x0f, 0x00, 0x00, 0x00,               // (15 bytes) {
+        0x10,                             //   (int32)
+            0x70, 0x69, 0x6e, 0x67, 0x00, //     "ping":
+            0x01, 0x00, 0x00, 0x00,       //     1
+    0x00,                                 // }
+}};
+// clang-format on
 
-        auto client = mongocxx::client{uri};
-        auto admin = client["admin"];
-        auto result = admin.run_command(make_document(kvp("ping", 1)));
-        std::cout << bsoncxx::to_json(result) << std::endl;
+} // namespace
 
-        return EXIT_SUCCESS;
-    } catch (std::exception const& xcp) {
-        std::cout << "connection failed: " << xcp.what() << std::endl;
-        return EXIT_FAILURE;
-    }
+int main(int argc, char** argv) try {
+#if MONGOCXX_ENABLE_UNSTABLE_ABI == 0
+    using view_type = bsoncxx::v1::document::view;
+    using instance_type = mongocxx::v1::instance;
+    using uri_type = mongocxx::v1::uri;
+    using client_type = mongocxx::v1::client;
+#else
+    using view_type = bsoncxx::document::view;
+    using instance_type = mongocxx::instance;
+    using uri_type = mongocxx::uri;
+    using client_type = mongocxx::client;
+#endif
+
+    instance_type instance;
+
+    client_type client{uri_type{(argc >= 2) ? argv[1] : uri_type::k_default_uri}};
+    auto admin = client["admin"];
+
+    // {"ping": 1}
+    auto const reply = admin.run_command(view_type{bytes.data(), bytes.size()});
+    auto const ok = static_cast<int>(reply["ok"].get_double().value);
+
+    // {"ok": 1}
+    std::cout << "{ok: " << static_cast<int>(ok) << '}' << std::endl;
+
+    return EXIT_SUCCESS;
+} catch (std::system_error const& ex) {
+    std::cerr << "unexpected failure: " << ex.what() << std::endl;
+    return EXIT_FAILURE;
 }

--- a/src/bsoncxx/cmake/CMakeLists.txt
+++ b/src/bsoncxx/cmake/CMakeLists.txt
@@ -28,11 +28,6 @@ if(1)
         @ONLY
     )
 
-    set(bsoncxx_target_includes "")
-    if(BSONCXX_ENABLE_UNSTABLE_ABI)
-       list(APPEND bsoncxx_target_includes ${CMAKE_INSTALL_INCLUDEDIR}/bsoncxx/v_noabi)
-    endif()
-    list(APPEND bsoncxx_target_includes ${CMAKE_INSTALL_INCLUDEDIR})
     install(TARGETS
         ${bsoncxx_target_list}
         EXPORT bsoncxx_targets
@@ -40,7 +35,8 @@ if(1)
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT dev
         INCLUDES DESTINATION
-        ${bsoncxx_target_includes}
+            "$<$<BOOL:$CACHE{BSONCXX_ENABLE_UNSTABLE_ABI}>:${CMAKE_INSTALL_INCLUDEDIR}/bsoncxx/v_noabi>"
+            "${CMAKE_INSTALL_INCLUDEDIR}"
     )
 
     install(EXPORT bsoncxx_targets

--- a/src/mongocxx/cmake/CMakeLists.txt
+++ b/src/mongocxx/cmake/CMakeLists.txt
@@ -32,11 +32,6 @@ if(1)
     endfunction()
     configure_mongocxx_config_cmake()
 
-    set(mongocxx_target_includes "")
-    if(MONGOCXX_ENABLE_UNSTABLE_ABI)
-       list(APPEND mongocxx_target_includes ${CMAKE_INSTALL_INCLUDEDIR}/mongocxx/v_noabi)
-    endif()
-    list(APPEND mongocxx_target_includes ${CMAKE_INSTALL_INCLUDEDIR})
     install(TARGETS
         ${mongocxx_target_list}
         EXPORT mongocxx_targets
@@ -44,7 +39,8 @@ if(1)
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT dev
         INCLUDES DESTINATION
-        ${mongocxx_target_includes}
+            "$<$<BOOL:$CACHE{MONGOCXX_ENABLE_UNSTABLE_ABI}>:${CMAKE_INSTALL_INCLUDEDIR}/mongocxx/v_noabi>"
+            "${CMAKE_INSTALL_INCLUDEDIR}"
     )
 
     install(EXPORT mongocxx_targets


### PR DESCRIPTION
Continuation of https://github.com/mongodb/mongo-cxx-driver/pull/1708.

Updates the `hello_*.cpp` components under `examples/projects`, which are already being used by EVG to validate import via CMake and pkg-config, to support v1-only build configurations by compiling with the `*_ENABLE_UNSTABLE_ABI=0` compile definition (via the `-D` compile flag). Note these correspond to the same preprocessor macros defined in the v_noabi [config.hpp](https://github.com/mongodb/mongo-cxx-driver/blob/06839f8ff0b43f7ea6a66addb0fcf3e449dc3f82/src/bsoncxx/lib/bsoncxx/v_noabi/bsoncxx/config/config.hpp.in#L22-L26) headers to disable exports of v_noabi symbols. In a v1-only install configuration, there are no v_noabi headers, so the preprocessor macro must be explicitly defined instead. This should allow for v1-only installations to be validated by directly building and executing the `hello_*.cpp` components with `*_ENABLE_UNSTABLE_ABI=0`, e.g. assuming `PKG_CONFIG_PATH` and `LD_LIBRARY_PATH` are set correctly:

```bash
$ g++ \
    -D BSONCXX_ENABLE_UNSTABLE_ABI=0 \
    $(pkgconf -cflags libbsoncxx1) \
    -o hello_bsoncxx hello_bsoncxx.cpp \
    $(pkgconf --libs libbsoncxx1)

$ ./hello_bsoncxx
Hello, world!
```